### PR TITLE
Rotate and display nrepl connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.2.0
 
+* <kbd>C-c M-d</kbd> will display current nREPL connection details.
+* <kbd>C-c M-r</kbd> will rotate and display the current nREPL connection.
 * Setting the variable `nrepl-buffer-name-show-port` will display the port on which the nRepl server is running.
 * nRepl buffer name uses project directory name; `*nrepl*` will appear as `*nrepl project-directory-name*`.
 * <kbd>C-c C-z</kbd> will select the clojure buffer based on the current namespace.

--- a/Cask
+++ b/Cask
@@ -4,3 +4,4 @@
 
 (depends-on "clojure-mode" "2.0.0")
 (depends-on "dash" "1.6.0")
+(depends-on "noflet" "0.0.8")

--- a/README.md
+++ b/README.md
@@ -291,6 +291,9 @@ Keyboard shortcut                    | Description
 <kbd>C-c C-n</kbd>                   | Eval the ns form.
 <kbd>C-c M-n</kbd>                   | Switch the namespace of the repl buffer to the namespace of the current buffer.
 <kbd>C-c C-z</kbd>                   | Select the REPL buffer. With a prefix argument - changes the namespace of the REPL buffer to the one of the currently visited source file.
+<kbd>C-u C-u C-c C-z</kbd>           | Select the REPL buffer based on a user prompt for a directory.
+<kbd>C-c M-d</kbd>                   | Display current REPL connection details, including project directory name, buffer namespace, host and port.
+<kbd>C-c M-r</kbd>                   | Rotate and display the current REPL connection.
 <kbd>C-c M-o</kbd>                   | Clear the entire REPL buffer, leaving only a prompt. Useful if you're running the REPL buffer in a side by side buffer.
 <kbd>C-c C-k</kbd>                   | Load the current buffer.
 <kbd>C-c C-l</kbd>                   | Load a file.
@@ -321,6 +324,8 @@ Keyboard shortcut                    | Description
 <kbd>C-c C-j</kbd> | Display JavaDoc (in your default browser) for the symbol at point.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.
 <kbd>C-c C-z</kbd> | Select the last clojure buffer. <kbd>C-u C-c C-z</kbd> will switch the clojure buffer to the namespace in the current buffer.
 <kbd>C-u C-u C-c C-z</kbd> | Select the clojure buffer based on a user prompt for a directory.
+<kbd>C-c M-d</kbd> | Display current REPL connection details, including project directory name, buffer namespace, host and port.
+<kbd>C-c M-r</kbd> | Rotate and display the current REPL connection.
 
 ### Macroexpansion buffer commands:
 
@@ -340,6 +345,10 @@ nrepl-quit</kbd> closes all sessions.
 nrepl.el commands in a clojure buffer use the default connection.  To make a
 connection default, switch to it's repl buffer and use
 <kbd>M-x nrepl-make-repl-connection-default</kbd>.
+
+To switch to the relevant nREPL buffer based on the clojure namespace in the current buffer, use: <kbd>C-c C-z</kbd>.
+
+You can display the current nREPL connection using <kbd>C-c M-d</kbd> and rotate through available connections using <kbd>C-c M-r</kbd>.
 
 ## Requirements:
 

--- a/nrepl.el
+++ b/nrepl.el
@@ -1540,6 +1540,8 @@ This will not work on non-current prompts."
     (define-key map (kbd "C-c C-b") 'nrepl-interrupt)
     (define-key map (kbd "C-c C-j") 'nrepl-javadoc)
     (define-key map (kbd "C-c M-s") 'nrepl-selector)
+    (define-key map (kbd "C-c M-r") 'nrepl-rotate-connection)
+    (define-key map (kbd "C-c M-d") 'nrepl-current-connection-info)
     map))
 
 (easy-menu-define nrepl-interaction-mode-menu nrepl-interaction-mode-map
@@ -1571,6 +1573,9 @@ This will not work on non-current prompts."
     ["Toggle REPL Pretty Print" nrepl-pretty-toggle]
     ["Clear REPL" nrepl-find-and-clear-repl-buffer]
     ["Interrupt" nrepl-interrupt]
+    "--"
+    ["Display current nrepl connection" nrepl-current-connection-info]
+    ["Rotate current nrepl connection" nrepl-rotate-connection]
     "--"
     ["Version info" nrepl-version]))
 
@@ -1641,6 +1646,8 @@ This will not work on non-current prompts."
     (define-key map (kbd "C-c M-m") 'nrepl-macroexpand-all)
     (define-key map (kbd "C-c C-z") 'nrepl-switch-to-last-clojure-buffer)
     (define-key map (kbd "C-c M-s") 'nrepl-selector)
+    (define-key map (kbd "C-c M-r") 'nrepl-rotate-connection)
+    (define-key map (kbd "C-c M-d") 'nrepl-current-connection-info)
     map))
 
 (easy-menu-define nrepl-mode-menu nrepl-mode-map
@@ -2225,6 +2232,26 @@ Refreshes EWOC."
   (let ((buffer (buffer-local-value 'nrepl-repl-buffer (get-buffer data))))
     (when buffer
       (select-window (display-buffer buffer)))))
+
+(defun nrepl-current-connection-info ()
+  "Display the current nrepl connection.
+Shows project name, current repl namespace, and host:port endpoint."
+  (interactive)
+  (with-current-buffer (get-buffer (nrepl-current-connection-buffer))
+    (message
+     (format "Active nrepl connection: %s:%s, %s:%s"
+	     (or (nrepl--project-name nrepl-project-dir) "<no project>")
+	     nrepl-buffer-ns
+	     (car nrepl-endpoint)
+	     (cadr nrepl-endpoint)))))
+
+(defun nrepl-rotate-connection ()
+  "Rotate and display the current nrepl connection."
+  (interactive)
+  (setq nrepl-connection-list
+	(append (cdr nrepl-connection-list)
+		(list (car nrepl-connection-list))))
+  (nrepl-current-connection-info))
 
 ;;; server messages
 


### PR DESCRIPTION
This part of my workflow, the ability to rotate amongst nrepl connections and display them. These chunks originated elsewhere on the web, i.e. a quick search for "nrepl-current-connection-infos" shows quite a few people have been adding this to their own dot-files.

Has something like this been considered? I guess some thought needs given to how it plays with the connection browser.
