### PR TITLE
Rebind `nrepl-interrupt` to `C-c C-c`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added support for pretty-printing in the REPL buffer.
 * Added a check for the presence of an existing `*nrepl*` buffer before
 creating a new one with `nrepl-jack-in` or `nrepl`.
-* `M-.` learned about namespaces.
+* <kbd>M-.</kbd> learned about namespaces.
+* Changed the keybinding for `nrepl-interrupt` to <kbd>C-c C-c</kbd>
 
 ### Bugs fixed

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ and it expects `clojure.pprint` to have been required already
 * <kbd>C-c C-p</kbd>: Evalulate the form preceding point and display the result in a popup buffer.
 * <kbd>C-M-x</kbd>: Evaluate the top level form under point and display the result in the echo area.  If invoked with a prefix argument, insert the result into the current buffer.
 * <kbd>C-c C-r</kbd>: Evaluate the region and display the result in the echo area.
-* <kbd>C-c C-b</kbd>: Interrupt any pending evaluations.
+* <kbd>C-c C-c</kbd>: Interrupt any pending evaluations.
 * <kbd>C-c C-m</kbd>: Invoke macroexpand-1 on the form at point and display the result in a macroexpansion buffer.  If invoked with a prefix argument, macroexpand is used instead of macroexpand-1.
 * <kbd>C-c M-m</kbd>: Invoke clojure.walk/macroexpand-all on the form at point and display the result in a macroexpansion buffer.
 * <kbd>C-c C-n</kbd>: Eval the ns form.
@@ -247,7 +247,7 @@ and it expects `clojure.pprint` to have been required already
 * <kbd>C-c M-o</kbd>: Clear the entire REPL buffer, leaving only a prompt.
 * <kbd>C-c C-o</kbd>: Remove the output of the previous evaluation from the REPL buffer.
 * <kbd>C-c C-u</kbd>: Kill all text from the prompt to the current point.
-* <kbd>C-c C-b</kbd>: Interrupt any pending evaluations.
+* <kbd>C-c C-c</kbd>: Interrupt any pending evaluations.
 * <kbd>C-up, C-down</kbd>: Goto to previous/next input in history.
 * <kbd>M-p, M-n</kbd>: Search the previous/next item in history using the current input
 as search pattern. If M-p/M-n is typed two times in a row, the second invocation

--- a/nrepl.el
+++ b/nrepl.el
@@ -1279,7 +1279,7 @@ This function is meant to be used in hooks to avoid lambda
     (define-key map (kbd "C-c M-o") 'nrepl-find-and-clear-repl-buffer)
     (define-key map (kbd "C-c C-k") 'nrepl-load-current-buffer)
     (define-key map (kbd "C-c C-l") 'nrepl-load-file)
-    (define-key map (kbd "C-c C-b") 'nrepl-interrupt)
+    (define-key map (kbd "C-c C-c") 'nrepl-interrupt)
     (define-key map (kbd "C-c C-j") 'nrepl-javadoc)
     map))
 
@@ -1366,7 +1366,7 @@ This function is meant to be used in hooks to avoid lambda
     (define-key map (kbd "M-s") 'nrepl-next-matching-input)
     (define-key map (kbd "C-c C-n") 'nrepl-next-prompt)
     (define-key map (kbd "C-c C-p") 'nrepl-previous-prompt)
-    (define-key map (kbd "C-c C-b") 'nrepl-interrupt)
+    (define-key map (kbd "C-c C-c") 'nrepl-interrupt)
     (define-key map (kbd "C-c C-j") 'nrepl-javadoc)
     (define-key map (kbd "C-c C-m") 'nrepl-macroexpand-1)
     (define-key map (kbd "C-c M-m") 'nrepl-macroexpand-all)


### PR DESCRIPTION
`C-c C-c` is the gold interrupt standard in Emacs (from `comint-mode`)
and has a nice mnemonic relation to the Unix shell's interrupt `C-c` key combo.

It makes perfect sense to me to use `C-c C-c` in both `nrepl-mode` and `nrepl-interaction-mode` and to preserve the `C-c C-b` for other functionality down the road.
