### PR TITLE
Allow buffers with no file to be formatted

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1879,9 +1879,7 @@ If no buffer is provided the command acts on the current buffer."
 
 Uses FORMATTER, a function of one argument, to convert the string contents
 of the buffer into a formatted string."
-  (unless buffer-file-name
-    (error "Buffer %s is not associated with a file" (buffer-name)))
-  (let* ((original (cider-file-string buffer-file-name))
+  (let* ((original (substring-no-properties (buffer-string)))
          (formatted (funcall formatter original)))
     (unless (equal original formatted)
       (erase-buffer)


### PR DESCRIPTION
Just found this when I had a scratch buffer with some EDN in that I wanted to format. It's easy to work around using the command for formatting the region, but I don't see any reason for this restriction (seeing as the formatting commands for both code and EDN work on strings alone and not files).