### PR TITLE
[Fix #921] Non-interactive `cider-jump-to-var`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
 * [#934](https://github.com/clojure-emacs/cider/issues/934): Remove
   `cider-turn-on-eldoc-mode` in favor of simply using `eldoc-mode`.
 
+### Bugs fixed
+
+* [#921](https://github.com/clojure-emacs/cider/issues/921): Fixed
+  non-functioning `cider-test-jump` from test reports.
+
 ## 0.8.2 / 2014-12-21
 
 ### Bugs fixed

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -717,16 +717,22 @@ OTHER-WINDOW is passed to `cider-jamp-to'."
         (cider-jump-to buffer (cons line nil) other-window)
       (message "No source location"))))
 
+(defun cider--jump-to-var (var &optional line)
+  "Jump to the definition of VAR, optionally at a specific LINE."
+  (-if-let (info (cider-var-info var))
+      (progn
+        (if line (setq info (nrepl-dict-put info "line" line)))
+        (cider--jump-to-loc-from-info info))
+    (message "Symbol %s not resolved" var)))
+
 (defun cider-jump-to-var (&optional var line)
   "Jump to the definition of VAR, optionally at a specific LINE.
 When called interactively, this operates on point, or falls back to a prompt."
   (interactive)
   (cider-ensure-op-supported "info")
-  (cider-read-symbol-name
-   "Symbol: " (lambda (var)
-                (-if-let (info (cider-var-info var))
-                    (cider--jump-to-loc-from-info info)
-                  (message "Symbol %s not resolved" var)))))
+  (if var
+      (cider--jump-to-var var line)
+    (cider-read-symbol-name "Symbol: " #'cider--jump-to-var)))
 
 (define-obsolete-function-alias 'cider-jump 'cider-jump-to-var "0.7.0")
 (defalias 'cider-jump-back 'pop-tag-mark)


### PR DESCRIPTION
Commit b130451 broke non-interactive use of `cider-jump-to-var`, which in turn broke `cider-test-jump`.  This commit fixes the former issue and thus also fixes the latter.

I'm not sure I follow what the naming convention for the internal helper function should be.  I'll gladly update if there's a better choice.