### PR TITLE
Fix cider-connect with bencode parser

### DIFF
--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -662,7 +662,7 @@ server responses."
 (defun nrepl--make-default-handler ()
   "Default handler which is invoked when no handler is found.
 Handles only stdout and stderr responses."
-  (nrepl-make-response-handler (cider-current-repl-buffer)
+  (nrepl-make-response-handler (cider-get-repl-buffer)
                                ;; VALUE
                                '()
                                ;; STDOUT


### PR DESCRIPTION
I found myself unable to connect to a running REPL after #778

The error was:

```
error in process filter: nrepl-current-connection-buffer: No nREPL connection buffer
error in process filter: No nREPL connection buffer
```

I'm not familiar with the codebase, so I don't know if this is an appropriate fix.

Anyways, thanks for coming up with this @vitoshka !
