### PR TITLE
[Fix #633] Refactor `cider-find-` and `cider-jump-`.

### DIFF
--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -393,13 +393,13 @@ it wraps to 0."
         (class (button-get button 'class))
         (method (button-get button 'method))
         (line (button-get button 'line)))
-    (let* ((info (if var
-                     (cider-var-info var)
-                   (cider-member-info class method)))
-           (file (cadr (assoc "file" info))))
-      (if (and file line)
-          (cider-jump-to-def-for (vector file line))
-        (error "No source info")))))
+    (-if-let* ((info (if var
+                         (cider-var-info var)
+                       (cider-member-info class method)))
+               (file (cadr (assoc "file" info)))
+               (buffer (cider-find-file file)))
+        (cider-jump-to buffer line)
+      (message "No source info"))))
 
 (defun cider-stacktrace-jump ()
   "Like `cider-jump', but uses the stack frame source at point, if available."

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -539,6 +539,6 @@
            (cider-find-ns () "user"))
     (should (string= (cider-symbol-at-point) ""))))
 
-(ert-deftest test-cider--resource-file-url-to-filename ()
-  (should (equal "/space test" (cider--resource-file-url-to-filename "file:/space%20test")))
-  (should (equal "C:/space test" (cider--resource-file-url-to-filename "file:/C:/space%20test"))))
+(ert-deftest test-cider--url-to-file ()
+  (should (equal "/space test" (cider--url-to-file "file:/space%20test")))
+  (should (equal "C:/space test" (cider--url-to-file "file:/C:/space%20test"))))


### PR DESCRIPTION
The functions for resolving and jumping to vars and files had become unwieldy. This makes them tractable, and uses the simplified behavior to fix:

[Fix #633] The `cider-jump` and `cider-test-clear-highlights` cases where a var exists after the file in which it was defined has been deleted.

[Fix #659] The `cider-test-clear-highlights` case where the user closes one REPL session and starts another in a different project.
