### PR TITLE
Don't move point when clearing or highlighting test results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ bug for `tidy` namespace display.
 * Font-lock properly error messages in the REPL resulting from interactive evaluation.
 * [#671](https://github.com/clojure-emacs/cider/issues/671): Remove problematic code that was
 setting the REPL's initial ns based on lein's `:init-ns` option.
+* [#695](https://github.com/clojure-emacs/cider/issues/695): Keep point at
+  original position when clearing or highlighting test results.
 
 ## 0.7.0 / 2014-08-05
 

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -636,17 +636,13 @@ path or an entry within a zip/jar archive."
                      (set-auto-mode)
                      (current-buffer))))))))
 
-(defun cider-find-var (var)
-  "Return a buffer visiting the definition for VAR, or nil if not found."
+(defun cider-find-var-file (var)
+  "Return the buffer visiting the file in which VAR is defined, or nil if
+not found."
   (cider-ensure-op-supported "info")
   (-when-let* ((info (cider-var-info var))
-               (file (cadr (assoc "file" info)))
-               (line (cadr (assoc "line" info)))
-               (buffer (cider-find-file file)))
-    (with-current-buffer buffer
-      (goto-char (point-min))
-      (forward-line (1- line))
-      buffer)))
+               (file (cadr (assoc "file" info))))
+    (cider-find-file file)))
 
 (defun cider-jump-to (buffer &optional pos)
   "Push current point onto marker ring, and jump to BUFFER to position POS.
@@ -790,9 +786,14 @@ as it's not obvious from their names alone which is which."
 
 Returns the cons of the buffer itself and the location of VAR's definition
 in the buffer."
-  (-when-let (buffer (cider-find-var var))
+  (-when-let* ((info (cider-var-info var))
+               (file (cadr (assoc "file" info)))
+               (line (cadr (assoc "line" info)))
+               (buffer (cider-find-file file)))
     (with-current-buffer buffer
-      (cons buffer (point)))))
+      (save-excursion
+        (goto-line line)
+        (cons buffer (point))))))
 
 (defun cider-company-docsig (thing)
   "Return signature for THING."

--- a/cider-test.el
+++ b/cider-test.el
@@ -348,7 +348,7 @@ With the actual value, the outermost '(not ...)' s-expression is removed."
   (dolist (result (rest results))
     (-when-let* ((var (first result))
                  (tests (rest result))
-                 (buffer (cider-find-var (concat ns "/" var))))
+                 (buffer (cider-find-var-file (concat ns "/" var))))
       (dolist (test tests)
         (nrepl-dbind-response test (type)
           (unless (equal "pass" type)
@@ -360,7 +360,7 @@ With the actual value, the outermost '(not ...)' s-expression is removed."
   (-when-let (ns cider-test-last-test-ns)
     (dolist (result (rest cider-test-last-results))
       (-when-let* ((var (first result))
-                   (buffer (cider-find-var (concat ns "/" var))))
+                   (buffer (cider-find-var-file (concat ns "/" var))))
         (with-current-buffer buffer
           (remove-overlays))))))
 


### PR DESCRIPTION
When running tests with cider-test failing tests are highlighted in the source
files, or if tests are passing again previous highlights are cleared. The code
that does this is using the `cider-find-var` function to find the buffer for a
vars under test and then does it's job.

`cider-find-var` used to move point to the line at which the var was found. This
is a problematic side effect, because code using `cider-find-var` to find the
buffer can't use save-excursion because it doesn't know which buffer to safe
beforehand.

This PR removes the `goto-line` in `cider-find-var` and returns just the buffer
without any side effect. The `cider-company-location` uses similar code as
`cider-find-var` but with `save-excursion` wrapped around it.
