### PR TITLE
[Fix #1014] Jump-to other window with prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@
 * [#1032](https://github.com/clojure-emacs/cider/issues/1032) New functions, `cider-find-dwim` and
   `cider-find-dwim-other-window`. These functions combine the functionality of `cider-jump-to-var` and
   `cider-jump-to-resource`. Which are now renamed to `cider-find-var` and `cider-find-resource` respectively.
+* [#1014](https://github.com/clojure-emacs/cider/issues/1014) A prefix of <kbd>-</kbd> causes `cider-find-var` and 
+  `cider-find-resource` to show results in other window. Additionally, a double prefix argument <kbd>C-u C-u</kbd>
+  inverts the meaning of `cider-prompt-for-symbol` and shows the results in other window.
 
 ### Changes
 


### PR DESCRIPTION
Pass the prefix-arg along to sub-functions to indicate 'other-window'.  This adds an optional 'other-window' argument to jump-to-var, cider--jump-to-var and jump-to-resource.  jump-to-var no longer uses cider-read-symbol-name so that the other window option can be passed along.  Jump-to-var only uses the other-window option in the case of non-interactive use, when var is not nil.  