### PR TITLE
Add apropos support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ for presenting fontified documentation, including Javadoc.
 integration.
 * [#22](https://github.com/clojure-emacs/cider/issues/22): New command
 `cider-jump-to-resource` (bound to <kbd>C-c M-.</kbd>).
+* [#664](https://github.com/clojure-emacs/cider/pull/664): New apropos support:
+search function/var names (bound to <kbd>C-c C-h a</kbd>) or documentation
+(bound to <kbd>C-c C-h d</kbd>).
 
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -568,6 +568,8 @@ Keyboard shortcut                    | Description
 <kbd>C-c M-.</kbd>                   | Jump to the resource referenced by the string at point.
 <kbd>M-,</kbd>                       | Return to your pre-jump location.
 <kbd>M-TAB</kbd>                     | Complete the symbol at point.
+<kbd>C-c C-h a</kbd>                 | Apropos search for functions/vars.
+<kbd>C-c C-h d</kbd>                 | Apropos search for documentation.
 
 ### cider-repl-mode
 

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -38,7 +38,9 @@
     (define-key map (kbd "M-,") 'cider-jump-back)
     (define-key map (kbd "C-c M-.") 'cider-jump-to-resource)
     (define-key map (kbd "M-TAB") 'complete-symbol)
-    (define-key map (kbd "C-M-x") 'cider-eval-defun-at-point)
+    (define-key map (kbd "C-c C-h a") 'cider-apropos)
+    (define-key map (kbd "C-c C-h d") 'cider-apropos-documentation)
+    (define-key map (kbd "C-M-x")   'cider-eval-defun-at-point)
     (define-key map (kbd "C-c C-c") 'cider-eval-defun-at-point)
     (define-key map (kbd "C-x C-e") 'cider-eval-last-sexp)
     (define-key map (kbd "C-c C-e") 'cider-eval-last-sexp)
@@ -94,6 +96,9 @@
         ["Jump to source" cider-jump]
         ["Jump to resource" cider-jump-to-resource]
         ["Jump back" cider-jump-back]
+        "--"
+        ["Search functions/vars" cider-apropos]
+        ["Search documentation" cider-apropos-documentation]
         "--"
         ["Display documentation" cider-doc]
         ["Display JavaDoc" cider-javadoc]


### PR DESCRIPTION
Add apropos search for function/var names (bound to <kbd>C-c C-h a</kbd>) and documentation (bound to <kbd>C-c C-h d</kbd>).
