### PR TITLE
Easier to understand how to set up dependencies

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -160,7 +160,7 @@ All of them are provided by CIDER's nREPL middleware(cider-nrepl).")
   "Check for support of middleware op OP.
 Signal an error if it is not supported."
   (unless (nrepl-op-supported-p op)
-    (error "Can't find nREPL middleware providing op \"%s\".  Please, install (or update) cider-nrepl %s and restart CIDER" op cider-version)))
+    (error "Can't find nREPL middleware providing op \"%s\".  Please, install (or update) cider-nrepl %s and restart CIDER" op (upcase cider-version))))
 
 (defun cider--check-required-nrepl-ops ()
   "Check whether all required nREPL ops are present."
@@ -169,7 +169,7 @@ Signal an error if it is not supported."
       (cider-repl-emit-interactive-output
        (format "WARNING: The following required nREPL ops are not supported: \n%s\nPlease, install (or update) cider-nrepl %s and restart CIDER"
                (cider-string-join missing-ops " ")
-               cider-version)))))
+               (upcase cider-version))))))
 
 ;;; Connection info
 (defun cider--java-version ()


### PR DESCRIPTION
This variable is used when presenting a message to the user asking her to upgrade `cider-nrepl` to the correct version.
The user should upgrade to x.x.x-SNAPSHOT, not x.x.x-snapshot
