### PR TITLE
[c9fcff3] set *print-right-margin* in REPL window

### DIFF
--- a/cider-repl.el
+++ b/cider-repl.el
@@ -546,7 +546,7 @@ If NEWLINE is true then add a newline at the end of the input."
   (let* ((input (cider-repl--current-input))
          (form (if (and (not (string-match "\\`[ \t\r\n]*\\'" input))
                         cider-repl-use-pretty-printing)
-                 (cider-format-pprint-eval input)
+                 (cider-format-pprint-eval input (1- (window-width)))
                  input)))
     (goto-char (point-max))
     (cider-repl--mark-input-start)


### PR DESCRIPTION
It didn't occur to me last time that this could also be used in REPL.
