### PR TITLE
cider-repl-buffer was changed to cider-repl-name

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -758,7 +758,7 @@ form, with symbol at point replaced by __prefix__."
                           ;; Important because `beginning-of-defun' and
                           ;; `ending-of-defun' work incorrectly in the REPL
                           ;; buffer, so context extraction fails there.
-                          (not (eq major-mode 'cider-repl-buffer)))
+                          (not (eq major-mode 'cider-repl-mode)))
                      (or (cider-completion-get-context-at-point)
                          "nil")
                    "nil")))


### PR DESCRIPTION
Because of this Compliment requests from REPL try to send context, so it may be the reason for bugs like clojure-emacs/cider#549.
