### PR TITLE
Fix nrepl-selector key binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.2.0
 
+### Bugs fixed
+
+* <kbd>C-c M-s</kbd> (`nrepl-selector`) was bound to non-existing symbol.
+
 ## 0.1.8 / 2013-08-08
 
 ### New features

--- a/nrepl.el
+++ b/nrepl.el
@@ -1521,7 +1521,7 @@ This will not work on non-current prompts."
     (define-key map (kbd "C-c C-l") 'nrepl-load-file)
     (define-key map (kbd "C-c C-b") 'nrepl-interrupt)
     (define-key map (kbd "C-c C-j") 'nrepl-javadoc)
-    (define-key map (kbd "C-c M-s") 'nrepl-select)
+    (define-key map (kbd "C-c M-s") 'nrepl-selector)
     map))
 
 (easy-menu-define nrepl-interaction-mode-menu nrepl-interaction-mode-map
@@ -1622,7 +1622,7 @@ This will not work on non-current prompts."
     (define-key map (kbd "C-c C-m") 'nrepl-macroexpand-1)
     (define-key map (kbd "C-c M-m") 'nrepl-macroexpand-all)
     (define-key map (kbd "C-c C-z") 'nrepl-switch-to-last-clojure-buffer)
-    (define-key map (kbd "C-c M-s") 'nrepl-select)
+    (define-key map (kbd "C-c M-s") 'nrepl-selector)
     map))
 
 (easy-menu-define nrepl-mode-menu nrepl-mode-map


### PR DESCRIPTION
Previously <kbd>C-c M-s</kbd> was bound to `nrepl-select`, which does not exist. You'd get this error message:

> Symbol's function definition is void: nrepl-select

This binds it to `nrepl-selector`, which I assume was the original intention.
