### PR TITLE
switch-to-relevant buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.2.0
 
+* <kbd>C-c C-z</kbd> will select the clojure buffer based on the current namespace.
+* <kbd>C-u C-u C-c C-z</kbd> will select the clojure buffer based on a user directory prompt.
+
 ### Bugs fixed
 
 * <kbd>C-c M-s</kbd> (`nrepl-selector`) was bound to non-existing symbol.

--- a/README.md
+++ b/README.md
@@ -305,7 +305,8 @@ Keyboard shortcut                    | Description
 <kbd>TAB</kbd> | Complete symbol at point.
 <kbd>C-c C-d</kbd> | Display doc string for the symbol at point.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol
 <kbd>C-c C-j</kbd> | Display JavaDoc (in your default browser) for the symbol at point.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.
-<kbd>C-c C-z</kbd> | Select the last clojure buffer.
+<kbd>C-c C-z</kbd> | Select the last clojure buffer. <kbd>C-u C-c C-z</kbd> will switch the clojure buffer to the namespace in the current buffer.
+<kbd>C-u C-u C-c C-z</kbd> | Select the clojure buffer based on a user prompt for a directory.
 
 ### Macroexpansion buffer commands:
 


### PR DESCRIPTION
Hi I added this function 'nrepl-switch-to-relevant-buffer'. It switches the user to the right nrepl buffer based on the current buffer. So if you have 2 nrepls open for project x and project y, if you open a project x file and run the function (key mapped of course) then you land on the right nrepl buffer. I couldn't see anything that caters for this in nrepl.el hence the pull request.

TBH I'm new to elisp so you might want to make sure it looks sane. Unfortunately since I moved this fn into nrepl.el, I can't seem to use it without eval'ling the nrepl.el in emacs. Not sure why this is? I get:

Symbol's function definition is void: nrepl-switch-to-relevant-buffer. I've tried byte-recompiling my emacs dir to no avail. 

Not sure what the issue is.
