### PR TITLE
Add standard key bindings for buttons in doc-mode.

### DIFF
--- a/cider-doc.el
+++ b/cider-doc.el
@@ -89,6 +89,8 @@
   (let ((map (make-sparse-keymap)))
     (define-key map "q" 'cider-popup-buffer-quit-function)
     (define-key map "j" 'cider-doc-javadoc)
+    (define-key map (kbd "<backtab>") 'backward-button)
+    (define-key map (kbd "TAB") 'forward-button)
     (easy-menu-define cider-doc-mode-menu map
       "Menu for CIDER's doc mode"
       '("Doc"


### PR DESCRIPTION
`TAB` - forward-button
`<backtab>` - backward-button

These are useful when the docs have URLs etc in them. This makes the navigation work the same as in help mode 
