### PR TITLE
Run tests against multiple versions of emacs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ elpa
 TAGS
 .DS_STORE
 dist
+.vagrant/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
+sudo: true
 language: emacs-lisp
 env:
-  - EMACS=emacs24
-#  - EMACS=emacs-snapshot
+  - EMACS_BINARY=emacs-24.3-bin PATH=$HOME/.evm/bin:$PATH
+  - EMACS_BINARY=emacs-24.4-bin PATH=$HOME/.evm/bin:$PATH
+  - EMACS_BINARY=emacs-24.5-bin PATH=$HOME/.evm/bin:$PATH
+  - EMACS_BINARY=emacs-snapshot
+
 before_script:
   - sh vagrant/provision.sh
-  - make EMACS=${EMACS} elpa
+  - make elpa
 script:
-  - make EMACS=${EMACS} test
+  - make test

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,13 @@ elpa:
 	$(CASK) update
 	touch $@
 
-.PHONY: build
+.PHONY: build version
 build : elpa $(OBJECTS)
 
-.PHONY: test
-test : build
+version:
+	$(EMACS) --version
+
+test : version build
 	$(CASK) exec $(EMACS) --no-site-file --no-site-lisp --batch \
 		$(EMACSFLAGS) \
 		-l test/run-tests

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -12,16 +12,35 @@ apt () {
     sudo apt-get install -yy "$@"
 }
 
+install_emacs() {
+    # no EMACS version is specified use snapshot.
+    if [ -z $EMACS_BINARY ];then
+        export EMACS_BINARY=emacs-snapshot
+    fi
+    echo $EMACS_BINARY
+
+    if [ $EMACS_BINARY = "emacs-snapshot" ]; then
+        ppa ppa:ubuntu-elisp/ppa
+        apt_update
+        apt emacs-snapshot emacs-snapshot-el
+    else
+        apt_update
+        apt git
+        # evm install
+        sudo mkdir -p /usr/local/evm
+        sudo chown $USER: /usr/local/evm
+        curl -fsSkL https://raw.github.com/rejeep/evm/master/go | bash
+        export PATH=$HOME/.evm/bin:$PATH
+        evm install $EMACS_BINARY
+        evm use $EMACS_BINARY
+    fi
+}
+
 # Silence debconf
 export DEBIAN_FRONTEND='noninteractive'
 
-# Bring in the necessary PPAs
-ppa ppa:cassou/emacs
-apt_update
-
-# Install Emacs 24.x and Emacs snapshot
-apt emacs24 emacs24-el emacs24-common-non-dfsg \
-    emacs-snapshot emacs-snapshot-el
+install_emacs
+emacs --version
 
 # Install Cask for Emacs dependency management
 CASK_VERSION=0.7.2


### PR DESCRIPTION
This will allow us the run tests against three different versions of emacs. 
These changes were suggested during #1269

There seems to be failures related to `24.1`, `24.2`.
```Dependency clojure-mode failed to install: Package `emacs-24.3' is unavailable```