### PR TITLE
Enable 'jump' keybindings for stacktrace navigation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@ Keyboard shortcut               | Description
 
 Keyboard shortcut               | Description
 --------------------------------|-------------------------------
-<kbd>Return</kbd> | navigate to the source location (if available) for the stacktrace frame
+<kbd>Return</kbd> and <kbd>M-.</kbd> | navigate to the source location (if available) for the stacktrace frame
 <kbd>j</kbd> | toggle display of java frames
 <kbd>c</kbd> | toggle display of clj frames
 <kbd>r</kbd> | toggle display of repl frames

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -553,7 +553,8 @@ added as a prefix to the LOCATION."
      ((and path (file-exists-p path)) (find-file path))
      (t (cider-find-resource resource)))
     (goto-char (point-min))
-    (forward-line (1- line))))
+    (forward-line (1- line))
+    (cider-mode 1))) ; enable cider-jump keybindings on java sources
 
 (defun cider--jump-to-def-op-fn (var)
   "Jump to VAR def by using the nREPL info op."

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -78,6 +78,7 @@
 
 (defvar cider-stacktrace-mode-map
   (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "M-.") 'cider-stacktrace-jump)
     (define-key map "j" 'cider-stacktrace-toggle-java)
     (define-key map "c" 'cider-stacktrace-toggle-clj)
     (define-key map "r" 'cider-stacktrace-toggle-repl)
@@ -213,6 +214,14 @@ Update `cider-stacktrace-hidden-frame-count' and indicate filters applied."
       (if (and file line)
           (cider-jump-to-def-for (vector file file line))
         (error "No source info")))))
+
+(defun cider-stacktrace-jump ()
+  "Like `cider-jump', but uses the stack frame source at point, if available."
+  (interactive)
+  (let ((button (button-at (point))))
+    (if (and button (button-get button 'line))
+        (cider-stacktrace-navigate button)
+      (call-interactively 'cider-jump))))
 
 
 ;; Rendering


### PR DESCRIPTION
Jump into a stack frame source location with `M-.` and out with `M-,`.
