### PR TITLE
Added nrepl-output-end missing value

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -155,7 +155,7 @@ joined together.")
 (defvar nrepl-output-start nil
   "Marker for the start of output.")
 
-(defvar nrepl-output-end
+(defvar nrepl-output-end nil
   "Marker for the end of output.")
 
 (defvar nrepl-sync-response nil


### PR DESCRIPTION
I think you meant to give `nrepl-output-end` `nil` as value. At any rate I'm pretty sure its value is missing whatever it might have been. 
