### PR TITLE
Fix occasional (wrong-type-argument stringp nil)

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1399,7 +1399,8 @@ If location could not be found, return nil."
         (let ((file (nth 0 info))
               (line (nth 1 info))
               (col (nth 2 info)))
-          (unless (cider--tooling-file-p file)
+          (unless (or (not (stringp file))
+                      (cider--tooling-file-p file))
             (-when-let (buffer (cider-find-file file))
               (with-current-buffer buffer
                 (save-excursion


### PR DESCRIPTION
This had been bugging me for a while. Sometimes the backtrace buffer is created and displayed correctly, but an error is signaled because tooling-file-p is called with a nil argument. This avoids that.