### PR TITLE
Change cider buffers designation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* New interactive command `cider-change-buffers-designation`.
 * Cider command uses `cider-known-endpoints`.
 * [#490](https://github.com/clojure-emacs/cider/pull/490) Dedicated
   support for `company-mode` in `cider-complete-at-point`.

--- a/README.md
+++ b/README.md
@@ -540,6 +540,8 @@ The single prefix <kbd>C-u C-c C-z</kbd>, will switch you to the relevant REPL b
 
 To explicitly choose the REPL buffer that <kbd>C-c C-z</kbd> uses based on project directory, use a double prefix <kbd>C-u C-u C-c C-z</kbd>. This assumes you have `cider-switch-to-relevant-repl` mapped to the var `cider-switch-to-repl-command` which is the default configuration.
 
+To change the designation used for CIDER buffers use <kbd>M-x cider-change-buffers-designation</kbd>. This changes the CIDER REPL buffer, nREPL connection buffer and nREPL server buffer. For example using `cider-change-buffers-designation` with the string "foo" would change `*cider-repl localhost*` to `*cider-repl foo*`.
+
 ## Requirements
 
 * [Leiningen](http://leiningen.org) 2.x (only for `cider-jack-in`)


### PR DESCRIPTION
How does this look for #480 & #431? It renames the repl, connection and server buffers using the supplied arg as a prefix.

Working on tests & the rest now.
