### PR TITLE
Bump the clojure-mode dep to 2.0.0.

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -7,7 +7,7 @@
 ;; URL: http://www.github.com/kingtim/nrepl.el
 ;; Version: 0.1.6
 ;; Keywords: languages, clojure, nrepl
-;; Package-Requires: ((clojure-mode "1.11"))
+;; Package-Requires: ((clojure-mode "2.0.0"))
 
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
clojure-mode 2.0.0 was recently released and it's the first version
that target's nrepl.el exclusively. It makes sense that the
upcoming nrepl.el 0.1.6 should require it, given the fact that many
nrepl improvements were incorporated into it.
