### PR TITLE
`cider-connect`: auto-detect ssh hosts and all running repls on local and remote hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## master (unreleased)
 
 ### New features
-
+* `cider-connect` now asks for remote hosts defined in machine-wide `ssh`
+  configuration files and automatically detects running instances of lein
+  server, both on local and remote machines.
 * New defcustom `cider-stacktrace-print-level`.  Controls the `*print-level*` used when
   pretty printing an exception cause's data.  Defaults to 50.
 * New interactive command `cider-undef`.

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -543,7 +543,9 @@ When invoked with a prefix ARG the command doesn't prompt for confirmation."
 Defaults to the current buffer.
 Return the tramp prefix, or nil if BUFFER is local."
   (let* ((buffer (or buffer (current-buffer)))
-         (name (buffer-file-name buffer)))
+         (name (or (buffer-file-name buffer)
+                   (with-current-buffer buffer
+                     default-directory))))
     (when (tramp-tramp-file-p name)
       (let ((vec (tramp-dissect-file-name name)))
         (tramp-make-tramp-file-name (tramp-file-name-method vec)

--- a/cider-util.el
+++ b/cider-util.el
@@ -157,6 +157,16 @@ to `fill-column'."
   "Join all STRINGS using SEPARATOR."
   (mapconcat 'identity strings separator))
 
+(defun cider-join-with-val-prop (candidates &optional sep)
+  "Each element EL in CANDIDATES join with SEP and set :val property to EL.
+Useful for `completing-read' when candidates are complex objects."
+  (mapcar (lambda (el)
+            (propertize (if (listp el)
+                            (cider-string-join el (or sep ":"))
+                          (format "%s" el))
+                        :val el))
+          candidates))
+
 (provide 'cider-util)
 
 ;;; cider-util.el ends here

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -455,25 +455,6 @@
       (dolist (buf (list b1 b2 b3 b1-repl b2-repl b3-repl))
         (kill-buffer buf)))))
 
-(ert-deftest test-cider-known-endpoint-candidates ()
-  (let ((cider-known-endpoints '(("label" "host" "port"))))
-    (noflet ((nrepl-current-host () "current-host")
-             (nrepl-default-port () "current-port"))
-      (should (equal '("current-host current-port" "label host port")
-                     (cider-known-endpoint-candidates))))))
-
-(ert-deftest test-cider-known-endpoint-candidates-remove-duplicates ()
-  (let ((cider-known-endpoints '(("label" "host" "port") ("label" "host" "port"))))
-    (noflet ((nrepl-current-host () "current-host")
-             (nrepl-default-port () "current-port"))
-      (should (equal '("current-host current-port" "label host port")
-                     (cider-known-endpoint-candidates))))))
-
-(ert-deftest test-cider-select-known-endpoint-remove-label ()
-  (noflet ((cider-known-endpoint-candidates () '())
-           (completing-read (dontcare dontcare) "label host port"))
-    (should (equal '("host" "port") (cider-select-known-endpoint)))))
-
 (ert-deftest test-cider-change-buffers-designation ()
   (with-temp-buffer
     (let ((server-buffer (current-buffer)))


### PR DESCRIPTION
Two main changes:
- `cider-connect` now interactively asks for host from a combined list of
  machine-wide ssh configuration and `cider-known-endpoints`.
  ![cider4](https://cloud.githubusercontent.com/assets/1363467/4297048/6562faf2-3e03-11e4-91f4-6619b7475736.png)
- Once the host has been selected `cider-connect` locates all running instances
  of lein servers. The machine must have `ps` and `grep` programs in the bin
  path.
  ![cider5](https://cloud.githubusercontent.com/assets/1363467/4297049/6a9982de-3e03-11e4-92e9-b6f88fc43e97.png)

The algorithm lists user processes with `ps` and retrives lein paths , then searches for `nrepl-port` files. This detection works fine if you run one server per project. If you run more servers at the same time lein will overwrite that file and will eventually delete it on first server exit. Hopefully this issue will be sorted soon in technomancy/leiningen#1686. 

It will probably not work on windows out of the box, but should not break anything.
