### PR TITLE
Replace :else with t in a cond expression.

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -347,7 +347,7 @@ Uses `find-file'."
              (archive-extract)
              (when (not buffer-already-open)
                (kill-buffer opened-buffer)))))
-        (:else (error "Unknown resource path %s" resource))))
+        (t (error "Unknown resource path %s" resource))))
 
 (defun nrepl-jump-to-def-for (location)
   ;; ugh; elisp destructuring doesn't work for vectors


### PR DESCRIPTION
While the use of `:else` in a catch-all cond clause
is idiomatic in Clojure, in Emacs Lisp the idiom is to use `t`.
