### PR TITLE
Add Feature: Select a function from ns with IDO and insert into REPL buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+### New features
+
+* <kbd>C-c M-f</kbd> Select a function from the current namespace using IDO and insert into the REPL buffer.
+
 ## 0.4.0 / 2013-12-03
 
 ### New features

--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ Keyboard shortcut                    | Description
 <kbd>C-u C-u C-c C-z</kbd> | Select the Clojure buffer based on a user prompt for a directory.
 <kbd>C-c M-d</kbd> | Display current REPL connection details, including project directory name, buffer namespace, host and port.
 <kbd>C-c M-r</kbd> | Rotate and display the current REPL connection.
+<kbd>C-c M-f</kbd> | Select a function from the current namespace using IDO and insert into nREPL buffer.
 
 In the REPL you can also use "shortcut commands" by pressing `,` at the beginning of a REPL line. You'll be presented with a list of commands you can quickly run (like quitting, displaying some info, clearing the REPL, etc). The character used to trigger the shortcuts is configurable via `cider-repl-shortcut-dispatch-char`. Here's how you can change it to `:`:
 

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -969,6 +969,7 @@ See command `cider-mode'."
 
 ;; this is horrible, but with async callbacks we can't rely on dynamic scope
 (defvar cider-ido-ns nil)
+(defvar cider-ido-var-callback nil)
 
 (defun cider-ido-form (ns)
   "Construct a Clojure form for ido read using NS."
@@ -990,38 +991,66 @@ See command `cider-mode'."
   "Perform up using NS."
   (mapconcat 'identity (butlast (split-string ns "\\.")) "."))
 
-(defun cider-ido-select (selected targets callback)
-  "Peform ido select using SELECTED, TARGETS and CALLBACK."
+(defun cider-ido-var-select (selected targets)
+  "Peform ido select using SELECTED and TARGETS."
   ;; TODO: immediate RET gives "" as selected for some reason
   ;; this is an OK workaround though
   (cond ((equal "" selected)
-         (cider-ido-select (car targets) targets callback))
+         (cider-ido-var-select (car targets) targets))
         ((equal "/" (substring selected -1)) ; selected a namespace
-         (cider-ido-read-var (substring selected 0 -1) callback))
+         (cider-ido-read-var (substring selected 0 -1) cider-ido-var-callback))
         ((equal ".." selected)
-         (cider-ido-read-var (cider-ido-up-ns cider-ido-ns) callback))
+         (cider-ido-read-var (cider-ido-up-ns cider-ido-ns) cider-ido-var-callback))
         ;; non ido variable selection techniques don't return qualified symbols, so this shouldn't either
-        (t (funcall callback selected))))
+        (t (funcall cider-ido-var-callback selected))))
 
-(defun cider-ido-read-var-handler (ido-callback buffer)
-  "Create an ido read var handler with IDO-CALLBACK for BUFFER."
-  (lexical-let ((ido-callback ido-callback))
+(defun cider-ido-read-sym-handler (label ido-select buffer)
+  "Create an ido read var handler with IDO-SELECT for BUFFER."
+  (lexical-let ((ido-select ido-select)
+                (label label))
     (nrepl-make-response-handler buffer
                                  (lambda (buffer value)
                                    ;; make sure to eval the callback in the buffer that the symbol was requested from so we get the right namespace
                                    (with-current-buffer buffer
                                      (let* ((targets (car (read-from-string value)))
-                                            (selected (ido-completing-read "Var: " targets nil t)))
-                                       (cider-ido-select selected targets ido-callback))))
+                                            (selected (ido-completing-read label targets nil t)))
+                                       (funcall ido-select selected targets))))
                                  nil nil nil)))
 
 (defun cider-ido-read-var (ns ido-callback)
   "Perform ido read var in NS using IDO-CALLBACK."
   ;; Have to be stateful =(
   (setq cider-ido-ns ns)
+  (setq cider-ido-var-callback ido-callback)
   (cider-tooling-eval (prin1-to-string (cider-ido-form cider-ido-ns))
-                     (cider-ido-read-var-handler ido-callback (current-buffer))
-                     nrepl-buffer-ns))
+                      (cider-ido-read-sym-handler "Var:" 'cider-ido-var-select (current-buffer))
+                      nrepl-buffer-ns))
+
+(defun cider-ido-fns-form (ns)
+  "Construct a Clojure form for reading fns using supplied NS."
+  (format "(let [fn-pred (fn [[k v]] (and (fn? (.get v))
+                                     (not (re-find #\"clojure.\" (str v)))))]
+              (sort
+                (map (comp name key)
+                     (filter fn-pred
+                         (concat
+                           (ns-interns '%s)
+                           (ns-refers '%s))))))" ns ns))
+
+(defun cider-ido-fn-callback (f targets)
+  (with-current-buffer (cider-current-repl-buffer)
+    (cider-repl--replace-input (format "(%s)" f))
+    (goto-char (- (point-max) 1))))
+
+(defun cider-load-fn-into-repl-buffer ()
+  "Browse functions available in current repl buffer using ido.
+Once selected, the name of the fn will appear in the repl buffer in parens
+ready to call."
+  (interactive)
+  (cider-tooling-eval (cider-ido-fns-form (cider-current-ns))
+                      (cider-ido-read-sym-handler (format "Fn: %s/" nrepl-buffer-ns)
+                                                  'cider-ido-fn-callback (current-buffer))
+                      nrepl-buffer-ns))
 
 (defun cider-read-symbol-name (prompt callback &optional query)
   "Either read a symbol name using PROMPT or choose the one at point.

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -975,6 +975,7 @@ ENDP) DELIM."
     (define-key map (kbd "C-c M-s") 'cider-selector)
     (define-key map (kbd "C-c M-r") 'cider-rotate-connection)
     (define-key map (kbd "C-c M-d") 'cider-display-current-connection-info)
+    (define-key map (kbd "C-c M-f") 'cider-load-fn-into-repl-buffer)
     (define-key map (kbd "C-c C-q") 'cider-quit)
     (define-key map (string cider-repl-shortcut-dispatch-char) 'cider-repl-handle-shortcut)
     map))


### PR DESCRIPTION
Interested to see if this is wanted as a feature, something I use and others have found useful. To try out, put some fns in user.clj and go to the repl and do C-c M-f, it'll help you choose a fn using ido and insert it into the repl buffer ready to run.

This is helpful as people often have utility fns they want to use regularly. ac-nrepl is close to save on the typing, but this PR only pulls back functions whereas ac-nepl does all vars. Also using ido is nicer to give you a 'browsing' experience, like 'what fns can I run in this ns?' Finally this PR filters out clojure core fns (which could be configurable).
