### PR TITLE
Relative path is better than absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ CIDER packs plenty of features. Here are some of them (in no particular order):
 * Minibuffer code evaluation
 * Integration with [company-mode](http://company-mode.github.io/) and [auto-complete-mode](https://github.com/clojure-emacs/ac-cider)
 
-![CIDER Screenshot](https://github.com/clojure-emacs/cider/raw/master/screenshots/cider-overview.png)
+![CIDER Screenshot](screenshots/cider-overview.png)
 
 ***
 


### PR DESCRIPTION
[This article](https://help.github.com/articles/relative-links-in-readmes/) says

> It is not recommended that you create absolute links in your READMEs with workarounds that refer to the URL, like this:
>
> https://github.com/<em>username</em>/<em>repo</em>/blob/branch/docs/more_words.md

See also
 - https://help.github.com/articles/relative-links-in-readmes/