### PR TITLE
Bug fix: Ensure nrepl-eval-sync waits for :done when response is chunked

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -1195,8 +1195,9 @@ The result is a plist with keys :value, :stderr and :stdout."
   (with-current-buffer "*nrepl-connection*"
     (setq nrepl-sync-response nil)
     (nrepl-send-request request (nrepl-sync-request-handler (current-buffer)))
-    (while (null nrepl-sync-response)
-      (accept-process-output nil 0 5))
+    (while (or (null nrepl-sync-response)
+               (null (plist-get nrepl-sync-response :done)))
+      (accept-process-output nil 0.005))
     nrepl-sync-response))
 
 (defun nrepl-send-string-sync (input &optional ns)


### PR DESCRIPTION
In the event of a chunked response, `nrepl-eval-sync` was previously stopping after the first chunk, rather than waiting for `:done`. This caused unpredictable breakage downstream: see purcell/ac-nrepl#8 and overtone/emacs-live#19.
