### PR TITLE
Use io.aviso.exception as the preferred way to print exceptions

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -656,8 +656,13 @@ They exist for compatibility with `next-error'."
             (and cider-popup-stacktraces (not replp)))
       (lexical-let ((cider-popup-on-error cider-popup-on-error))
         (with-current-buffer buffer
-          (cider-eval "(if-let [pst+ (clojure.core/resolve 'clj-stacktrace.repl/pst+)]
-                        (pst+ *e) (clojure.stacktrace/print-stack-trace *e))"
+          (cider-eval "(do (try (require 'io.aviso.exception)
+                             (catch Exception e nil))
+                         (let [exception-fns ['io.aviso.exception/write-exception
+                                              'clj-stacktrace.repl/pst+
+                                              'clojure.stacktrace/print-stack-trace]
+                               print-stack-trace (first (keep clojure.core/resolve exception-fns))]
+                           (print-stack-trace *e)))"
                       (nrepl-make-response-handler
                        (cider-make-popup-buffer cider-error-buffer)
                        nil


### PR DESCRIPTION
The [io.aviso.pretty](https://github.com/AvisoNovate/pretty) library has a great exception printer. I've been using it with cider for a few days and it just makes reading exceptions a lot easier. 

The problem with my below implementation is that it requires that the io.aviso/pretty library is included in the project's dependencies. Is there any way to dynamically depend on the library using nrepl itself?

It might also be worth including a way for users to set their preferred exception printing method by creating a new option such as `cider-preferred-stack-trace-printer`. I'd be happy to add this too if you think it's a better approach.

![screen shot 2013-11-23 at 10 35 41 am](https://f.cloud.github.com/assets/495730/1607085/21fd0516-546e-11e3-9e37-cc8ce265c4ed.png)
