### PR TITLE
[Fix #867] Update Grimoire URL to fix (cider-grimoire-lookup) regression due to HTTP 301 (Moved Permanently)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugs fixed
 
+* [#867](https://github.com/clojure-emacs/cider/issues/867): Update Grimoire URL to fix (cider-grimoire-lookup) regression due to HTTP 301 (Moved Permanently).
 * [#883](https://github.com/clojure-emacs/cider/issues/883): Encode properly the javadoc url.
 
 ## 0.8.1 / 2014-11-20

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ CIDER packs plenty of features. Here are some of them (in no particular order):
 * Value inspector
 * Function tracing
 * Interactive macroexpansion
-* [Grimoire](http://grimoire.arrdem.com/) integration
+* [Grimoire](http://conj.io/) integration
 * `clojure.test` integration
 * Classpath browser
 * Namespace browser

--- a/cider-grimoire.el
+++ b/cider-grimoire.el
@@ -27,7 +27,7 @@
 
 (require 'cider-interaction)
 
-(defconst cider-grimoire-url "http://grimoire.arrdem.com/")
+(defconst cider-grimoire-url "http://conj.io/")
 
 (defun cider-grimoire-replace-special (name)
   "Convert the dashes in NAME to a grimoire friendly format."

--- a/test/cider-grimoire-tests.el
+++ b/test/cider-grimoire-tests.el
@@ -11,7 +11,7 @@
   (should (equal (cider-grimoire-replace-special "/") "SLASH")))
 
 (ert-deftest cider-grimoire-url ()
-  (should (equal "http://grimoire.arrdem.com/1.5.0/clojure.core/even_QMARK/"
+  (should (equal "http://conj.io/1.5.0/clojure.core/even_QMARK/"
                  (cider-grimoire-url "even?" "clojure.core" "1.5.1")))
-  (should (equal "http://grimoire.arrdem.com/1.5.0/clojure.core/"
+  (should (equal "http://conj.io/1.5.0/clojure.core/"
                  (cider-grimoire-url nil "clojure.core" "1.5.1"))))


### PR DESCRIPTION
https://github.com/clojure-emacs/cider/issues/867#issuecomment-64121732
