### PR TITLE
add nrepl-eval-print-last-expression

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -744,7 +744,13 @@ in a macroexpansion buffer. Prefix argument forces pretty-printed output."
   (interactive "P")
   (if prefix
       (nrepl-interactive-eval-print (nrepl-last-expression))
-      (nrepl-interactive-eval (nrepl-last-expression))))
+    (nrepl-interactive-eval (nrepl-last-expression))))
+
+(defun nrepl-eval-print-last-expression ()
+  "Evaluate the expression preceding point and print value into
+  the current buffer"
+  (interactive)
+  (nrepl-interactive-eval-print (nrepl-last-expression)))
 
 ;;;;; History
 (defun nrepl-add-to-input-history (string)


### PR DESCRIPTION
Despite this functionality being available as a prefix mode to nrepl-eval-last-expression, this explicit fn is provided for 'compatibility' with slime-eval-print-last-expression as it was the first name I looked for, and only discovered the prefix version when I was about to implement it myself.
