### PR TITLE
[Fix #828] Fix completion issues and don't forget current project directory in `cider-connect`

### DIFF
--- a/cider-util.el
+++ b/cider-util.el
@@ -157,14 +157,15 @@ to `fill-column'."
   "Join all STRINGS using SEPARATOR."
   (mapconcat 'identity strings separator))
 
-(defun cider-join-with-val-prop (candidates &optional sep)
-  "Each element EL in CANDIDATES join with SEP and set :val property to EL.
-Useful for `completing-read' when candidates are complex objects."
+(defun cider-join-into-alist (candidates &optional separator)
+  "Make an alist from CANDIDATES.
+The keys are the elements joined with SEPARATOR and values are the original
+elements. Useful for `completing-read' when candidates are complex
+objects."
   (mapcar (lambda (el)
-            (propertize (if (listp el)
-                            (cider-string-join el (or sep ":"))
-                          (format "%s" el))
-                        :val el))
+            (if (listp el)
+                (cons (cider-string-join el (or separator ":")) el)
+              (cons el el)))
           candidates))
 
 (provide 'cider-util)


### PR DESCRIPTION
- Add default values to fix `ido-ubiquitous` and standard `completing-read`
- Look into current project directory for `nrepl-port` files
- Generalize and rename `nrepl-default-port` -> `nrepl-extract-port`
- Make sure that ports are always found in the right host (when connecting from
  remote files to localhost, or connection to different remotes than the
  current file's host)
