### PR TITLE
Fix undefined function

### DIFF
--- a/cider-util.el
+++ b/cider-util.el
@@ -100,7 +100,9 @@ PROP is the name of a text property."
         (setq-local delay-mode-hooks t)
         (setq delayed-mode-hooks nil)
         (funcall mode)
-        (font-lock-ensure)
+        (if (fboundp 'font-lock-ensure)
+            (font-lock-ensure)
+          (font-lock-fontify-buffer))
         (buffer-string))
     string))
 


### PR DESCRIPTION
`font-lock-ensure` is not defined in Emacs-24 and lower version.
related commit: a84e2c1