### PR TITLE
[Fix #1239] Add cider-refresh-show-log-buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [#1220](https://github.com/clojure-emacs/cider/issues/1220): Treat keywords as symbols in lookup commands like `cider-find-var`.
 * [#1241](https://github.com/clojure-emacs/cider/pull/1241): Passing a double prefix argument to `cider-refresh` will now clear the state of the namespace tracker used by the refresh middleware. This is useful for recovering from errors that a normal reload would not otherwise recover from, but may cause stale code in any deleted files to not be completely unloaded.
 * New defcustom `cider-result-use-clojure-font-lock` allows you disable the use of Clojure font-locking for interactive results.
+* [#1239](https://github.com/clojure-emacs/cider/issues/1239): New defcustom `cider-refresh-show-log-buffer`, controls the behaviour of the `*cider-refresh-log*` buffer when calling `cider-refresh`. When set to nil (the default), the log buffer will still be written to, but not displayed automatically. Instead, the most relevant information will be displayed in the echo area. When set to non-nil, the log buffer will be displayed every time `cider-refresh` is called.
 
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -544,6 +544,21 @@ passed or failed:
   expected to be side-effecting - they will always be executed serially, without
   retries.
 
+* By default, messages regarding the status of the in-progress reload will be
+  displayed in the echo area after you call `cider-refresh`. The same
+  information will also be recorded in the `*cider-refresh-log*` buffer, along
+  with anything printed to `*out*` or `*err*` by `cider-refresh-before-fn` and
+  `cider-refresh-start-fn`.
+
+* You can make the `*cider-refresh-log*` buffer display automatically after you
+  call `cider-refresh` by setting the `cider-refresh-show-log-buffer` variable
+  to a non-nil value (this will also prevent any related messages from also
+  being displayed in the echo area):
+
+```el
+(setq cider-refresh-show-log-buffer t)
+```
+
 ### REPL history
 
 * To make the REPL history wrap around when its end is reached:


### PR DESCRIPTION
Been using this for the past couple of days - definitely preferable to have it `nil` by default. Since the error buffer pops up when something goes wrong, the refresh log is only really useful to show when debugging using the output of the before/after fns.

Maybe a `cider-visit-refresh-log-buffer` command would be useful for quickly popping up the refresh log on demand - or add it as an option to the selector?