### PR TITLE
[#1032] Combine jump-to-var and jump-to-resource into one function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@
 * New defcustom, `cider-prompt-for-symbol`. Controls whether to prompt for
   symbol when interactive commands require one. Defaults to t, which always
   prompts. Currently applies to all documentation and source lookup commands.
+* [#1032](https://github.com/clojure-emacs/cider/issues/1032) New functions, `cider-find-dwim` and 
+  `cider-find-dwim-other-window`. These functions combine the functionality of `cider-jump-to-var` and 
+  `cider-jump-to-resource`. Which are now renamed to `cider-find-var` and `cider-find-resource` respectively.
+
 
 ### Changes
 
@@ -51,7 +55,7 @@
 * [#953](https://github.com/clojure-emacs/cider/pull/953) Use `sshx` instead of `ssh` in `cider-select-endpoint`
 * [#956](https://github.com/clojure-emacs/cider/pull/956) Eval full ns form only when needed.
 * Enable annotated completion candidates by default.
-* [#1031] (https://github.com/clojure-emacs/cider/pull/1031) Interactive functions prompt with
+* [#1031](https://github.com/clojure-emacs/cider/pull/1031) Interactive functions prompt with
   symbol at point as a default value.
 
 ### Bugs fixed

--- a/cider-macroexpansion.el
+++ b/cider-macroexpansion.el
@@ -169,14 +169,14 @@ and point is placed after the expanded form."
     (define-key map (kbd "q") 'cider-popup-buffer-quit-function)
     (define-key map (kbd "d") 'cider-doc)
     (define-key map (kbd "j") 'cider-javadoc)
-    (define-key map (kbd ".") 'cider-jump-to-var)
+    (define-key map (kbd ".") 'cider-find-var)
     (easy-menu-define cider-macroexpansion-mode-menu map
       "Menu for CIDER's doc mode"
       '("Macroexpansion"
         ["Restart expansion" cider-macroexpand-again]
         ["Macroexpand-1" cider-macroexpand-1-inplace]
         ["Macroexpand-all" cider-macroexpand-all-inplace]
-        ["Go to source" cider-jump-to-var]
+        ["Go to source" cider-find-var]
         ["Go to doc" cider-doc]
         ["Go to Javadoc" cider-docview-javadoc]
         ["Quit" cider-popup-buffer-quit-function]))

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -54,9 +54,9 @@ entirely."
 (defvar cider-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c C-d") #'cider-doc-map)
-    (define-key map (kbd "M-.") #'cider-jump-to-var)
+    (define-key map (kbd "M-.") #'cider-find-var)
     (define-key map (kbd "M-,") #'cider-jump-back)
-    (define-key map (kbd "C-c M-.") #'cider-jump-to-resource)
+    (define-key map (kbd "C-c M-.") #'cider-find-resource)
     (define-key map (kbd "M-TAB") #'complete-symbol)
     (define-key map (kbd "C-M-x")   #'cider-eval-defun-at-point)
     (define-key map (kbd "C-c C-c") #'cider-eval-defun-at-point)
@@ -113,8 +113,8 @@ entirely."
         ["Macroexpand-1" cider-macroexpand-1]
         ["Macroexpand-all" cider-macroexpand-all]
         "--"
-        ["Jump to source" cider-jump-to-var]
-        ["Jump to resource" cider-jump-to-resource]
+        ["Jump to source" cider-find-var]
+        ["Jump to resource" cider-find-resource]
         ["Jump back" cider-jump-back]
         "--"
         ["Run test" cider-test-run-test]

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1002,9 +1002,9 @@ constructs."
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map clojure-mode-map)
     (define-key map (kbd "C-c C-d") 'cider-doc-map)
-    (define-key map (kbd "M-.") 'cider-jump-to-var)
+    (define-key map (kbd "M-.") 'cider-find-var)
     (define-key map (kbd "M-,") 'cider-jump-back)
-    (define-key map (kbd "C-c M-.") 'cider-jump-to-resource)
+    (define-key map (kbd "C-c M-.") 'cider-find-resource)
     (define-key map (kbd "RET") 'cider-repl-return)
     (define-key map (kbd "TAB") 'cider-repl-tab)
     (define-key map (kbd "C-<return>") 'cider-repl-closing-return)
@@ -1045,8 +1045,8 @@ constructs."
         "--"
         ,cider-doc-menu
         "--"
-        ["Jump to source" cider-jump-to-var]
-        ["Jump to resource" cider-jump-to-resource]
+        ["Jump to source" cider-find-var]
+        ["Jump to resource" cider-find-resource]
         ["Jump back" cider-jump-back]
         ["Switch to Clojure buffer" cider-switch-to-last-clojure-buffer]
         "--"

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -430,12 +430,12 @@ it wraps to 0."
     (cider--jump-to-loc-from-info info t)))
 
 (defun cider-stacktrace-jump (&optional arg)
-  "Like `cider-jump-to-var', but uses the stack frame source at point, if available."
+  "Like `cider-find-var', but uses the stack frame source at point, if available."
   (interactive "P")
   (let ((button (button-at (point))))
     (if (and button (button-get button 'line))
         (cider-stacktrace-navigate button)
-      (cider-jump-to-var arg))))
+      (cider-find-var arg))))
 
 
 ;; Rendering

--- a/cider-test.el
+++ b/cider-test.el
@@ -162,15 +162,14 @@
       (goto-char pos))))
 
 (defun cider-test-jump (&optional arg)
-  "Like `cider-jump-to-var', but uses the test at point's definition, if available."
+  "Like `cider-find-var', but uses the test at point's definition, if available."
   (interactive "P")
   (let ((ns   (get-text-property (point) 'ns))
         (var  (get-text-property (point) 'var))
         (line (get-text-property (point) 'line)))
     (if (and ns var)
-        (cider-jump-to-var arg (concat ns "/" var) line)
-      (cider-jump-to-var arg))))
-
+        (cider-find-var arg (concat ns "/" var) line)
+      (cider-find-var arg))))
 
 ;;; Error stacktraces
 

--- a/doc/cider-refcard.tex
+++ b/doc/cider-refcard.tex
@@ -51,8 +51,8 @@
 \subgroup{Navigation}
 
 \key{M-,}{cider-jump-back}
-\key{M-.}{cider-jump-to-var}
-\key{C-c M-.}{cider-jump-to-resource}
+\key{M-.}{cider-find-var}
+\key{C-c M-.}{cider-find-resource}
 
 \subgroup{Evaluation}
 


### PR DESCRIPTION
This adds an entirely new function jump-to-resource-or-var.  
A prompt is given with thing at point as the default.  Thing-at-point uses 'filename as
that is more leniant than 'symbol.
First an attempt is made to find the resource. Upon failure jump to var is attempted.
C-u prefix will cause the result to go to other-window.