### PR TITLE
update `make tests` and add note to README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,4 @@ elpaclean : clean
 	rm -rf .cask # Clean packages installed for development
 
 %.elc : %.el
-	$(CASK) exec $(EMACS) --no-site-file --no-site-lisp --batch \
-	$(EMACSFLAGS) \
-	-f batch-byte-compile $<
+	$(CASK) build

--- a/README.md
+++ b/README.md
@@ -967,6 +967,9 @@ Run all tests with:
 $ make test
 ```
 
+(Note: tests may not run correctly inside Emacs' shell-mode buffers. Running
+in a terminal is recommended.)
+
 ## License
 
 Copyright © 2012-2014 Tim King, Phil Hagelberg, Bozhidar Batsov, Hugo


### PR DESCRIPTION
Uses `cask build` to byte-compile .elc files so that tests run with cask 0.7.2 and adds an explanatory note to the README about running tests in a terminal instead of Emacs. Resolves #922.
