### PR TITLE
Hiding the `*nrepl-server*` and `*nrepl-connection*` buffers.

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -93,8 +93,8 @@
   :type 'string
   :group 'nrepl)
 
-(defconst nrepl-connection-buffer "*nrepl-connection*")
-(defconst nrepl-server-buffer "*nrepl-server*")
+(defconst nrepl-connection-buffer " *nrepl-connection*")
+(defconst nrepl-server-buffer " *nrepl-server*")
 (defconst nrepl-nrepl-buffer "*nrepl*")
 (defconst nrepl-error-buffer "*nrepl-error*")
 (defconst nrepl-doc-buffer "*nrepl-doc*")


### PR DESCRIPTION
When navigating through the buffers (for example via C-x <left/right arrow key>) it is bothersome to skip over the _\_nrepl-server_\_ or _\_nrepl-connection_\_ buffer. They are now hidden.
