### PR TITLE
Make `cider-find-file` to do a bit more work in finding the stacktrace file.

### DIFF
--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -402,7 +402,8 @@ it wraps to 0."
          (class (button-get button 'class))
          (method (button-get button 'method))
          (info (or (and var (cider-var-info var))
-                   (and class method (cider-member-info class method))))
+                   (and class method (cider-member-info class method))
+                   `(("file" ,(button-get button 'file)))))
          ;; stacktrace returns more accurate line numbers
          (info (cons `("line" ,(button-get button 'line))
                      info)))
@@ -461,8 +462,8 @@ This associates text properties to enable filtering and source navigation."
                                     (if (member 'clj flags) ns class)
                                     (if (member 'clj flags) fn method))
                             'var var 'class class 'method method
-                            'name name 'line line 'flags flags
-                            'follow-link t
+                            'name name 'file file 'line line
+                            'flags flags 'follow-link t
                             'action 'cider-stacktrace-navigate
                             'help-echo "View source at this location"
                             'face 'cider-stacktrace-face)


### PR DESCRIPTION
Try your best to find the file even if the file is relative. The last resort measure is to iterate through clojure buffers and expand the file in each of those till an existing file has been found. 

This fixes #740 on emacs side by using the relative files provided in stacktrace. Even if #740 is fixed on nrepl side I think this patch doesn't harm and might prove useful in other circumstances.

Based on #761.
