### PR TITLE
Fix #211 - implement jump to error from stacktrace

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -1313,14 +1313,14 @@ Useful in hooks."
   "Minor mode for nrepl interaction from a Clojure buffer.
 
 \\{nrepl-interaction-mode-map}"
-   nil
-   " nREPL"
-   nrepl-interaction-mode-map
-   (make-local-variable 'completion-at-point-functions)
-   (add-to-list 'completion-at-point-functions
-                'nrepl-complete-at-point)
-   (add-to-list 'compilation-error-regexp-alist
-                '("(\\(.+\\):\\(.+\\))" 1 2)))
+  nil
+  " nREPL"
+  nrepl-interaction-mode-map
+  (make-local-variable 'completion-at-point-functions)
+  (add-to-list 'completion-at-point-functions
+               'nrepl-complete-at-point)
+  (add-to-list 'compilation-error-regexp-alist
+               '("(\\(.+\\):\\(.+\\))" 1 2)))
 
 (define-derived-mode nrepl-mode fundamental-mode "nREPL"
   "Major mode for nREPL interactions.


### PR DESCRIPTION
Now when someone gets a compilation error after `C-c C-k` the top error
of the stacktrace is clickable and it will take the user to the
offending line in the source code. This doesn't work when there is
no source file (say after eval last sexp) for obvious reasons. The functionality
relies on `compilation-minor-mode` being enabled in the error buffer (which is done
automatically after it's created).
