### PR TITLE
Small docstring fixes.

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -2302,7 +2302,7 @@ The result is a plist with keys :value, :stderr and :stdout."
     nrepl-sync-response))
 
 (defun nrepl-send-string-sync (input &optional ns session)
-  "Send the INPUT the backed synchronously.
+  "Send the INPUT to the backend synchronously.
 See command `nrepl-eval-request' for details about how NS and SESSION
 are processed."
   (nrepl-send-request-sync (nrepl-eval-request input ns session)))


### PR DESCRIPTION
- nrepl.el (nrepl-connection-buffer-name, nrepl-buffer-ns)
  (nrepl-tab-command, nrepl-macroexpand-expr-inplace)
  (nrepl-wrap-history, nrepl-history-read-filename)
  (nrepl-history-load, nrepl-history-save, nrepl-log-events)
  (nrepl-send-string-sync, nrepl-send-input, nrepl-return)
  (nrepl-recenter-if-needed, nrepl-find-and-clear-repl-buffer)
  (nrepl-find-or-create-repl-buffer, nrepl-ido-form)
  (nrepl-load-file-core, nrepl-load-file)
  (nrepl-possibly-disable-on-existing-clojure-buffers)
  (nrepl-close-ancilliary-buffers, nrepl-default-port): Small
  docstring fixes.
