### PR TITLE
Don't drop *out* on cider-interactive-eval-print

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -767,7 +767,8 @@ The handler simply inserts the result value in BUFFER."
                                (lambda (buffer value)
                                  (with-current-buffer buffer
                                    (insert (format "\n%s" value))))
-                               '()
+                               (lambda (_buffer value)
+                                 (cider-repl-emit-interactive-output value))
                                (lambda (_buffer err)
                                  (message "%s" err))
                                '()))


### PR DESCRIPTION
Print `*out*` to the repl buffer just like in cider-interactive-eval.

I think this is a more common expectation than dropping the `*out*`. Is there a better way to do this, perhaps so that it's configurable? I pretty much haven't written any elisp ever.
