### PR TITLE
Use nrepl hooks in cider

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -893,7 +893,6 @@ Useful in hooks."
       (nrepl-current-connection-buffer)
     (error nil)))
 
-;;;###autoload
 (defun cider-enable-on-existing-clojure-buffers ()
   "Enable interaction mode on existing Clojure buffers.
 See command `cider-mode'."
@@ -903,7 +902,6 @@ See command `cider-mode'."
     (with-current-buffer buffer
       (clojure-enable-cider))))
 
-;;;###autoload
 (defun cider-disable-on-existing-clojure-buffers ()
   "Disable interaction mode on existing Clojure buffers.
 See command `cider-mode'."
@@ -1116,6 +1114,10 @@ restart the server."
   (interactive)
   (cider-quit)
   (cider-jack-in current-prefix-arg))
+
+(add-hook 'nrepl-connected-hook 'cider-enable-on-existing-clojure-buffers)
+(add-hook 'nrepl-disconnected-hook
+          'cider-possibly-disable-on-existing-clojure-buffers)
 
 (provide 'cider-interaction)
 ;;; cider-interaction.el ends here

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -873,11 +873,6 @@ Falls back to `nrepl-port' if not found."
   (or (nrepl--port-from-file ".nrepl-port")
       (nrepl--port-from-file "target/repl-port")
       nrepl-port))
-
-;;;###autoload
-(add-hook 'nrepl-connected-hook 'cider-enable-on-existing-clojure-buffers)
-(add-hook 'nrepl-disconnected-hook
-          'cider-possibly-disable-on-existing-clojure-buffers)
 
 (provide 'nrepl-client)
 ;;; nrepl-client.el ends here


### PR DESCRIPTION
cider-jack-in or cider trigger autoload of cider.el, and thus require all of the cider files downto nrepl-client. Instead of doing an autoload on the connection triggers for cider in nrepl-client, we should leverage the fact that cider.el is the likely trigger for loading cider.

I'm less certain about calling the disconnection hook in nrepl-close versus automatically on each sentinel that quits.
