### PR TITLE
Double (Clojure + ClojureScript) client REPLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#1195](https://github.com/clojure-emacs/cider/pull/1195): CIDER can [create cljs REPLs](https://github.com/clojure-emacs/cider#clojurescript-usage). 
 * [#1191](https://github.com/clojure-emacs/cider/pull/1191): New custom variables `cider-debug-print-level` and `cider-debug-print-length`.
 * [#1188](https://github.com/clojure-emacs/cider/pull/1188): New debugging tool-bar.
 * [#1187](https://github.com/clojure-emacs/cider/pull/1187): The list of keys displayed by the debugger can be configured with `cider-debug-prompt`.

--- a/README.md
+++ b/README.md
@@ -717,45 +717,48 @@ section of your Leiningen project's configuration.
 
 ClojureScript support relies on the
 [piggieback](https://github.com/cemerick/piggieback) nREPL middleware being
-present in your REPL session. Version 0.2.0 or higher is recommended, and the
-below examples assume this, but version 0.1.5 is currently also supported.
+present in your REPL session.
 
-* Example usage of a non-browser connected Node.js REPL:
+1. Add the following dependencies to your `project.clj`
 
-  - At the Clojure REPL:
+   ```clojure
+   [com.cemerick/piggieback "0.2.1"]
+   [org.clojure/clojure "1.7.0"]
+   ```
 
-    ```clojure
-    (require '[cemerick.piggieback :as piggieback])
-    (require '[cljs.repl.node :as node])
-    (piggieback/cljs-repl (node/repl-env))
-    ```
+   as well as the following option:
 
-* Example usage of browser-connected Weasel REPL (requires
-e.g. `[weasel "0.6.0"]` in your project's `:dependencies`):
+   ```clojure
+   :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}
+   ```
 
-  - At the Clojure REPL:
+2. Issue <kbd>M-x</kbd> `customize-variable` <kbd>RET</kbd> `cider-cljs-repl` if
+   you'd like to change the REPL used (the default is `rhino`).
 
-    ```clojure
-    (require '[cemerick.piggieback :as piggieback])
-    (require '[weasel.repl.websocket :as weasel])
-    (piggieback/cljs-repl (weasel/repl-env :ip "127.0.0.1"
-                                           :port 9001))
-    ```
+3. Open a file in your project and issue <kbd>M-x</kbd>
+   `cider-jack-in-cljs`. This will start up the nREPL server, and then create
+   two REPL buffers for you, one in Clojure and one in ClojureScript. All usual
+   CIDER commands will be automatically directed to the appropriate REPL,
+   depending on whether you're visiting a `clj` or a `cljs` file.
 
-  - and in your ClojureScript:
+#### Browser-connected ClojureScript REPL
 
-    ```clojure
-    (ns my.cljs.core
-      (:require [weasel.repl :as repl]))
+Using Weasel, you can also have a browser-connected REPL.
 
-    (repl/connect "ws://localhost:9001")
-    ```
+1. Add `[weasel "0.6.0"]` to your project's `:dependencies`.
 
-The [clojure-quick-repls](https://github.com/symfrog/clojure-quick-repls)
-library provides helper functions to automate REPL creation for both Clojure and
-Clojurescript, and will also automatically route requests to the correct REPL
-according to the file extension of the current buffer (note that CIDER does not
-provide the latter functionality out-of-the-box).
+2. Issue <kbd>M-x</kbd> `customize-variable` <kbd>RET</kbd> `cider-cljs-repl`
+   and choose the `Weasel` option.
+
+3. Add this to your code:
+
+   ```clojure
+   (ns my.cljs.core
+     (:require [weasel.repl :as repl]))
+   (repl/connect "ws://localhost:9001")
+   ```
+
+4. Open a file in your project and issue `M-x cider-jack-in-cljs`.
 
 Provided that a Piggieback-enabled ClojureScript environment is active in your
 REPL session, code loading and evaluation will work seamlessly regardless of the

--- a/cider-debug.el
+++ b/cider-debug.el
@@ -268,6 +268,10 @@ Each element of LOCALS should be a list of at least two elements."
 (defun cider--debug-mode-redisplay ()
   "Display the input prompt to the user."
   (nrepl-dbind-response cider--debug-mode-response (debug-value input-type locals)
+    ;; The overlay code relies on window boundaries, but point could have been
+    ;; moved outside the window by some other code. Redisplay here to ensure the
+    ;; visible window includes point.
+    (redisplay)
     (when (or (eq cider-debug-prompt t)
               (eq cider-debug-prompt 'overlay))
       (if (overlayp cider--debug-prompt-overlay)

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -2160,6 +2160,10 @@ the string contents of the region into a formatted string."
 ;;; quiting
 (defun cider--close-buffer (buffer)
   "Close the BUFFER and kill its associated process (if any)."
+  (when nrepl-session
+    (nrepl-sync-request:close nrepl-session))
+  (when nrepl-tooling-session
+    (nrepl-sync-request:close nrepl-tooling-session))
   (when (get-buffer-process buffer)
     (delete-process (get-buffer-process buffer)))
   (when (get-buffer buffer)

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -312,7 +312,10 @@ Signal an error if it is not supported."
 Info contains project name, current REPL namespace, host:port
 endpoint and Clojure version."
   (with-current-buffer (get-buffer connection-buffer)
-    (format "Active nREPL connection: %s@%s:%s (Java %s, Clojure %s, nREPL %s)"
+    (format "Active nREPL connection: %s%s@%s:%s (Java %s, Clojure %s, nREPL %s)"
+            (if nrepl-sibling-buffer-alist
+                (upcase (concat cider-repl-type " "))
+              "")
             (or (nrepl--project-name nrepl-project-dir) "<no project>")
             (car nrepl-endpoint)
             (cadr nrepl-endpoint)

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -232,6 +232,9 @@ keep track of a namespace.
 This should never be set in Clojure buffers, as there the namespace
 should be extracted from the buffer's ns form.")
 
+(defvar-local cider-repl-type nil
+  "The type of this REPL buffer, usually either \"clj\" or \"cljs\".")
+
 (defun cider-ensure-op-supported (op)
   "Check for support of middleware op OP.
 Signal an error if it is not supported."

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -33,17 +33,29 @@
 (require 'cider-interaction)
 (require 'cider-eldoc)
 
+(defcustom cider-mode-line-show-connection t
+  "If the mode-line lighter should detail the connection."
+  :group 'cider
+  :type 'boolean
+  :package-version '(cider "0.10.0"))
+
 (defun cider--modeline-info ()
   "Return info for the `cider-mode' modeline.
 
 Info contains project name and host:port endpoint."
-  (let ((current-connection (nrepl-current-connection-buffer t)))
+  (let ((current-connection (cider-current-repl-buffer)))
     (if current-connection
         (with-current-buffer current-connection
-          (format "%s@%s:%s"
-                  (or (nrepl--project-name nrepl-project-dir) "<no project>")
-                  (car nrepl-endpoint)
-                  (cadr nrepl-endpoint)))
+          (concat
+           (when nrepl-sibling-buffer-alist
+             (concat cider-repl-type ":"))
+           (when cider-mode-line-show-connection
+             (format "%s@%s:%s"
+                     (or (nrepl--project-name nrepl-project-dir) "<no project>")
+                     (pcase (car nrepl-endpoint)
+                       ("localhost" "")
+                       (x x))
+                     (cadr nrepl-endpoint)))))
       "not connected")))
 
 ;;;###autoload

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -711,7 +711,9 @@ namespace to switch to."
                        (cider-current-ns))))
   (if (and ns (not (equal ns "")))
       (nrepl-request:eval (format "(in-ns '%s)" ns)
-                          (cider-repl-switch-ns-handler (cider-current-repl-buffer)))
+                          (cider-repl-switch-ns-handler (cider-current-repl-buffer))
+                          nil
+                          (cider-current-session))
     (error "No namespace selected")))
 
 

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -814,14 +814,15 @@ values of *1, *2, etc."
         (setq nrepl-versions versions)))))
 
 (defun nrepl-close-client-sessions ()
-  "Close the nREPL sessions for the active connection."
+  "Close the nREPL sessions for the active connection.
+If BUFFER is non-nil, close that buffer's connection."
   (nrepl-sync-request:close (nrepl-current-session))
   (nrepl-sync-request:close (nrepl-current-tooling-session)))
+(make-obsolete 'nrepl-close-client-sessions 'cider--close-buffer "0.10.0")
 
 (defun nrepl-close (connection-buffer)
   "Close the nREPL connection for CONNECTION-BUFFER."
   (interactive (list (nrepl-current-connection-buffer)))
-  (nrepl-close-client-sessions)
   (nrepl--close-connection-buffer connection-buffer)
   (run-hooks 'nrepl-disconnected-hook)
   (nrepl--connections-refresh))

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -1421,13 +1421,17 @@ The connections buffer is determined by
          (buffer (get-buffer connection))
          (endpoint (buffer-local-value 'nrepl-endpoint buffer)))
     (insert
-     (format "%s %-16s %5s   %s"
+     (format "%s %-16s %5s   %s%s"
              (if (equal connection (car nrepl-connection-list)) "*" " ")
              (car endpoint)
              (prin1-to-string (cadr endpoint))
              (or (nrepl--project-name
                   (buffer-local-value 'nrepl-project-dir buffer))
-                 "")))))
+                 "")
+             (with-current-buffer buffer
+               (if nrepl-sibling-buffer-alist
+                   (concat " " cider-repl-type)
+                 ""))))))
 
 (defun nrepl--project-name (stack)
   "Extracts a project name from STACK, possibly nil.


### PR DESCRIPTION
First, one needs to add these to `projec.clj` (as described on the Readme):

    :dependencies [[com.cemerick/piggieback "0.2.1"]
                   [org.clojure/tools.nrepl "0.2.10"]
                   [org.clojure/clojure "1.7.0"]]
    :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}

and then invoke `M-x cider-jack-in-clojurescript`. This should create two repl buffers.