### PR TITLE
Fix completing read port

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -264,7 +264,7 @@ Return a list of the form (HOST PORT), where PORT can be nil."
          (sel-port (completing-read (format "Port for %s: " host) ports
                                     nil nil nil nil (caar ports)))
          (port (or (cdr (assoc sel-port ports)) sel-port))
-         (port (if (listp port) (second port) port)))
+         (port (if (listp port) (cadr port) port)))
     (if (stringp port) (string-to-number port) port)))
 
 (defun cider-locate-running-nrepl-ports (&optional dir)


### PR DESCRIPTION
Hitting `C-c M-c` yields "Symbol's function definition is void: second".

Stack trace for 'project':
```
Debugger entered--Lisp error: (void-function second)
  second(("project" "51151"))
  cider--completing-read-port("localhost" (("project" "51151")))
  cider-select-endpoint()
  #<subr call-interactively>(cider-connect nil nil)
  ad-Advice-call-interactively(#<subr call-interactively> cider-connect nil nil)
  apply(ad-Advice-call-interactively #<subr call-interactively> (cider-connect nil nil))
  call-interactively(cider-connect nil nil)
  command-execute(cider-connect)
```