### PR TITLE
Use cider variants of lisp-eval-region and eval-last-sexp in repl

### DIFF
--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1045,6 +1045,8 @@ ENDP) DELIM."
     (define-key map (kbd "C-c M-i") 'cider-inspect)
     (define-key map (kbd "C-c M-t") 'cider-toggle-trace)
     (define-key map (kbd "C-c C-x") 'cider-refresh)
+    (define-key map (kbd "C-x C-e") 'cider-eval-last-sexp)
+    (define-key map (kbd "C-c C-r") 'cider-eval-region)
     (define-key map (string cider-repl-shortcut-dispatch-char) 'cider-repl-handle-shortcut)
     (easy-menu-define cider-repl-mode-menu map
       "Menu for CIDER's REPL mode"


### PR DESCRIPTION
It's an odd use case, but using C-c C-r or C-x C-e inside of a
cider repl should not throw an error about missing an inferior lisp
process. It is useful for inspecting values in the middle of a longer
sexp. This adds the same bindings used in the cider minor mode to the repl.
