### PR TITLE
Use project name in clojure buffer name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.2.0
 
+* Clojure buffer name uses project directory name; `*nrepl*` will appear as `*nrepl project-directory-name*`.
 * <kbd>C-c C-z</kbd> will select the clojure buffer based on the current namespace.
 * <kbd>C-u C-u C-c C-z</kbd> will select the clojure buffer based on a user directory prompt.
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,13 @@ than the REPL:
 (setq nrepl-popup-stacktraces-in-repl t)
 ```
 
+* The nrepl buffer name takes the format `*nrepl project-name*`.
+Change the separator from space to something else by overriding `nrepl-buffer-name-separator`.
+
+```lisp
+(setq nrepl-buffer-name-separator "-")
+```
+
 * Make <kbd>C-c C-z</kbd> switch to the `*nrepl*` buffer in the current window:
 
 ```lisp

--- a/nrepl.el
+++ b/nrepl.el
@@ -277,6 +277,12 @@ change the setting's value."
   :type 'boolean
   :group 'nrepl)
 
+(defcustom nrepl-buffer-name-separator " "
+  "Used in constructing the repl buffer name.
+The `nrepl-buffer-name-separator' separates `nrepl' from the project name."
+  :type '(string)
+  :group 'nrepl)
+
 (defun nrepl-make-variables-buffer-local (&rest variables)
   "Make all VARIABLES buffer local."
   (mapcar #'make-variable-buffer-local variables))
@@ -3184,13 +3190,23 @@ restart the server."
        nrepl-buffer-ns
        nrepl-tooling-session))))
 
+(defun nrepl-repl-buffer-name ()
+  "Create a repl buffer name based on current connection buffer."
+  (generate-new-buffer-name
+   (lexical-let ((project-name (with-current-buffer
+				   (get-buffer (nrepl-current-connection-buffer))
+				 (nrepl--project-name nrepl-project-dir))))
+     (if project-name
+	 (format "*nrepl%s%s*" nrepl-buffer-name-separator project-name)
+       "*nrepl*"))))
+
 (defun nrepl-create-repl-buffer (process)
   "Create a repl buffer for PROCESS."
   (nrepl-init-repl-buffer
    process
-   (let ((buf (generate-new-buffer-name "*nrepl*")))
-     (pop-to-buffer buf)
-     buf)))
+   (let ((buffer-name (nrepl-repl-buffer-name)))
+     (pop-to-buffer buffer-name)
+     buffer-name)))
 
 (defun nrepl-new-tooling-session-handler (process)
   "Create a new tooling session handler for PROCESS."

--- a/test/nrepl-tests.el
+++ b/test/nrepl-tests.el
@@ -349,3 +349,42 @@
 	(should (not (equal (current-buffer) b1)))
 	(nrepl-invoke-selector-method-by-key ?v)
 	(should (equal (current-buffer) b1))))))
+
+(ert-deftest test-nrepl-clojure-buffer-name ()
+  (with-temp-buffer
+    (lexical-let ((b1 (current-buffer)))
+      (let ((nrepl-connection-list (list (buffer-name b1))))
+	(should
+	 (equal (nrepl-repl-buffer-name) "*nrepl*"))))))
+
+(ert-deftest test-nrepl-clojure-buffer-name-based-on-project ()
+  (with-temp-buffer
+    (lexical-let ((b1 (current-buffer)))
+      (set (make-local-variable 'nrepl-project-dir) "proj")
+      (let ((nrepl-connection-list (list (buffer-name b1))))
+	(should
+	 (equal (nrepl-repl-buffer-name) "*nrepl proj*"))))))
+
+(ert-deftest test-nrepl-clojure-buffer-name-separator ()
+  (with-temp-buffer
+    (lexical-let ((b1 (current-buffer)))
+      (set (make-local-variable 'nrepl-project-dir) "proj")
+      (let ((nrepl-connection-list (list (buffer-name b1)))
+	    (nrepl-buffer-name-separator "X"))
+	(should
+	 (equal (nrepl-repl-buffer-name) "*nreplXproj*"))))))
+
+(ert-deftest test-nrepl-clojure-buffer-name-two-buffers-same-project ()
+  (with-temp-buffer
+    (set (make-local-variable 'nrepl-project-dir) "proj")
+    (let* ((nrepl-connection-list (list (buffer-name (current-buffer))))
+           (nrepl-new-buffer (nrepl-repl-buffer-name)))
+      (get-buffer-create nrepl-new-buffer)
+      (should
+       (equal nrepl-new-buffer "*nrepl proj*"))
+      (with-temp-buffer
+        (set (make-local-variable 'nrepl-project-dir) "proj")
+        (let ((nrepl-connection-list (list (buffer-name (current-buffer)))))
+          (should
+           (equal (nrepl-repl-buffer-name) "*nrepl proj*<2>")))
+        (kill-buffer nrepl-new-buffer)))))


### PR DESCRIPTION
I.e. _nrepl-fooproj_ instead of _nrepl_

The surrounding mechanics still apply so for a second clojure buffer you get _nrepl-fooproj_<2>

The name is taken from the project directory name. If no project exists, it defaults back to _nrepl_.
