### PR TITLE
enable eldoc in nrepl minor mode

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -910,7 +910,9 @@ This function is meant to be used in hooks to avoid lambda
    nrepl-interaction-mode-map
    (make-local-variable 'completion-at-point-functions)
    (add-to-list 'completion-at-point-functions
-		'nrepl-complete-at-point))
+		'nrepl-complete-at-point)
+   (nrepl-eldoc-enable-in-current-buffer))
+                
 
 (defun nrepl-mode ()
   "Major mode for nREPL interactions."


### PR DESCRIPTION
My emacs lisp skills are still pretty weak, so I'm not certain this is how eldoc mode should be enabled for nrepl buffers. But man, it's nice to see those hints down in the minibuffer.
