### PR TITLE
Adjusted the javadoc keybinding and mentioned it in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ section of this manual.
 * <kbd>C-c C-k</kbd>: Load the current buffer.
 * <kbd>C-c C-l</kbd>: Load a file.
 * <kbd>C-c C-d</kbd>: Display doc string for the symbol at point.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol
+* <kbd>C-c C-j</kbd>: Display JavaDoc (in your default browser) for the symbol at point.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol
 * <kbd>M-.</kbd>: Jump to the definition of a var.  If invoked with a prefix argument, or no symbol is found at point, prompt for a var.
 * <kbd>M-,</kbd>: Return to your pre-jump location.
 * <kbd>M-TAB</kbd>: Complete the symbol at point. (For `auto-complete` integration, see [`ac-nrepl`](https://github.com/purcell/ac-nrepl))
@@ -243,6 +244,8 @@ uses the same search pattern (even if the current input has changed).
 * <kbd>C-c C-n, C-c C-p</kbd>: Move between the current and previous prompts in the REPL buffer. Pressing RET on a line with old input copies that line to the newest prompt.
 
 * <kbd>TAB</kbd>: Complete symbol at point.
+* <kbd>C-c C-d</kbd>: Display doc string for the symbol at point.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol
+* <kbd>C-c C-j</kbd>: Display JavaDoc (in your default browser) for the symbol at point.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol
 
 ### Macroexpansion buffer commands:
 

--- a/nrepl.el
+++ b/nrepl.el
@@ -1142,7 +1142,7 @@ This function is meant to be used in hooks to avoid lambda
     (define-key map (kbd "C-c C-k") 'nrepl-load-current-buffer)
     (define-key map (kbd "C-c C-l") 'nrepl-load-file)
     (define-key map (kbd "C-c C-b") 'nrepl-interrupt)
-    (define-key map (kbd "C-c b") 'nrepl-javadoc)
+    (define-key map (kbd "C-c C-j") 'nrepl-javadoc)
     map))
 
 (easy-menu-define nrepl-interaction-mode-menu nrepl-interaction-mode-map
@@ -1159,6 +1159,7 @@ This function is meant to be used in hooks to avoid lambda
     ["Macroexpand-all last expression" nrepl-macroexpand-all]
     ["Set ns" nrepl-set-ns]
     ["Display documentation" nrepl-doc]
+    ["Display JavaDoc" nrepl-javadoc]
     ["Switch to REPL" nrepl-switch-to-repl-buffer]
     ["Load current buffer" nrepl-load-current-buffer]
     ["Load file" nrepl-load-file]
@@ -1221,7 +1222,7 @@ This function is meant to be used in hooks to avoid lambda
     (define-key map (kbd "C-c C-n") 'nrepl-next-prompt)
     (define-key map (kbd "C-c C-p") 'nrepl-previous-prompt)
     (define-key map (kbd "C-c C-b") 'nrepl-interrupt)
-    (define-key map (kbd "C-c b") 'nrepl-javadoc)
+    (define-key map (kbd "C-c C-j") 'nrepl-javadoc)
     map))
 
 (easy-menu-define nrepl-mode-menu nrepl-mode-map
@@ -1231,6 +1232,7 @@ This function is meant to be used in hooks to avoid lambda
     ["Jump back" nrepl-jump-back]
     ["Complete symbol" complete-symbol]
     ["Display documentation" nrepl-doc]
+    ["Display JavaDoc" nrepl-javadoc]
     ["Clear output" nrepl-clear-output]
     ["Clear buffer" nrepl-clear-buffer]
     ["Kill input" nrepl-kill-input]


### PR DESCRIPTION
`C-c b` is a very bad keybinding :-) In Emacs `C-c key` keybindings are reserved for the users and shouldn't be touch by major/minor modes. I changed the keybinding to `C-c C-j` (which also happens to be closer mnemonically to JavaDoc).
