### PR TITLE
[Fix #1078] Remove cider-load-fn-into-repl-buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,12 +40,13 @@
 * [#1032](https://github.com/clojure-emacs/cider/issues/1032) New functions, `cider-find-dwim` and
   `cider-find-dwim-other-window`. These functions combine the functionality of `cider-jump-to-var` and
   `cider-jump-to-resource`. Which are now renamed to `cider-find-var` and `cider-find-resource` respectively.
-* [#1014](https://github.com/clojure-emacs/cider/issues/1014) A prefix of <kbd>-</kbd> causes `cider-find-var` and 
+* [#1014](https://github.com/clojure-emacs/cider/issues/1014) A prefix of <kbd>-</kbd> causes `cider-find-var` and
   `cider-find-resource` to show results in other window. Additionally, a double prefix argument <kbd>C-u C-u</kbd>
   inverts the meaning of `cider-prompt-for-symbol` and shows the results in other window.
 
 ### Changes
 
+* [#1078] Removed `cider-load-fn-into-repl-buffer`, bound to `C-c M-f` in the repl.
 * [#1019](https://github.com/clojure-emacs/cider/pull/1019):
   <kbd>C-u C-M-x</kbd> no longer does `eval-defun`+print-result. Instead it debugs the form at point.
 * [#854](https://github.com/clojure-emacs/cider/pull/854) Error navigation now

--- a/README.md
+++ b/README.md
@@ -792,7 +792,6 @@ Keyboard shortcut                    | Description
 <kbd>C-c C-d a</kbd> | Apropos search for functions/vars.
 <kbd>C-c C-d A</kbd> | Apropos search for documentation.
 <kbd>C-c C-z</kbd> | Switch to the previous Clojure buffer. This complements <kbd>C-c C-z</kbd> used in cider-mode.
-<kbd>C-c M-f</kbd> | Select a function from the current namespace and insert into the REPL buffer.
 <kbd>C-c M-i</kbd> | Inspect expression. Will act on expression at point if present.
 <kbd>C-c M-n</kbd> | Select a namespace and switch to it.
 <kbd>C-c M-t v</kbd> | Toggle var tracing.

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1029,7 +1029,6 @@ constructs."
     (define-key map (kbd "C-c M-m") 'cider-macroexpand-all)
     (define-key map (kbd "C-c C-z") 'cider-switch-to-last-clojure-buffer)
     (define-key map (kbd "C-c M-s") 'cider-selector)
-    (define-key map (kbd "C-c M-f") 'cider-load-fn-into-repl-buffer)
     (define-key map (kbd "C-c C-q") 'cider-quit)
     (define-key map (kbd "C-c M-i") 'cider-inspect)
     (define-key map (kbd "C-c M-t v") 'cider-toggle-trace-var)


### PR DESCRIPTION
This function isn't terrible useful, as it only provides a completing read of
all the vars available in the namespace to insert into the repl.

Furthermore, company-mode already provides the completing read if you just start
typing.