### PR TITLE
Use project name as well as connected port in nrepl buffer name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 0.2.0
 
-* Clojure buffer name uses project directory name; `*nrepl*` will appear as `*nrepl project-directory-name*`.
+* Setting the variable `nrepl-buffer-name-show-port` will display the port on which the nRepl server is running.
+* nRepl buffer name uses project directory name; `*nrepl*` will appear as `*nrepl project-directory-name*`.
 * <kbd>C-c C-z</kbd> will select the clojure buffer based on the current namespace.
 * <kbd>C-u C-u C-c C-z</kbd> will select the clojure buffer based on a user directory prompt.
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,13 @@ Change the separator from space to something else by overriding `nrepl-buffer-na
 (setq nrepl-buffer-name-separator "-")
 ```
 
+* The nrepl buffer name can also display the port on which the nrepl server is running.
+Buffer name will look like *nrepl project-name:port*.
+
+```lisp
+(setq nrepl-buffer-name-show-port t)
+```
+
 * Make <kbd>C-c C-z</kbd> switch to the `*nrepl*` buffer in the current window:
 
 ```lisp

--- a/nrepl.el
+++ b/nrepl.el
@@ -284,6 +284,11 @@ The `nrepl-buffer-name-separator' separates `nrepl' from the project name."
   :type '(string)
   :group 'nrepl)
 
+(defcustom nrepl-buffer-name-show-port nil
+  "Show the connection port in the nrepl repl buffer name, if set to t."
+  :type 'boolean
+  :group 'nrepl)
+
 (defun nrepl-make-variables-buffer-local (&rest variables)
   "Make all VARIABLES buffer local."
   (mapcar #'make-variable-buffer-local variables))
@@ -3200,12 +3205,18 @@ restart the server."
 (defun nrepl-repl-buffer-name ()
   "Create a repl buffer name based on current connection buffer."
   (generate-new-buffer-name
-   (lexical-let ((project-name (with-current-buffer
-				   (get-buffer (nrepl-current-connection-buffer))
-				 (nrepl--project-name nrepl-project-dir))))
-     (if project-name
-	 (format "*nrepl%s%s*" nrepl-buffer-name-separator project-name)
-       "*nrepl*"))))
+   (lexical-let* ((buf (get-buffer (nrepl-current-connection-buffer)))
+                  (project-name (with-current-buffer buf
+                                  (nrepl--project-name nrepl-project-dir)))
+                  (nrepl-proj-name (if project-name
+                                       (format "%s%s"
+                                               nrepl-buffer-name-separator
+                                               project-name)
+                                     ""))
+                  (nrepl-proj-port (cadr (buffer-local-value 'nrepl-endpoint buf))))
+     (if nrepl-buffer-name-show-port
+       (format "*nrepl%s:%s*" nrepl-proj-name nrepl-proj-port)
+       (format "*nrepl%s*" nrepl-proj-name)))))
 
 (defun nrepl-create-repl-buffer (process)
   "Create a repl buffer for PROCESS."

--- a/test/nrepl-tests.el
+++ b/test/nrepl-tests.el
@@ -374,6 +374,31 @@
 	(should
 	 (equal (nrepl-repl-buffer-name) "*nreplXproj*"))))))
 
+(ert-deftest test-nrepl-clojure-buffer-name-show-port-t ()
+  (with-temp-buffer
+    (set (make-local-variable 'nrepl-buffer-name-show-port) t)
+    (set (make-local-variable 'nrepl-endpoint) '("localhost" 4009))
+    (let ((nrepl-connection-list (list (buffer-name (current-buffer)))))
+      (should
+       (equal (nrepl-repl-buffer-name) "*nrepl:4009*")))))
+
+(ert-deftest test-nrepl-clojure-buffer-name-show-port-nil ()
+  (with-temp-buffer
+    (set (make-local-variable 'nrepl-buffer-name-show-port) nil)
+    (set (make-local-variable 'nrepl-endpoint) '("localhost" 4009))
+    (let ((nrepl-connection-list (list (buffer-name (current-buffer)))))
+      (should
+       (equal (nrepl-repl-buffer-name) "*nrepl*")))))
+
+(ert-deftest test-nrepl-clojure-buffer-name-based-on-project-and-port ()
+  (with-temp-buffer
+    (set (make-local-variable 'nrepl-buffer-name-show-port) t)
+    (set (make-local-variable 'nrepl-project-dir) "proj")
+    (set (make-local-variable 'nrepl-endpoint) '("localhost" 4009))
+    (let ((nrepl-connection-list (list (buffer-name (current-buffer)))))
+      (should
+       (equal (nrepl-repl-buffer-name) "*nrepl proj:4009*")))))
+
 (ert-deftest test-nrepl-clojure-buffer-name-two-buffers-same-project ()
   (with-temp-buffer
     (set (make-local-variable 'nrepl-project-dir) "proj")
@@ -392,3 +417,22 @@
 (ert-deftest test-nrepl--find-rest-args-position ()
   (should (= (nrepl--find-rest-args-position [fmt & arg]) 1))
   (should (equal (nrepl--find-rest-args-position [fmt arg]) nil)))
+
+(ert-deftest test-nrepl-clojure-buffer-name-duplicate-proj-port ()
+  (with-temp-buffer
+    (set (make-local-variable 'nrepl-buffer-name-show-port) t)
+    (set (make-local-variable 'nrepl-project-dir) "proj")
+    (set (make-local-variable 'nrepl-endpoint) '("localhost" 4009))
+    (let* ((nrepl-connection-list (list (buffer-name (current-buffer))))
+           (nrepl-new-buffer (nrepl-repl-buffer-name)))
+      (get-buffer-create nrepl-new-buffer)
+      (should
+       (equal nrepl-new-buffer "*nrepl proj:4009*"))
+      (with-temp-buffer
+        (set (make-local-variable 'nrepl-buffer-name-show-port) t)
+        (set (make-local-variable 'nrepl-project-dir) "proj")
+        (set (make-local-variable 'nrepl-endpoint) '("localhost" 4009))
+        (let ((nrepl-connection-list (list (buffer-name (current-buffer)))))
+          (should
+           (equal (nrepl-repl-buffer-name) "*nrepl proj:4009*<2>")))
+        (kill-buffer nrepl-new-buffer)))))


### PR DESCRIPTION
This Pull Request is based off PR #352 submitted by @jonpither

> nrepl-fooproj instead of nrepl
> 
> The surrounding mechanics still apply so for a second clojure buffer you get nrepl-fooproj
> 
> The name is taken from the project directory name. If no project exists, it defaults back to nrepl.

The nrepl connection port is also important information, especially in production environments.

The name will now look like

_nrepl-fooproj-4005_
_nrepl-4005_
_nrepl-fooproj_
or 
_nrepl_

depending on the information available when creating the repl buffer.
