### PR TITLE
Fix broken stacktrace navigation to references of the form `foo/eval16959/fn`

### DIFF
--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -398,14 +398,14 @@ it wraps to 0."
 
 (defun cider-stacktrace-navigate (button)
   "Navigate to the stack frame source represented by the BUTTON."
-  (let* ((var (button-get button 'var))
-         (class (button-get button 'class))
-         (method (button-get button 'method))
-         (info (or (and var (cider-var-info var))
-                   (and class method (cider-member-info class method))
-                   `(dict "file" ,(button-get button 'file))))
-         ;; stacktrace returns more accurate line numbers
-         (info (nrepl-dict-put info "line" (button-get button 'line))))
+  (let ((info (-if-let* ((file (button-get button 'file))
+                         (line (button-get button 'line)))
+                  (nrepl-dict "file" file "line" line)
+                (let* ((var (button-get button 'var))
+                       (class (button-get button 'class))
+                       (method (button-get button 'method)))
+                  (or (and var (cider-var-info var))
+                      (and class method (cider-member-info class method)))))))
     (cider--jump-to-loc-from-info info t)))
 
 (defun cider-stacktrace-jump ()

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -300,6 +300,10 @@ If so ask the user for confirmation."
 
 ;;; nREPL dict
 
+(defun nrepl-dict (&rest key-vals)
+  "Create nREPL dict from KEY-VALS."
+  (cons 'dict key-vals))
+
 (defun nrepl-dict-p (object)
   "Return t if OBJECT is a nREPL dict."
   (and (listp object)


### PR DESCRIPTION
This used to work before the sync-request refactorinig. Because `cider-var-info` now returns a non-null value even for `no-info` case, the stacktrace info is never reached. 

Fix this by giving priority to stacktrace info whenever available.
