### PR TITLE
added cider-auto-select-test-report-buffer to cider-test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New features
 
+* New defcustom, `cider-auto-select-test-report-buffer` (boolean).
+  Controls whether the test report buffer is selected after running a test. Defaults to true.
 * Trigger Grimoire doc lookup from doc buffers by pressing <kbd>g</kbd> (in Emacs) and <kbd>G</kbd> (in browser).
 * [#903](https://github.com/clojure-emacs/cider/pull/903): Isolate
   `nrepl-client` connection logic from CIDER. New hooks `cider-connected-hook`

--- a/cider-test.el
+++ b/cider-test.el
@@ -47,6 +47,12 @@
   :group 'cider-test
   :package-version '(cider . "0.8.0"))
 
+(defcustom cider-auto-select-test-report-buffer t
+  "Determines if the test-report buffer should be auto-selected."
+  :type 'boolean
+  :group 'cider-test
+  :package-version '(cider . "0.9.0"))
+
 (defvar cider-test-last-test-ns nil
   "The namespace for which tests were last run.")
 
@@ -425,7 +431,8 @@ displayed. When test failures/errors occur, their sources are highlighted."
                 (when (or (not (zerop (+ error fail)))
                           cider-test-show-report-on-success)
                   (cider-test-render-report
-                   (cider-popup-buffer cider-test-report-buffer t)
+                   (cider-popup-buffer cider-test-report-buffer
+                                       cider-auto-select-test-report-buffer)
                    ns summary results)))))))))
 
 (defun cider-test-rerun-tests ()


### PR DESCRIPTION
This change makes it possible to not auto-select the test report-buffer. It's nice to be able to run your tests, make changes, re-run without having to switch buffers every time you run `C-c M-,`. You can disable the auto-select by setting `cider-auto-select-test-report-buffer` to nil.