### PR TITLE
Bind C-c ` to cider-visit-error-buffer

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -774,8 +774,9 @@ The handler simply inserts the result value in BUFFER."
   "Visit the `cider-error-buffer' (usually *cider-error*) if it exists."
   (interactive)
   (let ((buffer (get-buffer cider-error-buffer)))
-    (when buffer
-      (cider-popup-buffer-display buffer))))
+    (if buffer
+        (cider-popup-buffer-display buffer cider-auto-select-error-buffer)
+      (message "No %s buffer found" cider-error-buffer))))
 
 (defun cider-find-property (property &optional backward)
   "Find the next text region which has the specified PROPERTY.

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -38,6 +38,7 @@
     (define-key map (kbd "M-,") 'cider-jump-back)
     (define-key map (kbd "M-TAB") 'complete-symbol)
     (define-key map (kbd "C-M-x") 'cider-eval-defun-at-point)
+    (define-key map (kbd "C-c `") 'cider-visit-error-buffer)
     (define-key map (kbd "C-c C-c") 'cider-eval-defun-at-point)
     (define-key map (kbd "C-x C-e") 'cider-eval-last-sexp)
     (define-key map (kbd "C-c C-e") 'cider-eval-last-sexp)

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1047,6 +1047,7 @@ ENDP) DELIM."
     (define-key map (kbd "C-c C-u") 'cider-repl-kill-input)
     (define-key map (kbd "C-a") 'cider-repl-bol)
     (define-key map (kbd "C-S-a") 'cider-repl-bol-mark)
+    (define-key map (kbd "C-c `") 'cider-visit-error-buffer)
     (define-key map [home] 'cider-repl-bol)
     (define-key map [S-home] 'cider-repl-bol-mark)
     (define-key map (kbd "C-<up>") 'cider-repl-backward-input)


### PR DESCRIPTION
Hi,

I am a bit disconserned by the current behavior of stack-trace auto popping I
used to disable `cider-popup-on-error` and call `cider-visit-error-buffer`
whenever I needed it.

In cider-dev cider-popup-on-error is not used anymore, and as a result there is
no way to generate stacktrace in the background. When `cider-popup-stacktraces`
is set to nil, stacktrace buffer is not generated at all. I think this is a bug.

Anyways, the proposed patch is a first step towards the user pattern I have just
described. I think more people might find it useful. Even if stacktrace pops on
error, <kbd>C-c `</kbd> is still useful when the stacktrace has been covered for
whatever reason.

Thanks.
