### PR TITLE
Fix #194 - stacktrace buffer was not respecting nrepl-popup-stacktraces

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -180,7 +180,8 @@ joined together.")
 
 (defcustom nrepl-popup-stacktraces t
   "Non-nil means pop-up error stacktraces.
-   Nil means do not, useful when in repl"
+Nil means show only an error message in the minibuffer;
+useful when in REPL or you don't care about the stacktraces."
   :type 'boolean
   :group 'nrepl)
 


### PR DESCRIPTION
In `nrepl-default-err-handler` we were checking only if the major mode is
nrepl-mode which caused the `nrepl-popup-stacktraces` setting to be
ignored in clojure-mode. As a bonus I've simplified a lot the code
that was used to check the buffer's major mode.

This fixes issue #194.
