### PR TITLE
Feature/remote nrepl and nrepl jump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bugs fixed
 
+* M-. (nrepl-jump) on remote nrepl connection (across OS hosts) has been fixed.
+
 ## 0.1.7 / 2013-03-13
 
 ### New features

--- a/nrepl.el
+++ b/nrepl.el
@@ -58,6 +58,7 @@
 (require 'cl)
 (require 'easymenu)
 (require 'compile)
+(require 'tramp)
 
 (eval-when-compile
   (defvar paredit-version))
@@ -429,14 +430,53 @@ With a PREFIX argument, print the result in the current buffer."
    (save-excursion (backward-sexp) (point))
    (point)))
 
+(defcustom nrepl-use-local-resources t
+  "Use local resources under HOME if possible."
+  :type 'boolean
+  :group 'nrepl)
+
+(defun nrepl-tramp-prefix ()
+  "Top element on `find-tag-marker-ring` used to determine Clojure host."
+  (let ((jump-origin (buffer-file-name
+                      (marker-buffer
+                       (ring-ref find-tag-marker-ring 0)))))
+    (when (tramp-tramp-file-p jump-origin)
+      (let ((vec (tramp-dissect-file-name jump-origin)))
+        (tramp-make-tramp-file-name (tramp-file-name-method vec)
+                                    (tramp-file-name-user vec)
+                                    (tramp-file-name-host vec)
+                                    nil)))))
+
+(defun nrepl-home-prefix-adjustment (resource)
+  "System dependend HOME location will be adjusted in RESOURCE.
+Removes any leading slash if on Windows."
+  (save-match-data
+    (cond ((string-match "^\\/\\(Users\\|home\\)\\/\\w+\\(\\/.+\\)" resource)
+           (concat (getenv "HOME") (match-string 2 resource)))
+          ((and (eq system-type 'windows-nt)
+                (string-match "^/" resource)
+                (not (tramp-tramp-file-p resource)))
+           (substring resource 1))
+          resource)))
+
+(defun nrepl-emacs-or-clojure-side-adjustment (resource)
+  "Fix the RESOURCE path depending on `nrepl-use-local-resources`."
+  (let ((resource         (nrepl-home-prefix-adjustment resource))
+        (clojure-side-res (concat (nrepl-tramp-prefix) resource))
+        (emacs-side-res   resource))
+    (cond ((equal resource "") resource)
+	  ((and nrepl-use-local-resources
+		(file-exists-p emacs-side-res))
+	   emacs-side-res)
+	  ((file-exists-p clojure-side-res)
+	   clojure-side-res)
+	  (t
+	   resource))))
+
 (defun nrepl-find-file (filename)
   "Switch to a buffer visiting FILENAME.
-Removes any leading slash if on Windows.  Uses `find-file'."
-  (let ((fn (if (and (eq system-type 'windows-nt)
-                     (string-match "^/" filename))
-                (substring filename 1)
-              filename)))
-    (find-file fn)))
+Adjusts for HOME location using `nrepl-home-prefix-adjustment'.  Uses `find-file'."
+  (find-file (nrepl-emacs-or-clojure-side-adjustment filename)))
 
 (defun nrepl-find-resource (resource)
   "Find and display RESOURCE."
@@ -444,7 +484,7 @@ Removes any leading slash if on Windows.  Uses `find-file'."
          (nrepl-find-file (match-string 1 resource)))
         ((string-match "^\\(jar\\|zip\\):file:\\(.+\\)!/\\(.+\\)" resource)
          (let* ((jar (match-string 2 resource))
-                (path (match-string 3 resource))
+		(path (match-string 3 resource))
                 (buffer-already-open (get-buffer (file-name-nondirectory jar))))
            (nrepl-find-file jar)
            (goto-char (point-min))


### PR DESCRIPTION
TL;DR; this fixes M-. when connecting emacs to a remote instance of clojure.

---

When running emacs and clojure on different host types, nrepl-jump (M-.) will not jump to the correct location.

The Clojure snippet in `nrepl-jump-to-def` will always return a local path, in relation to Clojure, disregarding host and username information. Unfortunately, emacs need that information to locate the resources to jump to.

There are two cases:
- emacs has to jump to a resource located on the remote host. Clojure has give a local host, which is devastating if emacs is running on Linux and Clojure on MacOSX. (the location of the the files WILL differ on /home and /Users)
- emacs _could_ jump to a resource located locally (under ~/.m2, for example), but again, the path could be wrong.

Both these situations are fixed by `nrepl-emacs-or-clojure-side-adjustment` and the user has a choice: it is possible to let emacs save time by opening local resource files under ~/.m2 by leaving the custom variable `nrepl-use-local-resources` as initially defined. 
If this variable is set to nil (via M-x customize-variable), emacs will still adjust the path of the file returned by Clojure, because it is still wrong, as it is NOT pointing on the host running Clojure (the tramp information is simply missing because Clojure doesn't know that it is running on a remote host, when seen from emacs)

I have made the changes as minimal as possible, only injecting `nrepl-emacs-or-clojure-side-adjustment` in two of the original nrepl.el functions (nrepl-find-file and nrepl-find-resource). 

The patch has been tested in these ways, with nrepl-use-local-resources on or off
;; OK OK- clojure running remotely via "lein run"
;; OK OK - clojure running remotely via "java -jar target/repl-tests-0.1.0-SNAPSHOT-standalone.jar" 
;; OK OK - clojure running locally via "lein run"
;; OK OK - clojure running locally via "java -jar target/repl-tests-0.1.0-SNAPSHOT-standalone.jar"

I hope that this change can find it's way into nrepl.el.

Yours faithfully,
Karsten Lang Pedersen
