### PR TITLE
give cider-repl-handle-shortcut a nicer error message

### DIFF
--- a/cider-repl.el
+++ b/cider-repl.el
@@ -960,7 +960,12 @@ constructs."
     (let ((command (completing-read "Command: "
                                     (cider-repl--available-shortcuts))))
       (if (not (equal command ""))
-          (call-interactively (gethash command cider-repl-shortcuts))
+          (let ((command-func (gethash command cider-repl-shortcuts)))
+            (if command-func
+              (call-interactively (gethash command cider-repl-shortcuts))
+              (error "Unknown command %S. Available commands: %s"
+                     command-func
+                     (mapconcat 'identity (cider-repl--available-shortcuts) ", "))))
         (error "No command selected")))))
 
 


### PR DESCRIPTION
I got confused that ",quit" and ",cider-quit" weren't working at the cider repl. The error message I got was unhelpful. This makes it more helpful.