### PR TITLE
Provided a proper default indent-line-function for nrepl-mode

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -1172,6 +1172,7 @@ This function is meant to be used in hooks to avoid lambda
   (use-local-map nrepl-mode-map)
   (setq mode-name "nREPL"
         major-mode 'nrepl-mode)
+  (set (make-local-variable 'indent-line-function) 'lisp-indent-line)
   (make-local-variable 'completion-at-point-functions)
   (add-to-list 'completion-at-point-functions
                'nrepl-complete-at-point)


### PR DESCRIPTION
`nrepl-mode` was missing a default `indent-line-function` which was causing problems with commands that depended on it having been set(like `paredit-newline-and-indent`). All major modes should set this variable.
