### PR TITLE
Use the font-lock-comment-face to propertize the banner text

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -1690,7 +1690,7 @@ text property `nrepl-old-input'."
 (defun nrepl-insert-banner (ns)
   (when (zerop (buffer-size))
     (let ((welcome (concat "; nREPL " nrepl-current-version)))
-      (insert welcome)))
+      (insert (propertize welcome 'face 'font-lock-comment-face))))
   (goto-char (point-max))
   (nrepl-mark-output-start)
   (nrepl-mark-input-start)


### PR DESCRIPTION
Another small visual style change to make the overall aesthetics of nrepl.el more appealing (and more in line with other popular Emacs REPLs like IELM for instance).
