### PR TITLE
Add cider-jack-in-with-profile

### DIFF
--- a/cider-repl.el
+++ b/cider-repl.el
@@ -131,16 +131,14 @@ you'd like to use the default Emacs behavior use
   :group 'cider-repl)
 
 (defcustom cider-lein-command
-  "lein"
+  (or (executable-find "lein")
+      (executable-find "lein.bat"))
   "The command used to execute leiningen 2.x."
   :type 'string
   :group 'cider-repl)
 
-(defcustom cider-server-command
-  (if (or (locate-file cider-lein-command exec-path)
-          (locate-file (format "%s.bat" cider-lein-command) exec-path))
-      (format "%s repl :headless" cider-lein-command)
-    (format "echo \"%s repl :headless\" | eval $SHELL -l" cider-lein-command))
+(defcustom cider-lein-parameters
+  "repl :headless"
   "The command used to start the nREPL via command `cider-jack-in'.
 For a remote nREPL server lein must be in your PATH.  The remote
 proc is launched via sh rather than bash, so it might be necessary


### PR DESCRIPTION
I have a cross platform leiningen project with multiple profiles, for which I need to have repls which start with different profiles. At the moment I have to do `lein with-profile :local-test repl :headless` manually  which leaves a terminal floating around separate to my emacs window, and also leaves me not knowing which terminals are linked to which emacs windows.

I've proposed a cider-jack-in-with-profile interactive function, as cider-jack-in already had an optional parameter and so couldn't be overridden. This duplicated most of cider-jack-in and so I have split out the common functionality, cider-jack-in should be functionally unaffected.

Please feel free to advise on style and appropriate locations for functions. I needed to make cider-server-command more flexible and so moved it into a function, which means that the locate-file might need to happen more than once, but a jack-in is a relatively infrequent action anyway, so I don't know how much this matters.
