### PR TITLE
Send stderr output to the REPL buffer.

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -752,6 +752,7 @@ The handler simply inserts the result value in BUFFER."
                                (lambda (_buffer value)
                                  (cider-repl-emit-interactive-output value))
                                (lambda (buffer err)
+                                 (cider-repl-emit-interactive-output err)
                                  (message "%s" err)
                                  (cider-highlight-compilation-errors
                                   buffer err))


### PR DESCRIPTION
Reflection warnings are sent to stderr, and are currently displayed in
the minibuffer (though you can't actually see them there because they
get scrolled out of view).  They used to be displayed in the REPL, and
it is more helpful to have them displayed there.
