### PR TITLE
Partially remove sibling connections features

### DIFF
--- a/cider-client.el
+++ b/cider-client.el
@@ -79,12 +79,12 @@ Also close associated REPL and server buffers."
     (setq cider-connections
           (delq (buffer-name buffer) cider-connections))
     (when (buffer-live-p buffer)
-      (dolist (buf (cons buffer
-                         (with-current-buffer buffer
-                           (list nrepl-tunnel-buffer
-                                 nrepl-server-buffer))))
-        (when buf
-          (cider--close-buffer buf))))))
+      (with-current-buffer buffer
+        (when nrepl-tunnel-buffer
+          (cider--close-buffer nrepl-tunnel-buffer)))
+      ;; If this is the only (or last) REPL connected to its server, the
+      ;; kill-process hook will kill the server.
+      (cider--close-buffer buffer))))
 
 
 ;;; Connection Browser

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -2363,7 +2363,6 @@ the string contents of the region into a formatted string."
   "Close the BUFFER and kill its associated process (if any)."
   (when (buffer-live-p (get-buffer buffer))
     (with-current-buffer buffer
-      (setq nrepl--closing-connection t)
       (when nrepl-session
         (nrepl-sync-request:close (cider-current-repl-buffer) nrepl-session))
       (when nrepl-tooling-session
@@ -2376,7 +2375,7 @@ the string contents of the region into a formatted string."
   "Close buffers that are shared across connections."
   (interactive)
   (dolist (buf-name cider-ancillary-buffers)
-    (cider--close-buffer buf-name)))
+    (kill-buffer buf-name)))
 
 (defun cider--quit-connection (conn)
   "Quit the connection CONN."

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -48,7 +48,7 @@ Info contains project name and host:port endpoint."
     (if current-connection
         (with-current-buffer current-connection
           (concat
-           (when nrepl-sibling-buffer-alist
+           (when cider-repl-type
              (concat cider-repl-type ":"))
            (when cider-mode-line-show-connection
              (format "%s@%s:%s"

--- a/cider.el
+++ b/cider.el
@@ -192,8 +192,8 @@ REPL."
 
 (defun cider-create-sibling-cljs-repl (client-buffer)
   "Create a ClojureScript REPL with the same server as CLIENT-BUFFER.
-Link the new buffer with CLIENT-BUFFER, which should be the regular Clojure
-REPL started by the server process filter."
+The new buffer will correspond to the same project as CLIENT-BUFFER, which
+should be the regular Clojure REPL started by the server process filter."
   (interactive (list (cider-current-repl-buffer)))
   (let* ((nrepl-repl-buffer-name-template "*cider-repl CLJS%s*")
          (nrepl-create-client-buffer-function  #'cider-repl-create)
@@ -210,11 +210,9 @@ REPL started by the server process filter."
          (alist `(("cljs" . ,cljs-buffer)
                   ("clj"  . ,client-buffer))))
     (with-current-buffer client-buffer
-      (setq cider-repl-type "clj")
-      (setq nrepl-sibling-buffer-alist alist))
+      (setq cider-repl-type "clj"))
     (with-current-buffer cljs-buffer
       (setq cider-repl-type "cljs")
-      (setq nrepl-sibling-buffer-alist alist)
       (cider-nrepl-send-request
        (list "op" "eval"
              "ns" (cider-current-ns)


### PR DESCRIPTION
- REPL buffers are no longer marked as siblings. Instead, "siblings" are identified by REPLs in the same project.
- The smart dispatching logic is moved from cider-current-repl-buffer to cider-find-relevant-connection.
- Killing a REPL no longer offers to kill siblings.