### PR TITLE
Add cider-load-buffer-and-switch-to-repl-buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 ### New features
+* [#1232](https://github.com/clojure-emacs/cider/pull/1232): Add cider-load-buffer-and-switch-to-repl-buffer
 * [#1325](https://github.com/clojure-emacs/cider/issues/1325): Jump to error location when clicking on the error message in the stack-trace pop-up.
 * [#1301](https://github.com/clojure-emacs/cider/issues/1301): CIDER can do dynamic font-locking of defined variables, functions, and macros. This is controlled by the `cider-font-lock-dynamically` custom option.
 * [#1271](https://github.com/clojure-emacs/cider/issues/1271): New possible value (`always-save`) for `cider-prompt-save-file-on-load`.

--- a/README.md
+++ b/README.md
@@ -930,6 +930,7 @@ Keyboard shortcut                    | Description
 <kbd>C-c M-n</kbd>                   | Switch the namespace of the REPL buffer to the namespace of the current buffer.
 <kbd>C-c C-z</kbd>                   | Switch to the relevant REPL buffer. Use a prefix argument to change the namespace of the REPL buffer to match the currently visited source file.
 <kbd>C-u C-u C-c C-z</kbd>           | Switch to the REPL buffer based on a user prompt for a directory.
+<kbd>C-c M-z</kbd>                   | Load (eval) the current buffer and switch to the relevant REPL buffer. Use a prefix argument to change the namespace of the REPL buffer to match the currently visited source file.
 <kbd>C-c M-d</kbd>                   | Display default REPL connection details, including project directory name, buffer namespace, host and port.
 <kbd>C-c M-r</kbd>                   | Rotate and display the default nREPL connection.
 <kbd>C-c M-o</kbd>                   | Clear the entire REPL buffer, leaving only a prompt. Useful if you're running the REPL buffer in a side by side buffer.

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -581,6 +581,12 @@ of the namespace in the Clojure source buffer."
   (interactive "P")
   (cider--switch-to-repl-buffer (cider-current-repl-buffer) set-namespace))
 
+(defun cider-load-buffer-and-switch-to-repl-buffer (&optional set-namespace)
+  "Load the current buffer into the relevant REPL buffer and switch to it."
+  (interactive "P")
+  (cider-load-buffer)
+  (cider-switch-to-relevant-repl-buffer set-namespace))
+
 (defun cider-switch-to-last-clojure-buffer ()
   "Switch to the last Clojure buffer.
 The default keybinding for this command is

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -105,6 +105,7 @@ entirely."
     (define-key map (kbd "C-c M-t v") #'cider-toggle-trace-var)
     (define-key map (kbd "C-c M-t n") #'cider-toggle-trace-ns)
     (define-key map (kbd "C-c C-z") #'cider-switch-to-repl-buffer)
+    (define-key map (kbd "C-c M-z") #'cider-load-buffer-and-switch-to-repl-buffer)
     (define-key map (kbd "C-c M-o") #'cider-find-and-clear-repl-buffer)
     (define-key map (kbd "C-c C-k") #'cider-load-buffer)
     (define-key map (kbd "C-c C-l") #'cider-load-file)


### PR DESCRIPTION
@SirSkidmore and I wrote a command `C-c M-z` to abbreviate:

```
C-c C-k
C-u C-c C-z
```

Specifically, the function will load (eval) the current buffer, change the namespace of the REPL buffer to match the currently visited source file, and then switch to the relevant REPL buffer.

We thought about parameterizing the the function to selecting the REPL buffer, but that would have to be done before `cider-load-buffer` is invoked, and weren't sure how to handle that. While attempting to do it, the message from `cider-load-buffer` would be in the way unless you know to type something to get rid of it.