### PR TITLE
Add convenience bindings to clojure-mode-map for starting nrepl

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,10 @@ and it expects `clojure.pprint` to have been required already
     Prompts for a project root if given a prefix argument.
 * <kbd>M-x nrepl</kbd>: Connect to an already-running nrepl server.
 
+While you're in `clojure-mode`, `nrepl-jack-in` is bound for
+convenience to <kbd>C-c M-j</kbd> and `nrepl` is bound to <kbd>C-c
+M-c</kbd>.
+
 ### Clojure buffer commands:
 
 * <kbd>C-x C-e</kbd>: Evalulate the form preceding point and display the result in the echo area.  If invoked with a prefix argument, insert the result into the current buffer.

--- a/nrepl.el
+++ b/nrepl.el
@@ -2372,6 +2372,12 @@ restart the server."
   (when (nrepl-check-for-nrepl-buffer)
     (nrepl-connect host port)))
 
+;;;###autoload
+(eval-after-load 'clojure-mode
+  '(progn
+     (define-key clojure-mode-map (kbd "C-c M-j") 'nrepl-jack-in)
+     (define-key clojure-mode-map (kbd "C-c M-c") 'nrepl)))
+
 (provide 'nrepl)
 
 ;; Local Variables:


### PR DESCRIPTION
Since people are generally in some Clojure buffer when starting
nrepl.el it's useful to have convenient keybindings for that in
`clojure-mode-map`. The mnemonic for the keybindings are `j` for jack-in
and `c` for connect. The keybindings are autoloaded and added to
`clojure-mode-map` after `clojure-mode` has been loaded.
