### PR TITLE
Fix "making delay-mode-hooks buffer-local" message

### DIFF
--- a/cider-util.el
+++ b/cider-util.el
@@ -98,9 +98,9 @@ PROP is the name of a text property."
     (insert string)
     ;; suppress major mode hooks as we care only about their font-locking
     ;; otherwise modes like whitespace-mode and paredit might interfere
-    (let ((delay-mode-hooks t)
-          (delayed-mode-hooks nil))
-      (funcall mode))
+    (setq-local delay-mode-hooks t)
+    (setq delayed-mode-hooks nil)
+    (funcall mode)
     (font-lock-fontify-buffer)
     (buffer-string)))
 


### PR DESCRIPTION
On evaluation I am always getting 

```
Making delay-mode-hooks buffer-local while locally let-bound!
```

Fix this by avoiding let; `delay-mode-hooks` need not be let-bound because it's a permanent local variable.
