### PR TITLE
Fix typo in README.md where wrong double quotes was in use

### DIFF
--- a/README.md
+++ b/README.md
@@ -1034,7 +1034,7 @@ nasty bugs in 0.2.6). Unfortunately the latest `leiningen` (2.5.1) pulls in exac
 add this to your `profiles.clj`:
 
 ```clojure
-{:user {:dependencies [[org.clojure/tools.nrepl "0.2.10”]]}}
+{:user {:dependencies [[org.clojure/tools.nrepl "0.2.10"]]}}
 ```
 
 Make sure you add the newer nREPL dependency to the `:dependencies` key instead


### PR DESCRIPTION
There were some **fancy** double quotes in use in the `README.md`. Copy and pasting these instructions lead to the following error (taken from emacs `*Messages*` buffer):
```
Starting nREPL server via lein repl :headless...
error in process sentinel: cond: Could not start nREPL server: Could not transfer artifact org.clojure:tools.nrepl:pom:0.2.10”]]}} from/to central (https://repo1.maven.org/maven2/): Illegal character in path at index 62: https://repo1.maven.org/maven2/org/clojure/tools.nrepl/0.2.10”]]}}/tools.nrepl-0.2.10”]]}}.pom
This could be due to a typo in :dependencies or network issues.
If you are behind a proxy, try setting the 'http_proxy' environment variable.
 
error in process sentinel: Could not start nREPL server: Could not transfer artifact org.clojure:tools.nrepl:pom:0.2.10”]]}} from/to central (https://repo1.maven.org/maven2/): Illegal character in path at index 62: https://repo1.maven.org/maven2/org/clojure/tools.nrepl/0.2.10”]]}}/tools.nrepl-0.2.10”]]}}.pom
This could be due to a typo in :dependencies or network issues.
If you are behind a proxy, try setting the 'http_proxy' environment variable.
```
Changed to use a standard double quotes.