### PR TITLE
cider-browse-ns.el (cider-browse-ns--doc-at-point): Fixup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#1164](https://github.com/clojure-emacs/cider/pull/1164): Fix an error in `cider-browse-ns--doc-at-point`.
+
 ## 0.9.1 / 2015-06-24
 
 ### New features

--- a/cider-browse-ns.el
+++ b/cider-browse-ns.el
@@ -126,7 +126,7 @@
   "Expand browser according to thing at current point."
   (interactive)
   (-when-let (var (cider-browse-ns--var-at-point))
-    ((cider-doc-lookup var))))
+    (cider-doc-lookup var)))
 
 (defun cider-browse-ns--find-at-point ()
   (interactive)

--- a/cider-browse-ns.el
+++ b/cider-browse-ns.el
@@ -130,7 +130,7 @@
 
 (defun cider-browse-ns--find-at-point ()
   (interactive)
-  (when-let (var (cider-browse-ns--var-at-point))
+  (-when-let (var (cider-browse-ns--var-at-point))
     (cider-find-var current-prefix-arg var)))
 
 (defun cider-browse-ns--handle-mouse (event)


### PR DESCRIPTION
* cider-browse-ns.el (cider-browse-ns--doc-at-point): It was a malformed form
  previously.