### PR TITLE
Ensure text property keys are symbols.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#824](https://github.com/clojure-emacs/cider/issues/824): Fix REPL font-locking.
 * [#888](https://github.com/clojure-emacs/cider/issues/888): Handle comments in `cider-repl-mode`.
 * [#830](https://github.com/clojure-emacs/cider/issues/830): Stop using `load-file` for most interactive evaluation commands.
+* [#885](https://github.com/clojure-emacs/cider/issues/885): Translate nREPL-delivered map keys to symbols before adding as text properties.
 
 ## 0.8.1 / 2014-11-20
 

--- a/cider-test.el
+++ b/cider-test.el
@@ -270,7 +270,7 @@ With the actual value, the outermost '(not ...)' s-expression is removed."
   "Emit into BUFFER report detail for the TEST assertion."
   (with-current-buffer buffer
     (nrepl-dbind-response test (var context type message expected actual error)
-      (cider-propertize-region (cdr test)
+      (cider-propertize-region (cider-intern-keys (cdr test))
         (cider-insert (capitalize type) (cider-test-type-face type) nil " in ")
         (cider-insert var 'font-lock-function-name-face t)
         (when context  (cider-insert context 'font-lock-doc-face t))

--- a/cider-util.el
+++ b/cider-util.el
@@ -67,6 +67,14 @@ buffer-local wherever it is set."
 
 ;;; Text properties
 
+(defun cider-maybe-intern (name)
+  "If NAME is a symbol, return it; otherwise, intern it."
+  (if (symbolp name) name (intern name)))
+
+(defun cider-intern-keys (props)
+  "Copy plist-style PROPS with any non-symbol keys replaced with symbols."
+  (-map-indexed (lambda (i x) (if (oddp i) x (cider-maybe-intern x))) props))
+
 (defmacro cider-propertize-region (props &rest body)
   "Execute BODY and add PROPS to all the text it inserts.
 More precisely, PROPS are added to the region between the point's


### PR DESCRIPTION
Maps received via nREPL have string keys.  The Emacs Lisp text property functions expect all property keys to be symbols.  Thus we must first intern any non-symbol property keys prior to applying them as text properties.  Fixes #885.
