### PR TITLE
Add TravisCI build status image to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/kingtim/nrepl.el.png?branch=master)](https://travis-ci.org/kingtim/nrepl.el)
+
 # nrepl.el
 
 `nrepl.el` is an Emacs client for


### PR DESCRIPTION
This way we'll get a visual indication in the README itself about the status of the build.
