### PR TITLE
Add fill prefix for stacktrace messages

### DIFF
--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -299,6 +299,7 @@ This associates text properties to enable filtering and source navigation."
       (when cider-stacktrace-fill-column
         (when (numberp cider-stacktrace-fill-column)
           (setq-local fill-column cider-stacktrace-fill-column))
+        (setq-local fill-prefix "   ")
         (fill-region 0 (point)))
       (newline)
       ;; Stacktrace filters


### PR DESCRIPTION
Help distinguish individual exception messages by using a fill prefix to 
indent follow on lines of an exception message.
