### PR TITLE
Changes to the code that handles errors.  

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -809,7 +809,7 @@ This is controlled via `cider-interactive-eval-output-destination'."
                                (lambda (_buffer value)
                                  (cider-emit-interactive-eval-output value))
                                (lambda (buffer err)
-                                 (cider-emit-interactive-eval-output value)
+                                 (cider-emit-interactive-eval-output err)
                                  (cider-highlight-compilation-errors
                                   buffer err))
                                '()


### PR DESCRIPTION
There was a free/unbound variable.  Looks like a copy paste bug.

Note I am not sure how this ever really worked.
