### PR TITLE
Set correct name on find-or-create-repl-buffer

### DIFF
--- a/nrepl.el
+++ b/nrepl.el
@@ -2756,7 +2756,8 @@ Insert a banner, unless NOPROMPT is non-nil."
                                   (error "No active nREPL connection")
                                 (nrepl-init-repl-buffer
                                  (get-process buffer)
-                                 (get-buffer-create "*nrepl*")))))))))
+                                 (get-buffer-create
+                                  (nrepl-repl-buffer-name))))))))))
 
 (defun nrepl-switch-to-repl-buffer (arg)
   "Select the REPL buffer, when possible in an existing window.

--- a/test/nrepl-tests.el
+++ b/test/nrepl-tests.el
@@ -470,6 +470,14 @@
         (should
          (equal (nrepl-repl-buffer-name) "*nrepl*"))))))
 
+(ert-deftest test-nrepl-clojure-buffer-name-w/project ()
+  (with-temp-buffer
+    (lexical-let ((b1 (current-buffer)))
+      (let ((nrepl-connection-list (list (buffer-name b1)))
+            (nrepl-project-dir "/a/test/directory/project"))
+        (should
+         (equal (nrepl-repl-buffer-name) "*nrepl project*"))))))
+
 (ert-deftest test-nrepl--find-rest-args-position ()
   (should (= (nrepl--find-rest-args-position [fmt & arg]) 1))
   (should (equal (nrepl--find-rest-args-position [fmt arg]) nil)))


### PR DESCRIPTION
If the current nrepl-buffer is killed and then brought back up with
`nrepl-switch-to-repl-buffer` (C-c C-z), the new buffer has the name
"_nrepl_", when it should be "_nrepl /project-name/_". This patch fixes
the problem by calling `nrepl-repl-buffer-name` instead of using the
static "_nrepl_"-string.
