### PR TITLE
Add feature: Toggle tracing/untracing of a var at point.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 0.2.0
-
+* Add feature: Toggle tracing/untracing of a var at point. A var is traced/untraced with `C-c M-t`.
 * <kbd>C-c M-d</kbd> will display current nREPL connection details.
 * <kbd>C-c M-r</kbd> will rotate and display the current nREPL connection.
 * Setting the variable `nrepl-buffer-name-show-port` will display the port on which the nRepl server is running.
@@ -19,7 +19,6 @@
 ## 0.1.8 / 2013-08-08
 
 ### New features
-
 * Evaluate all namespace forms `(ns ...)` in the user namespace.
 * Add highlighting of compilation warnings in addition to existing highlighting of errors
 * Add support for selecting last Clojure source buffer with keybinding


### PR DESCRIPTION
add function: `nrepl-toggle-trace` - bound to `C-c` `M-t`
to trace the var at point.

Preconditions to make it work.
- clojure.tools.trace must be on the class path of the repl for this
  feature to work. Add it to your lein project.clj, like so:
  {:dependencies [org.clojure/tools.trace "0.7.5"]}
- The namespace of the buffer must be loaded into the repl (with
  e.g. C-c C-k)

This is a reopening of PR: https://github.com/clojure-emacs/nrepl.el/pull/329

Since the new structure for simple commands hasn't been implemented in master, I would like the tracing feature in nrepl using the current architecture.
