### PR TITLE
Add pagination of long collections to inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#1212](https://github.com/clojure-emacs/cider/pull/1212): Add pagination of long collections to inspector.
 * [#1201](https://github.com/clojure-emacs/cider/pull/1201): Integrate overlays with interactive evaluation. `cider-use-overlays` can be used to turn this on or off.
 * [#1195](https://github.com/clojure-emacs/cider/pull/1195): CIDER can [create cljs REPLs](https://github.com/clojure-emacs/cider#clojurescript-usage).
 * [#1191](https://github.com/clojure-emacs/cider/pull/1191): New custom variables `cider-debug-print-level` and `cider-debug-print-length`.

--- a/README.md
+++ b/README.md
@@ -875,6 +875,9 @@ Keyboard shortcut               | Description
 <kbd>Return</kbd> | inspect sub-objects
 <kbd>l</kbd> | pop to the parent object
 <kbd>g</kbd> | refresh the inspector (e.g. if viewing an atom/ref/agent)
+<kbd>SPC</kbd> | jump to next page in paginated view
+<kbd>M-SPC</kbd> | jump to previous page in paginated view
+<kbd>s</kbd> | set a new page size in paginated view
 
 ### cider-test-report-mode
 

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -46,6 +46,9 @@
     (define-key map [mouse-1] #'cider-inspector-operate-on-click)
     (define-key map "l" #'cider-inspector-pop)
     (define-key map "g" #'cider-inspector-refresh)
+    (define-key map "SPC" #'cider-inspector-next-page)
+    (define-key map "M-SPC" #'cider-inspector-prev-page)
+    (define-key map "s" #'cider-inspector-set-page-size)
     (define-key map [tab] #'cider-inspector-next-inspectable-object)
     (define-key map "\C-i" #'cider-inspector-next-inspectable-object)
     (define-key map [(shift tab)] #'cider-inspector-previous-inspectable-object) ; Emacs translates S-TAB
@@ -122,6 +125,34 @@ Used for all inspector nREPL ops."
   (interactive)
   (nrepl-send-request (list "op" "inspect-refresh"
                             "session" (nrepl-current-session))
+                      (cider-inspector-response-handler (current-buffer))))
+
+(defun cider-inspector-next-page ()
+  "Jump to the next page when inspecting a paginated sequence/map.
+
+Does nothing if already on the last page."
+  (interactive)
+  (nrepl-send-request (list "op" "inspect-next-page"
+                            "session" (nrepl-current-session))
+                      (cider-inspector-response-handler (current-buffer))))
+
+(defun cider-inspector-prev-page ()
+  "Jump to the previous page when expecting a paginated sequence/map.
+
+Does nothing if already on the first page."
+  (interactive)
+  (nrepl-send-request (list "op" "inspect-prev-page"
+                            "session" (nrepl-current-session))
+                      (cider-inspector-response-handler (current-buffer))))
+
+(defun cider-inspector-set-page-size (page-size)
+  "Set the page size in pagination mode to the specified value.
+
+Current page will be reset to zero."
+  (interactive "nPage size:")
+  (nrepl-send-request (list "op" "inspect-set-page-size"
+                            "session" (nrepl-current-session)
+                            "page-size" page-size)
                       (cider-inspector-response-handler (current-buffer))))
 
 ;; Render Inspector from Structured Values

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -36,6 +36,20 @@
 
 (defconst cider-inspector-buffer "*cider inspect*")
 
+;;; Customization
+(defgroup cider-inspector nil
+  "Presentation and behaviour of the cider value inspector."
+  :prefix "cider-inspector-"
+  :group 'cider
+  :package-version '(cider . "0.10.0"))
+
+(defcustom cider-inspector-page-size 32
+  "Default page size in paginated inspector view.
+The page size can be also changed interactively within the inspector."
+  :type '(integer :tag "Page size" 32)
+  :group 'cider-inspector
+  :package-version '(cider . "0.10.0"))
+
 (push cider-inspector-buffer cider-ancillary-buffers)
 
 (defvar cider-inspector-mode-map
@@ -106,7 +120,8 @@ Used for all inspector nREPL ops."
 (defun cider-inspect-expr (expr ns)
   (cider--prep-interactive-eval expr)
   (nrepl-send-request (append (nrepl--eval-request expr ns)
-                              (list "inspect" "true"))
+                              (list "inspect" "true"
+                                    "page-size" (or cider-inspector-page-size 32)))
                       (cider-inspector-response-handler (current-buffer))))
 
 (defun cider-inspector-pop ()


### PR DESCRIPTION
Frontend part of the pagination feature.

Keys are arbitrary, suggestions are welcome.

- `.` for next page
- `,` for previous page
- `z` to set a new page size inside the inspector

Missing features:

- [ ] specifying a default page size. Right now it is hardcoded to 32.

Sister pull request is clojure-emacs/cider-nrepl#238.