### PR TITLE
Example bind to localhost instead of every interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,7 +674,7 @@ e.g. `[com.cemerick/austin "0.1.5"]` in your project's `:plugins`):
     ```clojure
     (require 'weasel.repl.websocket)
     (cemerick.piggieback/cljs-repl
-      :repl-env (weasel.repl.websocket/repl-env :ip "0.0.0.0"
+      :repl-env (weasel.repl.websocket/repl-env :ip "127.0.0.1"
                                                 :port 9001))
     ```
 


### PR DESCRIPTION
No reason to listen to every network interface so that the websocket would accept connection form anybody that can reach your IP.