### PR TITLE
Convert nrepl-interaction-mode into a major mode

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -1186,12 +1186,11 @@ the buffer should appear."
 ;;;###autoload
 (defun nrepl-enable-on-existing-clojure-buffers ()
   (interactive)
-  (add-hook 'clojure-mode-hook 'clojure-enable-nrepl)
   (save-window-excursion
     (dolist (buffer (buffer-list))
       (with-current-buffer buffer
         (when (eq major-mode 'clojure-mode)
-          (clojure-enable-nrepl))))))
+          (clojure-nrepl-mode))))))
 
 ;;;###autoload
 (defun nrepl-jack-in ()


### PR DESCRIPTION
One effect of this change is that Clojure buffers will now show `nREPL-Interaction` as their major mode. I'd prefer to see `Clojure-Interaction`; however renaming the mode to clojure-interaction-mode would probably necessitate a renaming of this project.

Fixes #20
