### PR TITLE
Delay creation of error buffer until the error can be rendered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ when in buffer that's not visiting a file (e.g. a REPL buffer).
 * Tunneled ssh connection now deals correctly with the ssh password request.
 * [#1026](https://github.com/clojure-emacs/cider/issues/1026): The full `(ns ...)` form for the current buffer is now sent with all source-tracking eval requests, to fix ClojureScript compatibility.
 * [#1033](https://github.com/clojure-emacs/cider/issues/1033): Removed erroneous underlining from stacktrace frames and disabled frame filters in the error buffer.
+* The error buffer no longer pops up when there is no error to display.
 
 ## 0.8.2 / 2014-12-21
 


### PR DESCRIPTION
Right now when we make a `stacktrace` request, we create (and possibly display) the error buffer when we create the response handler. This means if we get a `no-error` response, or the op fails, or a response is never received, the user has to kill the empty error buffer manually.

This patch changes the error buffer creation to happen only when the contents are ready to render. When using the middleware, we now wait until all causes have been collected. For the non-middleware handler, we now make the `eval` request to print the stacktrace synchronously and render everything when it completes.

I think also making the `stacktrace` op just return a single message with a `:causes` slot would simplify this a bit. We could still make the request asynchronously, but would just render the causes when the response is received (rather than having to collate all the cause messages before rendering like we are now). 