### PR TITLE
Fix garbled error buffer when an eval op throws multiple exceptions

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1284,10 +1284,9 @@ If SELECT is non-nil, select the BUFFER."
     (-when-let (win (get-buffer-window buffer))
       (with-current-buffer buffer
         (set-window-point win (point))))
-    ;; Non nil `inhibit-same-window' ensures that current window is not covered
     (if select
-        (pop-to-buffer buffer `(nil . ((inhibit-same-window . ,pop-up-windows))))
-      (display-buffer buffer `(nil . ((inhibit-same-window . ,pop-up-windows))))))
+        (pop-to-buffer buffer)
+      (display-buffer buffer)))
   buffer)
 
 (defun cider-popup-buffer-quit (&optional kill)

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -531,6 +531,7 @@ This associates text properties to enable filtering and source navigation."
   (with-current-buffer buffer
     (cider-stacktrace-mode)
     (let ((inhibit-read-only t))
+      (erase-buffer)
       (newline)
       ;; Stacktrace filters
       (cider-stacktrace-render-filters


### PR DESCRIPTION
Fixes #753.

Seems there were two issues at play here: the error buffer was not being cleared, and it was being popped up in multiple windows.

I understand what the `inhibit-same-window` code was trying to accomplish, but I think the issue described in the comments for #866 is minor compared to two identical error windows popping and taking up the whole frame. Isn't the best way to configure this `display-buffer-alist`?