### PR TITLE
Debugger menu and configurable input prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#1187](https://github.com/clojure-emacs/cider/pull/1187): The list of keys displayed by the debugger can be configured with `cider-debug-prompt`.
 * [#1187](https://github.com/clojure-emacs/cider/pull/1187): While debugging, there is a menu on the menu-bar listing available commands.
 * [#1184](https://github.com/clojure-emacs/cider/pull/1184): When the user kills the repl buffer, CIDER will offer to kill the nrepl buffer and process too. Also, when the client (repl) process dies, the server (nrepl) process is killed too.
 * [#1182](https://github.com/clojure-emacs/cider/pull/1182): New command `cider-browse-instrumented-defs`, displays a buffer listing all defitions currently instrumented by the debugger.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#1187](https://github.com/clojure-emacs/cider/pull/1187): While debugging, there is a menu on the menu-bar listing available commands.
 * [#1184](https://github.com/clojure-emacs/cider/pull/1184): When the user kills the repl buffer, CIDER will offer to kill the nrepl buffer and process too. Also, when the client (repl) process dies, the server (nrepl) process is killed too.
 * [#1182](https://github.com/clojure-emacs/cider/pull/1182): New command `cider-browse-instrumented-defs`, displays a buffer listing all defitions currently instrumented by the debugger.
 * [#1182](https://github.com/clojure-emacs/cider/pull/1182): Definitions currently instrumented by the debugger are marked with a red box in the source buffer.

--- a/cider-debug.el
+++ b/cider-debug.el
@@ -290,6 +290,20 @@ In order to work properly, this mode must be activated by
     (setq cider--debug-mode-commands-alist nil)
     (setq cider--debug-mode-response nil)))
 
+(easy-menu-define cider-debug-mode-menu cider--debug-mode-map
+  "Menu for CIDER debug mode"
+  `("CIDER DEBUG"
+    ["Next step" (cider-debug-mode-send-reply ":next") :keys "n"]
+    ["Continue non-stop" (cider-debug-mode-send-reply ":continue") :keys "c"]
+    ["Quit" (cider-debug-mode-send-reply ":quit") :keys "q"]
+    "--"
+    ["Evaluate in current scope" (cider-debug-mode-send-reply ":eval") :keys "e"]
+    ["Inject value" (cider-debug-mode-send-reply ":inject") :keys "i"]
+    ["Inspect value" (cider-debug-mode-send-reply ":inspect")]
+    ["Inspect local variables" (cider-debug-mode-send-reply ":locals") :keys "l"]
+    "--"
+    ["Customize" (customize-group 'cider-debug)]))
+
 (defun cider-debug-mode-send-reply (command &optional key)
   "Reply to the message that started current bufer's debugging session.
 COMMAND is sent as the input option. KEY can be provided to reply to a

--- a/cider-debug.el
+++ b/cider-debug.el
@@ -302,9 +302,8 @@ In order to work properly, this mode must be activated by
                   (apply-partially #'cider--debug-lexical-eval
                                    (nrepl-dict-get cider--debug-mode-response "key")))
             ;; Set the keymap.
-            (let ((alist `((?\C-g  . ":quit")
-                           ,@(mapcar (lambda (k) (cons (string-to-char k) (concat ":" k)))
-                                     (-difference input-type '("inspect"))))))
+            (let ((alist (mapcar (lambda (k) (cons (string-to-char k) (concat ":" k)))
+                                 (-difference input-type '("inspect")))))
               (setq cider--debug-mode-commands-alist alist)
               (dolist (it alist)
                 (define-key cider--debug-mode-map (vector (car it)) #'cider-debug-mode-send-reply)))

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -144,6 +144,7 @@ entirely."
         ["Refresh loaded code" cider-refresh]
         "--"
         ["Debug top-level form" cider-debug-defun-at-point]
+        ["List instrumented defs" cider-browse-instrumented-defs]
         "--"
         ["Set ns" cider-repl-set-ns]
         ["Switch to REPL" cider-switch-to-repl-buffer]

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -39,14 +39,14 @@
 (ert-deftest test-debug-prompt ()
   (should (equal-including-properties
            (cider--debug-prompt '("a" "b" "c"))
-           #("a b c" 0 1 (face cider-debug-prompt-face) 2 3
+           #("a b c\n" 0 1 (face cider-debug-prompt-face) 2 3
              (face cider-debug-prompt-face) 4 5 (face cider-debug-prompt-face))))
   (should (equal-including-properties
            (cider--debug-prompt '("a" "bc"))
-           #("a bc" 0 1 (face cider-debug-prompt-face) 2 3 (face cider-debug-prompt-face))))
+           #("a bc\n" 0 1 (face cider-debug-prompt-face) 2 3 (face cider-debug-prompt-face))))
   (should (equal-including-properties
            (cider--debug-prompt '("abc"))
-           #("abc" 0 1 (face cider-debug-prompt-face)))))
+           #("abc\n" 0 1 (face cider-debug-prompt-face)))))
 
 (ert-deftest test-debug-move-point ()
   (with-temp-buffer


### PR DESCRIPTION
- The menu is pretty straightforward.
- The configurable input prompt (the list of debug keys) can be shown on the minibuffer, on an overlay above the function, on both, or not at all. I think I'll make `overlay` the default, so the echo-area will be less crowded. When the top of the function is not visible, the top of the window is used instead.

What do you say?