### PR TITLE
Try and use `markdown-mode' for Grimoire buffers

### DIFF
--- a/cider-grimoire.el
+++ b/cider-grimoire.el
@@ -65,8 +65,14 @@ opposite of what that option dictates."
            #'cider-grimoire-web-lookup))
 
 (defun cider-create-grimoire-buffer (content)
-  "Create a new grimoire buffer with CONTENT."
-  (with-current-buffer (cider-popup-buffer "*cider grimoire*" t)
+  "Create a new grimoire buffer with CONTENT.
+
+If `markdown-mode' has been installed and loaded, use it as the major mode
+for the Grimoire buffer."
+  (with-current-buffer
+      (if (fboundp 'markdown-mode)
+          (cider-popup-buffer "*cider grimoire*" t 'markdown-mode)
+        (cider-popup-buffer "*cider grimoire*" t))
     (read-only-mode -1)
     (insert content)
     (read-only-mode +1)


### PR DESCRIPTION
Currently, the **\*cider grimoire*** buffer is loaded up with \`fundamental-mode' as the
major mode. However, since Grimoire notes are written in Markdown, we can try
and use \`markdown-mode' to render them when possible.