### PR TITLE
Signal an error if nREPL is disconnected

### DIFF
--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -422,7 +422,8 @@ This is bound for the duration of the handling of that message")
   "The connection to use for nREPL interaction."
   (or nrepl-connection-dispatch
       nrepl-connection-buffer
-      (car (nrepl-connection-buffers))))
+      (car (nrepl-connection-buffers))
+      (error "No nREPL connection")))
 
 (defun nrepl-connection-buffers ()
   "Clean up dead buffers from the `nrepl-connection-list'.


### PR DESCRIPTION
This replaces the error "Wrong type argument: stringp, nil"
with something a little more clear.

I'm sure things can be made more robust, but this at least catches a common case.
