### PR TITLE
Fix `nrepl-switch-to-repl-buffer' to work with all connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 * <kbd>C-c M-r</kbd> will rotate and display the current nREPL connection.
 * Setting the variable `nrepl-buffer-name-show-port` will display the port on which the nRepl server is running.
 * nRepl buffer name uses project directory name; `*nrepl*` will appear as `*nrepl project-directory-name*`.
-* <kbd>C-c C-z</kbd> will select the clojure buffer based on the current namespace.
-* <kbd>C-u C-u C-c C-z</kbd> will select the clojure buffer based on a user directory prompt.
+* <kbd>C-c C-Z</kbd> will select the nrepl buffer based on the current namespace.
+* <kbd>C-u C-c C-Z</kbd> will select the nrepl buffer based on a user project directory prompt.
 
 ### Bugs fixed
 


### PR DESCRIPTION
Commit 12558e8 breaks `nrepl-switch-to-repl-buffer` functionality by
assuming that all nrepl connections will be made using
`nrepl-jack-in`.

Using `nrepl-jack-in` sets the variable `nrepl-project-dir` to the
correct value, but this information cannot be retrieved when we
connect to an existing nRepl server using `nrepl-connect`. Since
`nrepl-project-dir` is unbound, the function `file-truename` throws a
null value exception.

This commit checks if `nrepl-project-dir` is set before calling
`file-truename`. Further, the message "nREPL connection not found"
does not make sense and thus should not be displayed.
