### PR TITLE
Use sshx instead of ssh in cider-select-endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 * [#934](https://github.com/clojure-emacs/cider/issues/934): Remove
   `cider-turn-on-eldoc-mode` in favor of simply using `eldoc-mode`.
+* [#953](https://github.com/clojure-emacs/cider/pull/953) Use `sshx` instead of `ssh` in `cider-select-endpoint`
 
 ### Bugs fixed
 

--- a/cider.el
+++ b/cider.el
@@ -207,7 +207,7 @@ Create REPL buffer and start an nREPL client connection."
                          (let* ((change-dir-p (file-remote-p default-directory))
                                 (default-directory (if change-dir-p "~/" default-directory)))
                            (cider-locate-running-nrepl-ports (unless change-dir-p default-directory)))
-                       (let ((vec (vector "ssh" nil host "" nil))
+                       (let ((vec (vector "sshx" nil host "" nil))
                              ;; might connect to a different remote
                              (dir (when (file-remote-p default-directory)
                                     (with-parsed-tramp-file-name default-directory cur


### PR DESCRIPTION
I modified `cider-select-endpoint` function to use `sshx` instead of `ssh`.

`sshx` is similar to `ssh` well. `sshx` just opens a connection with `ssh -t -t host -l user /bin/sh`.

This means

- It tries to avoid any non-standard shell configuration on the remote host
- It tries to allocate a pseudo tty

So this is useful for users where normal login shell is configured heavily such as it asks them a number of questions when logging in.
This is also useful for users using well-configured `.ssh/config` and `ssh-agent`.
(And [the official document](http://www.gnu.org/software/tramp/) says Windows users will get some benefit, though I couldn't check it.)

Probably, this change is related to #822.

cf. <http://www.gnu.org/software/tramp/>