### PR TITLE
Leiningen self-install for nrepl

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -1654,8 +1654,8 @@ See `nrepl-server-command' for details."
   "Install the latest leiningen for use by nrepl.
 
 On windows, this requires installation of the gnutls library,
-alongside Emacs. You can download it here
-ftp://ftp.gnutls.org/gcrypt/gnutls/w32/. Dropping all the files
+alongside Emacs.  You can download it here
+ftp://ftp.gnutls.org/gcrypt/gnutls/w32/.  Dropping all the files
 from the bin directory of the download into the same directory as
 the Emacs executable should work."
   (interactive)


### PR DESCRIPTION
Adds a command to enable self-installation of leiningen. This also requires of nrepl-server-command variable, which now searches for leiningen every invocation. This should ease the installation of a working clojure environment, as lein2 current involves installing by hand on many platforms. 
