### PR TITLE
Allow third value 'tidy for cider-macroexpansion-suppress-namespaces.

### DIFF
--- a/cider-macroexpansion.el
+++ b/cider-macroexpansion.el
@@ -36,9 +36,19 @@
 
 (push cider-macroexpansion-buffer cider-ancilliary-buffers)
 
-(defcustom cider-macroexpansion-suppress-namespaces nil
-  "When non-nil namespaces won't be displayed in the macroexpansion buffer."
-  :type 'boolean
+(defcustom cider-macroexpansion-suppress-namespaces 'tidy
+  "Determines if namespaces are displayed in the macroexpansion buffer.
+Possible values are:
+
+  nil   ;=> Vars are fully-qualified in the expansion
+  t     ;=> Vars are displayed without namespace qualification
+  'tidy ;=> Vars that are :refer-ed or defined in the current namespace are
+            displayed with their simple name, non-refered vars from other
+            namespaces are refered using the alias for that namespace (if
+            defined), other vars are displayed fully qualified."
+  :type '(choice (const :tag "Suppress namespaces" t)
+                 (const :tag "Show namespaces" nil)
+                 (const :tag "Show namespace aliases" tidy))
   :group 'cider
   :package-version '(cider . "0.7.0"))
 


### PR DESCRIPTION
This is the elisp part of the cider-nrepl feature pull request https://github.com/clojure-emacs/cider-nrepl/pull/100.

I've chosen `tidy` as third value, because it does even more than just printing alias/var for vars from aliased namespaces.  It also handles refered vars and vars in the current namespace.
