### PR TITLE
[Fix #593] Fix error with no symbol at point

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -432,7 +432,7 @@ With a PREFIX argument, print the result in the current buffer."
 ;; FIXME: This doesn't have properly at the beginning of the REPL prompt
 (defun cider-symbol-at-point ()
   "Return the name of the symbol at point, otherwise nil."
-  (let ((str (or (substring-no-properties (thing-at-point 'symbol)) "")))
+  (let ((str (substring-no-properties (or (thing-at-point 'symbol) ""))))
     (if (equal str (concat (cider-find-ns) "> "))
         ""
       str)))


### PR DESCRIPTION
Shifts the `or` back inside `substring-no-properties` to guarantee that nil is never passed as an argument. Prevents `eldoc error: (stringp, nil)` from popping up when no symbol is at point.
