### PR TITLE
Add feature: switch back to clojure buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### New features
 
 * Add highlighting of compilation warnings in addition to existing highlighting of errors
+* Add support for selecting last clojure source buffer with keybinding
+<kbd>C-c C-z</kbd> (the same as `nrepl-switch-to-repl-buffer`).
 
 ### Bugs fixed
 

--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ Keyboard shortcut                    | Description
 <kbd>TAB</kbd> | Complete symbol at point.
 <kbd>C-c C-d</kbd> | Display doc string for the symbol at point.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol
 <kbd>C-c C-j</kbd> | Display JavaDoc (in your default browser) for the symbol at point.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.
+<kbd>C-c C-z</kbd> | Select the last clojure buffer.
 
 ### Macroexpansion buffer commands:
 

--- a/nrepl.el
+++ b/nrepl.el
@@ -1571,6 +1571,7 @@ This will not work on non-current prompts."
     (define-key map (kbd "C-c C-j") 'nrepl-javadoc)
     (define-key map (kbd "C-c C-m") 'nrepl-macroexpand-1)
     (define-key map (kbd "C-c M-m") 'nrepl-macroexpand-all)
+    (define-key map (kbd "C-c C-z") 'nrepl-switch-to-last-clojure-buffer)
     map))
 
 (easy-menu-define nrepl-mode-menu nrepl-mode-map
@@ -2523,6 +2524,7 @@ Insert a banner, unless NOPROMPT is non-nil."
     (nrepl-reset-markers)
     (unless noprompt
       (nrepl-insert-banner nrepl-buffer-ns))
+    (nrepl-remember-clojure-buffer nrepl-current-clojure-buffer)
     (current-buffer)))
 
 (defun nrepl-find-or-create-repl-buffer ()
@@ -2546,10 +2548,47 @@ of the current source file."
   (if (not (get-buffer (nrepl-current-connection-buffer)))
       (message "No active nREPL connection.")
     (progn
-      (when arg
-        (nrepl-set-ns (nrepl-current-ns)))
-      (pop-to-buffer (nrepl-find-or-create-repl-buffer))
-      (goto-char (point-max)))))
+      (let ((buffer (current-buffer)))
+        (when arg
+          (nrepl-set-ns (nrepl-current-ns)))
+        (pop-to-buffer (nrepl-find-or-create-repl-buffer))
+        (nrepl-remember-clojure-buffer buffer)
+        (goto-char (point-max))))))
+
+(make-variable-buffer-local
+ (defvar nrepl-last-clojure-buffer nil
+   "A buffer-local variable holding the last clojure source buffer.
+`nrepl-switch-to-last-clojure-buffer' uses this variable to jump
+back to last clojure source buffer."))
+
+
+(defvar nrepl-current-clojure-buffer nil
+  "This variable holds current buffer temporarily when connecting to a REPL.
+It is set to current buffer when `nrepl' or `nrepl-jack-in' is called.
+After the REPL buffer is created, the value of this variable is used
+to call `nrepl-remember-clojure-buffer'.")
+
+(defun nrepl-remember-clojure-buffer (buffer)
+  "Try to remember the BUFFER from which the user jumps.
+The BUFFER needs to be a clojure buffer and current major mode needs
+to be `nrepl-mode'.  The user can use `nrepl-switch-to-last-clojure-buffer'
+to jump back to the last clojure source buffer."
+  (when (and buffer
+             (eq 'clojure-mode (with-current-buffer buffer major-mode))
+             (eq 'nrepl-mode major-mode))
+    (setq nrepl-last-clojure-buffer buffer)))
+
+(defun nrepl-switch-to-last-clojure-buffer ()
+  "Switch to the last clojure buffer.
+The default keybinding for this command is
+the same as `nrepl-switch-to-repl-buffer',
+so that it is very convenient to jump between a
+clojure buffer and the REPL buffer."
+  (interactive)
+  (if (and (eq 'nrepl-mode major-mode)
+           (buffer-live-p nrepl-last-clojure-buffer))
+      (pop-to-buffer nrepl-last-clojure-buffer)
+    (message "Don't know the original clojure buffer")))
 
 (defun nrepl-set-ns (ns)
   "Switch the namespace of the nREPL buffer to NS."
@@ -2822,6 +2861,7 @@ See command `nrepl-interaction-mode'."
 If PROMPT-PROJECT is t, then prompt for the project for which to
 start the server."
   (interactive "P")
+  (setq nrepl-current-clojure-buffer (current-buffer))
   (lexical-let* ((project (when prompt-project
                             (ido-read-directory-name "Project: ")))
                  (project-dir (nrepl-project-directory-for
@@ -3028,6 +3068,7 @@ When NO-REPL-P is truthy, suppress creation of a repl buffer."
   "Connect nrepl to HOST and PORT."
   (interactive (list (read-string "Host: " nrepl-host nil nrepl-host)
                      (string-to-number (read-string "Port: " nrepl-port nil nrepl-port))))
+  (setq nrepl-current-clojure-buffer (current-buffer))
   (when (nrepl-check-for-repl-buffer `(,host ,port) nil)
     (nrepl-connect host port)))
 


### PR DESCRIPTION
It's very convenient to use <kbd>C-c C-z</kbd> to jump from a clojure buffer to repl buffer. It is even sweeter  if we can use the same key to jump back, just like [geiser](http://www.nongnu.org/geiser/) does for scheme-mode.

This pull request adds this feature to nrepl.el.
