### PR TITLE
Emit server log output at bottom of *nrepl-server* buffer.

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -2063,7 +2063,9 @@ under point, prompts for a var."
 ;;; server
 (defun nrepl-server-filter (process output)
   (with-current-buffer (process-buffer process)
-    (insert output))
+    (save-excursion
+      (goto-char (point-max))
+      (insert output)))
   (when (string-match "nREPL server started on port \\([0-9]+\\)" output)
     (let ((port (string-to-number (match-string 1 output))))
       (message (format "nREPL server started on %s" port))


### PR DESCRIPTION
Currently if the _nrepl-server_ buffer gains focus while the nrepl.el is writing to the buffer, the output will be inserted at the point's location. This is problematic if the point was moved away from (point-max).

This can happen if you:
1. clear the _nrepl-server_ buffer (ie. by M-S->, M-S-<, C-w)
2. execute code that causes nrepl.el to output to _nrepl-server_
3. C-x b _nrepl-server_

In order to prevent this behavior, this patch wraps a (save-excursion (goto-char (point-max) ...) around the code that outputs to _nrepl-server_.
