### PR TITLE
Don't try to switch namespace if we don't know which one to switch to.

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -2495,9 +2495,11 @@ of the current source file."
 (defun nrepl-set-ns (ns)
   "Switch the namespace of the nREPL buffer to NS."
   (interactive (list (nrepl-current-ns)))
-  (with-current-buffer (nrepl-current-repl-buffer)
-    (nrepl-send-string
-     (format "(in-ns '%s)" ns) (nrepl-handler (current-buffer)))))
+  (if ns
+      (with-current-buffer (nrepl-current-repl-buffer)
+        (nrepl-send-string
+         (format "(in-ns '%s)" ns) (nrepl-handler (current-buffer))))
+    (message "Sorry, I don't know what the current namespace is.")))
 
 (defun nrepl-symbol-at-point ()
   "Return the name of the symbol at point, otherwise nil."


### PR DESCRIPTION
`clojure-find-ns` is sometimes unable to figure out what the current namespace is. If that's the case, don't try to switch (avoids nasty exception) and show a friendly message.

One such case is `ns` forms with leading whitespace. Separate fix for this submitted to clojure-mode: [https://github.com/technomancy/clojure-mode/pull/171]

Without this fix, the following exception is thrown:

```
java.lang.NullPointerException: 
                        ConcurrentHashMap.java:276 java.util.concurrent.ConcurrentHashMap.hash
                        ConcurrentHashMap.java:932 java.util.concurrent.ConcurrentHashMap.get
                                Namespace.java:173 clojure.lang.Namespace.findOrCreate
                                       RT.java:238 clojure.lang.RT$1.invoke
                                  NO_SOURCE_FILE:1 user/eval10427
                                Compiler.java:6619 clojure.lang.Compiler.eval
                                Compiler.java:6582 clojure.lang.Compiler.eval
                                     core.clj:2852 clojure.core/eval
                                      main.clj:259 clojure.main/repl[fn]
                                      main.clj:259 clojure.main/repl[fn]
                                      main.clj:277 clojure.main/repl[fn]
                                      main.clj:277 clojure.main/repl
                                  RestFn.java:1096 clojure.lang.RestFn.invoke
                         interruptible_eval.clj:56 clojure.tools.nrepl.middleware.interruptible-eval/evaluate[fn]
                                      AFn.java:159 clojure.lang.AFn.applyToHelper
                                      AFn.java:151 clojure.lang.AFn.applyTo
                                      core.clj:617 clojure.core/apply
                                     core.clj:1788 clojure.core/with-bindings*
                                   RestFn.java:425 clojure.lang.RestFn.invoke
                         interruptible_eval.clj:41 clojure.tools.nrepl.middleware.interruptible-eval/evaluate
                        interruptible_eval.clj:171 clojure.tools.nrepl.middleware.interruptible-eval/interruptible-eval[fn]
                                     core.clj:2330 clojure.core/comp[fn]
                        interruptible_eval.clj:138 clojure.tools.nrepl.middleware.interruptible-eval/run-next[fn]
                                       AFn.java:24 clojure.lang.AFn.run
                      ThreadPoolExecutor.java:1110 java.util.concurrent.ThreadPoolExecutor.runWorker
                       ThreadPoolExecutor.java:603 java.util.concurrent.ThreadPoolExecutor$Worker.run
                                   Thread.java:722 java.lang.Thread.run


```
