### PR TITLE
Use clojure-mode to display the source code of functions

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -1935,7 +1935,9 @@ under point, prompts for a var."
 
 (defun nrepl-src-handler (symbol)
   (let ((form (format "(clojure.repl/source %s)" symbol))
-        (doc-buffer (nrepl-popup-buffer "*nREPL doc*" t)))
+        (doc-buffer (nrepl-popup-buffer "*nREPL doc*" nil)))
+    (with-current-buffer doc-buffer
+      (clojure-mode))
     (nrepl-send-string form
                        (nrepl-popup-eval-out-handler doc-buffer)
                        nrepl-buffer-ns


### PR DESCRIPTION
Use clojure-mode to fontify the source code of functions displayed via the recently added nrepl-src command.
