### PR TITLE
produce stacktrace buffer even when cider-popup-stacktraces is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ for presenting fontified documentation, including Javadoc.
 
 ### Changes
 
+* [#603](https://github.com/clojure-emacs/cider/pull/603) New variable
+`cider-show-error-buffer` to control the behavior of the error buffer. Obsoletes
+`cider-popup-on-error`, `cider-popup-stacktraces` and
+`cider-repl-popup-stacktraces`.
 * `cider-nrepl` is now required. Without it pretty much nothing will work.
 * Removed redundant command `cider-src`.
 * Renamed `nrepl-log-events` variable to `nrepl-log-messages`.

--- a/README.md
+++ b/README.md
@@ -189,20 +189,28 @@ following snippet:
 (setq cider-repl-pop-to-buffer-on-connect nil)
 ```
 
-* Stop the error buffer from popping up while working in buffers other
-than the REPL:
+* Configure whether the error buffer with stacktraces should be automatically
+  shown on error:
 
+  - Don't show on error:
+    
 ```el
-(setq cider-popup-stacktraces nil)
+    (setq cider-show-error-buffer nil)
+```    
+
+   Independently of the value of `cider-show-error-buffer`, the error buffer is
+   always generated in the background. Use `cider-visit-error-buffer` to visit
+   this buffer.
+
+  - Selective strategies:
+    
+```el
+    (setq cider-show-error-buffer 'except-in-repl) ; or
+    (setq cider-show-error-buffer 'only-in-repl)
 ```
 
-* Enable error buffer popping also in the REPL:
 
-```el
-(setq cider-repl-popup-stacktraces t)
-```
-
-* To disable auto-selection of the error (stacktrace) buffer when it's displayed:
+* To disable auto-selection of the error buffer when it's displayed:
 
 ```el
 (setq cider-auto-select-error-buffer nil)

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -73,13 +73,6 @@
   "Face for the result of an evaluation in the REPL buffer."
   :group 'cider-repl)
 
-(defcustom cider-repl-popup-stacktraces nil
-  "Non-nil means pop-up error stacktraces in the REPL buffer.
-Nil means show only an error message in the minibuffer.  This variable
-overrides `cider-popup-stacktraces' in REPL buffers."
-  :type 'boolean
-  :group 'cider-repl)
-
 (defcustom cider-repl-pop-to-buffer-on-connect t
   "Controls whether to pop to the REPL buffer on connect.
 


### PR DESCRIPTION
Fix the issues with stacktraces in #602. I have renamed the cider-popup-on-error because it wasn't really doing any popup and the name was conflicting with `cider-popup-stacktraces`.
