### PR TITLE
Switching to pst+ for stacktraces

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -507,7 +507,7 @@ joined together.")
                    (cdr (assq 'major-mode 
                               (buffer-local-variables buffer))))))
       (with-current-buffer buffer
-        (nrepl-send-string "(if-let [pst+ (resolve 'clj-stacktrace.repl/pst)]
+        (nrepl-send-string "(if-let [pst+ (resolve 'clj-stacktrace.repl/pst+)]
                         (pst+ *e) (clojure.stacktrace/print-stack-trace *e))"
                            nrepl-buffer-ns
                            (nrepl-make-response-handler


### PR DESCRIPTION
There's a note in #11 that says pst+ and bencode don't get along, but this has been working for me. The colored stacktraces make a big difference in readability.

If someone wants to elaborate on what the bencode problem is, I can take a look at it. 
