### PR TITLE
Don't suppress namespaces in macroexpansion

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -929,7 +929,7 @@ START, END and CURRENT-POINT are used to redraw the expansion."
 (defun nrepl-macroexpand-form (expander expr)
   "Macroexpand, using EXPANDER, the given EXPR."
   (format
-   "(clojure.pprint/write (%s '%s) :suppress-namespaces true :dispatch clojure.pprint/code-dispatch)"
+   "(clojure.pprint/write (%s '%s) :suppress-namespaces false :dispatch clojure.pprint/code-dispatch)"
    expander expr))
 
 (defun nrepl-macroexpand-expr (expander expr &optional buffer)


### PR DESCRIPTION
Suppressing namespaces makes it impossible to recursively expand in-place in
the macroexpansion buffer, in the case your macro calls are namespace
qualified.
