### PR TITLE
Add a cider-print-level defcustom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New features
 
+* New defcustom `cider-stacktrace-print-level`.  Controls the `*print-level*` used when
+  pretty printing an exception cause's data.  Defaults to 50.
 * New interactive command `cider-undef`.
 * New interactive command `cider-clear-compilation-highlights`.
 * First pass at a CIDER quick reference card.

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -993,7 +993,10 @@ They exist for compatibility with `next-error'."
   "Display in BUFFER the last SESSION exception, with middleware support."
   (let (causes)
     (nrepl-send-request
-     (list "op" "stacktrace" "session" session)
+     (append
+      (list "op" "stacktrace" "session" session)
+      (if cider-stacktrace-print-level
+          (list "print-level" cider-stacktrace-print-level)))
      (lambda (response)
        (nrepl-dbind-response response (class status)
          (cond (class  (setq causes (cons response causes)))

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -53,6 +53,13 @@ If nil, messages will not be wrapped.  If truthy but non-numeric,
   :group 'cider-stacktrace
   :package-version '(cider . "0.6.0"))
 
+(defcustom cider-stacktrace-print-level 50
+  "Set the maximum level of nested data to print.
+Used when displaying stacktrace data (used for clojure's *print-level*)."
+  :type '(choice integer (const nil))
+  :group 'cider
+  :package-version '(cider . "0.8.0"))
+
 (defvar cider-stacktrace-detail-max 2
   "The maximum detail level for causes.")
 


### PR DESCRIPTION
Controls the depth of printing of a stacktrace cause's data.  Can be used to
prevent circular data structures from causing exceptions not to display.

Depends on https://github.com/clojure-emacs/cider-nrepl/pull/112
