### PR TITLE
Fix cider-jump-to

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -686,6 +686,7 @@ otherwise `switch-to-buffer'."
     (switch-to-buffer buffer))
   (with-current-buffer buffer
     (widen)
+    (goto-char (point-min))
     (forward-line (1- (or line 1)))
     (back-to-indentation)
     (cider-mode +1)))


### PR DESCRIPTION
The line number was being used relative to point.
