### PR TITLE
Improved user experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ section of this manual.
 * <kbd>C-c C-n</kbd>: Eval the ns form.
 * <kbd>C-c M-n</kbd>: Switch the namespace of the repl buffer to the namespace of the current buffer.
 * <kbd>C-c C-z</kbd>: Select the repl buffer.
+* <kbd>C-c M-p</kbd>: Switch the *nrepl* NS to the current buffer and switch to the *nrepl* buffer.
 * <kbd>C-c M-o</kbd>: Clear the entire REPL buffer, leaving only a prompt. Useful if you're running the REPL buffer in a side by side buffer.
 * <kbd>C-c C-k</kbd>: Load the current buffer.
 * <kbd>C-c C-l</kbd>: Load a file.

--- a/nrepl.el
+++ b/nrepl.el
@@ -1149,6 +1149,7 @@ This function is meant to be used in hooks to avoid lambda
     (define-key map (kbd "C-c C-d") 'nrepl-doc)
     (define-key map (kbd "C-c C-s") 'nrepl-src)
     (define-key map (kbd "C-c C-z") 'nrepl-switch-to-repl-buffer)
+    (define-key map (kbd "C-c M-p") 'nrepl-set-ns-and-switch-to-repl-buffer)
     (define-key map (kbd "C-c M-o") 'nrepl-find-and-clear-repl-buffer)
     (define-key map (kbd "C-c C-k") 'nrepl-load-current-buffer)
     (define-key map (kbd "C-c C-l") 'nrepl-load-file)
@@ -1873,6 +1874,12 @@ the buffer should appear."
   (interactive (list (nrepl-current-ns)))
   (with-current-buffer nrepl-nrepl-buffer
     (nrepl-send-string (format "(in-ns '%s)" ns) (nrepl-handler (current-buffer)))))
+
+(defun nrepl-set-ns-and-switch-to-repl-buffer ()
+  "Sets the namespace of the *nrepl* buffer to `ns` and switches to it."
+  (interactive)
+  (nrepl-set-ns (nrepl-current-ns))
+  (nrepl-switch-to-repl-buffer))
 
 (defun nrepl-symbol-at-point ()
   "Return the name of the symbol at point, otherwise nil."


### PR DESCRIPTION
As a long time SLIME user I welcome this new nrepl tool for Emacs. Over the years I got used to some keybindings, so I add them here. Also, SLIME got rid of those connection buffers, which I did here too. It is a bit bothersome to navigate through the buffers (for example via `C-x <left/right arrow key>`) and have the _nrepl-server_ or _nrepl-connection_ buffer. Those are now hidden.
And as `nrepl-jack-in` is a bit lengthy, I added the `clj` alias.
