### PR TITLE
Refactor the interactive evaluation API

### DIFF
--- a/cider-client.el
+++ b/cider-client.el
@@ -154,16 +154,17 @@ unless ALL is truthy."
 
 ;;; Requests
 
-(defun cider-request:load-file (file-contents file-path file-name)
+(defun cider-request:load-file (file-contents file-path file-name &optional callback)
   "Perform the nREPL \"load-file\" op.
 FILE-CONTENTS, FILE-PATH and FILE-NAME are details of the file to be
-loaded."
+loaded. If CALLBACK is nil, use `cider-load-file-handler'."
   (nrepl-send-request (list "op" "load-file"
                             "session" (nrepl-current-session)
                             "file" file-contents
                             "file-path" file-path
                             "file-name" file-name)
-                      (cider-load-file-handler (current-buffer))))
+                      (or callback
+                          (cider-load-file-handler (current-buffer)))))
 
 
 ;;; Sync Requests


### PR DESCRIPTION
Before continuing on #815 I couldn't stop myself from cleaning up the interactive eval API. 

There is now one API entry point - `cider-interactive-eval`. All other commands are based on it. I am removing a couple of unnecessary API functions.  Entries like `cider-interactive-eval-in-repl` add naming redundancy with the corresponding handler. You can simply call `cider-interactive-eval` with `eval-in-repl` handler and the code will be just as clear. 

---

Other changes:
- The recent "dummy-file" change to interactive eval touched only two interactive 
  eval functions.  This patch completes the change.
- Simplify the code by removing unused or unnecessary API functions:
  `cider-interactive-eval-print`, `cider-popup-eval-print-handler`,
  `cider-popup-eval-print`, `cider-interactive-eval-to-repl`
- Rename `cider-interactive-eval-print-handler` -> `cider-eval-print-handler`.
- Bring all interactive eval functionality into one place and arrange
  functions in a logical order.
- `buffer` argument to interactive eval handlers is optional
