### PR TITLE
remove explicit dependence on pkg-info

### DIFF
--- a/cider-repl.el
+++ b/cider-repl.el
@@ -33,10 +33,10 @@
 (require 'cider-client)
 (require 'cider-interaction)
 (require 'cider-eldoc) ; for cider-turn-on-eldoc-mode
+(require 'cider-util)
 
 (require 'clojure-mode)
 (require 'easymenu)
-(require 'pkg-info)
 
 (eval-when-compile
   (defvar paredit-version)
@@ -224,9 +224,7 @@ positions before and after executing BODY."
 (defun cider-repl--banner ()
   "Generate the welcome REPL buffer banner."
   (format "; CIDER %s (Java %s, Clojure %s, nREPL %s)"
-          (condition-case nil
-              (pkg-info-version-info 'cider)
-            (error cider-version))
+          (cider--version)
           (cider--java-version)
           (cider--clojure-version)
           (cider--nrepl-version)))

--- a/cider-util.el
+++ b/cider-util.el
@@ -75,6 +75,12 @@ buffer-local wherever it is set."
   "Return a string of Clojure code that will eval and pretty-print FORM."
   (format "(let [x %s] (clojure.pprint/pprint x) x)" form))
 
+(autoload 'pkg-info-version-info "pkg-info.el")
+(defun cider--version ()
+  (condition-case nil
+      (pkg-info-version-info 'cider)
+    (error cider-version)))
+
 (provide 'cider-util)
 
 ;; Local Variables:

--- a/cider.el
+++ b/cider.el
@@ -59,13 +59,12 @@
   :link '(url-link :tag "Github" "https://github.com/clojure-emacs/cider")
   :link '(emacs-commentary-link :tag "Commentary" "cider"))
 
-(require 'pkg-info)
-
 (require 'cider-client)
 (require 'cider-interaction)
 (require 'cider-eldoc)
 (require 'cider-repl)
 (require 'cider-mode)
+(require 'cider-util)
 
 (defvar cider-version "0.7.0-snapshot"
   "Fallback version used when it cannot be extracted automatically.
@@ -84,8 +83,7 @@ This variable is used by the CIDER command."
 (defun cider-version ()
   "Display CIDER's version."
   (interactive)
-  (let ((version (pkg-info-version-info 'cider)))
-    (message "CIDER %s" version)))
+  (message "CIDER %s" (cider--version)))
 
 ;;;###autoload
 (defun cider-jack-in (&optional prompt-project)

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -56,6 +56,7 @@
     (should (equal (cider-repl--banner) "; CIDER 0.2.0 (Java 1.7, Clojure 1.5.1, nREPL 0.2.1)"))))
 
 (ert-deftest test-cider-repl--banner-version-fallback ()
+  (require 'pkg-info)
   (noflet ((pkg-info-version-info (library) (error "No package version"))
            (cider--java-version () "1.7")
            (cider--clojure-version () "1.5.1")


### PR DESCRIPTION
Hi, 

I have decided to install cider from scratch for development, but quickly realized to satisfy all the dependencies of cider is not a trivial task.

This patch removes the marginally useful dependence on pkg-info and, indirectly, epl.
