### PR TITLE
Add feature: Toggle tracing/untracing of a var at point.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 0.1.8 (current)
 
 ### New features
+* Add feature: Toggle tracing/untracing of a var at point. A var is traced/untraced
+	with `C-c M-t`.
 
 ### Bugs fixed
 


### PR DESCRIPTION
add function: `nrepl-toggle-trace` - bound to `C-c` `M-t`
to trace the var at point.

Preconditions to make it work.
- clojure.tools.trace must be on the class path of the repl for this
  feature to work. Add it to your lein project.clj, like so:
  {:dependencies [org.clojure/tools.trace "0.7.5"]}
- The namespace of the buffer must be loaded into the repl (with e.g. C-k)
