### PR TITLE
Add nrepl-autoloads.el file

### DIFF
--- a/nrepl-autoloads.el
+++ b/nrepl-autoloads.el
@@ -1,0 +1,49 @@
+;;; nrepl-autoloads.el --- automatically extracted autoloads
+;;
+;;; Code:
+
+
+;;;### (autoloads (nrepl nrepl-jack-in nrepl-disable-on-existing-clojure-buffers
+;;;;;;  nrepl-enable-on-existing-clojure-buffers nrepl-interaction-mode)
+;;;;;;  "nrepl" "nrepl.el" (20712 21744 0 0))
+;;; Generated autoloads from nrepl.el
+
+(autoload 'nrepl-interaction-mode "nrepl" "\
+Minor mode for nrepl interaction from a Clojure buffer.
+
+\\{nrepl-interaction-mode-map}
+
+\(fn &optional ARG)" t nil)
+
+(autoload 'nrepl-enable-on-existing-clojure-buffers "nrepl" "\
+
+
+\(fn)" t nil)
+
+(autoload 'nrepl-disable-on-existing-clojure-buffers "nrepl" "\
+
+
+\(fn)" t nil)
+
+(autoload 'nrepl-jack-in "nrepl" "\
+
+
+\(fn &optional PROMPT-PROJECT)" t nil)
+
+(add-hook 'nrepl-connected-hook 'nrepl-enable-on-existing-clojure-buffers)
+
+(autoload 'nrepl "nrepl" "\
+
+
+\(fn HOST PORT)" t nil)
+
+;;;***
+
+(provide 'nrepl-autoloads)
+;; Local Variables:
+;; version-control: never
+;; no-byte-compile: t
+;; no-update-autoloads: t
+;; coding: utf-8
+;; End:
+;;; nrepl-autoloads.el ends here


### PR DESCRIPTION
This file is a simple extraction of autoloaded functions from nrepl.el
(using the command `update-file-autoloads`)

The presence of this file makes loading nrepl faster since we can now
replace (require 'nrepl) with (require 'nrepl-autoloads)
