### PR TITLE
Fix behavior of `cider-switch-to-current-repl-buffer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugs fixed
 
+* [#1153](https://github.com/clojure-emacs/cider/pull/1153): Fix behavior of `cider-switch-to-current-repl-buffer`.
 * [#1139](https://github.com/clojure-emacs/cider/issues/1139): Fix evaluation of ns forms and of forms with unevaluated namespaces.
 * Replace `assert` with `cl-assert` (we don't use anything from `cl` now).
 * [#1135](https://github.com/clojure-emacs/cider/pull/1135): Fix a corner case with locals display in the debugger.

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -406,7 +406,9 @@ of the namespace in the Clojure source buffer."
   (let ((buffer (current-buffer)))
     (when (eq 4 arg)
       (cider-repl-set-ns (cider-current-ns)))
-    (pop-to-buffer (cider-get-repl-buffer))
+    (if cider-repl-display-in-current-window
+	(pop-to-buffer-same-window (cider-get-repl-buffer))
+      (pop-to-buffer (cider-get-repl-buffer)))
     (cider-remember-clojure-buffer buffer)
     (goto-char (point-max))))
 


### PR DESCRIPTION
This setting in my config file
```elisp
(setq cider-repl-display-in-current-window t)
```
breaks behavior of `cider-repl-display-in-current-window` command. See it in action. Each change of window layout or buffer in the movie below is an effect of hitting `C-c C-z`:
![lol](http://i.imgur.com/TDIb00U.gif)

This PR hopefully fixes that (watch out - this is my first elisp PR ever).

Software versions:

`; CIDER 0.9.1snapshot (package: 20150618.2308) (Java 1.8.0_25, Clojure 1.6.0, nREPL 0.2.8)`

`GNU Emacs 24.4.1 (x86_64-apple-darwin13.4.0, NS apple-appkit-1265.21) of 2014-10-21 on builder10-9.porkrind.org`

