### PR TITLE
Fix error in cider--check-required-nrepl-version

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -337,10 +337,8 @@ Signal an error if it is not supported."
     (if nrepl-version
         (when (version< nrepl-version cider-required-nrepl-version)
           (cider-repl-emit-interactive-stderr
-           (cider--insert-readme-button
-            (format "WARNING: CIDER requires nREPL %s (or newer) to work properly"
-                    cider-required-nrepl-version)
-            "warning-saying-you-have-to-use-nrepl-027")))
+           (format "WARNING: CIDER requires nREPL %s (or newer) to work properly"
+                   cider-required-nrepl-version)))
       (cider-repl-emit-interactive-stderr
        (format "WARNING: Can't determine nREPL's version. Please, update nREPL to %s."
                cider-required-nrepl-version)))))


### PR DESCRIPTION
* cider-interaction.el (cider--check-required-nrepl-version):
  `cider-repl-emit-interactive-stderr' requires a string, while
  `cider--insert-readme-button' returns an overlay. Remove
  `cider--insert-readme-button' to fix the error and bring back the old style.