### PR TITLE
Shortcut for cider-pprint-eval-last-sexp in the repl

### DIFF
--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1019,6 +1019,7 @@ ENDP) DELIM."
     (define-key map (kbd "C-c C-x") 'cider-refresh)
     (define-key map (kbd "C-x C-e") 'cider-eval-last-sexp)
     (define-key map (kbd "C-c C-r") 'cider-eval-region)
+    (define-key map (kbd "C-c C-f") 'cider-pprint-eval-last-sexp)
     (define-key map (string cider-repl-shortcut-dispatch-char) 'cider-repl-handle-shortcut)
     (easy-menu-define cider-repl-mode-menu map
       "Menu for CIDER's REPL mode"


### PR DESCRIPTION
Per discussion at #535, I tried using `cider-pprint-eval-defun-at-point` bound
to `C-c C-f` as it is in the interactive minor mode. Unfortunately
defun-at-point is not as well defined at the repl for some reason, I noticed
similar while experimenting with `cider-eval-defun-at-point` at the repl. So I
tried it with `cider-pprint-eval-last-sexp`, as that seemed more useful. I
guess the mnemonic would be see form?

This at least improves the case where the repl returns a very large vector, map
or quoted list and it needs to be inspected visually. It doesn't reformat it
in-place but it is reformatted in the popup buffer. I also think this plays well
with the exiting pprint toggle in the repl as a shortcut.
