### PR TITLE
Add support for pprint middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 * [#920](https://github.com/clojure-emacs/cider/issues/920): Support `cider-jack-in` for boot-based projects.
 * [#949](https://github.com/clojure-emacs/cider/issues/949): New custom var: `cider-default-repl-command`.
 * New code formatting commands - `cider-format-buffer`, `cider-format-region` and `cider-format-defun`.
+* Pretty printing functionality moved to middleware, adding support for ClojureScript.
+  - New command to eval and pprint result: `cider-interactive-pprint-eval`.
+  - `cider-format-pprint-eval` has been removed.
 
 ### Changes
 

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -551,15 +551,14 @@ If NEWLINE is true then add a newline at the end of the input."
         ;; by kill/yank.
         (overlay-put overlay 'read-only t)
         (overlay-put overlay 'font-lock-face 'cider-repl-input-face))))
-  (let* ((input (cider-repl--current-input))
-         (form (if (and (not (string-match "\\`[ \t\r\n]*\\'" input))
-                        cider-repl-use-pretty-printing)
-                 (cider-format-pprint-eval input (1- (window-width)))
-                 input)))
+  (let* ((input (cider-repl--current-input)))
     (goto-char (point-max))
     (cider-repl--mark-input-start)
     (cider-repl--mark-output-start)
-    (nrepl-request:eval form (cider-repl-handler (current-buffer)))))
+    (if (and (not (string-match "\\`[ \t\r\n]*\\'" input))
+             cider-repl-use-pretty-printing)
+        (nrepl-request:pprint-eval input (cider-repl-handler (current-buffer)) nil nil (1- (window-width)))
+      (nrepl-request:eval input (cider-repl-handler (current-buffer))))))
 
 (defun cider-repl-return (&optional end-of-input)
   "Evaluate the current input string, or insert a newline.

--- a/cider-util.el
+++ b/cider-util.el
@@ -142,15 +142,6 @@ Unless you specify a BUFFER it will default to the current one."
         (dark (eq (frame-parameter nil 'background-mode) 'dark)))
     (cider-scale-color color (if dark 0.05 -0.05))))
 
-(defun cider-format-pprint-eval (form &optional right-margin)
-  "Return a string of Clojure code that will eval and pretty-print FORM.
-Pretty printing will avoid going beyond column RIGHT-MARGIN which defaults
-to `fill-column'."
-  (format "(clojure.core/let [x %s]
-             (binding [clojure.pprint/*print-right-margin* %d]
-               (clojure.pprint/pprint x)) x)"
-          form (or right-margin fill-column)))
-
 (autoload 'pkg-info-version-info "pkg-info.el")
 
 (defun cider--version ()

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -945,6 +945,22 @@ Register CALLBACK as the response handler."
 If NS is non-nil, include it in the request. SESSION defaults to current session."
   (nrepl-send-request (nrepl--eval-request input ns session) callback))
 
+(defun nrepl--pprint-eval-request (input &optional ns session right-margin)
+  "Prepare :pprint-eval request message for INPUT.
+NS and SESSION are used for the context of the evaluation. RIGHT-MARGIN
+specifies the maximum column-width of the pretty-printed result, and is
+included in the request if non-nil."
+  (append (list "pprint" "true")
+          (and right-margin (list "right-margin" right-margin))
+          (nrepl--eval-request input ns session)))
+
+(defun nrepl-request:pprint-eval (input callback &optional ns session right-margin)
+  "Send the request INPUT and register the CALLBACK as the response handler.
+If NS is non-nil, include it in the request. SESSION defaults to current
+session. RIGHT-MARGIN specifies the maximum column width of the
+pretty-printed result, and is included in the request if non-nil."
+  (nrepl-send-request (nrepl--pprint-eval-request input ns session right-margin) callback))
+
 (defun nrepl-sync-request:clone ()
   "Sent a :clone request to create a new client session."
   (nrepl-send-sync-request '("op" "clone")))
@@ -968,6 +984,13 @@ If NS is non-nil, include it in the request. SESSION defaults to current session
 If NS is non-nil, include it in the request. SESSION defaults to current
 session."
   (nrepl-send-sync-request (nrepl--eval-request input ns session)))
+
+(defun nrepl-sync-request:pprint-eval (input &optional ns session right-margin)
+  "Send the INPUT to the nREPL server synchronously.
+If NS is non-nil, include it in the request. SESSION defaults to current
+session. RIGHT-MARGIN specifies the maximum column width of the
+pretty-printed result, and is included in the request if non-nil."
+  (nrepl-send-sync-request (nrepl--pprint-eval-request input ns session right-margin)))
 
 (defun nrepl-sessions ()
   "Get a list of active sessions for the current nREPL connections."


### PR DESCRIPTION
See clojure-emacs/cider-nrepl#149. Not sure on the design here, but I didn't think it would be appropriate to add both the `right-margin` opt and a `pprint` bool opt to any existing eval functions and so made new ones where appropriate. Feedback welcome.