### PR TITLE
Enable cider-jack-in on tramp buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * Cider command uses `cider-known-endpoints`.
 * [#490](https://github.com/clojure-emacs/cider/pull/490) Dedicated
   support for `company-mode` in `cider-complete-at-point`.
+* [#489](https://github.com/clojure-emacs/cider/issues/489) Enable
+  cider-jack-in on tramp source buffers.
 * [#460](https://github.com/clojure-emacs/cider/issues/460) Support for
 cider-nrepl's complete middleware for CLJ/CLJS autocomplete.
 * [#465](https://github.com/clojure-emacs/cider/issues/465) Support for

--- a/cider.el
+++ b/cider.el
@@ -103,10 +103,17 @@ start the server."
              (cmd (if project
                       (format "cd %s && %s" project cider-server-command)
                     cider-server-command))
-             (process (start-process-shell-command
-                       "nrepl-server"
-                       (generate-new-buffer-name (nrepl-server-buffer-name))
-                       cmd)))
+             (default-directory project-dir)
+             (nrepl-buffer-name (generate-new-buffer-name
+                                 (nrepl-server-buffer-name)))
+             (process
+              (progn
+                ;; the buffer has to be created before the proc:
+                (get-buffer-create nrepl-buffer-name)
+                (start-file-process-shell-command
+                 "nrepl-server"
+                 nrepl-buffer-name
+                 cmd))))
         (set-process-filter process 'nrepl-server-filter)
         (set-process-sentinel process 'nrepl-server-sentinel)
         (set-process-coding-system process 'utf-8-unix 'utf-8-unix)


### PR DESCRIPTION
When using cider-jack-in in a tramp source buffer, starts a remote nrepl
server, and connects to it.  By default, sets up an ssh tunnel to the
remote port.  This can be controlled using
`nrepl-on-connection-function`, which defaults to
`nrepl-connection-ssh-tunnel`.
