### PR TITLE
[Fix #671] Increase `nrepl-sync-request-timeout' to 30 seconds

### DIFF
--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -115,7 +115,7 @@ The `nrepl-buffer-name-separator' separates cider-repl from the project name."
   :type 'string
   :group 'nrepl)
 
-(defcustom nrepl-sync-request-timeout 10
+(defcustom nrepl-sync-request-timeout 30
   "The number of seconds to wait for a sync response.
 Setting this to nil disables the timeout functionality."
   :type 'integer


### PR DESCRIPTION
When jvm starts for the first time, the very first sync request `(str *ns*)` timeouts. 

As `nrepl-send-sync-request` doesn't have an explicit treatment of timeout error (`keyboard-quit`) the cause of the issue wasn't easy to detect. I have stumbled on it by accident while working on #729. In  #729 I have also fixed the error reporting in this and a couple of other places.
