### PR TITLE
[Fix #924] Ensure buffer local variable is not cleared by mode change.

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1205,8 +1205,8 @@ If prefix argument KILL is non-nil, kill the buffer instead of burying it."
     (erase-buffer)
     (when mode
       (funcall mode))
-    (setq-local cider-popup-output-marker (point-marker))
     (cider-popup-buffer-mode 1)
+    (setq-local cider-popup-output-marker (point-marker))
     (setq buffer-read-only t)
     (current-buffer)))
 


### PR DESCRIPTION
Fixes [#924](https://github.com/clojure-emacs/cider/issues/924)

Buffer local variable when creating a new popup buffer will not be cleared by major modes.
