### PR TITLE
[Fix #597] Don't process incomplete messages unless sure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ for presenting fontified documentation, including Javadoc.
 * `cider-select` can now switch to the `*cider-error*` buffer (bound to `x`).
 
 ### Changes
-
+* [#597](https://github.com/clojure-emacs/cider/issues/597) Don't process nREPL
+  messages unless the whole message has been received.
 * [#603](https://github.com/clojure-emacs/cider/pull/603) New variable
 `cider-show-error-buffer` to control the behavior of the error buffer. Obsoletes
 `cider-popup-on-error`, `cider-popup-stacktraces` and


### PR DESCRIPTION
The bencode decoder started driving me nuts. So, I decided to have a look and it turned to be a simple fix. It is still not a full proof solution but, it covers 99.99%  of cases without wasting decoding cycles on incomplete messages.

It probably also fixes the related #583 and #586.
