### PR TITLE
Fix evil's string objects not working in the repl

### DIFF
--- a/cider-repl.el
+++ b/cider-repl.el
@@ -297,7 +297,7 @@ If BACKWARD is non-nil search backward."
 
 (defun cider-end-of-proprange-p (property)
   "Return t if at the the end of a property range for PROPERTY."
-  (and (get-char-property (max 1 (1- (point))) property)
+  (and (get-char-property (max (point-min) (1- (point))) property)
        (not (get-char-property (point) property))))
 
 (defun cider-repl--mark-input-start ()


### PR DESCRIPTION
`ya"` etc didn't work in the repl due to a bug in `cider-end-of-proprange-p`.

@lyro found this when I filed a bug on the evil issue tracker.