### PR TITLE
Default host for the connection

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -66,6 +66,11 @@
   :type 'hook
   :group 'nrepl)
 
+(defcustom nrepl-host "127.0.0.1"
+   "The default hostname (or IP address) to connect to."
+   :type 'string
+   :group 'nrepl)
+
 (defvar nrepl-version "0.1.5-preview"
   "The current nrepl version.")
 
@@ -1703,7 +1708,8 @@ restart the server."
 
 ;;;###autoload
 (defun nrepl (host port)
-  (interactive "MHost: \nnPort: ")
+  (interactive (list (read-from-minibuffer "Host: " nrepl-host)
+                     (read-from-minibuffer "Port: ")))
   (nrepl-connect host port))
 
 (provide 'nrepl)


### PR DESCRIPTION
Hi,

This pull request implements a user configurable default host for nrepl. By defaults it is set to 127.0.0.1. It appears in the minibuffer when typing M-x nrepl RET
