### PR TITLE
Fixing reference to nrepl-connection-buffer in cider-change-buffers-designation.

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -171,6 +171,8 @@ Buffer names changed are cider-repl, nrepl-connection and nrepl-server."
         (rename-buffer new-connection-buffer-name)
         (setq nrepl-connection-list
               (cons new-connection-buffer-name (cdr nrepl-connection-list)))
+        (with-current-buffer (cider-current-repl-buffer)
+          (setq-local nrepl-connection-buffer new-connection-buffer-name))
         (when nrepl-server-buffer
           (let ((new-server-buffer-name (nrepl-format-buffer-name-template
                                          nrepl-server-buffer-name-template designation)))

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -464,7 +464,9 @@
                 (cider-change-buffers-designation)
                 (should (equal "*cider-repl bob*" (buffer-name repl-buffer)))
                 (should (equal "*nrepl-connection bob*" (buffer-name connection-buffer)))
-                (should (equal "*nrepl-server bob*" (buffer-name server-buffer)))))))))))
+                (should (equal "*nrepl-server bob*" (buffer-name server-buffer))))
+              (with-current-buffer repl-buffer
+                (should (equal "*nrepl-connection bob*" nrepl-connection-buffer))))))))))
 
 (ert-deftest test-cider-change-buffers-designation-to-existing-designation-has-no-effect ()
   (with-temp-buffer


### PR DESCRIPTION
Could you squash this into my previous commit?
