### PR TITLE
[Fix #1222] Add option to apply a single face to the results overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#1245](https://github.com/clojure-emacs/cider/pull/1245): New variable, `cider-ovelays-use-font-lock` controls whether results overlay should be font-locked or just use a single face.
 * [#1235](https://github.com/clojure-emacs/cider/pull/1235): Add support for syntax-quoted forms to the debugger.
 * [#1212](https://github.com/clojure-emacs/cider/pull/1212): Add pagination of long collections to inspector.
 * [#1237](https://github.com/clojure-emacs/cider/pull/1237): Add two functions for use with `cider-repl-prompt-function`, `cider-repl-prompt-lastname` and `repl-prompt-abbreviated`.

--- a/README.md
+++ b/README.md
@@ -665,6 +665,21 @@ CIDER integration for `eval-sexp-fu`.
 (require 'cider-eval-sexp-fu)
 ```
 
+### Overlays
+
+When you evaluate code in Clojure files, the result is displayed in the buffer itself, in an overlay right after the evaluated code.
+If you want this overlay to be font-locked (syntax-highlighted) like Clojure code, set the following variable.
+
+```el
+(setq cider-ovelays-use-font-lock t)
+```
+
+You can disable overlays entirely (and display results in the echo-area at the bottom) with the `cider-use-overlays` variable.
+
+```el
+(setq cider-use-overlays nil)
+```
+
 ## Basic Usage
 
 The only requirement to use CIDER is to have a nREPL server to


### PR DESCRIPTION
New variable, cider-ovelays-use-font-lock controls whether results overlay should be font-locked or just use a single face