### PR TITLE
Change cider-version to a defconst, so it reloads properly

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -70,7 +70,7 @@
 (require 'cider-debug)
 (require 'tramp-sh)
 
-(defvar cider-version "0.10.0-snapshot"
+(defconst cider-version "0.10.0-snapshot"
   "Fallback version used when it cannot be extracted automatically.
 Normally it won't be used, unless `pkg-info' fails to extract the
 version from the CIDER package or library.")


### PR DESCRIPTION
Small thing.
Without this, upgrading and reloading cider will not update the version until Emacs restarts. Which means the user will get "CIDER's version ... does not match" warnings even though they've already upgraded.

Only really matters starting with Emacs 25, since package.el doesn't reload after upgrades on emacs 24.