### PR TITLE
Changed the result's font face to make it visually more distinctive

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -111,7 +111,7 @@
   :group 'nrepl)
 
 (defface nrepl-result-face
-  '((t ()))
+  '((t (:inherit font-lock-variable-name-face)))
   "Face for the result of an evaluation in the nREPL client."
   :group 'nrepl)
 


### PR DESCRIPTION
I've changed the `nrepl-result-face` to make the evaluation results stand out a bit more. Feel free to ignore/close this PR if you think it doesn't improve the usability of nrepl.el.
