### PR TITLE
Add support for `(...) to the debugger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#1235](https://github.com/clojure-emacs/cider/pull/1235): Add support for syntax-quoted forms to the debugger.
 * [#1212](https://github.com/clojure-emacs/cider/pull/1212): Add pagination of long collections to inspector.
 * [#1201](https://github.com/clojure-emacs/cider/pull/1201): Integrate overlays with interactive evaluation. `cider-use-overlays` can be used to turn this on or off.
 * [#1195](https://github.com/clojure-emacs/cider/pull/1195): CIDER can [create cljs REPLs](https://github.com/clojure-emacs/cider#clojurescript-usage).

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -65,6 +65,43 @@
     (message "%S" (point))
     (should (string= (thing-at-point 'symbol) "2"))))
 
+(ert-deftest test-debug-move-point-syntax-quote ()
+  (with-temp-buffer
+    (clojure-mode)
+    (save-excursion (insert "(let [b 1] `((~b)))"))
+    (cider--debug-move-point '(2 1 1 1 1 1 1))
+    (should (string= (buffer-substring (point-min) (point)) "(let [b 1] `((~b"))
+    (goto-char (point-min))
+    (cider--debug-move-point '(2 1 1 1 1))
+    (should (string= (buffer-substring (point-min) (point)) "(let [b 1] `((~b)")))
+
+  (with-temp-buffer
+    (clojure-mode)
+    (save-excursion (insert "`((~a))"))
+    (cider--debug-move-point '(1 1 1 1 1 1))
+    (should (string= (buffer-substring (point-min) (point)) "`((~a"))
+    (goto-char (point-min))
+    (cider--debug-move-point '(1 1 1 1))
+    (should (string= (buffer-substring (point-min) (point)) "`((~a)")))
+
+  (with-temp-buffer
+    (clojure-mode)
+    (save-excursion (insert "`#{(~c)}"))
+    (cider--debug-move-point '(2 1 1 1 1 1))
+    (should (string= (buffer-substring (point-min) (point)) "`#{(~c"))
+    (goto-char (point-min))
+    (cider--debug-move-point '(2 1 1 1))
+    (should (string= (buffer-substring (point-min) (point)) "`#{(~c)")))
+
+  (with-temp-buffer
+    (clojure-mode)
+    (save-excursion (insert "`[(~d)]"))
+    (cider--debug-move-point '(2 1 1 1 1 1))
+    (should (string= (buffer-substring (point-min) (point)) "`[(~d"))
+    (goto-char (point-min))
+    (cider--debug-move-point '(2 1 1 1))
+    (should (string= (buffer-substring (point-min) (point)) "`[(~d)"))))
+
 (ert-deftest test-cider-connection-buffer-name ()
   (setq-local nrepl-endpoint '("localhost" 1))
   (let ((nrepl-hide-special-buffers nil))


### PR DESCRIPTION
This covers most cases, but it still doesn't cover when there's a hard quote inside the backticked form.