### PR TITLE
Clean symbol before doing look up

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -492,13 +492,22 @@ When invoked with a prefix ARG the command doesn't prompt for confirmation."
              (bounds-of-thing-at-point 'sexp)))
       (bounds-of-thing-at-point 'sexp)))
 
+(defun cider--clean-symbol (symbol)
+  "Return SYMBOL cleaned so a dictionary match can be found."
+  (if (string-equal symbol "")
+      symbol
+      (let* ((symbol (if (string-equal (substring symbol 0 1) "@")
+                         (substring symbol 1)
+                       symbol)))
+        symbol)))
+
 ;; FIXME: This doesn't have properly at the beginning of the REPL prompt
 (defun cider-symbol-at-point ()
   "Return the name of the symbol at point, otherwise nil."
   (let ((str (substring-no-properties (or (thing-at-point 'symbol) ""))))
     (if (equal str (concat (cider-current-ns) "> "))
         ""
-      str)))
+      (cider--clean-symbol str))))
 
 (defun cider-sexp-at-point ()
   "Return the sexp at point as a string, otherwise nil."

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -532,6 +532,10 @@
            (cider-current-ns () "user"))
     (should (string= (cider-symbol-at-point) ""))))
 
+(ert-deftest cider-symbol-at-point-deref ()
+  (noflet ((thing-at-point (thing) "@user"))
+          (should (string= (cider-symbol-at-point) "user"))))
+
 (ert-deftest test-cider--url-to-file ()
   (should (equal "/space test" (cider--url-to-file "file:/space%20test")))
   (should (equal "C:/space test" (cider--url-to-file "file:/C:/space%20test"))))


### PR DESCRIPTION
If you attempt to run `cider-jump-to-var` to find the definition of an
atom dereferenced with `@`, cider can't find the source location. If you remove
the `@` cider has no issues finding the location. This allows for cleaning
non-variable components out of a symbol before doing the look up to prevent this
issue.

Possible fix for https://github.com/clojure-emacs/cider/issues/886
