### PR TITLE
Always evaluate ns forms in the user namespace.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* Evaluate all namespace forms `(ns ...)` in the user namespace.
 * Add highlighting of compilation warnings in addition to existing highlighting of errors
 * Add support for selecting last clojure source buffer with keybinding
 <kbd>C-c C-z</kbd> (the same as `nrepl-switch-to-repl-buffer`).

--- a/nrepl.el
+++ b/nrepl.el
@@ -2222,7 +2222,10 @@ Use SESSION if it is non-nil, otherwise use the current session."
 (defun nrepl-send-string (input callback &optional ns session)
   "Send the request INPUT and register the CALLBACK as the response handler.
 See command `nrepl-eval-request' for details on how NS and SESSION are processed."
-  (nrepl-send-request (nrepl-eval-request input ns session) callback))
+  (let ((ns (if (string-match "[[:space:]]*\(ns\\([[:space:]]*$\\|[[:space:]]+\\)" input)
+                "user"
+              ns)))
+    (nrepl-send-request (nrepl-eval-request input ns session) callback)))
 
 (defun nrepl-sync-request-handler (buffer)
   "Make a synchronous request handler for BUFFER."


### PR DESCRIPTION
This allows ns forms to be interactively evaluated to create new
namespaces without them having had to already exist through other
means. This is something I almost always find myself doing in a live
coding workflow.
