### PR TITLE
Completion metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#934](https://github.com/clojure-emacs/cider/issues/934): Remove
   `cider-turn-on-eldoc-mode` in favor of simply using `eldoc-mode`.
 * [#953](https://github.com/clojure-emacs/cider/pull/953) Use `sshx` instead of `ssh` in `cider-select-endpoint`
+* Enable annotated completion candidates by default.
 
 ### Bugs fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   - `cider-format-pprint-eval` has been removed.
 * Warn when used with incompatible nREPL server.
 * Allow the prompt to be tailored by adding `cider-repl-prompt-function` and `cider-repl-default-prompt`.
+* Support for middleware-annotated completion candidates.
 
 ### Changes
 

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -119,7 +119,7 @@ which will use the default REPL connection."
   :group 'cider
   :package-version '(cider . "0.7.0"))
 
-(defcustom cider-annotate-completion-candidates nil
+(defcustom cider-annotate-completion-candidates t
   "When true, annotate completion candidates with some extra information."
   :type 'boolean
   :group 'cider


### PR DESCRIPTION
<img src="https://www.dropbox.com/s/9p5ubbzlkd30ohd/Screenshot%202015-02-27%2020.06.03.png?raw=1" height="200" /> <img src="https://www.dropbox.com/s/5tu7mu16r301o97/Screenshot%202015-02-27%2022.29.26.png?raw=1" height="200" />

I'm taking a cue from `company-clang`[1] in using text properties to store the metadata on the candidates.

We could make this configurable with `defcustom`s for:
* the format string (and also tag the candidate with `:ns`, which will then be passed as the second arg to `format`)
* a dict of `:type` to abbreviation

[1] [company-clang.el#L143](https://github.com/company-mode/company-mode/blob/master/company-clang.el#L143)