### PR TITLE
Fix meta-. wrt namespace resolution

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -367,7 +367,7 @@ joined together.")
   "Return a list of completions using complete.core/completions."
   (let ((strlst (plist-get
                  (nrepl-send-string-sync
-                  (format "(complete.core/completions \"%s\" *ns*)" str)
+                  (format "(do (require 'complete.core) (complete.core/completions \"%s\" *ns*))" str)
                   (nrepl-current-ns)
                   (nrepl-current-tooling-session))
                  :value)))


### PR DESCRIPTION
Fixed nrepl-jump-to-def to use nrepl-current-ns if required. Then fix nrepl-current-ns to be sure we calculate nrepl-buffer-ns before we try to use it.
