### PR TITLE
Only show cider-test-report buffer on test failures.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ are used to translate filenames from/to the nREPL server (default Cygwin impleme
 * Renamed `cider-macroexpansion-suppress-namespaces` to `cider-macroexpansion-display-namespaces`.
 * [#652](https://github.com/clojure-emacs/cider/issues/652): Suppress eldoc when
 an error message is displayed in the minibuffer.
+* [#719](https://github.com/clojure-emacs/cider/issues/719) The customization
+variable `cider-test-show-report-on-success` controls now, whether to show the
+`*cider-test-report*` buffer on passing tests. The default is to not show the
+buffer.
 
 ### Bugs fixed
 

--- a/cider-test.el
+++ b/cider-test.el
@@ -41,6 +41,12 @@
   :prefix "cider-test-"
   :group 'cider)
 
+(defcustom cider-test-show-report-on-success nil
+  "Whether to show the `*cider-test-report*` buffer on passing tests."
+  :type 'boolean
+  :group 'cider-test
+  :package-version '(cider . "0.8.0"))
+
 (defvar cider-test-last-test-ns nil
   "The namespace for which tests were last run.")
 
@@ -403,14 +409,16 @@ displayed. When test failures/errors occur, their sources are highlighted."
        (cond ((member "namespace-not-found" status)
               (message "No tests namespace: %s" ns))
              (results
-              (progn
+              (nrepl-dbind-response summary (error fail)
                 (setq cider-test-last-test-ns ns)
                 (setq cider-test-last-results results)
                 (cider-test-highlight-problems ns results)
                 (cider-test-echo-summary summary)
-                (cider-test-render-report
-                 (cider-popup-buffer cider-test-report-buffer t)
-                 ns summary results))))))))
+                (when (or (cl-plusp (+ error fail))
+                          cider-test-show-report-on-success)
+                  (cider-test-render-report
+                   (cider-popup-buffer cider-test-report-buffer t)
+                   ns summary results)))))))))
 
 (defun cider-test-rerun-tests ()
   "Rerun failed and erring tests from the last tested namespace."


### PR DESCRIPTION
This PR doesn't show the _cider-test-report_ on successful tests anymore. Most
people will close that buffer anyway right after it popped up, and a message in
the echo area is probably enough to indicate that everything is fine. Setting
`cider-test-report-on-success` to `t` restores the old behaviour.
