### PR TITLE
fixed handling of cider-sync-request:ns-list return value in cider-repl-...

### DIFF
--- a/cider-repl.el
+++ b/cider-repl.el
@@ -696,7 +696,7 @@ namespace to switch to."
   (interactive (list (if (or (derived-mode-p 'cider-repl-mode)
                              (null (cider-ns-form)))
                          (completing-read "Switch to namespace: "
-                                          (cider-sync-request:ns-list))
+                                          (first (read-from-string (cider-sync-request:ns-list))))
                        (cider-current-ns))))
   (if (and ns (not (equal ns "")))
       (nrepl-request:eval (format "(in-ns '%s)" ns)


### PR DESCRIPTION
Hi, @bbatsov. At least for a week I had an error with cider-repl-set-ns function. I've observed the following behaviour when I enter namespace name: 1) completion of namespace name couldn't be triggered and 2) when I manually enter correct namespace name, CIDER says in minibuffer that 'No namespace selected'. I've found that this bugs happens only with newest versions of org.clojure/tools.nrepl, specifically "0.2.7" and "0.2.8".
I was trying to pin-point exact source of the problem without much of success. After all, I'm not familliar with CIDER-nREPL interactions. At least I've found out that call to cider-sync-request:ns-list returns not a list of namespaces, but a version of that list converted to string.
I've made a commit that fixes this bug. Well, this is at least a workaround. Sorry for any inconvenience.

Arch Linux
Emacs 24.4
CIDER 0.9.0snapshot (package: 20150313.1021) (Java 1.8.0_31, Clojure 1.6.0, nREPL 0.2.8)