### PR TITLE
[Fix #798] Add hooks for clj{,c,s,x} files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 ### New features
 
+* [#798](https://github.com/clojure-emacs/cider/issues/798) hooks for buffers visiting `clj{,c,s,x}` files.
 * [#1019](https://github.com/clojure-emacs/cider/pull/1019): New file, cider-debug.el.
   Provides a new command, `cider-debug-defun-at-point`, bound to <kbd>C-u C-M-x</kbd>.
   Interactively debug top-level clojure forms.
-
 * New defcustom, `cider-auto-select-test-report-buffer` (boolean).
   Controls whether the test report buffer is selected after running a test. Defaults to true.
 * Trigger Grimoire doc lookup from doc buffers by pressing <kbd>g</kbd> (in Emacs) and <kbd>G</kbd> (in browser).

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -143,6 +143,42 @@ entirely."
         ["Version info" cider-version]))
     map))
 
+(defcustom cider-cljs-hook nil
+  "List of functions to call when `cider-mode' is activated in a cljs
+file."
+  :type 'hook
+  :group 'cider
+  :package-version '(cider . "0.9.0"))
+
+(defcustom cider-clj-hook nil
+  "List of functions to call when `cider-mode' is activated in a clj
+file."
+  :type 'hook
+  :group 'cider
+  :package-version '(cider . "0.9.0"))
+
+(defcustom cider-cljx-hook nil
+  "List of functions to call when `cider-mode' is activated in a cljx
+file."
+  :type 'hook
+  :group 'cider
+  :package-version '(cider . "0.9.0"))
+
+(defcustom cider-cljc-hook nil
+  "List of functions to call when `cider-mode' is activated in a cljc
+file."
+  :type 'hook
+  :group 'cider
+  :package-version '(cider . "0.9.0"))
+
+(defun cider--after-hook ()
+  "Called after `cider-mode' is turned on."
+  (pcase (file-name-extension (buffer-file-name (current-buffer)))
+    ("cljs" (run-hooks cider-cljs-hook))
+    ("clj" (run-hooks cider-clj-hook))
+    ("cljx" (run-hooks cider-cljx-hook))
+    ("cljc" (run-hooks cider-cljc-hook))))
+
 ;;;###autoload
 (define-minor-mode cider-mode
   "Minor mode for REPL interaction from a Clojure buffer.
@@ -151,6 +187,7 @@ entirely."
   nil
   cider-mode-line
   cider-mode-map
+  :after-hook cider--after-hook
   (cider-eldoc-setup)
   (make-local-variable 'completion-at-point-functions)
   (add-to-list 'completion-at-point-functions


### PR DESCRIPTION
For library authors writing minor modes for `cljs` or similar dialects of
clojure, a hook based on file extension is needed.