### PR TITLE
Refactoring and documenting nrepl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## master (unreleased)
 
+### Changes
+
+* nrepl-client.el refactoring:
+
+  - `nrepl-send-request-sync` was renamed into `nrepl-send-sync-request` to comply
+  -  with the names of other 'sync' variables.
+
+  - nREPL requests are now named with `nrepl-request:OP` where "OP" stands for
+    the type of the request (eval, clone etc.). The following functions
+    were renamed:
+    
+       nrepl-send-string -> nrepl-request:eval
+       nrepl-send-string-sync -> nrepl-sync-request:eval
+       nrepl-send-interrupt -> nrepl-request:interrupt
+       nrepl-send-stdin -> nrepl-request:stdin
+       nrepl-describe-session -> nrepl-request:describe
+       nrepl-create-client-session -> nrepl-request:clone
+
+
 ## 0.7.0 / 2014-08-05
 
 ### New features

--- a/cider-client.el
+++ b/cider-client.el
@@ -103,7 +103,7 @@ NS & SESSION specify the context in which to evaluate the request."
                (not (string= ns nrepl-buffer-ns))
                (not (cider-ns-form-p input)))
       (cider-eval-ns-form))
-    (nrepl-send-string input callback ns session)))
+    (nrepl-request:eval input callback ns session)))
 
 (defun cider-tooling-eval (input callback &optional ns)
   "Send the request INPUT and register the CALLBACK as the response handler.
@@ -114,7 +114,7 @@ NS specifies the namespace in which to evaluate the request."
 (defun cider-eval-sync (input &optional ns session)
   "Send the INPUT to the nREPL server synchronously.
 NS & SESSION specify the evaluation context."
-  (nrepl-send-string-sync input ns session))
+  (nrepl-sync-request:eval input ns session))
 
 (defun cider-eval-and-get-value (input &optional ns session)
   "Send the INPUT to the nREPL server synchronously and return the value.
@@ -160,7 +160,7 @@ loaded."
   (interactive)
   (let ((pending-request-ids (cider-util--hash-keys nrepl-pending-requests)))
     (dolist (request-id pending-request-ids)
-      (nrepl-send-interrupt request-id (cider-interrupt-handler (current-buffer))))))
+      (nrepl-request:interrupt request-id (cider-interrupt-handler (current-buffer))))))
 
 (defun cider-current-repl-buffer ()
   "The current REPL buffer."
@@ -204,7 +204,7 @@ contain a `candidates' key, it is returned as is."
 When multiple matching vars are returned you'll be prompted to select one,
 unless ALL is truthy."
   (when (and var (not (string= var "")))
-    (let ((val (plist-get (nrepl-send-request-sync
+    (let ((val (plist-get (nrepl-send-sync-request
                            (list "op" "info"
                                  "session" (nrepl-current-session)
                                  "ns" (cider-current-ns)
@@ -218,7 +218,7 @@ unless ALL is truthy."
 (defun cider-member-info (class member)
   "Return the CLASS MEMBER's info as an alist with list cdrs."
   (when (and class member)
-    (let ((val (plist-get (nrepl-send-request-sync
+    (let ((val (plist-get (nrepl-send-sync-request
                            (list "op" "info"
                                  "session" (nrepl-current-session)
                                  "class" class

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -631,7 +631,7 @@ When called interactively, this operates on point."
   (interactive (list (thing-at-point 'filename)))
   (cider-ensure-op-supported "resource")
   (-if-let* ((resource (-> (list "op" "resource" "name" path)
-                         (nrepl-send-request-sync)
+                         (nrepl-send-sync-request)
                          (plist-get :value)))
              (buffer (cider-find-file resource)))
       (cider-jump-to buffer line)
@@ -702,7 +702,7 @@ form, with symbol at point replaced by __prefix__."
   "Return a list of completions for STR using nREPL's \"complete\" op."
   (cider-ensure-op-supported "complete")
   (let ((strlst (plist-get
-                 (nrepl-send-request-sync
+                 (nrepl-send-sync-request
                   (list "op" "complete"
                         "session" (nrepl-current-session)
                         "ns" nrepl-buffer-ns
@@ -1052,7 +1052,7 @@ If location could not be found, return nil."
 (defun cider-need-input (buffer)
   "Handle an need-input request from BUFFER."
   (with-current-buffer buffer
-    (nrepl-send-stdin (concat (read-from-minibuffer "Stdin: ") "\n")
+    (nrepl-request:stdin (concat (read-from-minibuffer "Stdin: ") "\n")
                       (cider-stdin-handler buffer))))
 
 
@@ -1597,7 +1597,7 @@ strings, include private vars, and be case sensitive."
                             ,@(when docs-p '("docs?" "t"))
                             ,@(when privates-p '("privates?" "t"))
                             ,@(when case-sensitive-p '("case-sensitive?" "t")))
-                        (nrepl-send-request-sync)
+                        (nrepl-send-sync-request)
                         (plist-get :value))))
       (cider-show-apropos summary results query docs-p)
     (message "No apropos matches for %S" query)))

--- a/cider-macroexpansion.el
+++ b/cider-macroexpansion.el
@@ -66,7 +66,7 @@ This variable specifies both what was expanded and the expander.")
 (defun cider-macroexpansion (expander expr)
   "Macroexpand, using EXPANDER, the given EXPR."
   (cider-ensure-op-supported expander)
-  (plist-get (nrepl-send-request-sync
+  (plist-get (nrepl-send-sync-request
               (list "op" expander
                     "code" expr
                     "ns" (cider-current-ns)

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -155,7 +155,7 @@ joined together.")
 (defun cider-repl-buffer-name ()
   "Generate a REPL buffer name based on current connection buffer."
   (with-current-buffer (get-buffer (nrepl-current-connection-buffer))
-    (nrepl-buffer-name nrepl-repl-buffer-name-template)))
+    (nrepl-make-buffer-name nrepl-repl-buffer-name-template)))
 
 (defun cider-create-repl-buffer ()
   "Create a REPL buffer."

--- a/cider.el
+++ b/cider.el
@@ -125,16 +125,12 @@ start the server."
           (let* ((nrepl-project-dir project-dir)
                  (cmd (format "%s %s" cider-lein-command cider-lein-parameters))
                  (default-directory (or project-dir default-directory))
-                 (nrepl-buffer-name (generate-new-buffer-name
-                                     (nrepl-server-buffer-name)))
+                 (serv-buf-name (generate-new-buffer-name (nrepl-server-buffer-name)))
                  (process
                   (progn
                     ;; the buffer has to be created before the proc:
-                    (get-buffer-create nrepl-buffer-name)
-                    (start-file-process-shell-command
-                     "nrepl-server"
-                     nrepl-buffer-name
-                     cmd))))
+                    (get-buffer-create serv-buf-name)
+                    (start-file-process-shell-command "nrepl-server" serv-buf-name cmd))))
             (set-process-filter process 'nrepl-server-filter)
             (set-process-sentinel process 'nrepl-server-sentinel)
             (set-process-coding-system process 'utf-8-unix 'utf-8-unix)

--- a/test/cider-tests--no-auto.el
+++ b/test/cider-tests--no-auto.el
@@ -45,7 +45,7 @@ leading line of all dashes and trailing nil (when no doc is present) are removed
 from the latter. Remaining content is compared for string equality."
   (let ((repl-doc (with-temp-buffer
                     (let ((form (format "(clojure.repl/doc %s)" sym)))
-                      (insert (plist-get (nrepl-send-string-sync form) :stdout))
+                      (insert (plist-get (nrepl-send-sync-request form) :stdout))
                       (goto-char (point-min))
                       (while (re-search-forward "^  nil\n" nil t)
                         (replace-match ""))

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -67,7 +67,7 @@
       (should (equal (cider-repl--banner) "; CIDER 0.5.1 (Java 1.7, Clojure 1.5.1, nREPL 0.2.1, cider-nrepl 0.2.1)")))))
 
 (ert-deftest test-cider-var-info ()
-  (noflet ((nrepl-send-request-sync (list)
+  (noflet ((nrepl-send-sync-request (list)
                                     `(:value
                                       (dict
                                        ("arglists" . "([] [x] [x & ys])")
@@ -242,19 +242,19 @@
   (should (equal "*template*"
                  (nrepl-format-buffer-name-template "*template%s*" ""))))
 
-(ert-deftest test-nrepl-buffer-name ()
+(ert-deftest test-nrepl-make-buffer-name ()
   (with-temp-buffer
     (setq-local nrepl-endpoint '("localhost" 1))
     (let ((b1 (current-buffer)))
       (should
-       (equal (nrepl-buffer-name "*buff-name%s*") "*buff-name localhost*")))))
+       (equal (nrepl-make-buffer-name "*buff-name%s*") "*buff-name localhost*")))))
 
-(ert-deftest test-nrepl-buffer-name-based-on-project ()
+(ert-deftest test-nrepl-make-buffer-name-based-on-project ()
   (with-temp-buffer
     (let ((b1 (current-buffer)))
       (setq-local nrepl-project-dir "proj")
       (should
-       (equal (nrepl-buffer-name "*buff-name%s*") "*buff-name proj*")))))
+       (equal (nrepl-make-buffer-name "*buff-name%s*") "*buff-name proj*")))))
 
 (ert-deftest test-nrepl-buffer-name-separator ()
   (with-temp-buffer
@@ -262,21 +262,21 @@
       (setq-local nrepl-project-dir "proj")
       (let ((nrepl-buffer-name-separator "X"))
         (should
-         (equal (nrepl-buffer-name "*buff-name%s*") "*buff-nameXproj*"))))))
+         (equal (nrepl-make-buffer-name "*buff-name%s*") "*buff-nameXproj*"))))))
 
 (ert-deftest test-nrepl-buffer-name-show-port-t ()
   (with-temp-buffer
     (setq-local nrepl-buffer-name-show-port t)
     (setq-local nrepl-endpoint '("localhost" 4009))
     (should
-     (equal (nrepl-buffer-name "*buff-name%s*") "*buff-name localhost:4009*"))))
+     (equal (nrepl-make-buffer-name "*buff-name%s*") "*buff-name localhost:4009*"))))
 
 (ert-deftest test-nrepl-buffer-name-show-port-nil ()
   (with-temp-buffer
     (setq-local nrepl-buffer-name-show-port nil)
     (setq-local nrepl-endpoint '("localhost" 4009))
     (should
-     (equal (nrepl-buffer-name "*buff-name%s*") "*buff-name localhost*"))))
+     (equal (nrepl-make-buffer-name "*buff-name%s*") "*buff-name localhost*"))))
 
 (ert-deftest test-nrepl-buffer-name-based-on-project-and-port ()
   (with-temp-buffer
@@ -284,19 +284,19 @@
     (setq-local nrepl-project-dir "proj")
     (setq-local nrepl-endpoint '("localhost" 4009))
     (should
-     (equal (nrepl-buffer-name "*buff-name%s*") "*buff-name proj:4009*"))))
+     (equal (nrepl-make-buffer-name "*buff-name%s*") "*buff-name proj:4009*"))))
 
-(ert-deftest test-nrepl-buffer-name-two-buffers-same-project ()
+(ert-deftest test-nrepl-make-buffer-name-two-buffers-same-project ()
   (with-temp-buffer
     (setq-local nrepl-project-dir "proj")
-    (let* ((cider-new-buffer (nrepl-buffer-name "*buff-name%s*")))
+    (let* ((cider-new-buffer (nrepl-make-buffer-name "*buff-name%s*")))
       (get-buffer-create cider-new-buffer)
       (should
        (equal cider-new-buffer "*buff-name proj*"))
       (with-temp-buffer
         (setq-local nrepl-project-dir "proj")
         (should
-         (equal (nrepl-buffer-name "*buff-name%s*") "*buff-name proj*<2>"))
+         (equal (nrepl-make-buffer-name "*buff-name%s*") "*buff-name proj*<2>"))
         (kill-buffer cider-new-buffer)))))
 
 (ert-deftest test-nrepl-buffer-name-duplicate-proj-port ()
@@ -304,7 +304,7 @@
     (setq-local nrepl-buffer-name-show-port t)
     (setq-local nrepl-project-dir "proj")
     (setq-local nrepl-endpoint '("localhost" 4009))
-    (let* ((cider-new-buffer (nrepl-buffer-name "*buff-name%s*")))
+    (let* ((cider-new-buffer (nrepl-make-buffer-name "*buff-name%s*")))
       (get-buffer-create cider-new-buffer)
       (should
        (equal cider-new-buffer "*buff-name proj:4009*"))
@@ -313,7 +313,7 @@
         (setq-local nrepl-project-dir "proj")
         (setq-local nrepl-endpoint '("localhost" 4009))
         (should
-         (equal (nrepl-buffer-name  "*buff-name%s*") "*buff-name proj:4009*<2>"))
+         (equal (nrepl-make-buffer-name "*buff-name%s*") "*buff-name proj:4009*<2>"))
         (kill-buffer cider-new-buffer)))))
 
 (ert-deftest test-cider-clojure-buffer-name ()

--- a/test/nrepl-bencode-tests.el
+++ b/test/nrepl-bencode-tests.el
@@ -1,52 +1,52 @@
 (require 'nrepl-client)
 
-(ert-deftest test-nrepl-decode-string ()
-  (should (equal '("spam") (nrepl-decode "4:spam"))))
+(ert-deftest test-nrepl-bdecode-string ()
+  (should (equal '("spam") (nrepl-bdecode-string "4:spam"))))
 
-(ert-deftest test-nrepl-decode-integer ()
-  (should (equal '(3) (nrepl-decode "i3e"))))
+(ert-deftest test-nrepl-bdecode-integer ()
+  (should (equal '(3) (nrepl-bdecode-string "i3e"))))
 
-(ert-deftest test-nrepl-decode-negative-integer ()
-  (should (equal '(-3) (nrepl-decode "i-3e"))))
+(ert-deftest test-nrepl-bdecode-negative-integer ()
+  (should (equal '(-3) (nrepl-bdecode-string "i-3e"))))
 
 (ert-deftest test-nrepl-bdecode-list ()
   (should (equal '(("spam" "eggs"))
-                 (nrepl-decode "l4:spam4:eggse"))))
+                 (nrepl-bdecode-string "l4:spam4:eggse"))))
 
 (ert-deftest test-nrepl-bdecode-dict ()
   (should (equal '((dict ("cow" . "moo") ("spam" . "eggs")))
-                 (nrepl-decode  "d3:cow3:moo4:spam4:eggse"))))
+                 (nrepl-bdecode-string  "d3:cow3:moo4:spam4:eggse"))))
 
-(ert-deftest test-nrepl-decode-nrepl-response-value ()
+(ert-deftest test-nrepl-bdecode-nrepl-response-value ()
   (should (equal '((dict
                      ("ns" . "user")
                      ("session" . "20c51458-911e-47ec-97c2-c509aed95b12")
                      ("value" . "2")))
-                 (nrepl-decode "d2:ns4:user7:session36:20c51458-911e-47ec-97c2-c509aed95b125:value1:2e"))))
+                 (nrepl-bdecode-string "d2:ns4:user7:session36:20c51458-911e-47ec-97c2-c509aed95b125:value1:2e"))))
 
-(ert-deftest test-nrepl-decode-nrepl-response-status ()
+(ert-deftest test-nrepl-bdecode-nrepl-response-status ()
   (should (equal '((dict
                     ("session" . "f30dbd69-7095-40c1-8e98-7873ae71a07f")
                     ("status" "done")))
-                 (nrepl-decode "d7:session36:f30dbd69-7095-40c1-8e98-7873ae71a07f6:statusl4:doneee"))))
+                 (nrepl-bdecode-string "d7:session36:f30dbd69-7095-40c1-8e98-7873ae71a07f6:statusl4:doneee"))))
 
-(ert-deftest test-nrepl-decode-nrepl-response-err ()
+(ert-deftest test-nrepl-bdecode-nrepl-response-err ()
   (should (equal '((dict
                     ("err" . "FileNotFoundException Could not locate seesaw/core__init.class or seesaw/core.clj on classpath:   clojure.lang.RT.load (RT.java:432)\n")
                     ("session" . "f30dbd69-7095-40c1-8e98-7873ae71a07f")))
-                 (nrepl-decode
+                 (nrepl-bdecode-string
 "d3:err133:FileNotFoundException Could not locate seesaw/core__init.class or seesaw/core.clj on classpath:   clojure.lang.RT.load (RT.java:432)\n7:session36:f30dbd69-7095-40c1-8e98-7873ae71a07fe"))))
 
-(ert-deftest test-nrepl-decode-nrepl-response-exception ()
+(ert-deftest test-nrepl-bdecode-nrepl-response-exception ()
   (should (equal '((dict
                      ("ex" . "class java.io.FileNotFoundException")
                      ("root-ex" . "class java.io.FileNotFoundException")
                      ("session" . "f30dbd69-7095-40c1-8e98-7873ae71a07f")
                      ("status" "eval-error")))
-                 (nrepl-decode
+                 (nrepl-bdecode-string
                   "d2:ex35:class java.io.FileNotFoundException7:root-ex35:class java.io.FileNotFoundException7:session36:f30dbd69-7095-40c1-8e98-7873ae71a07f6:statusl10:eval-erroree"))))
 
-(ert-deftest test-nrepl-decode-nrepl-doc-output ()
+(ert-deftest test-nrepl-bdecode-nrepl-doc-output ()
   (should (equal '((dict
                     ("id" . "18")
                     ("out" . "clojure.core/reduce\n")
@@ -68,7 +68,7 @@
                     ("id" . "18")
                     ("session" . "6fc999d0-3795-4d51-85fc-ccca7537ee57")
                     ("status" "done")))
-                 (nrepl-decode "d2:id2:183:out20:clojure.core/reduce
+                 (nrepl-bdecode-string "d2:id2:183:out20:clojure.core/reduce
 7:session36:6fc999d0-3795-4d51-85fc-ccca7537ee57ed2:id2:183:out24:([f coll] [f val coll])
 7:session36:6fc999d0-3795-4d51-85fc-ccca7537ee57ed2:id2:183:out588:  f should be a function of 2 arguments. If val is not supplied,
   returns the result of applying f to the first 2 items in coll, then
@@ -81,7 +81,7 @@
   items, returns val and f is not called.
 7:session36:6fc999d0-3795-4d51-85fc-ccca7537ee57ed2:id2:182:ns4:user7:session36:6fc999d0-3795-4d51-85fc-ccca7537ee575:value3:niled2:id2:187:session36:6fc999d0-3795-4d51-85fc-ccca7537ee576:statusl4:doneee"))))
 
-(ert-deftest test-nrepl-decode-nrepl-response-multibyte ()
+(ert-deftest test-nrepl-bdecode-nrepl-response-multibyte ()
   (should (equal '((dict
                     ("id" . "42")
                     ("ns" . "user")
@@ -91,11 +91,11 @@
                     ("id". "42")
                     ("session" . "3f586403-ed47-4e4d-b8db-70522054f971")
                     ("status" "done")))
-                 (nrepl-decode
+                 (nrepl-bdecode-string
                   "d2:id2:422:ns4:user7:session36:3f586403-ed47-4e4d-b8db-70522054f9715:value5:\"←\"ed2:id2:427:session36:3f586403-ed47-4e4d-b8db-70522054f9716:statusl4:doneee"))))
 
-(ert-deftest test-nrepl-decode-nils ()
+(ert-deftest test-nrepl-bdecode-nils ()
   (should (equal '(("" nil (dict ("" . nil))))
-                 (nrepl-decode "l0:led0:leee")))
+                 (nrepl-bdecode-string "l0:led0:leee")))
   (should (equal '(("" nil (dict ("" . 6))))
-                 (nrepl-decode "l0:led0:i6eee"))))
+                 (nrepl-bdecode-string "l0:led0:i6eee"))))


### PR DESCRIPTION
While I was learning how nrepl works I decided to help future generations and document and re-factor in a systematic way `nrepl-client.el`.  The code was very dificult to follow for two main reasons, not always intuitive or systematic naming conventions and pretty chaotic organization of the file. Client side was spread all over the place.

For readabilty purposes I have made the changes it in 3 steps. 
- First commit is a refactoring pass and consists of mostly variable and function name changes. Some, mostly stylistic, code  improvments are there. The changes should be pretty self explanatory from the diff.  
- Second commit is the re-organization of the file structure.  I have moved the stuff around in chapters, namely:
  - BENCODE
  - CLIENT: PROCESS FILTER
  - CLIENT: INITIALIZATION
  - CLIENT: RESPONSE HANDLING
  - CLIENT: REQUEST HANDLING
  - SERVER
  - UTILITIES
  - CONNECTION BUFFER MANAGEMENT
  - CONNECTION BROWSER
  
  There are no explicit code changes in this commit.
- Third commit is mostly the documentation changes. I have added a hopefully comprehensive documentation of the client-server communication both in the comment section and in each of sections. 
