### PR TITLE
Bind g to nrepl-macroexpand-1-last-expression in macroexpansion buffers

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -625,7 +625,7 @@ joined together.")
    "Mode for nrepl macroexpansion buffers"
    nil
    (" ")
-   '(("g" .  nrepl-macroexpand-again)))
+   '(("g" .  nrepl-macroexpand-1-last-expression)))
 
 (defun nrepl-macroexpand-expr (macroexpand expr pprint-p &optional buffer)
   "Evaluate the expression preceding point and print the result


### PR DESCRIPTION
Before, it was bound to nrepl-macroexpand-again, which doesn't even exist...
