### PR TITLE
Look for nrepl port in .nrepl-port as well.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 * The variable `cider-repl-display-in-current-window` controls whether the REPL should be displayed in the current window when switched to.
 * `cider-repl-set-ns` can now be invoked in the REPL.
-
+* The content of `.nrepl-port`, if present, will be used as the
+  default port for <kbd>M-x nrepl</kbd>. This is in addition to `target/repl-port`.
+  
 ### Changes
 
 * Renamed package to CIDER.

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -910,16 +910,21 @@ When NO-REPL-P is truthy, suppress creation of a REPL buffer."
       (nrepl-describe-session process))
     process))
 
-(defun nrepl-default-port ()
-  "Attempt to read port from target/repl-port.
-Falls back to `nrepl-port' if not found."
+(defun nrepl--port-from-file (file)
+  "Attempts to read port from a file named by FILE."
   (let* ((dir (nrepl-project-directory-for (nrepl-current-dir)))
-         (f (expand-file-name "target/repl-port" dir))
-         (port (when (file-exists-p f)
-                 (with-temp-buffer
-                   (insert-file-contents f)
-                   (buffer-string)))))
-    (or port nrepl-port)))
+         (f (expand-file-name file dir)))
+    (when (file-exists-p f)
+      (with-temp-buffer
+        (insert-file-contents f)
+        (buffer-string)))))
+ 
+(defun nrepl-default-port ()
+  "Attempt to read port from .nrepl-port or target/repl-port.
+Falls back to `nrepl-port' if not found."
+  (or (nrepl--port-from-file ".nrepl-port")
+      (nrepl--port-from-file "target/repl-port")
+      nrepl-port))
 
 ;;;###autoload
 (add-hook 'nrepl-connected-hook 'cider-enable-on-existing-clojure-buffers)


### PR DESCRIPTION
Leiningen, Immutant, and soon mod-lang-clojure for Vert.x all write
the repl port to project-dir/.nrepl-port as a standard, well-known
location. This patch adds support for checking that file as well.

See https://github.com/technomancy/leiningen/issues/1296
