### PR TITLE
Add var to add extra eldoc safe commands.

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -141,6 +141,9 @@ joined together.")
 (defvar nrepl-err-handler 'nrepl-default-err-handler
   "Evaluation error handler")
 
+(defvar nrepl-extra-eldoc-commands '("nrepl-complete" "yas/expand")
+  "Extra commands to be added to eldoc's safe commands list.")
+
 (defcustom nrepl-popup-stacktraces t
   "Non-nil means pop-up error stacktraces.
    Nil means do not, useful when in repl"
@@ -398,6 +401,7 @@ joined together.")
 (defun nrepl-eldoc-enable-in-current-buffer ()
   (make-local-variable 'eldoc-documentation-function)
   (setq eldoc-documentation-function 'nrepl-eldoc)
+  (apply 'eldoc-add-command nrepl-extra-eldoc-commands)
   (turn-on-eldoc-mode))
 
 ;;; Response handlers


### PR DESCRIPTION
This fixes a bug where nrepl-complete (or other completion mechanisms) didn't
trigger eldoc display.
