### PR TITLE
Fix cider-insert-in-repl indenting too much

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1715,9 +1715,10 @@ If EVAL is non-nil the form will also be evaluated."
   (while (string-match "\\`[ \t\n\r]+\\|[ \t\n\r]+\\'" form)
     (setq form (replace-match "" t t form)))
   (with-current-buffer (cider-current-repl-buffer)
-    (let ((start-pos (point)))
+    (goto-char (point-max))
+    (let ((beg (point)))
       (insert form)
-      (indent-region start-pos (point)))
+      (indent-region beg (point)))
     (when eval
       (cider-repl-return)))
   (cider-switch-to-repl-buffer))

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1712,14 +1712,14 @@ the command `cider-debug-defun-at-point'."
 (defun cider-insert-in-repl (form eval)
   "Insert FORM in the REPL buffer and switch to it.
 If EVAL is non-nil the form will also be evaluated."
-  (let ((start-pos (point)))
-    (while (string-match "\\`[ \t\n\r]+\\|[ \t\n\r]+\\'" form)
-      (setq form (replace-match "" t t form)))
-    (with-current-buffer (cider-current-repl-buffer)
+  (while (string-match "\\`[ \t\n\r]+\\|[ \t\n\r]+\\'" form)
+    (setq form (replace-match "" t t form)))
+  (with-current-buffer (cider-current-repl-buffer)
+    (let ((start-pos (point)))
       (insert form)
-      (indent-region start-pos (point))
-      (when eval
-        (cider-repl-return))))
+      (indent-region start-pos (point)))
+    (when eval
+      (cider-repl-return)))
   (cider-switch-to-repl-buffer))
 
 (defun cider-insert-last-sexp-in-repl (&optional arg)


### PR DESCRIPTION
The intention was to indent the code that was just inserted.  The bug was that
the code grabbed the value of point from the source buffer instead of the repl
buffer to mark the start position when indenting.  The result, in most cases,
was that the entire repl sessions was re-indented.  As the repl can grow quite
long this often brought emacs to a grinding halt.