### PR TITLE
Kill server with client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#1184](https://github.com/clojure-emacs/cider/pull/1184): When the user kills the repl buffer, CIDER will offer to kill the nrepl buffer and process too. Also, when the client (repl) process dies, the server (nrepl) process is killed too.
 * [#1182](https://github.com/clojure-emacs/cider/pull/1182): New command `cider-browse-instrumented-defs`, displays a buffer listing all defitions currently instrumented by the debugger.
 * [#1182](https://github.com/clojure-emacs/cider/pull/1182): Definitions currently instrumented by the debugger are marked with a red box in the source buffer.
 * [#1174](https://github.com/clojure-emacs/cider/pull/1174): New command `cider-run`, runs the project's `-main` function.

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1572,7 +1572,8 @@ and automatically removed when killed."
     (when ancillary
       (add-to-list 'cider-ancillary-buffers name)
       (add-hook 'kill-buffer-hook
-                (lambda () (setq cider-ancillary-buffers (remove name cider-ancillary-buffers)))))
+                (lambda () (setq cider-ancillary-buffers (remove name cider-ancillary-buffers)))
+                nil 'local))
     (current-buffer)))
 
 (defun cider-emit-into-popup-buffer (buffer value)


### PR DESCRIPTION
Whenever the nrepl hangs for one reason or another, you have to kill two different buffers each with its own process. This hook makes it easier to kill the server after killing the client.