### PR TITLE
Disable electric-indent on stacktrace more cleanly.

### DIFF
--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -120,7 +120,7 @@ If nil, messages will not be wrapped.  If truthy but non-numeric,
 \\{cider-stacktrace-mode-map}"
   (setq buffer-read-only t)
   (setq-local truncate-lines t)
-  (setq-local electric-indent-functions (list (lambda (x) 'no-indent)))
+  (setq-local electric-indent-chars nil)
   (setq-local cider-stacktrace-prior-filters nil)
   (setq-local cider-stacktrace-hidden-frame-count 0)
   (setq-local cider-stacktrace-filters cider-stacktrace-default-filters))


### PR DESCRIPTION
Updated per the [suggestion](https://github.com/clojure-emacs/cider/pull/566#discussion_r12758919) of @dgutov on #566.
