### PR TITLE
Use repl buffer as connection buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ are used to translate filenames from/to the nREPL server (default Cygwin impleme
 
 ### Changes
 
+* REPL buffers are now connection buffers for REPL client connections.
+* Server and client cranking were isolated into `nrepl-start-server-process` and
+  `nrepl-start-client-process`.
+
 * nrepl-client.el refactoring:
 
   - `nrepl-send-request-sync` was renamed into `nrepl-send-sync-request` to comply

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -156,7 +156,7 @@ Signal an error if it is not supported."
   (unless (nrepl-op-supported-p op)
     (error "Can't find nREPL middleware providing op \"%s\".  Please, install (or update) cider-nrepl %s and restart CIDER" op cider-version)))
 
-(defun cider-verify-required-nrepl-ops ()
+(defun cider--check-required-nrepl-ops ()
   "Check whether all required nREPL ops are present."
   (let ((missing-ops (-remove 'nrepl-op-supported-p cider-required-nrepl-ops)))
     (when missing-ops
@@ -317,7 +317,7 @@ of the namespace in the Clojure source buffer."
   (let ((buffer (current-buffer)))
     (when (eq 4 arg)
       (cider-repl-set-ns (cider-current-ns)))
-    (pop-to-buffer (cider-find-or-create-repl-buffer))
+    (pop-to-buffer (cider-get-repl-buffer))
     (cider-remember-clojure-buffer buffer)
     (goto-char (point-max))))
 

--- a/cider-selector.el
+++ b/cider-selector.el
@@ -32,7 +32,7 @@
 
 (require 'cider-client)
 (require 'cider-interaction)
-(require 'cider-repl) ; for cider-find-or-create-repl-buffer
+(require 'cider-repl) ; for cider-get-repl-buffer
 
 (defconst cider-selector-help-buffer "*Selector Help*"
   "The name of the selector's help buffer.")
@@ -135,7 +135,7 @@ is chosen.  The returned buffer is selected with
 
 (def-cider-selector-method ?r
   "Current REPL buffer."
-  (cider-find-or-create-repl-buffer))
+  (cider-get-repl-buffer))
 
 (def-cider-selector-method ?n
   "Connections browser buffer."
@@ -153,7 +153,7 @@ is chosen.  The returned buffer is selected with
 (def-cider-selector-method ?s
  "Cycle to the next CIDER connection's REPL."
  (cider-rotate-connection)
- (cider-find-or-create-repl-buffer))
+ (cider-get-repl-buffer))
 
 (provide 'cider-selector)
 

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -96,19 +96,19 @@
            ,@body
          (mapc 'kill-buffer (list ,@buffer-names))))))
 
-(ert-deftest test-nrepl-make-repl-connection-default ()
+(ert-deftest test-nrepl-make-connection-default ()
   (let ((connections (nrepl-connection-buffers)))
     (cider-test-with-buffers
      (a b)
      (should (get-buffer a))
      (should (get-buffer b))
      ;; Add one connection
-     (nrepl-make-repl-connection-default a)
+     (nrepl-make-connection-default a)
      (should (equal (append (list (buffer-name a)) connections)
                     (nrepl-connection-buffers)))
      (should (equal (buffer-name a) (nrepl-current-connection-buffer)))
      ;; Add second connection
-     (nrepl-make-repl-connection-default b)
+     (nrepl-make-connection-default b)
      (should (equal (append (list (buffer-name b) (buffer-name a)) connections)
                     (nrepl-connection-buffers)))
      (should (equal (buffer-name b) (nrepl-current-connection-buffer))))))
@@ -117,8 +117,8 @@
   (let ((connections (nrepl-connection-buffers)))
     (cider-test-with-buffers
      (a b)
-     (nrepl-make-repl-connection-default a)
-     (nrepl-make-repl-connection-default b)
+     (nrepl-make-connection-default a)
+     (nrepl-make-connection-default b)
      ;; killing a buffer should see it purged from the connection list
      (kill-buffer a)
      (should (equal (append (list (buffer-name b)) connections)
@@ -168,8 +168,8 @@
   (let ((connections (nrepl-connection-buffers)))
     (cider-test-with-buffers
      (a b)
-     (nrepl-make-repl-connection-default a)
-     (nrepl-make-repl-connection-default b)
+     (nrepl-make-connection-default a)
+     (nrepl-make-connection-default b)
      ;; closing a buffer should see it removed from the connection list
      (nrepl-close a)
      (should (not (buffer-live-p a)))


### PR DESCRIPTION
This is a first comit on the road to replanting cider-repl on top of comint. 

 These are the related code adjustments that were (mostly) necessary for the patch:
- new functions `nrepl-start-client-process` and `nrepl-start-server-process`.
- `cider-init-repl-buffer` and `cider-create-repl-buffer` have clear cut
  separation of functionality
- `nrepl-make-buffer-name` and all `cider-create-xxx-buffer-name` take explicit
  dir, port and host variables.
- increase `nrepl-decode-timeout` to 0.025 for greater reliability
- merge `nrepl--handle-process-output` into client process filter
- remove `nrepl-connect` in favor of `nrepl-start-client-process`.
