### PR TITLE
Fix broken stacktrace navigation to references of the form `foo/eval16959/fn`

### DIFF
--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -403,9 +403,12 @@ it wraps to 0."
          (method (button-get button 'method))
          (info (or (and var (cider-var-info var))
                    (and class method (cider-member-info class method))
-                   `(dict "file" ,(button-get button 'file))))
+                   (nrepl-dict)))
          ;; stacktrace returns more accurate line numbers
-         (info (nrepl-dict-put info "line" (button-get button 'line))))
+         (info (nrepl-dict-put info "line" (button-get button 'line)))
+         ;; give priority to `info` files as `info` returns full paths.
+         (info (nrepl-dict-put info "file" (or (nrepl-dict-get info "file")
+                                               (button-get button 'file)))))
     (cider--jump-to-loc-from-info info t)))
 
 (defun cider-stacktrace-jump ()

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -303,6 +303,10 @@ If so ask the user for confirmation."
 
 ;;; nREPL dict
 
+(defun nrepl-dict (&rest key-vals)
+  "Create nREPL dict from KEY-VALS."
+  (cons 'dict key-vals))
+
 (defun nrepl-dict-p (object)
   "Return t if OBJECT is a nREPL dict."
   (and (listp object)


### PR DESCRIPTION
I closed #850 prematurely and cannot reopen it now. The problem is not fixed. Sometimes info middleware doesn't return file location. In those cases just pick the file from stacktrace.