### PR TITLE
Fix many compile warnings

### DIFF
--- a/cider-debug.el
+++ b/cider-debug.el
@@ -27,9 +27,12 @@
 
 (require 'nrepl-client)
 (require 'cider-interaction)
+(require 'cider-client)
 (require 'cider-inspector)
 (require 'cider-browse-ns)
+(require 'cider-util)
 (require 'dash)
+(require 'spinner)
 
 
 ;;; Customization
@@ -424,7 +427,7 @@ ID is the id of the message that instrumented CODE."
           (erase-buffer)
           (insert
            (format "%s" (cider--debug-trim-code code)))
-          (font-lock-fontify-buffer)
+          (cider--font-lock-ensure)
           (set-buffer-modified-p nil))))
     (switch-to-buffer buffer-name)
     (goto-char (point-min))))
@@ -445,7 +448,7 @@ sexp."
         (while coordinates
           (down-list)
           ;; Are we entering a syntax-quote?
-          (when (looking-back "`\\(#{\\|[{[(]\\)")
+          (when (looking-back "`\\(#{\\|[{[(]\\)" (line-beginning-position))
             ;; If we are, this affects all nested structures until the next `~',
             ;; so we set this variable for all following steps in the loop.
             (setq in-syntax-quote t))
@@ -458,7 +461,7 @@ sexp."
             (unless (eq ?\( (char-before))
               (pop coordinates)))
           ;; #(...) is read as (fn* ([] ...)), so we patch that here.
-          (when (looking-back "#(")
+          (when (looking-back "#(" (line-beginning-position))
             (pop coordinates))
           (if coordinates
               (let ((next (pop coordinates)))

--- a/cider-doc.el
+++ b/cider-doc.el
@@ -186,6 +186,8 @@
           "Can't find the source because it wasn't defined with `cider-eval-buffer'")))
     (error "No source location for %s" cider-docview-symbol)))
 
+(defvar cider-buffer-ns)
+
 (defun cider-docview-grimoire ()
   (interactive)
   (if cider-buffer-ns

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -194,7 +194,7 @@ Current page will be reset to zero."
         ((and (consp el) (eq (car el) :newline))
          (newline))
         ((and (consp el) (eq (car el) :value))
-         (cider-irender-value (cadr el) (caddr el)))
+         (cider-irender-value (cadr el) (cl-caddr el)))
         (t (message "Unrecognized inspector object: %s" el))))
 
 (defun cider-irender-value (value idx)
@@ -216,7 +216,7 @@ LIMIT is the maximum or minimum position in the current buffer.
 Return a list of two values: If an object could be found, the
 starting position of the found object and T is returned;
 otherwise LIMIT and NIL is returned."
-  (let ((finder (ecase direction
+  (let ((finder (cl-ecase direction
                   (next 'next-single-property-change)
                   (prev 'previous-single-property-change))))
     (let ((prop nil) (curpos (point)))

--- a/cider-macroexpansion.el
+++ b/cider-macroexpansion.el
@@ -143,7 +143,7 @@ If invoked with a PREFIX argument, use 'macroexpand' instead of
     (erase-buffer)
     (insert (format "%s" expansion))
     (goto-char (point-max))
-    (font-lock-fontify-buffer)))
+    (cider--font-lock-ensure)))
 
 (defun cider-redraw-macroexpansion-buffer (expansion buffer start end)
   "Redraw the macroexpansion with new EXPANSION.

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -32,6 +32,7 @@
 
 (require 'cider-interaction)
 (require 'cider-eldoc)
+(require 'cider-repl)
 
 (defcustom cider-mode-line-show-connection t
   "If the mode-line lighter should detail the connection."

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -38,6 +38,7 @@
 
 (require 'clojure-mode)
 (require 'easymenu)
+(require 'cl-lib)
 
 (eval-when-compile
   (defvar paredit-version)
@@ -638,7 +639,7 @@ are not balanced."
 If REPLACE is non-nil the current input is replaced with the old
 input; otherwise the new input is appended.  The old input has the
 text property `cider-old-input'."
-  (multiple-value-bind (beg end) (cider-property-bounds 'cider-old-input)
+  (cl-multiple-value-bind (beg end) (cider-property-bounds 'cider-old-input)
     (let ((old-input (buffer-substring beg end)) ;;preserve
           ;;properties, they will be removed later
           (offset (- (point) beg)))

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -87,6 +87,7 @@ cyclical data structures."
 (defvar-local cider-stacktrace-prior-filters nil)
 (defvar-local cider-stacktrace-cause-visibility nil)
 
+(defconst cider-error-buffer "*cider-error*")
 
 ;; Faces
 

--- a/cider-util.el
+++ b/cider-util.el
@@ -95,6 +95,13 @@ PROP is the name of a text property."
 
 ;;; Font lock
 
+(defun cider--font-lock-ensure ()
+  "Call `font-lock-ensure' or `font-lock-fontify-buffer', as appropriate."
+  (if (fboundp 'font-lock-ensure)
+      (font-lock-ensure)
+    (with-no-warnings
+      (font-lock-fontify-buffer))))
+
 (defun cider-font-lock-as (mode string)
   "Use MODE to font-lock the STRING."
   (if (or (null cider-font-lock-max-length)
@@ -106,9 +113,7 @@ PROP is the name of a text property."
         (setq-local delay-mode-hooks t)
         (setq delayed-mode-hooks nil)
         (funcall mode)
-        (if (fboundp 'font-lock-ensure)
-            (font-lock-ensure)
-          (font-lock-fontify-buffer))
+        (cider--font-lock-ensure)
         (buffer-string))
     string))
 
@@ -143,6 +148,8 @@ Unless you specify a BUFFER it will default to the current one."
     (cider-scale-color color (if dark 0.05 -0.05))))
 
 (autoload 'pkg-info-version-info "pkg-info.el")
+
+(defvar cider-version)
 
 (defun cider--version ()
   "Retrieve CIDER's version."

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -851,6 +851,7 @@ values of *1, *2, etc."
                              (cider-default-err-handler session))
   "Evaluation error handler.")
 
+(defvar cider-buffer-ns)
 (defun nrepl-make-response-handler (buffer value-handler stdout-handler
                                            stderr-handler done-handler
                                            &optional eval-error-handler)


### PR DESCRIPTION
Most of the remaining warnings would be fixed if we cleaned up
cider-interaction a little bit.
In the very least, there are many repl-related functions in there which
should cleanly fit into cider-repl.