### PR TITLE
Add support for format-edn middleware & fix #977

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#920](https://github.com/clojure-emacs/cider/issues/920): Support `cider-jack-in` for boot-based projects.
 * [#949](https://github.com/clojure-emacs/cider/issues/949): New custom var: `cider-default-repl-command`.
 * New code formatting commands - `cider-format-buffer`, `cider-format-region` and `cider-format-defun`.
+* New data formatting commands - `cider-format-edn-buffer` and `cider-format-edn-region`.
 * Pretty printing functionality moved to middleware, adding support for ClojureScript.
   - New command to eval and pprint result: `cider-interactive-pprint-eval`.
   - `cider-format-pprint-eval` has been removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ non-functioning `cider-test-jump` from test reports.
 `user` namespace when using `cider-interactive-eval`.
 * [#954](https://github.com/clojure-emacs/cider/issues/954): Detect properly a project's root
 when in buffer that's not visiting a file (e.g. a REPL buffer).
+* [#977](https://github.com/clojure-emacs/cider/issues/977): `cider-format-region` now respects indentation of the region start position
 
 ## 0.8.2 / 2014-12-21
 

--- a/cider-client.el
+++ b/cider-client.el
@@ -243,6 +243,19 @@ loaded. If CALLBACK is nil, use `cider-load-file-handler'."
       (nrepl-send-sync-request)
       (nrepl-dict-get "formatted-code")))
 
+(defun cider-sync-request:format-edn (edn &optional right-margin)
+  "Perform \"format-edn\" op with EDN and RIGHT-MARGIN."
+  (let* ((response (-> (list "op" "format-edn"
+                             "edn" edn)
+                       (append (and right-margin (list "right-margin" right-margin)))
+                       (nrepl-send-sync-request)))
+         (err (nrepl-dict-get response "err")))
+    (when err
+      ;; err will be a stacktrace with a first line that looks like:
+      ;; "clojure.lang.ExceptionInfo: Unmatched delimiter ]"
+      (error (first (split-string err "\n"))))
+    (nrepl-dict-get response "formatted-edn")))
+
 (provide 'cider-client)
 
 ;;; cider-client.el ends here

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1794,6 +1794,12 @@ of the buffer into a formatted string."
   (cider--format-buffer (lambda (edn)
                           (cider-sync-request:format-edn edn fill-column))))
 
+(defun cider--format-reindent (formatted start)
+  "Reindent FORMATTED to align with buffer position START."
+  (let* ((start-column (save-excursion (goto-char start) (current-column)))
+         (indent-line (concat "\n" (make-string start-column ? ))))
+    (replace-regexp-in-string "\n" indent-line formatted)))
+
 (defun cider--format-region (start end formatter)
   "Format the contents of the given region.
 
@@ -1801,10 +1807,11 @@ START and END are the character positions of the start and end of the
 region.  FORMATTER is a function of one argument which is used to convert
 the string contents of the region into a formatted string."
   (let* ((original (buffer-substring-no-properties start end))
-         (formatted (funcall formatter original)))
+         (formatted (funcall formatter original))
+         (indented (cider--format-reindent formatted start)))
     (unless (equal original indented)
       (delete-region start end)
-      (insert formatted))))
+      (insert indented))))
 
 (defun cider-format-region (start end)
   "Format the Clojure code in the current region."


### PR DESCRIPTION
I'm sure there's a better way to do `cider--format-reindent`. Originally I thought of `indent-buffer` after insertion, but that would only work for EDN.

Feedback welcome!