### PR TITLE
Include filename in file-path when loading

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -1687,7 +1687,7 @@ under point, prompts for a var."
 
 (defun nrepl-load-file-op (filename)
   (nrepl-send-load-file (nrepl-file-string filename)
-                        (file-name-directory filename)
+                        filename
                         (file-name-nondirectory filename)))
 
 (defun nrepl-load-file-core (filename)


### PR DESCRIPTION
`nrepl-jump` has been jumping to directories for me instead of the proper source location because the filename wasn't included in the file-path.

This resolves that.

The example in the tools.nrepl source makes it appear that this change is correct.

https://github.com/clojure/tools.nrepl/blob/master/src/main/clojure/clojure/tools/nrepl/middleware/load_file.clj#L31
