### PR TITLE
Isolate `nrepl-client` connection logic from CIDER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### New features
 
 * Trigger Grimoire doc lookup from doc buffers by pressing <kbd>g</kbd> (in Emacs) and <kbd>G</kbd> (in browser).
+* [#903](https://github.com/clojure-emacs/cider/pull/903): Isolate
+  `nrepl-client` connection logic from CIDER. New hooks `cider-connected-hook`
+  and `cider-disconnected-hook`.
 
 ## 0.8.2 / 2014-12-21
 

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1801,10 +1801,6 @@ restart the server."
           (cider-jack-in prompt-project))
       (error "Can't restart CIDER for unknown project"))))
 
-(add-hook 'nrepl-connected-hook 'cider-enable-on-existing-clojure-buffers)
-(add-hook 'nrepl-disconnected-hook
-          'cider-possibly-disable-on-existing-clojure-buffers)
-
 (provide 'cider-interaction)
 
 ;;; cider-interaction.el ends here

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -162,16 +162,19 @@ PROJECT-DIR, PORT and HOST are as in `nrepl-make-buffer-name'."
                            (current-buffer))
     (nrepl-make-buffer-name nrepl-repl-buffer-name-template project-dir host port)))
 
-(defun cider-repl-create (&optional project-dir host port)
+(defun cider-repl-create (endpoint)
   "Create a REPL buffer and install `cider-repl-mode'.
-PROJECT-DIR, PORT and HOST are as in `nrepl-make-buffer-name'."
+ENDPOINT is a plist as returned by `nrepl-connect'."
   ;; Connection might not have been set as yet. Please don't send requests here.
-  (let ((buf (nrepl-make-buffer-name nrepl-repl-buffer-name-template
-                                     project-dir host port)))
+  (let ((buf (nrepl-make-buffer-name nrepl-repl-buffer-name-template nil
+                                     (plist-get endpoint :host)
+                                     (plist-get endpoint :port))))
     (with-current-buffer (get-buffer-create buf)
       (unless (derived-mode-p 'cider-repl-mode)
         (cider-repl-mode))
-      (cider-repl-reset-markers))
+      (cider-repl-reset-markers)
+      (add-hook 'nrepl-connected-hook 'cider--connected-handler nil 'local)
+      (add-hook 'nrepl-disconnected-hook 'cider--disconnected-handler nil 'local))
     buf))
 
 (defun cider-repl-require-repl-utils ()

--- a/cider.el
+++ b/cider.el
@@ -92,6 +92,18 @@ This variable is used by `cider-connect'."
   :type 'list
   :group 'cider)
 
+(defcustom cider-connected-hook nil
+  "List of functions to call when connected to Clojure nREPL server."
+  :type 'hook
+  :group 'cider
+  :version "0.9.0")
+
+(defcustom cider-disconnected-hook nil
+  "List of functions to call when disconnected from the Clojure nREPL server."
+  :type 'hook
+  :group 'cider
+  :version "0.9.0")
+
 (defvar cider-ps-running-nrepls-command "ps u | grep leiningen"
   "Process snapshot command used in `cider-locate-running-nrepl-ports'.")
 
@@ -118,7 +130,8 @@ start the server."
   (interactive "P")
   (setq cider-current-clojure-buffer (current-buffer))
   (if (cider--lein-present-p)
-      (let* ((project (when prompt-project
+      (let* ((nrepl-create-client-buffer-function  #'cider-repl-create)
+             (project (when prompt-project
                         (read-directory-name "Project: ")))
              (project-dir (nrepl-project-directory-for
                            (or project (nrepl-current-dir))))
@@ -140,7 +153,8 @@ Create REPL buffer and start an nREPL client connection."
   (interactive (cider-select-endpoint))
   (setq cider-current-clojure-buffer (current-buffer))
   (when (nrepl-check-for-repl-buffer `(,host ,port) nil)
-    (nrepl-start-client-process host port t)))
+    (let ((nrepl-create-client-buffer-function  #'cider-repl-create))
+      (nrepl-start-client-process host port))))
 
 (defun cider-select-endpoint ()
   "Interactively select the host and port to connect to."
@@ -233,6 +247,25 @@ In case `default-directory' is non-local we assume the command is available."
   (or (file-remote-p default-directory)
       (executable-find cider-lein-command)
       (executable-find (concat cider-lein-command ".bat"))))
+
+(defun cider--connected-handler ()
+  "Handle cider initialization after nREPL connection has been established.
+This function is appended to `nrepl-connected-hook' in the client process
+buffer."
+  ;; `nrepl-connected-hook' is run in connection buffer
+  (cider-repl-init (current-buffer))
+  (cider--check-required-nrepl-ops)
+  (cider--check-middleware-compatibility)
+  (cider-enable-on-existing-clojure-buffers)
+  (run-hooks 'cider-connected-hook))
+
+(defun cider--disconnected-handler ()
+  "Cleanup after nREPL connection has been lost or closed.
+This function is appended to `nrepl-disconnected-hook' in the client
+process buffer."
+  ;; `nrepl-connected-hook' is run in connection buffer
+  (cider-possibly-disable-on-existing-clojure-buffers)
+  (run-hooks 'cider-disconnected-hook))
 
 ;;;###autoload
 (eval-after-load 'clojure-mode


### PR DESCRIPTION
Hi Bozhidar,

I have just writen  a [nREPL client and server for R](https://github.com/vspinu/R-nREPL/tree/master/) and with this patch I can sucesfuly [connect/jack-in](https://github.com/vspinu/edamot/blob/master/edamot.el). There are a bunch of other, less critical, cider links that must be broken. I will be addressing those gradually. 

I hope you would be fine with spliting nrepl into a separte package eventually. 

Thanks.

---

Allow `nrepl-client` to be used by non CIDER frontends.
- Frontends can control the creation of the client buffer through
  `nrepl-create-client-buffer-function`.
- Each frontend has it's own `xxx-connected-hook` which is run by
  `xxx--connected-handler`. The latter function is placed in the local
  `nrepl-connected-hook` during the client buffer initialization. Similarly for
  `xxx-disconnected-hook`.
- Rename `nrepl--init-connection-buffer` -> nrepl--init-capabilities
