### PR TITLE
Add support for `pprint-out` slot in eval responses

### DIFF
--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -839,16 +839,19 @@ When `nrepl-log-messages' is non-nil, *nrepl-messages* buffer contains
 server responses."
   (lambda (response)
     (nrepl-dbind-response response (value ns out err status id ex root-ex
-                                          session)
+                                          session pprint-out)
+      (with-current-buffer buffer
+        (when (and ns (not (derived-mode-p 'clojure-mode)))
+          (setq cider-buffer-ns ns)))
       (cond (value
-             (with-current-buffer buffer
-               (when (and ns (not (derived-mode-p 'clojure-mode)))
-                 (setq cider-buffer-ns ns)))
              (when value-handler
                (funcall value-handler buffer value)))
             (out
              (when stdout-handler
                (funcall stdout-handler buffer out)))
+            (pprint-out
+             (when stdout-handler
+               (funcall stdout-handler buffer pprint-out)))
             (err
              (when stderr-handler
                (funcall stderr-handler buffer err)))


### PR DESCRIPTION
Adding this directly to `nrepl-client.el` is obviously not the correct long-term solution, but I'm not sure how best to modify `nrepl-make-response-handler` to make it open to this kind of extension. It already has a couple of other CIDER-specific things that we should pull out - it sets `cider-buffer-ns`, and also uses `nrepl-err-handler`, which defaults to `cider-default-err-handler`.

Perhaps we should instead create response handlers by composing higher order functions that take any relevant arguments, and optionally the next handler to be called, e.g.

```emacs-lisp
(defun cider--ns-response-handler (&optional handler)
  (lambda (response)
    (nrepl-dbind-response response (ns)
      (with-current-buffer buffer
        (when (and ns (not (derived-mode-p 'clojure-mode)))
          (setq cider-buffer-ns ns))))
    (when handler
      (funcall handler response))))

(defun cider-repl--value-response-handler (buffer &optional handler)
  (lambda (response)
    (nrepl-dbind-response response (value)
      (if value
          (cider-repl-emit-result buffer value t)
        (funcall handler response)))))

(defun cider-repl--out-response-handler (buffer &optional handler)
  (lambda (response)
    (nrepl-dbind-response response (out)
      (if out
          (cider-repl-emit-output buffer out)
        (funcall handler response)))))

;; etc.
```

A caller making an nREPL request will then simply construct their response handler using function composition:

```emacs-lisp
(->> (cider-repl--out-response-handler buffer)
     (cider-repl--value-response-handler buffer)
     (cider--ns-response-handler)
     ...)
```

This is, IMO, a nicer and more flexible API than having one monolithic `nrepl-make-response-handler` that takes six arguments, five of them being functions with slightly differing arities.

The trade-off being that it's a bit more verbose, and now the caller needs to concern itself with how the dispatching of handlers occurs (although we could always leave `nrepl-make-response-handler` there for simpler cases where the defaults work fine).

Thoughts?