### PR TITLE
Tidying up switch-to-relevant-buffer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ the option `cider-repl-use-clojure-font-lock`.
 
 * [#316](https://github.com/clojure-emacs/cider/issues/316) Honor the `:init-ns` namespace on startup.
 * [#436](https://github.com/clojure-emacs/cider/issues/436) Fix an infinite loop when evaluating ns forms.
+* [#435](https://github.com/clojure-emacs/cider/issues/435) Fix trampling of `cider-switch-to-repl-buffer` by `cider-switch-to-relevant-repl-buffer`.
 
 ## 0.4.0 / 2013-12-03
 

--- a/README.md
+++ b/README.md
@@ -232,6 +232,17 @@ font-locked as in `clojure-mode` use the following:
 (setq cider-repl-use-clojure-font-lock t)
 ```
 
+* You can control the <kbd>C-c C-z</kbd> key behavior of switching to the REPL buffer
+with the `cider-switch-to-repl-command` variable.  While the default command
+`cider-switch-to-relevant-repl-buffer` should be an adequate choice for
+most users, `cider-switch-to-current-repl-buffer` offers a simpler alternative
+where CIDER will not attempt to match the correct REPL buffer based on
+underlying project directories:
+
+```el
+(setq cider-switch-to-repl-command 'cider-switch-to-current-repl-buffer)
+```
+
 ### REPL History
 
 * To make the REPL history wrap around when its end is reached:
@@ -408,10 +419,10 @@ Keyboard shortcut                    | Description
 <kbd>C-c M-m</kbd>                   | Invoke `clojure.walk/macroexpand-all` on the form at point and display the result in a macroexpansion buffer.
 <kbd>C-c C-n</kbd>                   | Eval the ns form.
 <kbd>C-c M-n</kbd>                   | Switch the namespace of the REPL buffer to the namespace of the current buffer.
-<kbd>C-c C-z</kbd>                   | Select the REPL buffer. With a prefix argument - changes the namespace of the REPL buffer to the one of the currently visited source file.
-<kbd>C-u C-u C-c C-z</kbd>           | Select the REPL buffer based on a user prompt for a directory.
-<kbd>C-c M-d</kbd>                   | Display current REPL connection details, including project directory name, buffer namespace, host and port.
-<kbd>C-c M-r</kbd>                   | Rotate and display the current REPL connection.
+<kbd>C-c C-z</kbd>                   | Switch to the relevant REPL buffer. Use a prefix argument to change the namespace of the REPL buffer to match the currently visited source file.
+<kbd>C-u C-u C-c C-z</kbd>           | Switch to the REPL buffer based on a user prompt for a directory.
+<kbd>C-c M-d</kbd>                   | Display default REPL connection details, including project directory name, buffer namespace, host and port.
+<kbd>C-c M-r</kbd>                   | Rotate and display the default nREPL connection.
 <kbd>C-c M-o</kbd>                   | Clear the entire REPL buffer, leaving only a prompt. Useful if you're running the REPL buffer in a side by side buffer.
 <kbd>C-c C-k</kbd>                   | Load the current buffer.
 <kbd>C-c C-l</kbd>                   | Load a file.
@@ -440,10 +451,7 @@ Keyboard shortcut                    | Description
 <kbd>TAB</kbd> | Complete symbol at point.
 <kbd>C-c C-d</kbd> | Display doc string for the symbol at point.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol
 <kbd>C-c C-j</kbd> | Display JavaDoc (in your default browser) for the symbol at point.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.
-<kbd>C-c C-z</kbd> | Select the last Clojure buffer. <kbd>C-u C-c C-z</kbd> will switch the Clojure buffer to the namespace in the current buffer.
-<kbd>C-u C-u C-c C-z</kbd> | Select the Clojure buffer based on a user prompt for a directory.
-<kbd>C-c M-d</kbd> | Display current REPL connection details, including project directory name, buffer namespace, host and port.
-<kbd>C-c M-r</kbd> | Rotate and display the current REPL connection.
+<kbd>C-c C-z</kbd> | Switch to the previous Clojure buffer. This complements <kbd>C-c C-z</kbd> used in cider-mode.
 <kbd>C-c M-f</kbd> | Select a function from the current namespace using IDO and insert into nREPL buffer.
 
 In the REPL you can also use "shortcut commands" by pressing `,` at the beginning of a REPL line. You'll be presented with a list of commands you can quickly run (like quitting, displaying some info, clearing the REPL, etc). The character used to trigger the shortcuts is configurable via `cider-repl-shortcut-dispatch-char`. Here's how you can change it to `:`:
@@ -463,17 +471,19 @@ Keyboard shortcut               | Description
 
 ### Managing multiple sessions
 
-You can connect to multiple nREPL servers and use <kbd>M-x cider-jack-in</kbd> multiple
-times.  To close a single nREPL session, use <kbd>M-x nrepl-close</kbd>.  <kbd>M-x
-cider-quit</kbd> closes all sessions.
+You can connect to multiple nREPL servers using <kbd>M-x cider-jack-in</kbd> multiple
+times.  To close the current nREPL connection, use <kbd>M-x nrepl-close</kbd>. <kbd>M-x
+cider-quit</kbd> closes all connections.
 
-CIDER commands in a Clojure buffer use the default connection.  To make a
-connection default, switch to it's REPL buffer and use
-<kbd>M-x nrepl-make-repl-connection-default</kbd>.
+CIDER maintains a list of nREPL connections and a single 'default' connection. When you execute CIDER commands in a Clojure editing buffer such as to compile a namespace, these commands are executed against the default connection.
 
-To switch to the relevant REPL buffer based on the Clojure namespace in the current buffer, use: <kbd>C-c C-z</kbd>.
+You can display the default nREPL connection using <kbd>C-c M-d</kbd> and rotate the default connection using <kbd>C-c M-r</kbd>. Another option for setting the default connection is to execute the command <kbd>M-x nrepl-make-repl-connection-default</kbd> in the appropriate REPL buffer.
 
-You can display the current nREPL connection using <kbd>C-c M-d</kbd> and rotate through available connections using <kbd>C-c M-r</kbd>.
+To switch to the relevant REPL buffer based on the Clojure namespace in the current Clojure buffer, use: <kbd>C-c C-z</kbd>. You can then use the same key combination to switch back to the Clojure buffer you came from.
+
+The single prefix <kbd>C-u C-c C-z</kbd>, will switch you to the relevant REPL buffer and set the namespace in that buffer based on namespace in the current Clojure buffer.
+
+To explicitly choose the REPL buffer that <kbd>C-c C-z</kbd> uses based on project directory, use a double prefix <kbd>C-u C-u C-c C-z</kbd>. This assumes you have `cider-switch-to-relevant-repl` mapped to the var `cider-switch-to-repl-command` which is the default configuration.
 
 ## Requirements
 

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -55,7 +55,6 @@
     (define-key map (kbd "C-c C-d") 'cider-doc)
     (define-key map (kbd "C-c C-s") 'cider-src)
     (define-key map (kbd "C-c C-z") 'cider-switch-to-repl-buffer)
-    (define-key map (kbd "C-c C-Z") 'cider-switch-to-relevant-repl-buffer)
     (define-key map (kbd "C-c M-o") 'cider-find-and-clear-repl-buffer)
     (define-key map (kbd "C-c C-k") 'cider-load-current-buffer)
     (define-key map (kbd "C-c C-l") 'cider-load-file)

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1034,8 +1034,6 @@ ENDP) DELIM."
     (define-key map (kbd "C-c M-m") 'cider-macroexpand-all)
     (define-key map (kbd "C-c C-z") 'cider-switch-to-last-clojure-buffer)
     (define-key map (kbd "C-c M-s") 'cider-selector)
-    (define-key map (kbd "C-c M-r") 'cider-rotate-connection)
-    (define-key map (kbd "C-c M-d") 'cider-display-current-connection-info)
     (define-key map (kbd "C-c M-f") 'cider-load-fn-into-repl-buffer)
     (define-key map (kbd "C-c C-q") 'cider-quit)
     (define-key map (string cider-repl-shortcut-dispatch-char) 'cider-repl-handle-shortcut)


### PR DESCRIPTION
Hi,

What's in here:

1) cider-switch-to-relevant-repl-buffer is mapped to C-c C-z. I've tidied related keybindings, and specially removed the ability to rotate and to display the current nrepl connection from the REPL mode (still exists for CIDER mode). It makes little sense to do it here, and generally I think it's good to prune where possible.

2) cider-switch-to-relevant-repl-buffer again takes 2 prefix args (first one does the namespace switch, second one triggers IDO to select project).

3) Switch will NOT be made based on project dir if there exists a REPL connection without a project dir. If this is so, then a message is printed.

4) Better message output when a switch is made.

Some notes:

1) I've kept cider-switch-to-repl-buffer around. This is because it's quite discreet in what it does and it does offer users an option if they dislike the funkier behavour. In time someone might remove it.

2) I've tried to make "Managing multiple sessions" in the readme a little more easy going. There are issues around the precise terminology to use, like "CIDER minor mode" vs "Clojure buffer", or "current nrepl connection" vs "default nrepl connection", "switch vs select".
