### PR TITLE
Case handling in nrepl-project-directory-for

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -468,12 +468,6 @@ is ambiguity, therefore nil is returned."
       (file-name-directory buffer-file-name)
     default-directory))
 
-(defun cider-project-directory-for (dir-name)
-  "Return the project directory for the specified DIR-NAME."
-  (when dir-name
-    (or (locate-dominating-file dir-name "project.clj")
-        (locate-dominating-file dir-name "build.boot"))))
-
 (defun cider-set-relevant-connection (&optional do-prompt)
   "Try to set the current REPL buffer based on the the current Clojure source buffer.
 If succesful, return the new connection buffer.
@@ -482,10 +476,10 @@ directory."
   (interactive "P")
   (cider-ensure-connected)
   (let* ((project-directory
-          (cider-project-directory-for
+          (clojure-project-dir
            (or (when do-prompt
                  (read-directory-name "Project: "
-                                      (cider-project-directory-for (buffer-file-name))
+                                      (clojure-project-dir (buffer-file-name))
                                       nil
                                       'confirm))
                (cider-current-dir))))

--- a/cider.el
+++ b/cider.el
@@ -229,7 +229,7 @@ own buffer."
     (if (funcall (cider-command-present-p project-type))
         (let* ((project (when prompt-project
                           (read-directory-name "Project: ")))
-               (project-dir (cider-project-directory-for
+               (project-dir (clojure-project-dir
                              (or project (cider-current-dir))))
                (params (if prompt-project
                            (read-string (format "nREPL server command: %s "
@@ -337,7 +337,7 @@ of list of the form (project-dir port)."
          (proj-ports (mapcar (lambda (d)
                                (-when-let (port (and d (nrepl-extract-port (cider--file-path d))))
                                  (list (file-name-nondirectory (directory-file-name d)) port)))
-                             (cons (cider-project-directory-for dir) paths))))
+                             (cons (clojure-project-dir dir) paths))))
     (-distinct (delq nil proj-ports))))
 
 (defun cider--running-nrepl-paths ()
@@ -355,7 +355,7 @@ Use `cider-ps-running-nrepls-command' and `cider-ps-running-nrepl-path-regexp-li
 (defun cider-project-type ()
   "Determine the type, either leiningen or boot, of the current project.
 If both project file types are present, prompt the user to choose."
-  (let* ((default-directory (cider-project-directory-for (cider-current-dir)))
+  (let* ((default-directory (clojure-project-dir (cider-current-dir)))
          (lein-project-exists (file-exists-p "project.clj"))
          (boot-project-exists (file-exists-p "build.boot")))
     (cond ((and lein-project-exists boot-project-exists)

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -385,7 +385,7 @@
   (should (equal (cider--find-rest-args-position [fmt arg]) nil)))
 
 (ert-deftest test-cider-switch-to-relevant-repl-buffer ()
-  (noflet ((cider-project-directory-for (dontcare)
+  (noflet ((clojure-project-dir (dontcare)
                                         nrepl-project-dir))
     (let* ((b1 (generate-new-buffer "temp"))
            (b2 (generate-new-buffer "temp"))
@@ -435,7 +435,7 @@
         (kill-buffer buf)))))
 
 (ert-deftest test-cider-switch-to-relevant-repl-buffer-ambiguous-project-dir ()
-  (noflet ((cider-project-directory-for (dontcare)
+  (noflet ((clojure-project-dir (dontcare)
                                         nrepl-project-dir))
     (let* ((b1 (generate-new-buffer "temp"))
            (b2 (generate-new-buffer "temp"))
@@ -459,7 +459,7 @@
         (kill-buffer buf)))))
 
 (ert-deftest test-cider-switch-to-relevant-repl-buffer-ambiguous-if-two-projects ()
-  (noflet ((cider-project-directory-for (dontcare)
+  (noflet ((clojure-project-dir (dontcare)
                                         nrepl-project-dir))
     (let* ((b1 (generate-new-buffer "temp"))
            (b2 (generate-new-buffer "temp"))


### PR DESCRIPTION
Some case example:

- `/a/project.clj`
- `/a/b/build.boot`

if your default-directory is `/a/b`, then in existing code `(nrepl-project-directory-for-test (nrepl-current-dir))` always returns `/a/`. So this isn't what we want.

Replaced code will returns `/a/b/`.