### PR TITLE
set pprint/*print-right-margin* to popup window width

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1344,23 +1344,24 @@ Print its value into the current buffer."
   (interactive)
   (cider-interactive-eval-print (cider-last-sexp)))
 
+(defun cider--pprint-form (form)
+  "Pretty print FORM in popup buffer."
+  (let* ((result-buffer (cider-popup-buffer cider-result-buffer nil 'clojure-mode))
+         (right-margin (max fill-column
+                            (1- (window-width (get-buffer-window result-buffer))))))
+    (cider-eval (cider-format-pprint-eval form right-margin)
+                (cider-popup-eval-out-handler result-buffer)
+                (cider-current-ns))))
+
 (defun cider-pprint-eval-last-sexp ()
   "Evaluate the sexp preceding point and pprint its value in a popup buffer."
   (interactive)
-  (let ((form (cider-last-sexp))
-        (result-buffer (cider-popup-buffer cider-result-buffer nil 'clojure-mode)))
-    (cider-eval (cider-format-pprint-eval form)
-                (cider-popup-eval-out-handler result-buffer)
-                (cider-current-ns))))
+  (cider--pprint-form (cider-last-sexp)))
 
 (defun cider-pprint-eval-defun-at-point ()
   "Evaluate the top-level form at point and pprint its value in a popup buffer."
   (interactive)
-  (let ((form (cider-defun-at-point))
-        (result-buffer (cider-popup-buffer cider-result-buffer nil 'clojure-mode)))
-    (cider-eval (cider-format-pprint-eval form)
-                (cider-popup-eval-out-handler result-buffer)
-                (cider-current-ns))))
+  (cider--pprint-form (cider-defun-at-point)))
 
 (defun cider-insert-in-repl (form eval)
   "Insert FORM in the REPL buffer and switch to it.

--- a/cider-util.el
+++ b/cider-util.el
@@ -134,9 +134,14 @@ Unless you specify a BUFFER it will default to the current one."
         (dark (eq (frame-parameter nil 'background-mode) 'dark)))
     (cider-scale-color color (if dark 0.05 -0.05))))
 
-(defun cider-format-pprint-eval (form)
-  "Return a string of Clojure code that will eval and pretty-print FORM."
-  (format "(clojure.core/let [x %s] (clojure.pprint/pprint x) x)" form))
+(defun cider-format-pprint-eval (form &optional right-margin)
+  "Return a string of Clojure code that will eval and pretty-print FORM.
+Pretty printing will avoid going beyond column RIGHT-MARGIN which defaults
+to `fill-column'."
+  (format "(clojure.core/let [x %s]
+             (binding [clojure.pprint/*print-right-margin* %d]
+               (clojure.pprint/pprint x)) x)"
+          form (or right-margin fill-column)))
 
 (autoload 'pkg-info-version-info "pkg-info.el")
 


### PR DESCRIPTION
I am also changing the clojure form to return nil. Why would it return the object if it's used for side effects only? 
