### PR TITLE
Address some corner cases

### DIFF
--- a/cider-debug.el
+++ b/cider-debug.el
@@ -298,6 +298,8 @@ In order to work properly, this mode must be activated by
       (if cider--debug-mode-response
           (nrepl-dbind-response cider--debug-mode-response (input-type)
             (setq-local tool-bar-map cider--debug-mode-tool-bar-map)
+            (add-hook 'kill-buffer-hook #'cider--debug-quit nil 'local)
+            (add-hook 'before-revert-hook #'cider--debug-quit nil 'local)
             (unless (consp input-type)
               (error "debug-mode activated on a message not asking for commands: %s" cider--debug-mode-response))
             ;; Integrate with eval commands.
@@ -380,6 +382,12 @@ specific message."
          "key" (or key (nrepl-dict-get cider--debug-mode-response "key")))
    #'ignore)
   (ignore-errors (cider--debug-mode -1)))
+
+(defun cider--debug-quit ()
+  "Send a :quit reply to the debugger. Used in hooks."
+  (when cider--debug-mode
+    (cider-debug-mode-send-reply ":quit")
+    (message "Quitting debug session")))
 
 
 ;;; Movement logic

--- a/cider-overlays.el
+++ b/cider-overlays.el
@@ -91,6 +91,10 @@ PROPS is a plist of properties and values to add to the overlay."
 VALUE is used as the overlay's after-string property, meaning it is
 displayed at the end of the overlay. The overlay itself is placed from
 beginning to end of current line.
+Return nil if the overlay was not placed or is not visible, and return the
+overlay otherwise.
+
+Return the overlay if it was placed successfully, and nil if it failed.
 
 If WHERE is a number or a marker, it is the character position of the line
 to use, otherwise use `point'.
@@ -120,8 +124,10 @@ PROPS are passed to `cider--make-overlay' with a type of result."
             (pcase duration
               ((pred numberp) (run-at-time duration nil #'cider--delete-overlay o))
               (`command (add-hook 'post-command-hook #'cider--remove-result-overlay nil 'local)))
-            o)))
-    (message "%s%s" cider-eval-result-prefix value)))
+            (-when-let (win (get-buffer-window buffer))
+              (when (pos-visible-in-window-p (point) win)
+                o)))))
+    nil))
 
 
 ;;; Displaying eval result
@@ -135,16 +141,22 @@ This function also removes itself from `post-command-hook'."
   "Display the result VALUE of an interactive eval operation.
 VALUE is syntax-highlighted and displayed in the echo area.
 If POINT and `cider-use-overlays' are non-nil, it is also displayed in an
-overlay at point."
-  (let ((font-value (cider-font-lock-as-clojure value)))
-    (when (and point cider-use-overlays)
-      (cider--make-result-overlay font-value point cider-eval-result-duration))
-    (message "%s%s" cider-eval-result-prefix font-value)
-    ;; Display the message anyway, but quickly erase it if we shouldn't have
-    ;; displayed it. This way it's always available in the Messages buffer.
-    (when (and cider-use-overlays
-               (not (eq cider-use-overlays 'both)))
-      (message nil))))
+overlay at the end of the line containing POINT.
+Note that, while POINT can be a number, it's preferable to be a marker, as
+that will better handle some corner cases where the original buffer is not
+focused."
+  (let* ((font-value (cider-font-lock-as-clojure value))
+         (used-overlay
+          (when (and point cider-use-overlays)
+            (cider--make-result-overlay font-value point cider-eval-result-duration))))
+    (message
+     "%s"
+     (propertize (format "%s%s" cider-eval-result-prefix font-value)
+                 ;; The following hides the message from the echo-area, but
+                 ;; displays it in the Messages buffer. We only hide the message
+                 ;; if the user wants to AND if the overlay succeeded.
+                 'invisible (and used-overlay
+                                 (not (eq cider-use-overlays 'both)))))))
 
 (provide 'cider-overlays)
 ;;; cider-overlays.el ends here

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -892,9 +892,10 @@ server responses."
   (lambda (response)
     (nrepl-dbind-response response (value ns out err status id ex root-ex
                                           session pprint-out)
-      (with-current-buffer buffer
-        (when (and ns (not (derived-mode-p 'clojure-mode)))
-          (setq cider-buffer-ns ns)))
+      (when (buffer-live-p buffer)
+        (with-current-buffer buffer
+          (when (and ns (not (derived-mode-p 'clojure-mode)))
+            (setq cider-buffer-ns ns))))
       (cond (value
              (when value-handler
                (funcall value-handler buffer value)))


### PR DESCRIPTION
- Add some safeguards to stop the debugger when the buffer is killed or reverted, so you don't get stuck in an unrecoverable debugging session.
- Change display-eval-result to be smarter when it receives a marker, so it does the right thing when the original buffer was killed before evaluation finished. 
- If the result overlay would be out of view (or in a hidden buffer) it will also display the result as a message regardless of user option.
- Hiding the message is better handled now. Instead of messaging the result and then messaging `nil` to hide it, we simply message the result with an `invisible` property. This means it's not displayed in the echo area, but shows up on the Messages buffer.
- `interactive-eval` takes a `bounds` third argument (instead of a point). This allows it to properly provide a good marker to `display-eval-result` (isntead of just giving it the `point-marker`), so the result of the evaluation is always displayed at the end of the sexp, instead of at line where point happens to be located.