### PR TITLE
Improve the formatting of the keyboard shortcuts section

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Keyboard shortcut               | Description
 
 ### Managing multiple sessions
 
-You can connection to multiple nREPL servers and use <kbd>M-x nrepl-jack-in</kbd> multiple
+You can connect to multiple nREPL servers and use <kbd>M-x nrepl-jack-in</kbd> multiple
 times.  To close a single nREPL session, use <kbd>M-x nrepl-close</kbd>.  <kbd>M-x
 nrepl-quit</kbd> closes all sessions.
 


### PR DESCRIPTION
I've reformatted the keyboard shortcuts section using GFM's table support. Personally I find the keyboard shortcuts section much more readable this way. I've also fixed a few errors, cleaned up the content there and made it a bit more consistent.
