### PR TITLE
nrepl-bdecode-buffer did not handle negative integers.

### DIFF
--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -185,7 +185,7 @@ To be used for tooling calls (i.e. completion, eldoc, etc)")
 ;;; and modified to work with utf-8
 (defun nrepl-bdecode-buffer ()
   "Decode a bencoded string in the current buffer starting at point."
-  (cond ((looking-at "i\\([0-9]+\\)e")
+  (cond ((looking-at "i\\(-*[0-9]+\\)e")
          (goto-char (match-end 0))
          (string-to-number (match-string 1)))
         ((looking-at "\\([0-9]+\\):")


### PR DESCRIPTION
This threw a silent (and therefore nasty) bug that froze the repl when a large
stack trace contained a negative number.

Regex now modified to accept an optional leading negative.
