### PR TITLE
Changed the name of nrepl's error buffer

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -88,7 +88,7 @@
 (defvar nrepl-connection-buffer "*nrepl-connection*")
 (defvar nrepl-server-buffer "*nrepl-server*")
 (defvar nrepl-nrepl-buffer "*nrepl*")
-(defvar nrepl-error-buffer "*nREPL error*")
+(defvar nrepl-error-buffer "*nrepl-error*")
 
 (defface nrepl-prompt-face
   '((t (:inherit font-lock-keyword-face)))


### PR DESCRIPTION
Just a minor stylistic change to make the names of nREPL.el's buffers consistent.
