### PR TITLE
[Fix #838] Create an alias for `eldoc-beginning-of-sexp'.

### DIFF
--- a/cider-eldoc.el
+++ b/cider-eldoc.el
@@ -36,7 +36,8 @@
 (require 'eldoc)
 (require 'dash)
 
-(unless (fboundp 'eldoc-beginning-of-sexp)                                                                              
+(when (and (not (fboundp 'eldoc-beginning-of-sexp))
+           (fboundp 'elisp--beginning-of-sexp))
   (defalias 'eldoc-beginning-of-sexp 'elisp--beginning-of-sexp))
 
 (defvar cider-extra-eldoc-commands '("yas-expand")


### PR DESCRIPTION
Proposed workaround for people that use emacs trunk.
