### PR TITLE
Configurable print-level and length for debugger values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#1191](https://github.com/clojure-emacs/cider/pull/1191): New custom variables `cider-debug-print-level` and `cider-debug-print-length`.
 * [#1188](https://github.com/clojure-emacs/cider/pull/1188): New debugging tool-bar.
 * [#1187](https://github.com/clojure-emacs/cider/pull/1187): The list of keys displayed by the debugger can be configured with `cider-debug-prompt`.
 * [#1187](https://github.com/clojure-emacs/cider/pull/1187): While debugging, there is a menu on the menu-bar listing available commands.

--- a/cider-debug.el
+++ b/cider-debug.el
@@ -90,6 +90,22 @@ configure `cider-debug-prompt' instead."
   :group'cider-debug
   :package-version"0.9.1")
 
+(defcustom cider-debug-print-level nil
+  "print-level for values displayed by the debugger.
+This variable must be set before starting the repl connection."
+  :type '(choice (const :tag "No limit" nil)
+                 (integer :tag "Max depth" 2))
+  :group 'cider-debug
+  :package-version '(cider-debug . "0.10.0"))
+
+(defcustom cider-debug-print-length nil
+  "print-length for values displayed by the debugger.
+This variable must be set before starting the repl connection."
+  :type '(choice (const :tag "No limit" nil)
+                 (integer :tag "Max depth" 4))
+  :group 'cider-debug
+  :package-version '(cider-debug . "0.10.0"))
+
 
 ;;; Implementation
 (defun cider--update-instrumented-defs (defs)
@@ -134,7 +150,9 @@ configure `cider-debug-prompt' instead."
 (defun cider--debug-init-connection ()
   "Initialize a connection with clj-debugger."
   (nrepl-send-request
-   '("op" "init-debugger")
+   '("op" "init-debugger"
+     "print-level" cider-debug-print-level
+     "print-length" cider-debug-print-length)
    (lambda (response)
      (nrepl-dbind-response response (status id instrumented-defs ns)
        (if (not (member "done" status))


### PR DESCRIPTION
Goes with https://github.com/clojure-emacs/cider-nrepl/pull/231