### PR TITLE
Fix macroexpansion

### DIFF
--- a/cider-macroexpansion.el
+++ b/cider-macroexpansion.el
@@ -70,7 +70,9 @@ This variable specifies both what was expanded and the expander.")
               (list "op" expander
                     "code" expr
                     "ns" (cider-current-ns)
-                    "suppress-namespaces" cider-macroexpansion-suppress-namespaces)) :value))
+                    "suppress-namespaces"
+                    (symbol-name cider-macroexpansion-suppress-namespaces)))
+             :value))
 
 (defun cider-macroexpand-expr (expander expr)
   "Macroexpand, use EXPANDER, the given EXPR."


### PR DESCRIPTION
Macro expansion was giveing a "nrepl-netstring: Wrong type argument: stringp, 
tidy" message.  This calls symbol-name on 
cider-macroexpansion-suppress-namespaces before passing it to 
nrepl-send-request-sync.
