### PR TITLE
[Fix #814] Use `cider-current-ns` instead of `nrepl-buffer-ns`

### DIFF
--- a/cider-client.el
+++ b/cider-client.el
@@ -96,13 +96,7 @@ NS & SESSION specify the context in which to evaluate the request."
   ;; namespace forms are always evaluated in the "user" namespace
   (let ((ns (if (cider-ns-form-p input)
                 "user"
-              ns)))
-    ;; prevent forms from being evaluated in the wrong or a non-existing namespace
-    (when (and ns
-               (derived-mode-p 'clojure-mode)
-               (not (string= ns nrepl-buffer-ns))
-               (not (cider-ns-form-p input)))
-      (cider-eval-ns-form))
+              (or ns (cider-current-ns)))))
     (nrepl-request:eval input callback ns session)))
 
 (defun cider-tooling-eval (input callback &optional ns)

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -503,7 +503,7 @@ When invoked with a prefix ARG the command doesn't prompt for confirmation."
 (defun cider-symbol-at-point ()
   "Return the name of the symbol at point, otherwise nil."
   (let ((str (substring-no-properties (or (thing-at-point 'symbol) ""))))
-    (if (equal str (concat (cider-find-ns) "> "))
+    (if (equal str (concat (cider-current-ns) "> "))
         ""
       str)))
 
@@ -910,7 +910,6 @@ This is controlled via `cider-interactive-eval-output-destination'."
                                (lambda (buffer value)
                                  (message "%s" value)
                                  (with-current-buffer buffer
-                                   (setq nrepl-buffer-ns (clojure-find-ns))
                                    (run-hooks 'cider-file-loaded-hook)))
                                (lambda (_buffer value)
                                  (cider-emit-interactive-eval-output value))
@@ -1207,29 +1206,17 @@ If prefix argument KILL-BUFFER-P is non-nil, kill the buffer instead of burying 
       (ansi-color-apply-on-region (point-min) (point-max)))
     (goto-char (point-min))))
 
-;;; Namespace handling
-(defun cider-find-ns ()
-  "Return the ns of the current buffer.
-
-For Clojure buffers the ns is extracted from the ns header.  If
-it's missing \"user\" is used as fallback."
-  (cond
-   ((derived-mode-p 'clojure-mode)
-    (or (save-restriction
-          (widen)
-          (clojure-find-ns))
-        "user"))
-   ((derived-mode-p 'cider-repl-mode)
-    nrepl-buffer-ns)))
-
 (defun cider-current-ns ()
-  "Return the ns in the current context.
-If `nrepl-buffer-ns' has a value then return that, otherwise
-search for and read a `ns' form."
-  (let ((ns nrepl-buffer-ns))
-    (or (and (string= ns "user")
-             (cider-find-ns))
-        ns)))
+  "Return current ns.
+The ns is extracted from the ns form.  If missing, use current REPL's ns,
+otherwise fall back to \"user\"."
+  (if (derived-mode-p 'cider-repl-mode)
+      nrepl-buffer-ns
+    (or (clojure-find-ns)
+        (-when-let (repl-buf (cider-current-repl-buffer))
+          (buffer-local-value 'nrepl-buffer-ns (get-buffer repl-buf)))
+        nrepl-buffer-ns
+        "user")))
 
 
 ;;; Evaluation
@@ -1256,10 +1243,7 @@ START-POS is a starting position of the form in the original context."
                       ""
                     (or (-when-let (form (cider-ns-form))
                           (replace-regexp-in-string ":reload\\(-all\\)?\\>" "" form))
-                        (->> (get-buffer (cider-current-repl-buffer))
-                          (buffer-local-value 'nrepl-buffer-ns)
-                          (setq nrepl-buffer-ns)
-                          (format "(ns %s)")))))
+                        (format "(ns %s)" (cider-current-ns)))))
          (ns-form-lines (length (split-string ns-form "\n")))
          (start-pos (or start-pos 1))
          (start-line (line-number-at-pos start-pos))
@@ -1423,7 +1407,6 @@ See command `cider-mode'."
   (interactive)
   (dolist (buffer (cider-util--clojure-buffers))
     (with-current-buffer buffer
-      (setq nrepl-buffer-ns "user")
       (clojure-disable-cider))))
 
 (defun cider-possibly-disable-on-existing-clojure-buffers ()
@@ -1488,8 +1471,7 @@ The result of the completing read will be passed to COMPLETING-READ-CALLBACK."
 
 (defun cider-completing-read-sym-form (label form callback)
   "Eval the FORM and pass the result to the response handler."
-  (cider-tooling-eval form (cider-completing-read-sym-handler label callback (current-buffer))
-                      nrepl-buffer-ns))
+  (cider-tooling-eval form (cider-completing-read-sym-handler label callback (current-buffer))))
 
 (defun cider-completing-read-var (prompt ns callback)
   "Perform completing read var in NS using CALLBACK."
@@ -1513,12 +1495,13 @@ The result of the completing read will be passed to COMPLETING-READ-CALLBACK."
 Once selected, the name of the fn will appear in the repl buffer in parens
 ready to call."
   (interactive)
-  (cider-completing-read-sym-form (format "Fn: %s/" nrepl-buffer-ns)
-                                  (cider-fetch-fns-form (cider-current-ns))
-                                  (lambda (f _targets)
-                                    (with-current-buffer (cider-current-repl-buffer)
-                                      (cider-repl--replace-input (format "(%s)" f))
-                                      (goto-char (- (point-max) 1))))))
+  (let ((ns (cider-current-ns)))
+    (cider-completing-read-sym-form (format "Fn: %s/" ns)
+                                    (cider-fetch-fns-form ns)
+                                    (lambda (f _targets)
+                                      (with-current-buffer (cider-current-repl-buffer)
+                                        (cider-repl--replace-input (format "(%s)" f))
+                                        (goto-char (- (point-max) 1)))))))
 
 (defun cider-read-symbol-name (prompt callback &optional query)
   "Either read a symbol name using PROMPT or choose the one at point.
@@ -1531,7 +1514,7 @@ if there is no symbol at point, or if QUERY is non-nil."
                  (not symbol-name)
                  (equal "" symbol-name)))
         (funcall callback symbol-name)
-      (cider-completing-read-var prompt nrepl-buffer-ns callback))))
+      (cider-completing-read-var prompt (cider-current-ns) callback))))
 
 (defun cider-toggle-trace (query)
   "Toggle tracing for the given QUERY.
@@ -1735,12 +1718,6 @@ strings, include private vars, and be case sensitive."
   (cider-tooling-eval
    "(clojure.core/require 'clojure.tools.namespace.repl) (clojure.tools.namespace.repl/refresh)"
    (cider-interactive-eval-handler (current-buffer))))
-
-;; TODO: implement reloading ns
-(defun cider-eval-load-file (form)
-  "Load FORM."
-  (let ((buffer (current-buffer)))
-    (cider-eval form (cider-interactive-eval-handler buffer))))
 
 (defun cider-file-string (file)
   "Read the contents of a FILE and return as a string."

--- a/cider-macroexpansion.el
+++ b/cider-macroexpansion.el
@@ -85,7 +85,7 @@ This variable specifies both what was expanded and the expander.")
 (defun cider-macroexpand-again ()
   "Repeat the last macroexpansion."
   (interactive)
-  (cider-initialize-macroexpansion-buffer cider-last-macroexpand-expression nrepl-buffer-ns))
+  (cider-initialize-macroexpansion-buffer cider-last-macroexpand-expression (cider-current-ns)))
 
 ;;;###autoload
 (defun cider-macroexpand-1 (&optional prefix)

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -551,7 +551,7 @@ If NEWLINE is true then add a newline at the end of the input."
     (goto-char (point-max))
     (cider-repl--mark-input-start)
     (cider-repl--mark-output-start)
-    (cider-eval form (cider-repl-handler (current-buffer)) nrepl-buffer-ns)))
+    (cider-eval form (cider-repl-handler (current-buffer)))))
 
 (defun cider-repl-return (&optional end-of-input)
   "Evaluate the current input string, or insert a newline.

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -214,7 +214,7 @@ To be used for tooling calls (i.e. completion, eldoc, etc)")
 
 (defvar-local nrepl-completed-requests nil)
 
-(defvar-local nrepl-buffer-ns "user"
+(defvar-local nrepl-buffer-ns nil
   "Current Clojure namespace of this buffer.")
 
 (defvar-local nrepl-last-sync-response nil
@@ -624,6 +624,7 @@ the newly created client connection process."
             ;; FIXME: REPL and connection buffers are the same thing
             nrepl-connection-buffer client-buf
             nrepl-repl-buffer (when replp client-buf)
+            nrepl-buffer-ns "user"
             nrepl-tunnel-buffer (and tunnel-proc (process-buffer tunnel-proc))
             nrepl-pending-requests (make-hash-table :test 'equal)
             nrepl-completed-requests (make-hash-table :test 'equal)))
@@ -711,8 +712,6 @@ server responses."
     (nrepl-dbind-response response (value ns out err status id ex root-ex
                                           session)
       (cond (value
-             (with-current-buffer buffer
-               (when ns (setq nrepl-buffer-ns ns)))
              (when value-handler
                (funcall value-handler buffer value)))
             (out

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -530,7 +530,7 @@
 
 (ert-deftest cider-symbol-at-point-at-repl-prompt ()
   (noflet ((thing-at-point (thing) "user> ")
-           (cider-find-ns () "user"))
+           (cider-current-ns () "user"))
     (should (string= (cider-symbol-at-point) ""))))
 
 (ert-deftest test-cider--url-to-file ()


### PR DESCRIPTION
The recent interactive eval improvements essentially broke eldoc, completion and all other stuff that relies directly or indirectly on `nrepl-buffer-ns`. This has to do with the fact that `:load-file` op returns `:main` or "user" ns and cider's default handler eagerly sets it everywhere it can. Therefore, after each interactive evaluation `nrepl-buffer-ns` has a wrong value.

The usage of `nrepl-buffer-ns` is unavoidable in special buffers (repl, scratch, macroexpanion, doc etc). It also might be used as a cache in clojure buffers, but then it should be reset to nil in buffer modification hook.  It should be fine for now, but to fully set this issue straight one would need to set  we need to rewrite the response handling first. 

---

Other changes:
- Don't reset `nrepl-buffer-ns` in default response handler.
- Remove `cider-find-ns` (it's confusing to have two functions doing almost the same thing).
- Use nil global value of `nrepl-buffer-ns`. This will allow easy detection of cases when this variable is used but shouldn't.
