### PR TITLE
Uppercase the print cider version

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -310,7 +310,7 @@ Signal an error if it is not supported."
        (unless (and middleware-version (equal cider-version middleware-version))
          (cider-repl-emit-interactive-err-output
           (format "ERROR: CIDER's version (%s) does not match cider-nrepl's version (%s). Things will break!"
-                  cider-version middleware-version)))))
+                  (upcase cider-version) middleware-version)))))
    '()
    '()
    '()))


### PR DESCRIPTION
#### What's this PR do?
This PR simply uppercases the `cider-version` in the middleware check callback.  

```
ERROR: CIDER's version (0.10.0-SNAPSHOT) does not match cider-nrepl's version (0.9.0). Things will break!
```

This is also keeps things consistent with the other areas where `upcase` is applied to `cider-version`.