### PR TITLE
Make test-cider-connections-buffer pass.

### DIFF
--- a/test/nrepl-tests.el
+++ b/test/nrepl-tests.el
@@ -300,11 +300,11 @@
 (ert-deftest test-cider-connections-buffer ()
   (with-temp-buffer
     (lexical-let ((b1 (current-buffer)))
-      (set (make-local-variable 'cider-endpoint) '("localhost" 4005))
+      (set (make-local-variable 'nrepl-endpoint) '("localhost" 4005))
       (set (make-local-variable 'nrepl-project-dir) "proj")
       (with-temp-buffer
         (lexical-let ((b2 (current-buffer)))
-          (set (make-local-variable 'cider-endpoint) '("123.123.123.123" 4006))
+          (set (make-local-variable 'nrepl-endpoint) '("123.123.123.123" 4006))
           (let ((nrepl-connection-list
                  (list (buffer-name b1) (buffer-name b2))))
             (nrepl-connection-browser)
@@ -315,7 +315,7 @@
   123.123.123.123   4006   \n\n"
                              (buffer-string)))
               (goto-char 80)         ; somewhere in the second connection listed
-              (cider-connections-make-default)
+              (nrepl-connections-make-default)
               (should (equal (buffer-name b2) (first nrepl-connection-list)))
               (should (equal "  Host              Port   Project
 
@@ -323,7 +323,7 @@
 * 123.123.123.123   4006   \n\n"
                              (buffer-string)))
               (goto-char 80)         ; somewhere in the second connection listed
-              (cider-connections-close-connection)
+              (nrepl-connections-close-connection)
               (should (equal (list (buffer-name b1)) nrepl-connection-list))
               (should (equal "  Host              Port   Project
 
@@ -334,7 +334,7 @@
                   (with-current-buffer b1
                     (set (make-local-variable 'nrepl-repl-buffer) b3))
                   (with-current-buffer "*nrepl-connections*"
-                    (cider-connections-goto-connection)
+                    (nrepl-connections-goto-connection)
                     (should (equal b3 (current-buffer))))))
               (kill-buffer "*nrepl-connections*"))))))))
 


### PR DESCRIPTION
I've just rolled back some cider\* names to nrepl\* names. Fixes the test, not sure if you'd rather go through and rename the fns throughout.
