### PR TITLE
Use `pop-to-buffer` in `cider-jump-to`.

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -696,7 +696,7 @@ When called interactively, this operates on point, or falls back to a prompt."
         (-if-let* ((ns (cadr (assoc "ns" info)))
                    (name (cadr (assoc "name" info)))
                    (buffer (cider-find-buffer ns))
-                   (pos (cider-locate-def buffer name)))
+                   (pos (cider-locate-def name buffer)))
             (cider-jump-to buffer pos)
           (message "No source available for %s" var)))
     (message "Symbol %s not resolved" var)))

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -412,7 +412,7 @@ it wraps to 0."
       (-if-let* ((ns (cadr (assoc "ns" info)))
                  (name (cadr (assoc "name" info)))
                  (buffer (cider-find-buffer ns))
-                 (pos (cider-locate-def buffer name)))
+                 (pos (cider-locate-def name buffer line)))
           (cider-jump-to buffer pos)
         (message "No source info")))))
 

--- a/cider-util.el
+++ b/cider-util.el
@@ -152,17 +152,21 @@ Unless you specify a BUFFER it will default to the current one."
     (--filter (equal ns (with-current-buffer it (clojure-find-ns))))
     (car)))
 
-(defun cider-locate-def (buffer name)
-  "Locate in BUFFER the definition of var NAME.
-This is a regexp search and currently works only for top level clojure
-forms that start with '(def'."
+(defun cider-locate-def (name buffer &optional offset-lines)
+  "Locate the definition of var NAME in BUFFER.
+When OFFSET-LINES is non-nil, adjust the returned position by this many
+lines. This is a regexp search and currently works only for top level
+clojure forms that start with '(def'."
   (with-current-buffer buffer
     (save-restriction
       (widen)
       (goto-char (point-min))
       (re-search-forward (format "(def.* %s\\( \\|$\\)" name)
                          nil 'no-error)
-      (goto-char (match-beginning 0)))))
+      (goto-char (match-beginning 0))
+      (when offset-lines
+        (forward-line (1- offset-lines)))
+      (point))))
 
 ;;; Strings
 


### PR DESCRIPTION
`cider-jump-to` displays the buffer even when it is already visible. 

Using `switch-to-buffer` in interactive use is almost always wrong. 
