### PR TITLE
Added a customizable result prefix so that form evaluation results may b...

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -175,11 +175,10 @@ joined together.")
 (defvar nrepl-ops nil
   "Available nREPL server ops (from describe).")
 
-(defcustom nrepl-popup-stacktraces t
-  "Non-nil means pop-up error stacktraces.
-   Nil means do not, useful when in repl"
-  :type 'boolean
-  :group 'nrepl)
+(defcustom nrepl-result-prefix nil
+  "A prefix prepended to form evaluation results."
+  :group 'nrepl
+  :type 'string)
 
 (defun nrepl-make-variables-buffer-local (&rest variables)
   (mapcar #'make-variable-buffer-local variables))
@@ -1281,7 +1280,8 @@ Return the position of the prompt beginning."
           (when (and bol (not (bolp))) (insert-before-markers "\n"))
           (nrepl-propertize-region `(face nrepl-result-face
                                           rear-nonsticky (face))
-                                   (insert-before-markers string)))))
+                                   (insert-before-markers
+                                    (concat nrepl-result-prefix string))))))
     (nrepl-show-maximum-output)))
 
 (defun nrepl-default-handler (response)


### PR DESCRIPTION
I've added a customizable result prefix, so that form evaluation results may be made more visually distinctive from console output. If one were to set `nrepl-result-prefix` to `=>` we'd get the following behaviour:

```
user> 20
=> 20

user> (print "hello")
hello
=> nil
```

instead of the default

```
user> 20
20

user> (print "hello")
hello
nil
```

I guess many people might this helpful and it's totally opt-in.
