### PR TITLE
Allow the prompt to be tailored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   - New command to eval and pprint result: `cider-interactive-pprint-eval`.
   - `cider-format-pprint-eval` has been removed.
 * Warn when used with incompatible nREPL server.
+* Allow the prompt to be tailored by adding `cider-repl-prompt-function` and `cider-repl-default-prompt`.
 
 ### Changes
 

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -363,6 +363,16 @@ This will not work on non-current prompts."
 
 (put 'cider-save-marker 'lisp-indent-function 1)
 
+(defun cider-repl-default-prompt (namespace)
+  "Return a prompt string that mentions NAMESPACE."
+  (format "%s> " namespace))
+
+(defcustom cider-repl-prompt-function #'cider-repl-default-prompt
+  "A function that returns a prompt string.
+Takes one argument, a namespace name."
+  :type 'function
+  :group 'cider-repl)
+
 (defun cider-repl--insert-prompt (namespace)
   "Insert the prompt (before markers!), taking into account NAMESPACE.
 Set point after the prompt.
@@ -372,7 +382,7 @@ Return the position of the prompt beginning."
     (cider-save-marker cider-repl-output-end
       (unless (bolp) (insert-before-markers "\n"))
       (let ((prompt-start (point))
-            (prompt (format "%s> " namespace)))
+            (prompt (funcall cider-repl-prompt-function namespace)))
         (cider-propertize-region
             '(font-lock-face cider-repl-prompt-face read-only t intangible t
                              field cider-repl-prompt


### PR DESCRIPTION
The prompt string is currently hidden in `cider-repl--insert-prompt`, and so it cannot be tailored.

This pull request adds `cider-repl--prompt-function` and `cider-repl--default-prompt`. This allows the prompt to be tailored, either by setting `cider-repl--prompt-function` or perhaps by advising `cider-repl--default-prompt`.

If it's a good idea, I'm happy to update the README to describe this. I think I would probably only describe setting `cider-repl--prompt-function`, and not the possibility of using advice. (But maybe that would just be cluttering the README with something that most people wouldn't be interested in.)