### PR TITLE
[Fix #626] Enable `cider-test-run-test` on any Clojure buffer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,7 @@ Keyboard shortcut                    | Description
 <kbd>C-c ,</kbd>                     | Run tests for namespace.
 <kbd>C-c C-,</kbd>                   | Re-run test failures/errors for namespace.
 <kbd>C-c M-,</kbd>                   | Run test at point.
+<kbd>C-c r</kbd>                     | Show the test report buffer.
 <kbd>M-.</kbd>                       | Jump to the definition of a symbol.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.
 <kbd>M-,</kbd>                       | Return to your pre-jump location.
 <kbd>M-TAB</kbd>                     | Complete the symbol at point.

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -63,6 +63,7 @@
     (define-key map (kbd "C-c C-j") 'cider-javadoc)
     (define-key map (kbd "C-c ,")   'cider-test-run-tests)
     (define-key map (kbd "C-c C-,") 'cider-test-rerun-tests)
+    (define-key map (kbd "C-c M-,") 'cider-test-run-test)
     (define-key map (kbd "C-c r")   'cider-test-show-report)
     (define-key map (kbd "C-c M-s") 'cider-selector)
     (define-key map (kbd "C-c M-r") 'cider-rotate-connection)
@@ -109,6 +110,11 @@
     ["Display documentation" cider-doc]
     ["Display JavaDoc" cider-javadoc]
     ["Inspect" cider-inspect]
+    "--"
+    ["Run test" cider-test-run-test]
+    ["Run all tests" cider-test-run-tests]
+    ["Rerun failed/erring tests" cider-test-rerun-tests]
+    ["Show test report" cider-test-show-report]
     "--"
     ["Set ns" cider-repl-set-ns]
     ["Switch to REPL" cider-switch-to-repl-buffer]

--- a/cider-test.el
+++ b/cider-test.el
@@ -425,13 +425,20 @@ displayed. When test failures/errors occur, their sources are highlighted."
     (message "No namespace to test in current context")))
 
 (defun cider-test-run-test ()
-  "Run the test at point."
+  "Run the test at point.
+The test ns/var exist as text properties on report items and on highlighted
+failed/erred test definitions. When not found, a test definition at point
+is searched."
   (interactive)
   (let ((ns  (get-text-property (point) 'ns))
         (var (get-text-property (point) 'var)))
     (if (and ns var)
         (cider-test-execute ns nil (list var))
-      (message "No test at point"))))
+      (let ((ns  (clojure-find-ns))
+            (def (clojure-find-def)))
+        (if (and ns (member (first def) '("deftest" "defspec")))
+            (cider-test-execute ns nil (rest def))
+          (message "No test at point"))))))
 
 (provide 'cider-test)
 


### PR DESCRIPTION
Previously this command was only enabled in the report buffer and on tests that had previous failures/errors. This requires `clojure-mode` [#238](https://github.com/clojure-emacs/clojure-mode/pull/238).

Also, update context menus and key binding documentation.
