### PR TITLE
Don't make info request for empty symbol

### DIFF
--- a/cider-client.el
+++ b/cider-client.el
@@ -203,7 +203,7 @@ contain a `candidates' key, it is returned as is."
 
 When multiple matching vars are returned you'll be prompted to select one,
 unless ALL is truthy."
-  (when var
+  (when (and var (not (string= var "")))
     (let ((val (plist-get (nrepl-send-request-sync
                            (list "op" "info"
                                  "session" (nrepl-current-session)

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -83,7 +83,8 @@
                                       :done t))
            (nrepl-current-session () nil)
            (cider-current-ns () "user"))
-    (should (equal (cadr (assoc "doc" (cider-var-info "str"))) "stub" ))))
+          (should (equal (cadr (assoc "doc" (cider-var-info "str"))) "stub" ))
+          (should (not (cider-var-info "")))))
 
 (ert-deftest test-cider-get-var-attr ()
   (let ((var-info '(("doc" "var doc") ("arglists" "var arglists"))))


### PR DESCRIPTION
When the symbol is an empty string, don't request info on it.
