### PR TITLE
Add cider-undef with C-c C-u binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* New interactive command `cider-undef`.
 * First pass at a CIDER quick reference card.
 
 * `completion-at-point` now annotates functions, macros and special forms, thus making it

--- a/README.md
+++ b/README.md
@@ -560,6 +560,7 @@ Keyboard shortcut                    | Description
 <kbd>C-c C-d j</kbd>                   | Display JavaDoc (in your default browser) for the symbol at point.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.
 <kbd>C-c M-i</kbd>                   | Inspect expression. Will act on expression at point if present.
 <kbd>C-c M-t</kbd>                   | Toggle var tracing.
+<kbd>C-c C-u</kbd>                   | Undefine a symbol. If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.
 <kbd>C-c ,</kbd>                     | Run tests for namespace.
 <kbd>C-c C-,</kbd>                   | Re-run test failures/errors for namespace.
 <kbd>C-c M-,</kbd>                   | Run test at point.

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -145,7 +145,7 @@ which will use the default REPL connection."
     "inspect-start" "inspect-refresh"
     "inspect-pop" "inspect-push" "inspect-reset"
     "macroexpand" "macroexpand-1" "macroexpand-all"
-    "resource" "stacktrace" "toggle-trace")
+    "resource" "stacktrace" "toggle-trace" "undef")
   "A list of nREPL ops required by CIDER to function properly.
 
 All of them are provided by CIDER's nREPL middleware(cider-nrepl).")
@@ -1606,6 +1606,20 @@ strings, include private vars, and be case sensitive."
   "Shortcut for (cider-apropos <query> nil t)."
   (interactive)
   (cider-apropos (read-string "Clojure documentation Apropos: ") nil t))
+
+(defun cider-undef (symbol)
+  "Undefine the SYMBOL."
+  (interactive "P")
+  (cider-ensure-op-supported "undef")
+  (cider-read-symbol-name
+   "Undefine symbol: "
+   (lambda (sym)
+     (nrepl-send-request
+      (list "op" "undef"
+            "ns" (cider-current-ns)
+            "symbol" sym)
+      (cider-interactive-eval-handler (current-buffer))))
+   symbol))
 
 (defun cider-refresh ()
   "Refresh loaded code."

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -69,6 +69,7 @@ entirely."
     (define-key map (kbd "C-c C-r") 'cider-eval-region)
     (define-key map (kbd "C-c C-n") 'cider-eval-ns-form)
     (define-key map (kbd "C-c M-:") 'cider-read-and-eval)
+    (define-key map (kbd "C-c C-u") 'cider-undef)
     (define-key map (kbd "C-c C-m") 'cider-macroexpand-1)
     (define-key map (kbd "C-c M-m") 'cider-macroexpand-all)
     (define-key map (kbd "C-c M-n") 'cider-repl-set-ns)


### PR DESCRIPTION
Adds an undef command for removing a symbol from the current namespace.

Depends on https://github.com/clojure-emacs/cider-nrepl/pull/107
