### PR TITLE
Use standard tag ring mechanism for jumping to and back from definitions

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -330,10 +330,7 @@ Empty strings and duplicates are ignored."
   (interactive "P")
   (nrepl-read-symbol-name "Symbol: " 'nrepl-jump-to-def query))
 
-(defun nrepl-jump-back ()
-  "Return to the location from which `nrepl-jump-to-def' was invoked."
-  (interactive)
-  (pop-tag-mark))
+(defalias 'nrepl-jump-back 'pop-tag-mark)
 
 (defun nrepl-perform-complete (buffer beginning-of-symbol value)
   (with-current-buffer buffer


### PR DESCRIPTION
Slime (and my elisp-slime-nav library) use the built-in etags
mechanism for maintaining a poppable stack of jump locations. This
commits simplifies nrepl.el's jump mechanism by using the same trick.

Additionally, this commit solves a problem whereby a jump location
would unnecessarily be pushed when trying to jump to the non-existent
definition of a bogus or undefined symbol.
