### PR TITLE
Fix certain documentation urls not opening on OS X.

### DIFF
--- a/cider-doc.el
+++ b/cider-doc.el
@@ -159,7 +159,7 @@
   "Open the Javadoc for the current class, if available."
   (interactive)
   (if cider-docview-javadoc-url
-      (browse-url cider-docview-javadoc-url)
+      (browse-url (url-encode-url cider-docview-javadoc-url))
     (message "No Javadoc available for %s" cider-docview-symbol)))
 
 (defun cider-docview-source ()
@@ -319,7 +319,7 @@ Tables are marked to be ignored by line wrap."
                               'url url
                               'follow-link t
                               'action (lambda (x)
-                                        (browse-url (button-get x 'url))))
+                                        (browse-url (url-encode-url (button-get x 'url)))))
           (newline))
         (when javadoc
           (newline)
@@ -329,7 +329,7 @@ Tables are marked to be ignored by line wrap."
                               'url javadoc
                               'follow-link t
                               'action (lambda (x)
-                                        (browse-url (button-get x 'url))))
+                                        (browse-url (url-encode-url (button-get x 'url)))))
           (insert ".")
           (newline))
         (let ((beg (point-min))


### PR DESCRIPTION
For an example of a url that wouldn't load, see the cider-doc view for Integer/parseInt.
(browse-url "http://docs.oracle.com/javase/7/docs/api/java/lang/Integer.html#parseInt(java.lang.String, int)")
does not work on OS X. Emacs issues the command

```
open 'http://docs.oracle.com/javase/7/docs/api/java/lang/Integer.html#parseInt(java.lang.String, int)'
```

which does not work correctly: you are sent to http://docs.oracle.com/javase/7/docs/api/java/lang/Integer.html%23parseInt(java.lang.String,%20int)

Url-encoding the input to browse-url fixes this.

I'm sure about the change to the javadoc button.
I'm sure about the change to cider-docview-javadoc.
I'm not sure about the change to the url button, since I don't know how to find
documentation for which this button actually gets created.

I have not tested this on any platform except OS X.
