### PR TITLE
[Fix #1252] Fix breakage in cider-repl-clear-buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 * Renamed `cider-repl-output-face` to `cider-repl-stdout-face` and `cider-repl-err-output-face` to `cider-repl-stderr-face`.
 
 ### Bugs fixed
-
+* [#1252](https://github.com/clojure-emacs/cider/issues/1252) `cider-repl-clear-buffer` stops working in certain circumstances.
 * [#1164](https://github.com/clojure-emacs/cider/pull/1164): Fix an error in `cider-browse-ns--doc-at-point`.
 * [#1189](https://github.com/clojure-emacs/cider/issues/1189): Don't show result from automatic ns form evaluation.
 * [#1079](https://github.com/clojure-emacs/cider/issues/1079): Don't try to font-lock very long results. The maximum font-lockable result length is controlled by `cider-font-lock-max-length`.

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -686,12 +686,8 @@ text property `cider-old-input'."
 
 (defun cider-repl--end-of-line-before-input-start ()
   "Return the position of the end of the line preceding the beginning of input."
-  (save-excursion
-    (goto-char cider-repl-input-start-mark)
-    ;; do not use `previous-line', but `line-move' with noerror
-    ;; moving up from the first line should not throw error
-    (line-move -1 t nil nil)
-    (line-end-position)))
+  (1- (previous-single-property-change cider-repl-input-start-mark 'field nil
+                                       (1+ (point-min)))))
 
 (defun cider-repl-clear-output ()
   "Delete the output inserted since the last input."


### PR DESCRIPTION
After running cider-repl-clear-buffer and then loading a file creating
output (e.g. because it contains println statements) the output would
appear in the wrong place, causing the prompt to disappear.

The problem was in the function responsible for putting POINT in the right
place before emitting evaluation results into the repl buffer.  When the
prompt was the first line in the buffer,
cider-repl--end-of-line-before-input-start didn't move point at all.

cider-repl--end-of-line-before-input-start is now changed to move backward
past the cider-repl-prompt field in order to find the appropriate output
position.
