### PR TITLE
[Fix #1061] Add cider-find-ns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#1061](https://github.com/clojure-emacs/cider/issues/1061) New command `cider-find-ns`, bound to <kbd>c-c c-.</kbd>, which prompts for an ns and jumps to the corresponding source file.
 * [#1019](https://github.com/clojure-emacs/cider/pull/1019): New file, cider-debug.el.
   Provides a new command, `cider-debug-defun-at-point`, bound to <kbd>C-u C-M-x</kbd>.
   Interactively debug top-level clojure forms.

--- a/README.md
+++ b/README.md
@@ -763,6 +763,7 @@ Keyboard shortcut                    | Description
 <kbd>C-c C-t</kbd>                   | Show the test report buffer.
 <kbd>M-.</kbd>                       | Jump to the definition of a symbol.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.
 <kbd>C-c M-.</kbd>                   | Jump to the resource referenced by the string at point.
+<kbd>C-c C-.</kbd>                   | Jump to some namespace on the classpath.
 <kbd>M-,</kbd>                       | Return to your pre-jump location.
 <kbd>M-TAB</kbd>                     | Complete the symbol at point.
 <kbd>C-c C-d g</kbd>                 | Lookup symbol in Grimoire.
@@ -793,6 +794,7 @@ Keyboard shortcut                    | Description
 <kbd>C-c C-z</kbd> | Switch to the previous Clojure buffer. This complements <kbd>C-c C-z</kbd> used in cider-mode.
 <kbd>C-c M-i</kbd> | Inspect expression. Will act on expression at point if present.
 <kbd>C-c M-n</kbd> | Select a namespace and switch to it.
+<kbd>C-c C-.</kbd> | Jump to some namespace on the classpath.
 <kbd>C-c M-t v</kbd> | Toggle var tracing.
 <kbd>C-c M-t n</kbd> | Toggle namespace tracing.
 

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -55,6 +55,7 @@ entirely."
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c C-d") #'cider-doc-map)
     (define-key map (kbd "M-.") #'cider-find-var)
+    (define-key map (kbd "C-c C-.") #'cider-find-ns)
     (define-key map (kbd "M-,") #'cider-jump-back)
     (define-key map (kbd "C-c M-.") #'cider-find-resource)
     (define-key map (kbd "M-TAB") #'complete-symbol)

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1003,6 +1003,7 @@ constructs."
     (set-keymap-parent map clojure-mode-map)
     (define-key map (kbd "C-c C-d") 'cider-doc-map)
     (define-key map (kbd "M-.") 'cider-find-var)
+    (define-key map (kbd "C-c C-.") #'cider-find-ns)
     (define-key map (kbd "M-,") 'cider-jump-back)
     (define-key map (kbd "C-c M-.") 'cider-find-resource)
     (define-key map (kbd "RET") 'cider-repl-return)


### PR DESCRIPTION
Provide a completing read of available namespaces and jump to the file
containing its definition.