### PR TITLE
Use should instead of assert in tests.

### DIFF
--- a/test/nrepl-tests.el
+++ b/test/nrepl-tests.el
@@ -1,4 +1,4 @@
-;;; nrepl-tests.el 
+;;; nrepl-tests.el
 
 ;; Copyright © 2012 Tim King
 
@@ -28,47 +28,45 @@
 ;;
 ;;; Code:
 
-(eval-when-compile
-  (require 'cl))
 (require 'ert)
 (require 'nrepl)
 
 (ert-deftest test-nrepl-decode-string ()
-  (assert (equal '("spam") (nrepl-decode "4:spam"))))
+  (should (equal '("spam") (nrepl-decode "4:spam"))))
 
 (ert-deftest test-nrepl-decode-integer ()
-  (assert (equal '(3) (nrepl-decode "i3e"))))
+  (should (equal '(3) (nrepl-decode "i3e"))))
 
 (ert-deftest test-nrepl-bdecode-list ()
-  (assert (equal '(("spam" "eggs"))
+  (should (equal '(("spam" "eggs"))
                  (nrepl-decode "l4:spam4:eggse"))))
 
 (ert-deftest test-nrepl-bdecode-dict ()
-  (assert (equal '((dict ("cow" . "moo") ("spam" . "eggs")))
+  (should (equal '((dict ("cow" . "moo") ("spam" . "eggs")))
                  (nrepl-decode  "d3:cow3:moo4:spam4:eggse"))))
 
 (ert-deftest test-nrepl-decode-nrepl-response-value ()
-  (assert (equal '((dict
+  (should (equal '((dict
                      ("ns" . "user")
                      ("session" . "20c51458-911e-47ec-97c2-c509aed95b12")
                      ("value" . "2")))
                  (nrepl-decode "d2:ns4:user7:session36:20c51458-911e-47ec-97c2-c509aed95b125:value1:2e"))))
 
 (ert-deftest test-nrepl-decode-nrepl-response-status ()
-  (assert (equal '((dict
+  (should (equal '((dict
                     ("session" . "f30dbd69-7095-40c1-8e98-7873ae71a07f")
                     ("status" "done")))
                  (nrepl-decode "d7:session36:f30dbd69-7095-40c1-8e98-7873ae71a07f6:statusl4:doneee"))))
 
 (ert-deftest test-nrepl-decode-nrepl-response-err ()
-  (assert (equal '((dict
+  (should (equal '((dict
                     ("err" . "FileNotFoundException Could not locate seesaw/core__init.class or seesaw/core.clj on classpath:   clojure.lang.RT.load (RT.java:432)\n")
                     ("session" . "f30dbd69-7095-40c1-8e98-7873ae71a07f")))
                  (nrepl-decode
 "d3:err133:FileNotFoundException Could not locate seesaw/core__init.class or seesaw/core.clj on classpath:   clojure.lang.RT.load (RT.java:432)\n7:session36:f30dbd69-7095-40c1-8e98-7873ae71a07fe"))))
 
 (ert-deftest test-nrepl-decode-nrepl-response-exception ()
-  (assert (equal '((dict
+  (should (equal '((dict
                      ("ex" . "class java.io.FileNotFoundException")
                      ("root-ex" . "class java.io.FileNotFoundException")
                      ("session" . "f30dbd69-7095-40c1-8e98-7873ae71a07f")
@@ -77,7 +75,7 @@
                   "d2:ex35:class java.io.FileNotFoundException7:root-ex35:class java.io.FileNotFoundException7:session36:f30dbd69-7095-40c1-8e98-7873ae71a07f6:statusl10:eval-erroree"))))
 
 (ert-deftest test-nrepl-decode-nrepl-doc-output ()
-  (assert (equal '((dict
+  (should (equal '((dict
                     ("id" . "18")
                     ("out" . "clojure.core/reduce\n")
                     ("session" . "6fc999d0-3795-4d51-85fc-ccca7537ee57"))
@@ -112,7 +110,7 @@
 7:session36:6fc999d0-3795-4d51-85fc-ccca7537ee57ed2:id2:182:ns4:user7:session36:6fc999d0-3795-4d51-85fc-ccca7537ee575:value3:niled2:id2:187:session36:6fc999d0-3795-4d51-85fc-ccca7537ee576:statusl4:doneee"))))
 
 (ert-deftest test-nrepl-decode-nrepl-response-multibyte ()
-  (assert (equal '((dict
+  (should (equal '((dict
                     ("id" . "42")
                     ("ns" . "user")
                     ("session" . "3f586403-ed47-4e4d-b8db-70522054f971")
@@ -123,4 +121,3 @@
                     ("status" "done")))
                  (nrepl-decode
                   "d2:id2:422:ns4:user7:session36:3f586403-ed47-4e4d-b8db-70522054f9715:value5:\"←\"ed2:id2:427:session36:3f586403-ed47-4e4d-b8db-70522054f9716:statusl4:doneee"))))
-


### PR DESCRIPTION
In ert tests `should`(which is part of the ert library itself) should be used instead of `assert`. The change is transparent.
