### PR TITLE
Add password listener to `nrepl--ssh-tunnel-filter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 
 ### Bugs fixed
 
+* Tunneled ssh connections now deal correctly with ssh password requests.
 * [#921](https://github.com/clojure-emacs/cider/issues/921): Fixed
 non-functioning `cider-test-jump` from test reports.
 * [#909](https://github.com/clojure-emacs/cider/issues/909): Fixed

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -671,6 +671,8 @@ If NO-ERROR is non-nil, show messages instead of throwing an error."
        (?h . ,host)
        (?u . ,(if user (format "-l '%s' " user) ""))))))
 
+(autoload 'comint-watch-for-password-prompt "comint"  "(autoload).")
+
 (defun nrepl--ssh-tunnel-filter (port)
   "Return a process filter that waits for PORT to appear in process output."
   (let ((port-string (format "LOCALHOST:%s" port)))
@@ -684,7 +686,8 @@ If NO-ERROR is non-nil, show messages instead of throwing an error."
             (save-excursion
               (goto-char (process-mark proc))
               (insert string)
-              (set-marker (process-mark proc) (point)))
+              (set-marker (process-mark proc) (point))
+              (comint-watch-for-password-prompt string))
             (if moving (goto-char (process-mark proc)))))))))
 
 


### PR DESCRIPTION
`cider-connect` locks on password authentification without this.