### PR TITLE
[Fix #949] Define custom cider-default-project-type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   `nrepl-client` connection logic from CIDER. New hooks `cider-connected-hook`
   and `cider-disconnected-hook`.
 * [#920](https://github.com/clojure-emacs/cider/issues/920): Support `cider-jack-in` for boot-based projects.
+* [#949](https://github.com/clojure-emacs/cider/issues/949): New custom var: `cider-default-repl-command`.
 
 ### Changes
 

--- a/cider.el
+++ b/cider.el
@@ -98,6 +98,15 @@ version from the CIDER package or library.")
   :group 'cider
   :package-version '(cider . "0.9.0"))
 
+(defcustom cider-default-repl-command
+  "lein"
+  "Determines the default command and parameters to use when connecting to nREPL.
+This value will only be consulted when no identifying file types, ie project.clj for
+leiningen or build.boot for boot, could be found."
+  :type 'string
+  :group 'cider
+  :package-version '(cider . "0.9.0"))
+
 (defcustom cider-known-endpoints nil
   "Specify a list of custom endpoints where each endpoint is a list.
 For example: '((\"label\" \"host\" \"port\")).
@@ -158,7 +167,7 @@ If PROMPT-PROJECT is t, then prompt for the project for which to
 start the server."
   (interactive "P")
   (setq cider-current-clojure-buffer (current-buffer))
-  (let ((project-type (cider-project-type)))
+  (let ((project-type (or (cider-project-type) cider-default-repl-command)))
     (if (funcall (cider-command-present-p project-type))
         (let* ((nrepl-create-client-buffer-function  #'cider-repl-create)
                (project (when prompt-project


### PR DESCRIPTION
Custom var is used with `cider-jack-in` when connecting to project-less REPLs.

(Both Leiningen and Boot support REPLs outside of projects: Cider users can choose which command to default to.)