### PR TITLE
Add `cider-prompt-for-symbol` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@
 * [#958](https://github.com/clojure-emacs/cider/pull/958) Reuse existing repl
   buffers with dead processes. Users are now informed about existing zombie repl
   buffers and are offered the choice to reuse those for new connections.
+* New defcustom, `cider-prompt-for-symbol`. Controls whether to prompt for
+  symbol when interactive commands require one. Defaults to t, which always
+  prompts. Currently applies to all documentation and source lookup commands.
 
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -256,6 +256,11 @@ When using `switch-to-buffer`, pressing <kbd>SPC</kbd> after the command will
 make the hidden buffers visible. They'll always be visible in
 `list-buffers` (<kbd>C-x C-b</kbd>).
 
+* By default, interactive commands that require a symbol will prompt for the
+  symbol, with the prompt defaulting to the symbol at point. You can set
+  `cider-prompt-for-symbol` to nil to instead try the command with the symbol at
+  point first, and only prompt if that fails.
+
 * You can control the <kbd>TAB</kbd> key behavior in the REPL via the
 `cider-repl-tab-command` variable.  While the default command
 `cider-repl-indent-and-complete-symbol` should be an adequate choice for

--- a/cider-doc.el
+++ b/cider-doc.el
@@ -169,7 +169,7 @@
   (interactive)
   (if cider-docview-javadoc-url
       (browse-url cider-docview-javadoc-url)
-    (message "No Javadoc available for %s" cider-docview-symbol)))
+    (error "No Javadoc available for %s" cider-docview-symbol)))
 
 (defun cider-docview-source ()
   "Open the source for the current symbol, if available."
@@ -179,19 +179,19 @@
                          (not (cider--tooling-file-p cider-docview-file))
                          (cider-find-file cider-docview-file))))
         (cider-jump-to buffer (cons cider-docview-line nil) nil))
-    (message "No source location for %s" cider-docview-symbol)))
+    (error "No source location for %s" cider-docview-symbol)))
 
 (defun cider-docview-grimoire ()
   (interactive)
   (if cider-buffer-ns
       (cider-grimoire-lookup cider-docview-symbol)
-    (message "%s cannot be looked up on Grimoire" cider-docview-symbol)))
+    (error "%s cannot be looked up on Grimoire" cider-docview-symbol)))
 
 (defun cider-docview-grimoire-web ()
   (interactive)
   (if cider-buffer-ns
       (cider-grimoire-web-lookup cider-docview-symbol)
-    (message "%s cannot be looked up on Grimoire" cider-docview-symbol)))
+    (error "%s cannot be looked up on Grimoire" cider-docview-symbol)))
 
 
 ;;; Font Lock and Formatting

--- a/cider-grimoire.el
+++ b/cider-grimoire.el
@@ -49,13 +49,19 @@
       (let ((name (nrepl-dict-get var-info "name"))
             (ns (nrepl-dict-get var-info "ns")))
         (browse-url (cider-grimoire-url name ns)))
-    (message "Symbol %s not resolved" symbol)))
+    (error "Symbol %s not resolved" symbol)))
 
 ;;;###autoload
-(defun cider-grimoire-web ()
-  "Open the grimoire documentation for QUERY in the default web browser."
-  (interactive)
-  (cider-read-symbol-name "Grimoire doc for: " 'cider-grimoire-web-lookup))
+(defun cider-grimoire-web (&optional arg)
+  "Open grimoire documentation in the default web browser.
+
+Prompts for the symbol to use, or uses the symbol at point, depending on
+the value of `cider-prompt-for-symbol'. With prefix arg ARG, does the
+opposite of what that option dictates."
+  (interactive "P")
+  (funcall (cider-prompt-for-symbol-function arg)
+           "Grimoire doc for: "
+           #'cider-grimoire-web-lookup))
 
 (defun cider-create-grimoire-buffer (content)
   "Create a new grimoire buffer with CONTENT."
@@ -82,12 +88,18 @@
                         (delete-blank-lines)
                         ;; and create a new buffer with whatever is left
                         (pop-to-buffer (cider-create-grimoire-buffer (buffer-string))))))
-    (message "Symbol %s not resolved" symbol)))
+    (error "Symbol %s not resolved" symbol)))
 
 ;;;###autoload
-(defun cider-grimoire ()
-  "Open the grimoire documentation for QUERY in a popup buffer."
-  (interactive)
-  (cider-read-symbol-name "Grimoire doc for: " 'cider-grimoire-lookup))
+(defun cider-grimoire (&optional arg)
+  "Open grimoire documentation in a popup buffer.
+
+Prompts for the symbol to use, or uses the symbol at point, depending on
+the value of `cider-prompt-for-symbol'. With prefix arg ARG, does the
+opposite of what that option dictates."
+  (interactive "P")
+  (funcall (cider-prompt-for-symbol-function arg)
+           "Grimoire doc for:"
+           #'cider-grimoire-lookup))
 
 (provide 'cider-grimoire)

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -429,13 +429,13 @@ it wraps to 0."
                                                (button-get button 'file)))))
     (cider--jump-to-loc-from-info info t)))
 
-(defun cider-stacktrace-jump ()
+(defun cider-stacktrace-jump (&optional arg)
   "Like `cider-jump-to-var', but uses the stack frame source at point, if available."
-  (interactive)
+  (interactive "P")
   (let ((button (button-at (point))))
     (if (and button (button-get button 'line))
         (cider-stacktrace-navigate button)
-      (call-interactively 'cider-jump-to-var))))
+      (cider-jump-to-var arg))))
 
 
 ;; Rendering

--- a/cider-test.el
+++ b/cider-test.el
@@ -161,15 +161,15 @@
     (-when-let (pos (next-single-property-change (point) 'type))
       (goto-char pos))))
 
-(defun cider-test-jump ()
+(defun cider-test-jump (&optional arg)
   "Like `cider-jump-to-var', but uses the test at point's definition, if available."
-  (interactive)
+  (interactive "P")
   (let ((ns   (get-text-property (point) 'ns))
         (var  (get-text-property (point) 'var))
         (line (get-text-property (point) 'line)))
     (if (and ns var)
-        (cider-jump-to-var (concat ns "/" var) line)
-      (call-interactively 'cider-jump-to-var))))
+        (cider-jump-to-var arg (concat ns "/" var) line)
+      (cider-jump-to-var arg))))
 
 
 ;;; Error stacktraces


### PR DESCRIPTION
As proposed in the comments of #1014. Defaults to the old behaviour currently - what should it be?