### PR TITLE
Organize connection closing a bit

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -2167,13 +2167,15 @@ the string contents of the region into a formatted string."
 ;;; quiting
 (defun cider--close-buffer (buffer)
   "Close the BUFFER and kill its associated process (if any)."
-  (when nrepl-session
-    (nrepl-sync-request:close nrepl-session))
-  (when nrepl-tooling-session
-    (nrepl-sync-request:close nrepl-tooling-session))
-  (when (get-buffer-process buffer)
-    (delete-process (get-buffer-process buffer)))
-  (when (get-buffer buffer)
+  (when (buffer-live-p (get-buffer buffer))
+    (with-current-buffer buffer
+      (setq nrepl--closing-connection t)
+      (when nrepl-session
+        (nrepl-sync-request:close nrepl-session))
+      (when nrepl-tooling-session
+        (nrepl-sync-request:close nrepl-tooling-session))
+      (when (get-buffer-process buffer)
+        (delete-process (get-buffer-process buffer))))
     (kill-buffer buffer)))
 
 (defun cider-close-ancillary-buffers ()


### PR DESCRIPTION
While I was doing this, I spotted a few snippets which were being executed in the wrong buffer (the process sentinel isn't necessarily called in the process buffer).
I also added a safeguard so that the sentinels and hooks don't interfere with `nrepl--close-connection-buffer`. In the end, it feels like everytime I touch this side of the code it only gets more complicated.... =/

The order for closing things looks like it's correct now. The `sync-request:close` is indeed executed and returns successfully. I was surprised to find out that this doesn't terminate the process naturally (we still have to kill it manually).

---
Do stuff in the proper buffers.
Kill the client before the server.
Clarify the closing message.
Sentinels don't kill server/client counterparts if we're properly closing stuff.
