### PR TITLE
Set eldoc function when reading from minibuffer

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -519,6 +519,7 @@ reading input."
         (set-syntax-table clojure-mode-syntax-table)
         (add-hook 'completion-at-point-functions
                   #'cider-complete-at-point nil t)
+        (setq-local eldoc-documentation-function #'cider-eldoc)
         (run-hooks 'eval-expression-minibuffer-setup-hook))
     (read-from-minibuffer prompt initial-value
                           cider-minibuffer-map nil


### PR DESCRIPTION
Emacs supports eldoc also in the minibuffer.  For that, one can add eldoc-mode
to eval-expression-minibuffer-setup-hook.  cider-read-from-minibuffer runs the
functions in that hook but doesn't set eldoc-documentation-function for the
minibuffer.  Therefore, one gets an eldoc message telling that eldoc isn't
supported when cider-read-from-minibuffer is called and eldoc-mode is in
eval-expression-minibuffer-setup-hook.

This patch sets eldoc-documentation-function locally in the minibuffer before
cider-read-from-minibuffer runs the functions in
eval-expression-minibuffer-setup-hook.  This fixes issue #1105.