### PR TITLE
Fix most compiler warnings

### DIFF
--- a/cider-doc.el
+++ b/cider-doc.el
@@ -356,7 +356,7 @@ Tables are marked to be ignored by line wrap."
         (newline)
         (insert-text-button "[source]"
                             'follow-link t
-                            'action (lambda (x)
+                            'action (lambda (_x)
                                       (cider-docview-source)))
         (let ((beg (point-min))
               (end (point-max)))

--- a/cider-grimoire.el
+++ b/cider-grimoire.el
@@ -26,6 +26,7 @@
 ;;; Code:
 
 (require 'cider-interaction)
+(require 'url-vars)
 
 (defconst cider-grimoire-url "http://conj.io/")
 

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -70,14 +70,14 @@
   (cider-inspect-expr expression (cider-current-ns)))
 
 ;; Operations
-(defun cider-inspector--value-handler (buffer value)
+(defun cider-inspector--value-handler (_buffer value)
   (cider-make-popup-buffer cider-inspector-buffer 'cider-inspector-mode)
   (cider-irender cider-inspector-buffer value))
 
-(defun cider-inspector--out-handler (buffer value)
+(defun cider-inspector--out-handler (_buffer value)
   (cider-emit-interactive-eval-output value))
 
-(defun cider-inspector--err-handler (buffer err)
+(defun cider-inspector--err-handler (_buffer err)
   (cider-emit-interactive-eval-err-output err))
 
 (defun cider-inspector--done-handler (buffer)

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -842,7 +842,7 @@ value is thing at point."
     (pcase narg
       (-1 t) ; -
       (16 t) ; empty empty
-      (narg nil))))
+      (_ nil))))
 
 (defun cider--invert-prefix-arg (arg)
   "Invert the effect of prefix value ARG on `cider-prompt-for-symbol'.
@@ -853,7 +853,7 @@ This function preserves the `other-window' meaning of ARG."
       (16 -1)   ; empty empty -> -
       (-1 16)   ; - -> empty empty
       (4 nil)   ; empty -> no-prefix
-      (nil 4)))) ; no-prefix -> empty
+      (_ 4)))) ; no-prefix -> empty
 
 (defun cider--prefix-invert-prompt-p (arg)
   "Test prefix value ARG for its effect on `cider-prompt-for-symbol`."
@@ -861,7 +861,7 @@ This function preserves the `other-window' meaning of ARG."
     (pcase narg
       (16 t) ; empty empty
       (4 t)  ; empty
-      (narg nil))))
+      (_ nil))))
 
 (defun cider--prompt-for-symbol-p (&optional prefix)
   "Check if cider should prompt for symbol.
@@ -1092,7 +1092,7 @@ The handler simply inserts the result value in BUFFER."
                                      (insert value)))
                                  (lambda (_buffer out)
                                    (cider-repl-emit-interactive-output out))
-                                 (lambda (buffer err)
+                                 (lambda (_buffer err)
                                    (cider-handle-compilation-errors err eval-buffer))
                                  '())))
 
@@ -1138,7 +1138,7 @@ This is controlled via `cider-interactive-eval-output-destination'."
                                    (cider--display-interactive-eval-result value))
                                  (lambda (_buffer out)
                                    (cider-emit-interactive-eval-output out))
-                                 (lambda (buffer err)
+                                 (lambda (_buffer err)
                                    (cider-emit-interactive-eval-err-output err)
                                    (cider-handle-compilation-errors err eval-buffer))
                                  '())))
@@ -1153,7 +1153,7 @@ This is controlled via `cider-interactive-eval-output-destination'."
                                      (run-hooks 'cider-file-loaded-hook)))
                                  (lambda (_buffer value)
                                    (cider-emit-interactive-eval-output value))
-                                 (lambda (buffer err)
+                                 (lambda (_buffer err)
                                    (cider-emit-interactive-eval-err-output err)
                                    (cider-handle-compilation-errors err eval-buffer))
                                  '()

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -613,11 +613,6 @@ When invoked with a prefix ARG the command doesn't prompt for confirmation."
      (point))
    (point)))
 
-(defun cider-last-sexp-start-pos ()
-  (save-excursion
-    (backward-sexp)
-    (point)))
-
 ;;;
 (defun cider-tramp-prefix (&optional buffer)
   "Use the filename for BUFFER to determine a tramp prefix.

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1473,6 +1473,8 @@ If prefix argument KILL is non-nil, kill the buffer instead of burying it."
   (interactive)
   (quit-restore-window (selected-window) (if kill 'kill 'append)))
 
+(defvar-local cider-popup-output-marker nil)
+
 (defun cider-make-popup-buffer (name &optional mode)
   "Create a temporary buffer called NAME using major MODE (if specified)."
   (with-current-buffer (get-buffer-create name)
@@ -1482,7 +1484,7 @@ If prefix argument KILL is non-nil, kill the buffer instead of burying it."
     (when mode
       (funcall mode))
     (cider-popup-buffer-mode 1)
-    (setq-local cider-popup-output-marker (point-marker))
+    (setq cider-popup-output-marker (point-marker))
     (setq buffer-read-only t)
     (current-buffer)))
 

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1661,8 +1661,7 @@ If invoked with a PREFIX argument, print the result in the current buffer."
 (defun cider-eval-last-sexp-and-replace ()
   "Evaluate the expression preceding point and replace it with its result."
   (interactive)
-  (let ((last-sexp (cider-last-sexp))
-        (start-pos (cider-last-sexp-start-pos)))
+  (let ((last-sexp (cider-last-sexp)))
     ;; we have to be sure the evaluation won't result in an error
     (nrepl-sync-request:eval last-sexp)
     ;; seems like the sexp is valid, so we can safely kill it

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1301,7 +1301,7 @@ into a new error buffer."
        ;; after it has been handled, so it's fine to set it unconditionally here
        (setq causes (cider--handle-stacktrace-response response causes))))))
 
-(defun cider-default-err-handler (buffer ex root-ex session)
+(defun cider-default-err-handler (session)
   "Make an error handler for BUFFER, EX, ROOT-EX and SESSION.
 This function determines how the error buffer is shown, and then delegates
 the actual error content to the eval or op handler."

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -191,7 +191,7 @@ ENDPOINT is a plist as returned by `nrepl-connect'."
 (defun cider-repl-require-repl-utils ()
   "Require standard REPL util functions into the current REPL."
   (interactive)
-  (cider-eval
+  (nrepl-request:eval
    "(when (clojure.core/resolve 'clojure.main/repl-requires)
       (clojure.core/map clojure.core/require clojure.main/repl-requires))"
    (lambda (response) nil)))

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -194,7 +194,7 @@ ENDPOINT is a plist as returned by `nrepl-connect'."
   (nrepl-request:eval
    "(when (clojure.core/resolve 'clojure.main/repl-requires)
       (clojure.core/map clojure.core/require clojure.main/repl-requires))"
-   (lambda (response) nil)))
+   (lambda (_response) nil)))
 
 (defun cider-repl-set-initial-ns (buffer)
   "Set the REPL BUFFER's initial namespace (by altering `cider-buffer-ns').
@@ -691,7 +691,7 @@ text property `cider-old-input'."
 (defun cider-repl-switch-ns-handler (buffer)
   "Make a nREPL evaluation handler for the REPL BUFFER's ns switching."
   (nrepl-make-response-handler buffer
-                               (lambda (buffer value))
+                               (lambda (_buffer _value))
                                (lambda (buffer out)
                                  (cider-repl-emit-output buffer out))
                                (lambda (buffer err)

--- a/cider-test.el
+++ b/cider-test.el
@@ -307,7 +307,7 @@ With the actual value, the outermost '(not ...)' s-expression is removed."
         (unless (zerop (+ fail error))
           (cider-insert "Results" 'bold t "\n")
           (nrepl-dict-map
-           (lambda (var tests)
+           (lambda (_var tests)
              (dolist (test tests)
                (nrepl-dbind-response test (type)
                  (unless (equal "pass" type)

--- a/cider-test.el
+++ b/cider-test.el
@@ -193,8 +193,8 @@
                                               cider-auto-select-error-buffer)
                           (reverse causes))))))))))
 
-(defun cider-test-stacktrace (&optional button)
-  "Display stacktrace for the erring test at point, optionally from BUTTON."
+(defun cider-test-stacktrace ()
+  "Display stacktrace for the erring test at point."
   (interactive)
   (let ((ns    (get-text-property (point) 'ns))
         (var   (get-text-property (point) 'var))
@@ -289,7 +289,7 @@ With the actual value, the outermost '(not ...)' s-expression is removed."
                   (progn (insert-text-button
                           error
                           'follow-link t
-                          'action 'cider-test-stacktrace
+                          'action '(lambda (_button) (cider-test-stacktrace))
                           'help-echo "View causes and stacktrace")
                          (newline))
                 (insert (cider-font-lock-as-clojure actual)))))

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -145,6 +145,43 @@ as returned by `nrepl-connect'. ")
 In case of a special value 'new, a new buffer is created.")
 
 
+;;; Buffer Local Declarations
+
+;; These variables are used to track the state of nREPL connections
+(defvar-local nrepl-connection-buffer nil)
+(defvar-local nrepl-server-buffer nil)
+(defvar-local nrepl-repl-buffer nil)
+(defvar-local nrepl-endpoint nil)
+(defvar-local nrepl-project-dir nil)
+(defvar-local nrepl-tunnel-buffer nil)
+
+(defvar-local nrepl-session nil
+  "Current nREPL session id.")
+
+(defvar-local nrepl-tooling-session nil
+  "Current nREPL tooling session id.
+To be used for tooling calls (i.e. completion, eldoc, etc)")
+
+(defvar-local nrepl-request-counter 0
+  "Continuation serial number counter.")
+
+(defvar-local nrepl-pending-requests nil)
+
+(defvar-local nrepl-completed-requests nil)
+
+(defvar-local nrepl-last-sync-response nil
+  "Result of the last sync request.")
+
+(defvar-local nrepl-last-sync-request-timestamp nil
+  "The time when the last sync request was initiated.")
+
+(defvar-local nrepl-ops nil
+  "Available nREPL server ops (from describe).")
+
+(defvar-local nrepl-versions nil
+  "Version information received from the describe op.")
+
+
 ;;; nREPL Buffer Names
 
 (defconst nrepl-message-buffer-name "*nrepl-messages*")
@@ -207,43 +244,6 @@ PROJECT-DIR, HOST and PORT are as in `nrepl-make-buffer-name'."
   (nrepl--make-hidden-name
    (nrepl-make-buffer-name nrepl-tunnel-buffer-name-template
                            project-dir host port)))
-
-
-;;; Buffer Local Declarations
-
-;; These variables are used to track the state of nREPL connections
-(defvar-local nrepl-connection-buffer nil)
-(defvar-local nrepl-server-buffer nil)
-(defvar-local nrepl-repl-buffer nil)
-(defvar-local nrepl-endpoint nil)
-(defvar-local nrepl-project-dir nil)
-(defvar-local nrepl-tunnel-buffer nil)
-
-(defvar-local nrepl-session nil
-  "Current nREPL session id.")
-
-(defvar-local nrepl-tooling-session nil
-  "Current nREPL tooling session id.
-To be used for tooling calls (i.e. completion, eldoc, etc)")
-
-(defvar-local nrepl-request-counter 0
-  "Continuation serial number counter.")
-
-(defvar-local nrepl-pending-requests nil)
-
-(defvar-local nrepl-completed-requests nil)
-
-(defvar-local nrepl-last-sync-response nil
-  "Result of the last sync request.")
-
-(defvar-local nrepl-last-sync-request-timestamp nil
-  "The time when the last sync request was initiated.")
-
-(defvar-local nrepl-ops nil
-  "Available nREPL server ops (from describe).")
-
-(defvar-local nrepl-versions nil
-  "Version information received from the describe op.")
 
 
 ;;; Utilities

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -812,7 +812,8 @@ for functionality like pretty-printing won't clobber the values of *1, *2, etc."
 ;; After being decoded, responses (aka, messages from the server) are dispatched
 ;; to handlers. Handlers are constructed with `nrepl-make-response-handler'.
 
-(defvar nrepl-err-handler 'cider-default-err-handler
+(defvar nrepl-err-handler '(lambda (_buffer _ex _root-ex session)
+                             (cider-default-err-handler session))
   "Evaluation error handler.")
 
 (defvar-local nrepl--input-handler-queue (make-queue)


### PR DESCRIPTION
Gets us partway to #875. This is pretty weird though:

```
In cider-eval-buffer:
cider-interaction.el:1644:8:Warning: function cider-eval-buffer used to take
    0-1 arguments, now takes 0
```

`cider-eval-buffer` is defined [here](https://github.com/clojure-emacs/cider/blob/master/cider-interaction.el#L1647) but is then aliased to `cider-load-buffer` [here](https://github.com/clojure-emacs/cider/blob/master/cider-interaction.el#L2001). The alias was added to fix #865 - I guess for now we should just delete `cider-eval-buffer` and keep the alias? If/when the source-tracking eval patch is merged to nREPL we can look into making the distinction between eval and load more clear, and have these as separate commands again.

The following warnings will require more significant restructuring of things, mostly handled by #1068:

```
In nrepl-make-response-handler:
nrepl-client.el:873:24:Warning: assignment to free variable `cider-buffer-ns'

In end of data:
nrepl-client.el:1442:1:Warning: the following functions are not known to be
    defined: cider-need-input, cider-current-repl-buffer,
    cider-repl-emit-output, cider-repl-emit-err-output,
    cider-repl-emit-interactive-err-output, cider--close-buffer,
    cider-popup-buffer-mode

In cider--version:
cider-util.el:151:12:Warning: reference to free variable `cider-version'

In end of data:
cider-repl.el:1106:1:Warning: the function `cider-version' is not known to be
    defined.

In end of data:
cider-mode.el:162:1:Warning: the following functions are not known to be
    defined: cider-macroexpand-1, cider-macroexpand-all, cider-inspect,
    cider-selector

In cider-ensure-op-supported:
cider-interaction.el:239:136:Warning: reference to free variable
    `cider-version'

In cider--check-required-nrepl-ops:
cider-interaction.el:248:24:Warning: reference to free variable
    `cider-version'

In cider--check-middleware-compatibility-callback:
cider-interaction.el:291:47:Warning: reference to free variable
    `cider-version'

In end of data:
cider-interaction.el:2151:1:Warning: the function `cider-jack-in' is not known
    to be defined.

In end of data:
cider-doc.el:394:1:Warning: the following functions are not known to be
    defined: cider-apropos, cider-apropos-documentation, cider-grimoire,
    cider-grimoire-web, cider-grimoire-lookup, cider-grimoire-web-lookup
```