### PR TITLE
Add an option to disable automatic cider-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### New features
 
+* [#1109](https://github.com/clojure-emacs/cider/issues/1061) New defcustom `cider-auto-mode`.
+On by default, when nil don't automatically enable `cider-mode` in all Clojure buffers.
+
 * [#1061](https://github.com/clojure-emacs/cider/issues/1061) New command `cider-find-ns`, bound to <kbd>C-c C-.</kbd>, which prompts for an ns and jumps to the corresponding source file.
 * [#1019](https://github.com/clojure-emacs/cider/pull/1019): New file, cider-debug.el.
   Provides a new command, `cider-debug-defun-at-point`, bound to <kbd>C-u C-M-x</kbd>.

--- a/cider.el
+++ b/cider.el
@@ -130,6 +130,11 @@ This variable is used by `cider-connect'."
   :group 'cider
   :version "0.9.0")
 
+(defcustom cider-auto-mode t
+  "When non-nil, automatically enable `cider-mode' for all Clojure buffers."
+  :type 'boolean
+  :version "0.9.0")
+
 (defvar cider-ps-running-nrepls-command "ps u | grep leiningen"
   "Process snapshot command used in `cider-locate-running-nrepl-ports'.")
 
@@ -323,7 +328,8 @@ buffer."
   (cider--check-required-nrepl-version)
   (cider--check-required-nrepl-ops)
   (cider--check-middleware-compatibility)
-  (cider-enable-on-existing-clojure-buffers)
+  (when cider-auto-mode
+    (cider-enable-on-existing-clojure-buffers))
   (run-hooks 'cider-connected-hook))
 
 (defun cider--disconnected-handler ()


### PR DESCRIPTION
* cider.el (cider-auto-mode): New defcustom.
(cider--connected-handler): Don't auto-enable `cider-mode' for all
`clojure-mode' buffers when `cider-auto-mode' is nil.