### PR TITLE
Suppress byte-compilation warning

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -57,6 +57,9 @@
 (require 'cl)
 (require 'easymenu)
 
+(eval-when-compile
+  (defvar paredit-version))
+
 (defgroup nrepl nil
   "Interaction with the Clojure nREPL Server."
   :prefix "nrepl-"


### PR DESCRIPTION
This takes care of the byte-compilation warning
about a reference to a free variable `paredit-version`.
