### PR TITLE
Create cider-doc-map and add "\C" versions of the keys when it makes sense.

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1396,7 +1396,7 @@ point, prompts for a var."
 (defun cider-create-doc-buffer (symbol)
   "Populates *cider-doc* with the documentation for SYMBOL."
   (-when-let (info (cider-var-info symbol))
-    (cider-doc-render (cider-make-popup-buffer cider-doc-buffer) symbol info)))
+    (cider-docview-render (cider-make-popup-buffer cider-doc-buffer) symbol info)))
 
 (defun cider-doc-lookup (symbol)
   "Look up documentation for SYMBOL."

--- a/cider-macroexpansion.el
+++ b/cider-macroexpansion.el
@@ -167,7 +167,7 @@ and point is placed after the expanded form."
         ["Macroexpand-all" cider-macroexpand-all-inplace]
         ["Go to source" cider-jump-to-var]
         ["Go to doc" cider-doc]
-        ["Go to Javadoc" cider-doc-javadoc]
+        ["Go to Javadoc" cider-docview-javadoc]
         ["Quit" cider-popup-buffer-quit-function]))
     (cl-labels ((redefine-key (from to)
                               (dolist (mapping (where-is-internal from cider-mode-map))

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -52,16 +52,11 @@ entirely."
 
 (defvar cider-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "M-.") 'cider-jump)
+    (define-key map (kbd "C-c C-d") 'cider-doc-map)
+    (define-key map (kbd "M-.") 'cider-jump-to-var)
     (define-key map (kbd "M-,") 'cider-jump-back)
     (define-key map (kbd "C-c M-.") 'cider-jump-to-resource)
     (define-key map (kbd "M-TAB") 'complete-symbol)
-    (define-key map (kbd "C-c C-d a") 'cider-apropos)
-    (define-key map (kbd "C-c C-d A") 'cider-apropos-documentation)
-    (define-key map (kbd "C-c C-d g") 'cider-grimoire)
-    (define-key map (kbd "C-c C-d h") 'cider-grimoire-web)
-    (define-key map (kbd "C-c C-d j") 'cider-javadoc)
-    (define-key map (kbd "C-c C-d d") 'cider-doc)
     (define-key map (kbd "C-M-x")   'cider-eval-defun-at-point)
     (define-key map (kbd "C-c C-c") 'cider-eval-defun-at-point)
     (define-key map (kbd "C-x C-e") 'cider-eval-last-sexp)
@@ -95,14 +90,16 @@ entirely."
     (define-key map (kbd "C-c C-q") 'cider-quit)
     (easy-menu-define cider-mode-menu map
       "Menu for CIDER mode"
-      '("CIDER"
+      `("CIDER"
         ["Complete symbol" complete-symbol]
+        "--"
+        ,cider-doc-menu
         "--"
         ["Eval top-level sexp at point" cider-eval-defun-at-point]
         ["Eval last sexp" cider-eval-last-sexp]
         ["Eval last sexp in popup buffer" cider-pprint-eval-last-sexp]
         ["Eval last sexp to REPL buffer" cider-eval-last-sexp-to-repl]
-        ["Eval last sexp and replace it with its result" cider-eval-last-sexp-and-replace]
+        ["Eval last sexp and replace" cider-eval-last-sexp-and-replace]
         ["Eval region" cider-eval-region]
         ["Eval ns form" cider-eval-ns-form]
         ["Insert last sexp in REPL" cider-insert-last-sexp-in-repl]
@@ -110,26 +107,19 @@ entirely."
         ["Load current buffer" cider-load-current-buffer]
         ["Load file" cider-load-file]
         "--"
-        ["Macroexpand-1 last expression" cider-macroexpand-1]
-        ["Macroexpand-all last expression" cider-macroexpand-all]
+        ["Macroexpand-1" cider-macroexpand-1]
+        ["Macroexpand-all" cider-macroexpand-all]
         "--"
-        ["Jump to source" cider-jump]
+        ["Jump to source" cider-jump-to-var]
         ["Jump to resource" cider-jump-to-resource]
         ["Jump back" cider-jump-back]
-        "--"
-        ["Search functions/vars" cider-apropos]
-        ["Search documentation" cider-apropos-documentation]
-        "--"
-        ["Display documentation" cider-doc]
-        ["Display JavaDoc" cider-javadoc]
-        ["Display Grimoire documentation" cider-grimoire]
-        ["Display Grimoire documentation in browser" cider-grimoire-web]
-        ["Inspect" cider-inspect]
         "--"
         ["Run test" cider-test-run-test]
         ["Run all tests" cider-test-run-tests]
         ["Rerun failed/erring tests" cider-test-rerun-tests]
         ["Show test report" cider-test-show-report]
+        "--"
+        ["Inspect" cider-inspect]
         "--"
         ["Set ns" cider-repl-set-ns]
         ["Switch to REPL" cider-switch-to-repl-buffer]
@@ -141,8 +131,8 @@ entirely."
         ["Quit" cider-quit]
         ["Restart" cider-restart]
         "--"
-        ["Display current nREPL connection" cider-display-current-connection-info]
-        ["Rotate current nREPL connection" cider-rotate-connection]
+        ["Display nREPL connection" cider-display-current-connection-info]
+        ["Rotate nREPL connection" cider-rotate-connection]
         "--"
         ["Version info" cider-version]))
     map))

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -32,6 +32,7 @@
 
 (require 'cider-client)
 (require 'cider-interaction)
+(require 'cider-doc)
 (require 'cider-eldoc) ; for cider-turn-on-eldoc-mode
 (require 'cider-util)
 
@@ -981,6 +982,7 @@ ENDP) DELIM."
 (defvar cider-repl-mode-map
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map clojure-mode-map)
+    (define-key map (kbd "C-c C-d") 'cider-doc-map)
     (define-key map (kbd "M-.") 'cider-jump)
     (define-key map (kbd "M-,") 'cider-jump-back)
     (define-key map (kbd "C-c M-.") 'cider-jump-to-resource)
@@ -988,12 +990,6 @@ ENDP) DELIM."
     (define-key map (kbd "TAB") 'cider-repl-tab)
     (define-key map (kbd "C-<return>") 'cider-repl-closing-return)
     (define-key map (kbd "C-j") 'cider-repl-newline-and-indent)
-    (define-key map (kbd "C-c C-d a") 'cider-apropos)
-    (define-key map (kbd "C-c C-d A") 'cider-apropos-documentation)
-    (define-key map (kbd "C-c C-d g") 'cider-grimoire)
-    (define-key map (kbd "C-c C-d h") 'cider-grimoire-web)
-    (define-key map (kbd "C-c C-d d") 'cider-doc)
-    (define-key map (kbd "C-c C-d j") 'cider-javadoc)
     (define-key map (kbd "C-c C-o") 'cider-repl-clear-output)
     (define-key map (kbd "C-c M-o") 'cider-repl-clear-buffer)
     (define-key map (kbd "C-c M-n") 'cider-repl-set-ns)
@@ -1026,24 +1022,19 @@ ENDP) DELIM."
     (define-key map (string cider-repl-shortcut-dispatch-char) 'cider-repl-handle-shortcut)
     (easy-menu-define cider-repl-mode-menu map
       "Menu for CIDER's REPL mode"
-      '("REPL"
+      `("REPL"
         ["Complete symbol" complete-symbol]
+        "--"
+        ,cider-doc-menu
         "--"
         ["Jump to source" cider-jump]
         ["Jump to resource" cider-jump-to-resource]
         ["Jump back" cider-jump-back]
         "--"
-        ["Search functions/vars" cider-apropos]
-        ["Search documentation" cider-apropos-documentation]
-        "--"
-        ["Display documentation" cider-doc]
-        ["Display JavaDoc" cider-javadoc]
-        ["Display Grimoire documentation" cider-grimoire]
-        ["Display Grimoire documentation in browser" cider-grimoire-web]
         ["Inspect" cider-inspect]
         "--"
         ["Set REPL ns" cider-repl-set-ns]
-        ["Toggle pretty printing of results" cider-repl-toggle-pretty-printing]
+        ["Toggle pretty printing" cider-repl-toggle-pretty-printing]
         ["Clear output" cider-repl-clear-output]
         ["Clear buffer" cider-repl-clear-buffer]
         ["Refresh loaded code" cider-refresh]


### PR DESCRIPTION
Very nice initiative to create a doc map. Thanks. 

This patch adds a couple of control prefixed keys. For my brain <kbd>C-c C-d C-d</kbd> is much more convenient than <kbd>C-c C-d d</kbd>.
