### PR TITLE
Route all non-repl evals through nrepl-current-buffer function.

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -1146,12 +1146,13 @@ balanced."
 (defun nrepl-current-ns ()
   "Return the ns in the current context.
 Use `nrepl-buffer-ns' when in a repl buffer, otherwise search for
-and read a `ns' form."
+and read a `ns' form. Fall back to \"user\" if none is found."
   (if (equal major-mode 'nrepl-mode)
       nrepl-buffer-ns
     (save-restriction
       (widen)
-      (clojure-find-ns))))
+      (or (clojure-find-ns)
+          "user"))))
 
 ;; Words of inspiration
 (defun nrepl-user-first-name ()


### PR DESCRIPTION
This implements the fixes discussed on the mailing list:
https://groups.google.com/group/nrepl-el/browse_thread/thread/26971a4e4717189a

The `nrepl-current-ns` function now checks the major mode and looks for an ns form if the mode isn't `nrepl-mode`.
