### PR TITLE
Add support for controlling the value of `*print-length*'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * <kbd>C-c M-f</kbd> Select a function from the current namespace using IDO and insert into the REPL buffer.
 * `cider-read-and-eval` now supports completion and keeps history.
+* Added ability to limit the number of objects printed in collections
+  by managing `*print-length*`. `cider-repl-print-length` can be used
+  to set a limit, and `cider-repl-toggle-print-length-limiting` can be
+  used to toggle the enforcement of the limit.
 
 ## 0.4.0 / 2013-12-03
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ of SLIME + [swank-clojure](https://github.com/technomancy/swank-clojure).
 	- [Connect to a running nREPL server](#connect-to-a-running-nrepl-server)
 	- [Using the cider minor mode](#using-the-cider-minor-mode)
 	- [Pretty printing in the REPL](#pretty-printing-in-the-repl)
+    - [Limiting printed output in the REPL](#limiting-printed-output-in-the-repl)
 - [Keyboard shortcuts](#keyboard-shortcuts)
 	- [cider-mode](#cider-mode)
 	- [cider-repl-mode](#cider-repl-mode)
@@ -194,6 +195,13 @@ Buffer name will look like *cider project-name:port*.
 (setq cider-repl-display-in-current-window t)
 ```
 
+* Limit the number of items of each collection the printer will print
+  to 100:
+
+```el
+(setq cider-repl-print-length 100) ; the default is nil, no limit
+```
+
 ### REPL History
 
 * To make the REPL history wrap around when its end is reached:
@@ -331,6 +339,17 @@ and it expects `clojure.pprint` to have been required already
 (the default in more recent versions of Clojure):
 
 <kbd>M-x cider-toggle-pretty-printing</kbd>
+
+### Limiting printed output in the REPL
+
+Accidentally printing large objects can be detrimental to your
+productivity. Clojure provides the `*print-length*` var which, if set,
+controls how many items of each collection the printer will print. You
+can supply a default value for REPL sessions by setting the
+`cider-repl-print-length` variable to an integer value. The
+enforcement of this limit can then be toggled using:
+
+<kbd>M-x cider-toggle-print-length-limiting</kbd>
 
 ## Keyboard shortcuts
 

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -93,6 +93,15 @@ change the setting's value."
   :type 'boolean
   :group 'cider-repl)
 
+(defcustom cider-repl-print-length nil
+  "Non-nil means limit the number of objects printed in REPL to this value.
+This is implemented by setting the value of the Clojure var
+*print-length*.  The `cider-repl-toggle-print-length-limiting'
+command can be used to interactively change whether this setting
+is enforced or not."
+  :type 'integer
+  :group 'cider-repl)
+
 (defcustom cider-repl-tab-command 'cider-repl-indent-and-complete-symbol
   "Select the command to be invoked by the TAB key.
 The default option is `cider-repl-indent-and-complete-symbol'.  If
@@ -226,6 +235,8 @@ Insert a banner, unless NOPROMPT is non-nil."
       (cider-repl-mode))
     ;; use the same requires by default as clojure.main does
     (cider-eval-sync nrepl-repl-requires-sexp)
+    (when cider-repl-print-length
+      (cider-repl-set-print-length cider-repl-print-length))
     (cider-repl-reset-markers)
     (unless noprompt
       (cider-repl--insert-banner-and-prompt nrepl-buffer-ns))
@@ -593,6 +604,23 @@ text property `cider-old-input'."
   (setq cider-repl-use-pretty-printing (not cider-repl-use-pretty-printing))
   (message "Pretty printing in nREPL %s."
            (if cider-repl-use-pretty-printing "enabled" "disabled")))
+
+(defun cider-repl-set-print-length (print-length)
+  "Set the clojure var *print-length* to PRINT-LENGTH."
+  (let* ((form (format "(set! *print-length* %d)"
+                       print-length)))
+    (cider-eval-sync form)))
+
+(defun cider-repl-toggle-print-length-limiting ()
+  "Toggle the enforcement of `cider-repl-print-length'."
+  (interactive)
+  (when (integerp cider-repl-print-length)
+    (let* ((form (format "(set! *print-length* (if *print-length* nil %d))"
+                         cider-repl-print-length))
+           (print-length (cider-eval-and-get-value form)))
+      (if print-length
+          (message "*print-length* limited to %d" print-length)
+        (message "*print-length* unlimited")))))
 
 (defvar cider-repl-clear-buffer-hook)
 


### PR DESCRIPTION
This commit allows the user to avoid killing Emacs when accidentally
printing large data structures in the REPL. It accomplishes this by
managing the Clojure var `*print-length*` which controls how many objects to
print in each collection.

Introduces two variables:
- `cider-repl-print-length`: the desired value of `*print-length*`
- `cider-repl-limit-print-length`: whether to limit the print length or not.

Introduces a interactive function:
- `cider-repl-toggle-print-length-limiting`: for toggling whether to
  limit the print length or not
