### PR TITLE
Set comment-start and comment-end in cider-repl-mode.

### DIFF
--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1049,6 +1049,8 @@ constructs."
 
 \\{cider-repl-mode-map}"
   (lisp-mode-variables nil)
+  (setq-local comment-start ";")
+  (setq-local comment-end "")
   (setq-local lisp-indent-function 'clojure-indent-function)
   (setq-local indent-line-function 'lisp-indent-line)
   (make-local-variable 'completion-at-point-functions)


### PR DESCRIPTION
Fix #888.
