### PR TITLE
Added keybinding and menu entry, updated readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ section of this manual.
 * <kbd>C-c C-n</kbd>: Eval the ns form.
 * <kbd>C-c M-n</kbd>: Switch the namespace of the repl buffer to the namespace of the current buffer.
 * <kbd>C-c C-z</kbd>: Select the repl buffer.
+* <kbd>C-c M-p</kbd>: Switch the *nrepl* NS to the current buffer and switch to the *nrepl* buffer.
 * <kbd>C-c M-o</kbd>: Clear the entire REPL buffer, leaving only a prompt. Useful if you're running the REPL buffer in a side by side buffer.
 * <kbd>C-c C-k</kbd>: Load the current buffer.
 * <kbd>C-c C-l</kbd>: Load a file.

--- a/nrepl.el
+++ b/nrepl.el
@@ -1149,6 +1149,7 @@ This function is meant to be used in hooks to avoid lambda
     (define-key map (kbd "C-c C-d") 'nrepl-doc)
     (define-key map (kbd "C-c C-s") 'nrepl-src)
     (define-key map (kbd "C-c C-z") 'nrepl-switch-to-repl-buffer)
+    (define-key map (kbd "C-c M-p") 'nrepl-set-ns-and-switch-to-repl-buffer)
     (define-key map (kbd "C-c M-o") 'nrepl-find-and-clear-repl-buffer)
     (define-key map (kbd "C-c C-k") 'nrepl-load-current-buffer)
     (define-key map (kbd "C-c C-l") 'nrepl-load-file)
@@ -1173,6 +1174,7 @@ This function is meant to be used in hooks to avoid lambda
     ["Display Source" nrepl-src]
     ["Display JavaDoc" nrepl-javadoc]
     ["Switch to REPL" nrepl-switch-to-repl-buffer]
+    ["Set ns and switch to REPL" nrepl-set-ns-and-switch-to-repl-buffer]
     ["Clear REPL" nrepl-find-and-clear-repl-buffer]
     ["Load current buffer" nrepl-load-current-buffer]
     ["Load file" nrepl-load-file]
@@ -1873,6 +1875,12 @@ the buffer should appear."
   (interactive (list (nrepl-current-ns)))
   (with-current-buffer nrepl-nrepl-buffer
     (nrepl-send-string (format "(in-ns '%s)" ns) (nrepl-handler (current-buffer)))))
+
+(defun nrepl-set-ns-and-switch-to-repl-buffer ()
+  "Sets the namespace of the *nrepl* buffer to `ns` and switches to it."
+  (interactive)
+  (nrepl-set-ns (nrepl-current-ns))
+  (nrepl-switch-to-repl-buffer))
 
 (defun nrepl-symbol-at-point ()
   "Return the name of the symbol at point, otherwise nil."


### PR DESCRIPTION
`C-c M-p` combines `C-c M-n` and `C-c C-z`. Also ex SLIME users (be it from CL
or CLJ) will find this keybinding convenient. Menu entry added, as suggested by bbatsov.
