### PR TITLE
[Fix #894] Fix (cider-javadoc) regression: unable to input Java class name when no "symbol-at-point".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugs fixed
 
+* [#894](https://github.com/clojure-emacs/cider/issues/894): Fix (cider-javadoc) regression "unable to input Java class name when not (symbol-at-point)" due to complecting (cider-read-symbol-name) and (cider-completing-read-var): Not all symbols are vars, e.g., Java classes on JVM.
 * [#867](https://github.com/clojure-emacs/cider/issues/867): Update Grimoire URL to fix (cider-grimoire-lookup) regression due to HTTP 301 (Moved Permanently).
 * [#883](https://github.com/clojure-emacs/cider/issues/883): Encode properly the javadoc url.
 

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -836,7 +836,7 @@ in the buffer."
 (defun cider-javadoc (query)
   "Browse Javadoc on the Java symbol QUERY at point."
   (interactive "P")
-  (cider-read-symbol-name "Javadoc for: " 'cider-javadoc-handler query))
+  (cider-read-symbol-name "Javadoc for: " 'cider-javadoc-handler query t))
 
 (defun cider-stdin-handler (&optional buffer)
   "Make a stdin response handler for BUFFER."
@@ -1542,18 +1542,19 @@ ready to call."
                                         (cider-repl--replace-input (format "(%s)" f))
                                         (goto-char (- (point-max) 1)))))))
 
-(defun cider-read-symbol-name (prompt callback &optional query)
+(defun cider-read-symbol-name (prompt callback &optional query notvarp)
   "Either read a symbol name using PROMPT or choose the one at point.
-Use CALLBACK as the completing read var callback.
-The user is prompted with PROMPT if a prefix argument is in effect,
-if there is no symbol at point, or if QUERY is non-nil."
+
+Use CALLBACK as the completing read var callback. The user is prompted with PROMPT if a prefix argument is in effect, if there is no symbol at point, or if QUERY is non-nil. Signal that the symbol is not a var (and hence not completing by var) if NOTVARP is t."
   (let ((symbol-name (cider-symbol-at-point)))
     (if (not (or current-prefix-arg
                  query
                  (not symbol-name)
                  (equal "" symbol-name)))
         (funcall callback symbol-name)
-      (cider-completing-read-var prompt (cider-current-ns) callback))))
+      (if notvarp
+          (funcall callback (cider-read-from-minibuffer prompt))
+        (cider-completing-read-var prompt (cider-current-ns) callback)))))
 
 (defun cider-sync-request:toggle-trace-var (symbol)
   "Toggle var tracing for SYMBOL."


### PR DESCRIPTION
The regression derives from complecting "cider-read-symbol-name" and "cider-completing-read-var": Not all symbols are vars, e.g., Java classes on JVM.

The current solution is to add an optional parameter "notvarp" to "cider-read-symbol-name": When "notvarp" is nil (the default), complete var by the current "cider-completing-read-var"; otherwise (when "notvarp" is t), use "cider-read-from-minibuffer". "cider-javadoc" can call "cider-read-symbol-name" with "notvarp" being t to bypass "cider-completing-read-var".

The logic is that, by its name, "cider-read-symbol-name" should work for both vars and non-var symbols (e.g., Java classes). However, most majority of current use of "cider-read-symbol-name" is for vars. So add a "notvarp" predicate (nil by default) would bridge the semantic gap between "cider-read-symbol-name" and "cider-completing-read-var" without disturbing most uses.

WISHLIST: If only there could be a completion function for Java classes, perhaps derived on the nrepl side by (ns-imports _ns_), ...
