### PR TITLE
Make nrepl work with fish-shell

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -1313,7 +1313,7 @@ This function is meant to be used in hooks to avoid lambda
   (if (or (locate-file nrepl-lein-command exec-path)
           (locate-file (format "%s.bat" nrepl-lein-command) exec-path))
       (format "%s repl :headless" nrepl-lein-command)
-    (format "echo \"%s repl :headless\" | $SHELL -l" nrepl-lein-command))
+    (format "echo \"%s repl :headless\" | eval $SHELL -l" nrepl-lein-command))
   "The command used to start the nREPL via nrepl-jack-in.
 For a remote nREPL server lein must be in your PATH.  The remote
 proc is launched via sh rather than bash, so it might be necessary


### PR DESCRIPTION
fish shell doesn't support to use variables as commands
(on purpose, see: http://lwn.net/Articles/136232/ "Impossible to Validate the Syntax" )
