### PR TITLE
Cider command uses known endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* Cider command uses `cider-known-endpoints`.
 * [#490](https://github.com/clojure-emacs/cider/pull/490) Dedicated
   support for `company-mode` in `cider-complete-at-point`.
 * [#460](https://github.com/clojure-emacs/cider/issues/460) Support for

--- a/README.md
+++ b/README.md
@@ -268,6 +268,15 @@ underlying project directories:
 (setq cider-switch-to-repl-command 'cider-switch-to-current-repl-buffer)
 ```
 
+* You can configure known endpoints used by the cider command. This is useful if you
+have a list of common host/ports you want to establish remote nREPL connections to.
+Using an optional label is helpful for identifying each host.
+If you want to bypass IDO selection of an endpoint, use <kbd>C-j</kbd>.
+
+```el
+(setq cider-known-endpoints '(("host-a" "10.10.10.1" "7888") ("host-b" "7888")))
+```
+
 ### REPL History
 
 * To make the REPL history wrap around when its end is reached:

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -412,3 +412,22 @@
 
       (dolist (buf (list b1 b2 b3 b1-repl b2-repl b3-repl))
         (kill-buffer buf)))))
+
+(ert-deftest test-cider-known-endpoint-candidates ()
+  (let ((cider-known-endpoints '(("label" "host" "port"))))
+    (noflet ((nrepl-current-host () "current-host")
+             (nrepl-default-port () "current-port"))
+      (should (equal '("current-host current-port" "label host port")
+                     (cider-known-endpoint-candidates))))))
+
+(ert-deftest test-cider-known-endpoint-candidates-remove-duplicates ()
+  (let ((cider-known-endpoints '(("label" "host" "port") ("label" "host" "port"))))
+    (noflet ((nrepl-current-host () "current-host")
+             (nrepl-default-port () "current-port"))
+      (should (equal '("current-host current-port" "label host port")
+                     (cider-known-endpoint-candidates))))))
+
+(ert-deftest test-cider-select-known-endpoint-remove-label ()
+  (noflet ((cider-known-endpoint-candidates () '())
+           (ido-completing-read (dontcare dontcare) "label host port"))
+      (should (equal '("host" "port") (cider-select-known-endpoint)))))


### PR DESCRIPTION
Looking for feedback - please give this a try.

I'm currently a bit stuck in that there is no way to turn off IDO matching against host/label. This needs to be resolved IMO before this PR can be merged.

I'll also get some tests written.

Configure your endpoints like:

(setq cider-known-endpoints '(("Random" "11.254.76.52" "7888")
                              ("123.250.71.56" "7888")))

The label is optional.
