### PR TITLE
Fix #593 by removing extra argument in thing-at-point

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -432,7 +432,7 @@ With a PREFIX argument, print the result in the current buffer."
 ;; FIXME: This doesn't have properly at the beginning of the REPL prompt
 (defun cider-symbol-at-point ()
   "Return the name of the symbol at point, otherwise nil."
-  (let ((str (or (thing-at-point 'symbol t) "")))
+  (let ((str (or (thing-at-point 'symbol) "")))
     (if (equal str (concat (cider-find-ns) "> "))
         ""
       str)))


### PR DESCRIPTION
An extra t was inserted into `thing-at-point`, which caused eldoc to fail. This pull request fixes issue #593 by removing the `t` that was accidentally introduced in d1b2edb.
