### PR TITLE
[fix #772] and fix broken `cider-eval-and-get-value`

### DIFF
--- a/cider-browse-ns.el
+++ b/cider-browse-ns.el
@@ -96,7 +96,7 @@
   (interactive (list (completing-read "Browse namespace: " (cider--all-ns))))
   (with-current-buffer (cider-popup-buffer cider-browse-ns-buffer t)
     (let* ((form "(sort (map name (keys (ns-publics (quote %s)))))")
-           (vars (cider-eval-and-get-value (format form namespace))))
+           (vars (cider-sync-eval-and-parse (format form namespace))))
       (cider-browse-ns-list (current-buffer)
                             namespace
                             (mapcar (lambda (var)
@@ -110,7 +110,7 @@
   "List all loaded namespaces in BUFFER."
   (interactive)
   (with-current-buffer (cider-popup-buffer cider-browse-ns-buffer t)
-    (let ((names (cider-eval-and-get-value
+    (let ((names (cider-sync-eval-and-parse
                   "(->> (all-ns)
                         (map ns-name)
                         (map name)
@@ -139,6 +139,8 @@
   (interactive "e")
   (cider-browse-ns-operate-on-point))
 
+
+(define-obsolete-variable-alias 'cider-eval-and-get-value 'cider-sync-eval-and-parse "0.8.0")
 
 (provide 'cider-browse-ns)
 

--- a/cider-client.el
+++ b/cider-client.el
@@ -116,24 +116,17 @@ NS specifies the namespace in which to evaluate the request."
 NS & SESSION specify the evaluation context."
   (nrepl-sync-request:eval input ns session))
 
-(defun cider-eval-and-get-value (input &optional ns session)
+(defun cider-sync-eval-and-parse (input &optional ns session)
   "Send the INPUT to the nREPL server synchronously and return the value.
-NS & SESSION specify the evaluation context."
-  (cider-get-value (cider-eval-sync input ns session)))
+NS & SESSION specify the evaluation context.  The output must be a readable
+Emacs list or a vector of other lists and vectors as `read' is used to
+convert the output into an Emacs object."
+  (read (plist-get (cider-eval-sync input ns session) :value)))
 
 (defun cider-tooling-eval-sync (input &optional ns)
   "Send the INPUT to the nREPL server using a tooling session synchronously.
 NS specifies the namespace in which to evaluate the request."
   (cider-eval-sync input ns (nrepl-current-tooling-session)))
-
-(defun cider-get-raw-value (eval-result)
-  "Get the raw value (as string) from EVAL-RESULT."
-  (plist-get eval-result :value))
-
-(defun cider-get-value (eval-result)
-  "Get the value from EVAL-RESULT."
-  (with-output-to-string
-    (message "%s" (cider-get-raw-value eval-result))))
 
 (defun cider-send-op (op attributes handler)
   "Send the specified OP with ATTRIBUTES and response HANDLER."

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1329,7 +1329,7 @@ If invoked with a PREFIX argument, print the result in the current buffer."
   (interactive)
   (let ((last-sexp (cider-last-sexp)))
     ;; we have to be sure the evaluation won't result in an error
-    (cider-eval-and-get-value last-sexp)
+    (cider-eval-sync last-sexp)
     ;; seems like the sexp is valid, so we can safely kill it
     (backward-kill-sexp)
     (cider-interactive-eval-print last-sexp)))
@@ -1400,7 +1400,7 @@ If invoked with a prefix ARG eval the expression after inserting it."
 (defun cider-ping ()
   "Check that communication with the server works."
   (interactive)
-  (message "%s" (cider-eval-and-get-value "\"PONG\"")))
+  (message "%s" (cider-sync-eval-and-parse "\"PONG\"")))
 
 (defun clojure-enable-cider ()
   "Turn on CIDER mode (see command `cider-mode').

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -656,7 +656,7 @@ text property `cider-old-input'."
 
 (defun cider--all-ns ()
   "Get a list of the available namespaces."
-  (cider-eval-and-get-value
+  (cider-sync-eval-and-parse
    "(clojure.core/map clojure.core/str (clojure.core/all-ns))"))
 
 (defun cider-repl-set-ns (ns)

--- a/test/cider-tests--no-auto.el
+++ b/test/cider-tests--no-auto.el
@@ -69,7 +69,7 @@ from the latter. Remaining content is compared for string equality."
 
 (defun cider-test-all-docs ()
   "Verify docs for all special forms and every public var in `clojure/core'."
-  (let ((syms (cider-eval-and-get-value
+  (let ((syms (cider-sync-eval-and-parse
                "(->> (merge @#'clojure.repl/special-doc-map
                      (->> (ns-map 'clojure.core)
                           (filter (every-pred


### PR DESCRIPTION
1efc9fa broke `cider--all-ns` and almost all of `cider-browse-ns`.  Fix  #772 for real and return `read` to `cider-eval-and-get-value` with an optional `no-read` argument. Also clean a couple of historical one-line functions which were used only once.
