### PR TITLE
Fix argument order of plist-get to avoid squashing stderr/stdout results

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -1143,12 +1143,12 @@ buffer."
                                  (setq nrepl-sync-response
                                        (plist-put nrepl-sync-response :value value)))
                                (lambda (buffer out)
-                                 (let ((so-far (plist-get :stdout nrepl-sync-response)))
+                                 (let ((so-far (plist-get nrepl-sync-response :stdout)))
                                    (setq nrepl-sync-response
                                          (plist-put nrepl-sync-response
                                                     :stdout (concat so-far out)))))
                                (lambda (buffer err)
-                                 (let ((so-far (plist-get :stderr nrepl-sync-response)))
+                                 (let ((so-far (plist-get nrepl-sync-response :stderr)))
                                    (setq nrepl-sync-response
                                          (plist-put nrepl-sync-response
                                                     :stderr (concat so-far err)))))


### PR DESCRIPTION
This corrects a small error in my already-merged for synchronous evaluation.
