### PR TITLE
Fixes for compilation-error-regexp-alist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ creating a new one with `nrepl-jack-in` or `nrepl`.
 
 ### Bugs fixed
 
+* More accurate matching of filenames in stacktraces.
+
 ## 0.1.6 / 2013-01-29
 
 ### New features

--- a/nrepl.el
+++ b/nrepl.el
@@ -1475,6 +1475,14 @@ Useful in hooks."
 Useful in hooks."
   (nrepl-interaction-mode -1))
 
+(defvar nrepl-compilation-regexps '("(\\([^)]+\\):\\([[:digit:]]+\\))" 1 2)
+  "Specifications for matching errors in Clojure stacktraces.
+See `compilation-error-regexp-alist' for help on their format.")
+
+(add-to-list 'compilation-error-regexp-alist-alist
+             (cons 'nrepl nrepl-compilation-regexps))
+(add-to-list 'compilation-error-regexp-alist 'nrepl)
+
 ;;;###autoload
 (define-minor-mode nrepl-interaction-mode
   "Minor mode for nrepl interaction from a Clojure buffer.
@@ -1485,9 +1493,7 @@ Useful in hooks."
   nrepl-interaction-mode-map
   (make-local-variable 'completion-at-point-functions)
   (add-to-list 'completion-at-point-functions
-               'nrepl-complete-at-point)
-  (add-to-list 'compilation-error-regexp-alist
-               '("(\\(.+\\):\\(.+\\))" 1 2)))
+               'nrepl-complete-at-point))
 
 (define-derived-mode nrepl-mode fundamental-mode "nREPL"
   "Major mode for nREPL interactions.


### PR DESCRIPTION
- Makes matching of filenames of the form (foo.clj:XX) in stacktraces
  more accurate (avoiding some spurious highlighting in compilation
  buffers).
- Uses a more idiomatic entry for `compilation-error-alist`, namely a
  symbol which points to `compilation-error-regex-alist-alist`.
- Moves the code adding entries to the former variables to the
  top-level, instead of calling it over and over everytime a repl is
  started.
