### PR TITLE
Use the comment font face for the output cleared text

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -1745,7 +1745,8 @@ buffer in which the command was invoked."
         (delete-region start end)
         (save-excursion
           (goto-char start)
-          (insert ";;; output cleared"))))))
+          (insert
+           (propertize ";;; output cleared" 'face 'font-lock-comment-face)))))))
 
 (defun nrepl-find-ns ()
   (or (save-restriction


### PR DESCRIPTION
I think this font face makes it more apparent that the output of the previous function has been cleared.
