### PR TITLE
[#955] Reuse existing repl buffer when cleint process has died

### DIFF
--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -1187,12 +1187,19 @@ found."
         (error "No nREPL connection buffer"))))
 
 (defun nrepl-connection-buffers ()
-  "Return the connection list.
-Purge the dead buffers from the `nrepl-connection-list' beforehand."
+  "Return the list of connection buffers."
   (setq nrepl-connection-list
         (-remove (lambda (buffer)
                    (not (buffer-live-p (get-buffer buffer))))
                  nrepl-connection-list)))
+
+(defun nrepl-repl-buffers ()
+  "Return the list of REPL buffers.
+Purge the dead buffers from the `nrepl-connection-list' beforehand."
+  (-filter
+   (lambda (buffer)
+     (with-current-buffer buffer (derived-mode-p 'cider-repl-mode)))
+   (buffer-list)))
 
 ;; FIXME: Bad user api; don't burden users with management of
 ;; the connection list, same holds for `cider-rotate-connection'.


### PR DESCRIPTION
This addresses only the user case when the port is preserved. When port is not preserved, new repl buffer is generated as before.  This makes me wonder if port should be part of the buffer name in the first place. It makes repl buffer re-usage difficult.