### PR TITLE
Add feature: switch back to clojure buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### New features
 
+* Add support for selecting last clojure source buffer with keybinding
+<kbd>C-c C-z</kbd> (the same as `nrepl-switch-to-repl-buffer`).
+
 ### Bugs fixed
 
 ## 0.1.7 / 2013-03-13

--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ Keyboard shortcut                    | Description
 <kbd>TAB</kbd> | Complete symbol at point.
 <kbd>C-c C-d</kbd> | Display doc string for the symbol at point.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol
 <kbd>C-c C-j</kbd> | Display JavaDoc (in your default browser) for the symbol at point.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.
+<kbd>C-c C-z</kbd> | Select the last clojure buffer.
 
 ### Macroexpansion buffer commands:
 


### PR DESCRIPTION
It's very convenient to use <kbd>C-c C-z</kbd> to jump from a clojure buffer to repl buffer. It is even sweeter  if we can use the same key to jump back, just like [geiser](http://www.nongnu.org/geiser/) does for scheme-mode.

This pull request adds this feature to nrepl.el.
