### PR TITLE
Make the error handler configurable

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -138,6 +138,9 @@ joined together.")
 (defvar nrepl-sync-response nil
   "Result of the last sync request.")
 
+(defvar nrepl-err-handler 'nrepl-default-err-handler
+  "Evaluation error handler")
+
 (defcustom nrepl-popup-stacktraces t
   "Non-nil means pop-up error stacktraces.
    Nil means do not, useful when in repl"
@@ -430,7 +433,7 @@ joined together.")
                (if (member "interrupted" status)
                    (message "Evaluation interrupted."))
                (if (member "eval-error" status)
-                   (nrepl-err-handler buffer ex root-ex))
+                   (funcall nrepl-err-handler buffer ex root-ex))
                (if (member "need-input" status)
                    (nrepl-need-input buffer))
                (if (member "done" status)
@@ -496,7 +499,7 @@ joined together.")
                                  (nrepl-emit-into-popup-buffer buffer str))
                                '()))
 
-(defun nrepl-err-handler (buffer ex root-ex)
+(defun nrepl-default-err-handler (buffer ex root-ex)
   ;; TODO: use pst+ here for colorization. currently breaks bencode.
   ;; TODO: use ex and root-ex as fallback values to display when pst/print-stack-trace-not-found
   (if (or nrepl-popup-stacktraces


### PR DESCRIPTION
This allows override of the error handler function invoked when an eval
throws an exception.

For example, this will allow nrepl-ritz to display exceptions in a SLDB
style buffer.
