### PR TITLE
Include cider-test.el in package.

### DIFF
--- a/Cask
+++ b/Cask
@@ -3,5 +3,7 @@
 
 (package-file "cider.el")
 
+(files "*.el" (:exclude ".dir-locals.el"))
+
 (development
  (depends-on "noflet"))

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -24,7 +24,7 @@ apt emacs24 emacs24-el emacs24-common-non-dfsg \
     emacs-snapshot emacs-snapshot-el
 
 # Install Cask for Emacs dependency management
-CASK_VERSION=0.5.0
+CASK_VERSION=0.7.0
 CASK_DIR=/opt/cask-$CASK_VERSION
 CASK_ARCHIVE=https://github.com/cask/cask/archive/v$CASK_VERSION.tar.gz
 if ! [ -d "$CASK_DIR" -a -x "/$CASK_DIR/bin/cask" ]; then


### PR DESCRIPTION
Cask uses `package-default-files-spec`, which excludes `"*-test.el"`, by default.
