### PR TITLE
Support Java method description from middleware.

### DIFF
--- a/cider-client.el
+++ b/cider-client.el
@@ -185,6 +185,17 @@ it if it's not a dict."
                           :value)))
       (cider--dict-to-alist val))))
 
+(defun cider-member-info (class member)
+  "Return the CLASS MEMBER's info as an alist with list cdrs."
+  (when (and class member)
+    (let ((val (plist-get (nrepl-send-request-sync
+                           (list "op" "info"
+                                 "session" (nrepl-current-session)
+                                 "class" class
+                                 "member" member))
+                          :value)))
+      (cider--dict-to-alist val))))
+
 (defun cider-get-var-attr (var attr)
   "Return VAR's ATTR."
   (cadr (assoc attr (cider-var-info var))))

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -201,14 +201,18 @@ Update `cider-stacktrace-hidden-frame-count' and indicate filters applied."
     (sit-for 5)))
 
 (defun cider-stacktrace-navigate (button)
-  "Navigate to the stack frame represented by the BUTTON."
+  "Navigate to the stack frame source represented by the BUTTON."
   (let ((var (button-get button 'var))
+        (class (button-get button 'class))
+        (method (button-get button 'method))
         (line (button-get button 'line)))
-    (condition-case nil
-        (let* ((info (cider-var-info var))
-               (file (cadr (assoc "file" info))))
-          (cider-jump-to-def-for (vector file file line)))
-      (error "No source info"))))
+    (let* ((info (if var
+                     (cider-var-info var)
+                   (cider-member-info class method)))
+           (file (cadr (assoc "file" info))))
+      (if (and file line)
+          (cider-jump-to-def-for (vector file file line))
+        (error "No source info")))))
 
 
 ;; Rendering
@@ -254,7 +258,8 @@ This associates text properties to enable filtering and source navigation."
                                     (if (member 'repl flags) "REPL" file) line
                                     (if (member 'clj flags) ns class)
                                     (if (member 'clj flags) fn method))
-                            'name name 'var var 'line line 'flags flags
+                            'var var 'class class 'method method
+                            'name name 'line line 'flags flags
                             'follow-link t
                             'action 'cider-stacktrace-navigate
                             'help-echo "View source at this location"


### PR DESCRIPTION
This gives Java methods similar support to Clojure vars for jumping into function source definitions from stack frames.

The accompanying PR for `cider-nrepl` is [40](https://github.com/clojure-emacs/cider-nrepl/pull/40).
