### PR TITLE
Cygwin support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 simpler to gain understanding of what you're using.
 * When invoked with a prefix argument `cider-quit` doesn't ask for confirmation.
 * Enhance stacktrace to definition navigation to work for interactively defined vars.
+* New vars: `cider-to-nrepl-filename-function` and `cider-from-nrepl-filename-function`
+are used to translate filenames from/to the nREPL server (default Cygwin implementation provided).
 
 ### Changes
 

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -557,3 +557,14 @@
                  (cider-grimoire-url "even?" "clojure.core" "1.5.1")))
   (should (equal "http://grimoire.arrdem.com/1.5.0/clojure.core/"
                  (cider-grimoire-url nil "clojure.core" "1.5.1"))))
+
+;;; Cygwin tests
+
+(ert-deftest cider-translate-filenames ()
+  (let ((windows-file-name "C:/foo/bar")
+        (unix-file-name "/cygdrive/c/foo/bar"))
+    (if (eq system-type 'cygwin)
+        (and (should (equal (funcall cider-from-nrepl-filename-function windows-file-name) unix-file-name))
+             (should (equal (funcall cider-to-nrepl-filename-function unix-file-name) windows-file-name)))
+      (and (should (eq (funcall cider-from-nrepl-filename-function unix-file-name) unix-file-name))
+           (should (eq (funcall cider-to-nrepl-filename-function unix-file-name) unix-file-name))))))


### PR DESCRIPTION
As discussed in #506, Cygwin requires _native <-> Cygwin_ filename translations.

In this new pull request  default translation functions are provided for Cygwin systems, so users don't have to setup this.
