### PR TITLE
Fix cider-current-repl-buffer calls referring to nonexistent function

### DIFF
--- a/cider-client.el
+++ b/cider-client.el
@@ -412,7 +412,7 @@ loaded. If CALLBACK is nil, use `cider-load-file-handler'."
                              "ns" (cider-current-ns)
                              "symbol" str
                              "context" context)
-                       (nrepl-send-sync-request (cider-current-repl) 'abort-on-input)))
+                     (nrepl-send-sync-request (cider-current-repl-buffer) 'abort-on-input)))
     (nrepl-dict-get dict "completions")))
 
 (defun cider-sync-request:info (symbol &optional class member)
@@ -436,7 +436,7 @@ loaded. If CALLBACK is nil, use `cider-load-file-handler'."
                           ,@(when symbol (list "symbol" symbol))
                           ,@(when class (list "class" class))
                           ,@(when member (list "member" member)))
-                        (nrepl-send-sync-request (cider-current-repl) 'abort-on-input)))
+                        (nrepl-send-sync-request (cider-current-repl-buffer) 'abort-on-input)))
     (if (member "no-eldoc" (nrepl-dict-get eldoc "status"))
         nil
       eldoc)))

--- a/cider-eldoc.el
+++ b/cider-eldoc.el
@@ -123,7 +123,7 @@ Return the number of nested sexp the point was over or after. "
 
 (defun cider-eldoc-arglist (thing)
   "Return the arglist for THING."
-  (when (and (nrepl-op-supported-p "eldoc" (cider-current-repl))
+  (when (and (nrepl-op-supported-p "eldoc" (cider-current-repl-buffer))
              thing
              (not (string= thing ""))
              (not (string-prefix-p ":" thing)))

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -292,12 +292,12 @@ the project associated with a connection and the default connection.")
 (defun cider-ensure-op-supported (op)
   "Check for support of middleware op OP.
 Signal an error if it is not supported."
-  (unless (nrepl-op-supported-p op (cider-current-repl))
+  (unless (nrepl-op-supported-p op (cider-current-repl-buffer))
     (error "Can't find nREPL middleware providing op \"%s\".  Please, install (or update) cider-nrepl %s and restart CIDER" op (upcase cider-version))))
 
 (defun cider--check-required-nrepl-ops ()
   "Check whether all required nREPL ops are present."
-  (let* ((current-connection (cider-current-repl))
+  (let* ((current-connection (cider-current-repl-buffer))
          (missing-ops (-remove (lambda (op) (nrepl-op-supported-p op current-connection)) cider-required-nrepl-ops)))
     (when missing-ops
       (cider-repl-emit-interactive-stderr
@@ -1482,7 +1482,7 @@ into a new error buffer."
   "Make an error handler for BUFFER, EX, ROOT-EX and SESSION.
 This function determines how the error buffer is shown, and then delegates
 the actual error content to the eval or op handler."
-  (if (nrepl-op-supported-p "stacktrace" (cider-current-repl))
+  (if (nrepl-op-supported-p "stacktrace" (cider-current-repl-buffer))
       (cider-default-err-op-handler session)
     (cider-default-err-eval-handler session)))
 

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -943,7 +943,7 @@ Handles only stdout and stderr responses."
 REQUEST is a pair list of the form (\"op\" \"operation\" \"par1-name\"
 \"par1\" ... ). See the code of `nrepl-request:clone',
 `nrepl-request:stdin', etc."
-  (let* ((connection (or connection (cider-current-repl)))
+  (let* ((connection (or connection (cider-current-repl-buffer)))
          (id (nrepl-next-request-id connection))
          (request (cons 'dict (lax-plist-put request "id" id)))
          (message (nrepl-bencode request)))
@@ -961,7 +961,7 @@ Hold till final \"done\" message has arrived and join all response messages
 of the same \"op\" that came along.
 If ABORT-ON-INPUT is non-nil, the function will return nil at the first
 sign of user input, so as not to hang the interface."
-  (let* ((connection (or connection (cider-current-repl)))
+  (let* ((connection (or connection (cider-current-repl-buffer)))
          (time0 (current-time))
          (response (cons 'dict nil))
          (nrepl-ongoing-sync-request t)


### PR DESCRIPTION
Trying the new overlay code I discovered cider would crash on startup. I looked at the recent changes and saw some changes in the way the client now requires an explicit buffer.

After this change, I'm able to start cider on my hobby project again.

I'm not that familiar with the cider code base, so in case this is erroneous, please discard it.

; CIDER 0.10.0snapshot (package: 20150825.602) (Java 1.7.0_79, Clojure 1.7.0, nREPL 0.2.10)