### PR TITLE
Fix encountering "need-input" status in `nrepl-send-sync-request'

### DIFF
--- a/cider-debug.el
+++ b/cider-debug.el
@@ -101,7 +101,7 @@ CONNECTION-BUFFER is the nrepl buffer."
   (let ((cider-interactive-eval-result-prefix
          "(n)ext (c)ontinue (i)nject => "))
     (cider--display-interactive-eval-result
-     cider--current-debug-value))
+     (or cider--current-debug-value "#unknown#")))
   (let ((input
          (cl-case (read-char)
            ;; These keys were chosen to match edebug rather than clj-debugger.


### PR DESCRIPTION
* nrepl-client.el (nrepl-send-sync-request): On encountering
"need-input" try to call the appropriate handler or
`cider-need-input'.

* cider-debug.el (cider--debug-read-command): Be more careful with
what we try to print. If we encounter a similar problem in the future,
the user won't be faced with an error.