### PR TITLE
enable clojure-mode on the grimoir buffer

### DIFF
--- a/cider-grimoire.el
+++ b/cider-grimoire.el
@@ -70,6 +70,7 @@ opposite of what that option dictates."
     (read-only-mode -1)
     (insert content)
     (read-only-mode +1)
+    (clojure-mode)
     (goto-char (point-min))
     (current-buffer)))
 


### PR DESCRIPTION
Gives nice syntax highlighting for the grimoir buffer.
There might be smarter ways to do that, but I think that should be good enough..