### PR TITLE
Add clojure.core qualifier to fns where missing

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -458,7 +458,7 @@ Uses `find-file'."
   "Return a list of completions for STR using complete.core/completions."
   (let ((strlst
          (cider-eval-and-get-value
-          (format "(require 'complete.core) (complete.core/completions \"%s\" *ns*)" str)
+          (format "(clojure.core/require 'complete.core) (complete.core/completions \"%s\" *ns*)" str)
           nrepl-buffer-ns
           (nrepl-current-tooling-session))))
     (when strlst

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -632,7 +632,8 @@ text property `cider-old-input'."
 
 (defun cider--all-ns ()
   "Get a list of the available namespaces."
-  (read (cider-eval-and-get-value "(map str (all-ns))")))
+  (read (cider-eval-and-get-value
+         "(clojure.core/map clojure.core/str (clojure.core/all-ns))")))
 
 (defun cider-repl-set-ns (ns)
   "Switch the namespace of the REPL buffer to NS.

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -80,7 +80,7 @@ The `nrepl-buffer-name-separator' separates `nrepl' from the project name."
   :type 'string
   :group 'nrepl)
 
-(defvar nrepl-repl-requires-sexp "(apply require '[[clojure.repl :refer (source apropos dir pst doc find-doc)] [clojure.java.javadoc :refer (javadoc)] [clojure.pprint :refer (pp pprint)]])"
+(defvar nrepl-repl-requires-sexp "(clojure.core/apply clojure.core/require '[[clojure.repl :refer (source apropos dir pst doc find-doc)] [clojure.java.javadoc :refer (javadoc)] [clojure.pprint :refer (pp pprint)]])"
   "Things to require in the tooling session and the REPL buffer.")
 
 (defvar nrepl-connection-buffer nil)


### PR DESCRIPTION
This is already the case in most places, but the few exceptions can cause errors if the code Cider sends is evaluated in an ns where `apply` or `require` either isn't present or is bound to something unexpected.

I created a [minimal example project](https://github.com/johnmastro/cider-name-qualification-error-example) that triggers an error when you jack in. The `:main` ns is set to `testproject.core`, which excludes `clojure.core/apply` and defines its own. The stacktrace from the resulting exception is [here](https://github.com/johnmastro/cider-name-qualification-error-example/blob/master/stacktrace.txt). (The `project.clj` is [here](https://github.com/johnmastro/cider-name-qualification-error-example/blob/master/project.clj) and `testproject.core` is [here](https://github.com/johnmastro/cider-name-qualification-error-example/blob/master/src/testproject/core.clj).)

Defining your own `apply` is admittedly rare (I came across this error while writing a toy metacircular interpreter) but I don't think there's a downside to adding the namespace qualification.
