### PR TITLE
Fixed nrepl-symbol-at-point's behaviour when at the beginning of the line

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -1850,6 +1850,7 @@ the buffer should appear."
   "Return the name of the symbol at point, otherwise nil."
   (let ((str (thing-at-point 'symbol)))
     (and str
+         (not (equal str (concat (nrepl-find-ns) "> ")))
          (not (equal str ""))
          (substring-no-properties str))))
 


### PR DESCRIPTION
There was a bug with `nrepl-symbol-at-point` if you were at the beginning of a line just after the prompt - instead of an empty string `thing-at-point` returned the current prompt (like `user>`). I've added a simple check to avoid that problem. 
