### PR TITLE
Fix bug when completing with no prefix near point.

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1026,7 +1026,7 @@ form, with symbol at point replaced by __prefix__."
              (context (cider-defun-at-point))
              (_ (beginning-of-defun))
              (expr-start (point)))
-        (concat (substring context 0 (- pref-start expr-start))
+        (concat (when pref-start (substring context 0 (- pref-start expr-start)))
                 "__prefix__"
                 (substring context (- pref-end expr-start)))))))
 


### PR DESCRIPTION
Repro:

1. Insert in clojure buffer:

        (let [_] (partition-by (apply <)))

2. Put point at "_".
3. `C-d` to delete the underscore.
3. `C-c C-d C-d s p <tab>`

Error is thrown.