### PR TITLE
Properly quote backslash in file names. Fixes #72

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -1462,7 +1462,9 @@ under point, prompts for a var."
                                  nil (if (buffer-file-name)
                                          (file-name-nondirectory
                                           (buffer-file-name))))))
-   (let ((fn (convert-standard-filename (expand-file-name filename))))
+   (let ((fn (replace-regexp-in-string
+        "\\\\" "\\\\\\\\"
+	      (convert-standard-filename (expand-file-name filename)))))
      (nrepl-interactive-eval
       (format "(clojure.core/load-file \"%s\")\n(in-ns '%s)\n" fn (nrepl-current-ns)))
      (message "Loading %s..." fn)))


### PR DESCRIPTION
Escape "\" as "\" in clojure string. Fixes issue #72
