### PR TITLE
Use clojure.stacktrace/print-cause-trace

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -766,7 +766,7 @@ They exist for compatibility with `next-error'."
       (lexical-let ((cider-popup-on-error cider-popup-on-error))
         (with-current-buffer buffer
           (cider-eval "(if-let [pst+ (clojure.core/resolve 'clj-stacktrace.repl/pst+)]
-                        (pst+ *e) (clojure.stacktrace/print-stack-trace *e))"
+                        (pst+ *e) (clojure.stacktrace/print-cause-trace *e))"
                       (nrepl-make-response-handler
                        (cider-make-popup-buffer cider-error-buffer)
                        nil


### PR DESCRIPTION
When displaying exceptions without clj-stacktrace, use print-cause-trace 
rather than print-stack-trace, so that the exception chain is displayed.
