### PR TITLE
Update inspector to use :inspect option of eval op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
   - `cider-annotate-completion-function` controls how the annotations are formatted.
   - `cider-completion-annotations-alist` controls the abbreviations used in annotations.
   - `cider-completion-annotations-include-ns` controls when to include the candidate namespace in annotations.
+* Inspector middleware now relies on `eval` middleware, adding support for ClojureScript.
 
 ### Changes
 

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -196,8 +196,7 @@ if the candidate is not namespace-qualified."
 
 (defvar cider-required-nrepl-ops
   '("apropos" "classpath" "complete" "eldoc" "format-code" "format-edn" "info"
-    "inspect-start" "inspect-refresh"
-    "inspect-pop" "inspect-push" "inspect-reset"
+    "inspect-pop" "inspect-push" "inspect-refresh"
     "macroexpand" "ns-list" "ns-vars"
     "resource" "stacktrace" "toggle-trace-var" "toggle-trace-ns" "undef")
   "A list of nREPL ops required by CIDER to function properly.


### PR DESCRIPTION
see clojure-emacs/cider-nrepl#164

Since eval can return multiple values, I've added some (very basic) logic for dealing with this - each successive `:value` response is rendered into the inspector buffer, but it is only popped up once the `:status #{:done}` response is received (so the last result of evaluating the expr is inspected). We check if the inspector buffer exists in the done handler in case it's been killed between the `:value` and `:status #{:done}` responses.

I'm passing the current buffer to `nrepl-make-response-handler` rather than the inspector buffer, as we have to close over it for `cider-popup-buffer-display` to work in the `done` handler (since it's an async request, `(current-buffer)` returns the connection buffer inside the handler - see [here](https://github.com/clojure-emacs/cider/blob/master/nrepl-client.el#L891)).

Currently, the [way piggieback works](https://github.com/cemerick/piggieback/blob/master/src/cemerick/piggieback.clj#L123) is that it calls `read-string` on the result returned by the CLJS REPL. If it reads succesfully the value is returned, otherwise the result is simply printed (and `nil` is returned). This means inspecting simple readable data structures works well in CLJS, but it's not possible to inspect something like `(atom {:a [1 2 3]})` as the result can't be read. Perhaps a good enhancement would be to send the `:out` responses to the REPL buffer, or some `*cider-inspect-out*` buffer - what do you think?