### PR TITLE
Just require 'cl directly, since it's used at runtime

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -48,8 +48,7 @@
 (require 'arc-mode)
 (require 'ansi-color)
 (require 'eldoc)
-(eval-when-compile
-  (require 'cl))
+(require 'cl)
 
 (defgroup nrepl nil
   "Interaction with the Clojure nREPL Server."


### PR DESCRIPTION
This results in fewer warnings, since wrapping (require 'cl)
in (eval-when-compile ...) prompts the following complaints:

```
In nrepl-display-popup-buffer:
nrepl.el:566:61:Warning: function `find' from cl package called at runtime

In nrepl-history-write:
nrepl.el:802:53:Warning: function `subseq' from cl package called at runtime

In nrepl-histories-merge:
nrepl.el:833:34:Warning: function `subseq' from cl package called at runtime
```
