### PR TITLE
Show host in buffer name when no project directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ from interactive evaluation displayed in the minibuffer.
 * Added the ability to font-lock input and results in the REPL as Clojure code. This is controlled via
 the option `cider-repl-use-clojure-font-lock`.
 * Added `cider-pprint-eval-defun-at-point`, a companion to `cider-pprint-eval-last-sexp` which works on the top-level form.
+* The REPL buffer name uses host if no project directory available; `*cider-repl*` will appear as `*cider-repl <host>*`.
 
 ### Bugs fixed
 

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -105,15 +105,16 @@ buffer will be hidden.")
 (defun nrepl-buffer-name (buffer-name-template)
   "Generate a buffer name using BUFFER-NAME-TEMPLATE.
 
-The name will include the project name if available.  The name will
-also include the connection port if `nrepl-buffer-name-show-port' is true."
+The name will include the project name if available or the
+endpoint host if it is not.  The name will also include the
+connection port if `nrepl-buffer-name-show-port' is true."
   (generate-new-buffer-name
    (let ((project-name (nrepl--project-name nrepl-project-dir))
          (nrepl-proj-port (cadr nrepl-endpoint)))
      (format
       buffer-name-template
-      (concat (if project-name
-                  (format "%s%s" nrepl-buffer-name-separator project-name) "")
+      (concat (format "%s%s" nrepl-buffer-name-separator
+                      (if project-name project-name (car nrepl-endpoint)))
               (if (and nrepl-proj-port nrepl-buffer-name-show-port)
                   (format ":%s" nrepl-proj-port) ""))))))
 

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -34,16 +34,18 @@
 
 ;;;; generic
 (ert-deftest test-cider-connection-buffer-name ()
+  (set (make-local-variable 'nrepl-endpoint) '("localhost" 1))
   (let ((nrepl-hide-special-buffers nil))
-    (should (equal (nrepl-connection-buffer-name) "*nrepl-connection*")))
+    (should (equal (nrepl-connection-buffer-name) "*nrepl-connection localhost*")))
   (let ((nrepl-hide-special-buffers t))
-    (should (equal (nrepl-connection-buffer-name) " *nrepl-connection*"))))
+    (should (equal (nrepl-connection-buffer-name) " *nrepl-connection localhost*"))))
 
 (ert-deftest test-cider-server-buffer-name ()
+  (set (make-local-variable 'nrepl-endpoint) '("localhost" 1))
   (let ((nrepl-hide-special-buffers nil))
-    (should (equal (nrepl-server-buffer-name) "*nrepl-server*")))
+    (should (equal (nrepl-server-buffer-name) "*nrepl-server localhost*")))
   (let ((nrepl-hide-special-buffers t))
-    (should (equal (nrepl-server-buffer-name) " *nrepl-server*"))))
+    (should (equal (nrepl-server-buffer-name) " *nrepl-server localhost*"))))
 
 (ert-deftest test-cider-repl--banner ()
   (noflet ((cider-version () "0.2.0")
@@ -181,9 +183,10 @@
 
 (ert-deftest test-nrepl-buffer-name ()
   (with-temp-buffer
+    (set (make-local-variable 'nrepl-endpoint) '("localhost" 1))
     (let ((b1 (current-buffer)))
       (should
-       (equal (nrepl-buffer-name "*buff-name%s*") "*buff-name*")))))
+       (equal (nrepl-buffer-name "*buff-name%s*") "*buff-name localhost*")))))
 
 (ert-deftest test-nrepl-buffer-name-based-on-project ()
   (with-temp-buffer
@@ -205,14 +208,14 @@
     (set (make-local-variable 'nrepl-buffer-name-show-port) t)
     (set (make-local-variable 'nrepl-endpoint) '("localhost" 4009))
     (should
-     (equal (nrepl-buffer-name "*buff-name%s*") "*buff-name:4009*"))))
+     (equal (nrepl-buffer-name "*buff-name%s*") "*buff-name localhost:4009*"))))
 
 (ert-deftest test-nrepl-buffer-name-show-port-nil ()
   (with-temp-buffer
     (set (make-local-variable 'nrepl-buffer-name-show-port) nil)
     (set (make-local-variable 'nrepl-endpoint) '("localhost" 4009))
     (should
-     (equal (nrepl-buffer-name "*buff-name%s*") "*buff-name*"))))
+     (equal (nrepl-buffer-name "*buff-name%s*") "*buff-name localhost*"))))
 
 (ert-deftest test-nrepl-buffer-name-based-on-project-and-port ()
   (with-temp-buffer
@@ -254,10 +257,11 @@
 
 (ert-deftest test-cider-clojure-buffer-name ()
   (with-temp-buffer
+    (set (make-local-variable 'nrepl-endpoint) '("localhost" 1))
     (let ((b1 (current-buffer)))
       (let ((nrepl-connection-list (list (buffer-name b1))))
         (should
-         (equal (cider-repl-buffer-name) "*cider-repl*"))))))
+         (equal (cider-repl-buffer-name) "*cider-repl localhost*"))))))
 
 (ert-deftest test-cider-clojure-buffer-name-w/project ()
   (with-temp-buffer


### PR DESCRIPTION
It's not great at present that if you open a repl session to a host as oppose to jack in from a directory, the buffer-name doesn't display this somehow.

So with this change you get _cider-repl 127.0.0.1_ or whatever the host is that you connect to.
