### PR TITLE
Move generally useful functions to cider-util.

### DIFF
--- a/cider-doc.el
+++ b/cider-doc.el
@@ -72,32 +72,15 @@
   :package-version '(cider . "0.7.0"))
 
 
-;; Colors
-
-(defun cider-doc-scale-color (color scale)
-  "For a COLOR hex string or name, adjust intensity of RGB components by SCALE."
-  (let* ((rgb (color-values color))
-         (scaled-rgb (mapcar (lambda (n)
-                               (format "%04x" (round (+ n (* scale 65535)))))
-                             rgb)))
-    (apply 'concat "#" scaled-rgb)))
-
-(defun cider-doc-scale-background-color ()
-  "Scale the current background color to get a slighted muted version."
-  (let ((color (frame-parameter nil 'background-color))
-        (dark (eq (frame-parameter nil 'background-mode) 'dark)))
-    (cider-doc-scale-color color (if dark 0.05 -0.05))))
+;; Colors & Theme Support
 
 (defvar cider-doc-code-background-color
-  (cider-doc-scale-background-color)
+  (cider-scale-background-color)
   "Background color for code blocks.")
-
-
-;; Theme Support
 
 (defadvice enable-theme (after cider-doc-adapt-to-theme activate)
   "When theme is changed, update `cider-doc-code-background-color'."
-  (setq cider-doc-code-background-color (cider-doc-scale-background-color)))
+  (setq cider-doc-code-background-color (cider-scale-background-color)))
 
 
 ;; Mode & key bindings

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -99,17 +99,6 @@
     (nrepl-send-request (list "op" "inspect-refresh")
                         (cider-render-response buffer))))
 
-;; Utilities
-(defmacro cider-propertize-region (props &rest body)
-  "Execute BODY and add PROPS to all the text it inserts.
-More precisely, PROPS are added to the region between the point's
-positions before and after executing BODY."
-  (let ((start (cl-gensym)))
-    `(let ((,start (point)))
-       (prog1 (progn ,@body)
-         (add-text-properties ,start (point) ,props)))))
-
-
 ;; Render Inspector from Structured Values
 (defun cider-irender (buffer str)
   (with-current-buffer buffer

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -166,17 +166,6 @@ joined together.")
     (set markname (make-marker))
     (set-marker (symbol-value markname) (point))))
 
-(defmacro cider-propertize-region (props &rest body)
-  "Add PROPS to all text inserted by executing BODY.
-More precisely, PROPS are added to the region between the point's
-positions before and after executing BODY."
-  (let ((start (make-symbol "start-pos")))
-    `(let ((,start (point)))
-       (prog1 (progn ,@body)
-         (add-text-properties ,start (point) ,props)))))
-
-(put 'cider-propertize-region 'lisp-indent-function 1)
-
 ;;; REPL init
 (defun cider-repl-buffer-name ()
   "Generate a REPL buffer name based on current connection buffer."
@@ -261,12 +250,6 @@ Insert a banner, unless NOPROMPT is non-nil."
                                   (cider-repl-buffer-name))))))))))
 
 ;;; REPL interaction
-(defun cider-property-bounds (prop)
-  "Return the the positions of the previous and next change to PROP.
-PROP is the name of a text property."
-  (assert (get-text-property (point) prop))
-  (let ((end (next-single-char-property-change (point) prop)))
-    (list (previous-single-char-property-change end prop) end)))
 
 (defun cider-repl--in-input-area-p ()
   "Return t if in input area."


### PR DESCRIPTION
Move `cider-propertize-region` (which was defined in two places) and `cider-property-bounds` to `cider-util`. Do the same with color scaling functions from `cider-doc`.
