### PR TITLE
Name REPL buffers with `*clojure` prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ are used to translate filenames from/to the nREPL server (default Cygwin impleme
 
 ### Changes
 
+* Cider REPL buffers are now named with `clojure` prefix. 
 * bencode decoder was rewriten:
   - nREPL dicts are now plists and accessor api is given by `nrepl-dict-p`,
     `nrepl-dict-get` and `nrepl-dict-put`.

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -132,7 +132,7 @@ buffer will be hidden."
 
 ;;; nREPL Buffer Names
 
-(defconst nrepl-repl-buffer-name-template "*cider-repl%s*")
+(defconst nrepl-repl-buffer-name-template "*clojure%s*")
 (defconst nrepl-connection-buffer-name-template "*nrepl-connection%s*")
 (defconst nrepl-server-buffer-name-template "*nrepl-server%s*")
 (defconst nrepl-tunnel-buffer-name-template "*nrepl-tunnel%s*")

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -333,7 +333,7 @@
     (let ((b1 (current-buffer)))
       (let ((nrepl-connection-list (list (buffer-name b1))))
         (should
-         (equal (cider-repl-buffer-name) "*cider-repl localhost*"))))))
+         (equal (cider-repl-buffer-name) "*clojure localhost*"))))))
 
 (ert-deftest test-cider-clojure-buffer-name-w/project ()
   (with-temp-buffer
@@ -341,7 +341,7 @@
       (let ((nrepl-connection-list (list (buffer-name b1)))
             (nrepl-project-dir "/a/test/directory/project"))
         (should
-         (equal (cider-repl-buffer-name) "*cider-repl project*"))))))
+         (equal (cider-repl-buffer-name) "*clojure project*"))))))
 
 (ert-deftest test-cider--find-rest-args-position ()
   (should (= (cider--find-rest-args-position [fmt & arg]) 1))
@@ -486,7 +486,7 @@
                 (setq-local nrepl-server-buffer (buffer-name server-buffer)))
               (noflet ((read-string (dontcare) "bob"))
                 (cider-change-buffers-designation)
-                (should (equal "*cider-repl bob*" (buffer-name repl-buffer)))
+                (should (equal "*clojure bob*" (buffer-name repl-buffer)))
                 (should (equal "*nrepl-connection bob*" (buffer-name connection-buffer)))
                 (should (equal "*nrepl-server bob*" (buffer-name server-buffer))))
               (with-current-buffer repl-buffer
@@ -499,7 +499,7 @@
         (let* ((connection-buffer (current-buffer))
                (nrepl-connection-list (list (buffer-name connection-buffer))))
           (with-temp-buffer
-            (rename-buffer "*cider-repl bob*") ;; Make a buffer that already has the designation
+            (rename-buffer "*clojure bob*") ;; Make a buffer that already has the designation
             (with-temp-buffer
               (let* ((repl-buffer (current-buffer))
                      (before-repl-buffer-name (buffer-name repl-buffer))
@@ -523,7 +523,7 @@
            (nrepl-connection-list (list (buffer-name connection-buffer))))
       (with-temp-buffer
         (let ((repl-buffer (current-buffer)))
-          (rename-buffer "*cider-repl bob*")
+          (rename-buffer "*clojure bob*")
           (with-temp-buffer
             (with-current-buffer connection-buffer
               (setq-local nrepl-repl-buffer (buffer-name repl-buffer)))
@@ -535,7 +535,7 @@
            (nrepl-connection-list (list (buffer-name connection-buffer))))
       (with-temp-buffer
         (let ((repl-buffer (current-buffer)))
-          (rename-buffer "*cider-repl*")
+          (rename-buffer "*clojure*")
           (with-temp-buffer
             (with-current-buffer connection-buffer
               (setq-local nrepl-repl-buffer (buffer-name repl-buffer)))


### PR DESCRIPTION
Emacs convention is to name REPL buffers with language prefix and *cider-repl` prefix doesn't play well in switching buffers because of the redundancy with other buffers.

`cider` is never unique as a plethora of cider buffers can be floating around. `repl` is not unique either.`*nrepl-messages*`, `*nrepl-server<x>*`, `nrepl-client.el` are always there for me. Beside that, I have plenty of Gnus buffers that contain `replied` in them. So it's pretty difficult to switch to REPL buffers even with IDO. 

On the other hand `clojure` is an unique name and no confusion with other packages is likely to occur in the future.
