### PR TITLE
Restore errantly removed 'cider-stacktrace-face'.

### DIFF
--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -86,6 +86,12 @@ If nil, messages will not be wrapped.  If truthy but non-numeric,
   :group 'cider-stacktrace
   :package-version '(cider . "0.6.0"))
 
+(defface cider-stacktrace-face
+  '((t (:inherit default)))
+  "Face for stack frame text"
+  :group 'cider-stacktrace
+  :package-version '(cider . "0.6.0"))
+
 (defface cider-stacktrace-ns-face
   '((t (:inherit font-lock-comment-face)))
   "Face for stack frame namespace name"


### PR DESCRIPTION
This was a mistaken clean-up casualty.
