### PR TITLE
Fix vagrant provision failure

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,8 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant::Config.run do |config|
-  config.vm.box = "precise64"
-  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  config.vm.box = "ubuntu/trusty64"
 
   config.vm.provision :shell, :path => "vagrant/provision.sh"
 end

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -29,7 +29,7 @@ CASK_DIR=/opt/cask-$CASK_VERSION
 CASK_ARCHIVE=https://github.com/cask/cask/archive/v$CASK_VERSION.tar.gz
 if ! [ -d "$CASK_DIR" -a -x "/$CASK_DIR/bin/cask" ]; then
     sudo rm -rf "$CASK_DIR"
-    wget -O - $CASK_ARCHIVE | sudo tar xz -C /opt
+    wget -q -O - $CASK_ARCHIVE | sudo tar xz -C /opt
     # Bring Cask into $PATH
     sudo ln -fs "$CASK_DIR/bin/cask" /usr/local/bin
 fi


### PR DESCRIPTION
A simple `vagrant up` fails. The default image seems to not
have `apt-add-repository`.

Fixed by installing `python-software-properties` before adding ppa.

This only affects local development, not travisci.