### PR TITLE
Connection vs repl

### DIFF
--- a/cider-client.el
+++ b/cider-client.el
@@ -208,7 +208,7 @@ Refreshes EWOC."
 
 (defun cider--connections-goto-connection (_ewoc data)
   "Goto the REPL for the connection in _EWOC specified by DATA."
-  (-when-let (buffer (with-current-buffer data nrepl-repl-buffer))
+  (-when-let (buffer (with-current-buffer data nrepl-connection-buffer))
     (select-window (display-buffer buffer))))
 
 
@@ -229,13 +229,13 @@ Refreshes EWOC."
 
 (defun cider-nrepl-op-supported-p (op)
   "Check whether the current connection supports the nREPL middleware OP."
-  (nrepl-op-supported-p op (cider-current-repl-buffer)))
+  (nrepl-op-supported-p op (cider-find-relevant-connection)))
 
 (defun cider-nrepl-send-request (request callback)
   "Send REQUEST and register response handler CALLBACK.
 REQUEST is a pair list of the form (\"op\" \"operation\" \"par1-name\"
 \"par1\" ... )."
-  (nrepl-send-request request callback (cider-current-repl-buffer)))
+  (nrepl-send-request request callback (cider-find-relevant-connection)))
 
 (defun cider-nrepl-send-sync-request (request &optional abort-on-input)
   "Send REQUEST to the nREPL server synchronously.
@@ -243,7 +243,7 @@ Hold till final \"done\" message has arrived and join all response messages
 of the same \"op\" that came along.
 If ABORT-ON-INPUT is non-nil, the function will return nil at the first
 sign of user input, so as not to hang the interface."
-  (nrepl-send-sync-request request (cider-current-repl-buffer) abort-on-input))
+  (nrepl-send-sync-request request (cider-find-relevant-connection) abort-on-input))
 
 (defun cider-nrepl-request:eval (input callback &optional ns point)
   "Send the request INPUT and register the CALLBACK as the response handler.
@@ -251,7 +251,7 @@ If NS is non-nil, include it in the request. POINT, if non-nil, is the
 position of INPUT in its buffer."
   (nrepl-request:eval input
                       callback
-                      (cider-current-repl-buffer)
+                      (cider-find-relevant-connection)
                       (cider-current-session)
                       ns
                       point))
@@ -261,7 +261,7 @@ position of INPUT in its buffer."
 If NS is non-nil, include it in the request."
   (nrepl-sync-request:eval
    input
-   (cider-current-repl-buffer)
+   (cider-find-relevant-connection)
    (cider-current-session)))
 
 (defun cider-tooling-eval (input callback &optional ns)
@@ -270,42 +270,38 @@ NS specifies the namespace in which to evaluate the request."
   ;; namespace forms are always evaluated in the "user" namespace
   (nrepl-request:eval input
                       callback
-                      (cider-current-repl-buffer)
+                      (cider-find-relevant-connection)
                       (cider-current-tooling-session)
                       ns))
 
 (declare-function cider-find-relevant-connection "cider-interaction")
-(defun cider-current-repl-buffer ()
+(defalias 'cider-current-repl-buffer #'cider-find-relevant-connection
   "The current REPL buffer.
-Return the REPL buffer given by using `cider-find-relevant-connection'."
-  (-when-let (buf (cider-find-relevant-connection))
-    (with-current-buffer buf
-      ;; FIXME: Is the connection buffer ever different from the REPL buffer?
-      nrepl-repl-buffer)))
+Return the REPL buffer given by `cider-find-relevant-connection'.")
 
 (declare-function cider-interrupt-handler "cider-interaction")
 (defun cider-interrupt ()
   "Interrupt any pending evaluations."
   (interactive)
-  (with-current-buffer (cider-current-repl-buffer)
+  (with-current-buffer (cider-find-relevant-connection)
     (let ((pending-request-ids (cider-util--hash-keys nrepl-pending-requests)))
       (dolist (request-id pending-request-ids)
         (nrepl-request:interrupt
          request-id
          (cider-interrupt-handler (current-buffer))
-         (cider-current-repl-buffer)
+         (cider-find-relevant-connection)
          (cider-current-session))))))
 
 (defun cider-current-session ()
   "The REPL session to use for this buffer."
-  (with-current-buffer (cider-current-repl-buffer)
+  (with-current-buffer (cider-find-relevant-connection)
     nrepl-session))
 
 (define-obsolete-function-alias 'nrepl-current-session 'cider-current-session "0.10")
 
 (defun cider-current-tooling-session ()
   "Return the current tooling session."
-  (with-current-buffer (cider-current-repl-buffer)
+  (with-current-buffer (cider-find-relevant-connection)
     nrepl-tooling-session))
 
 (define-obsolete-function-alias 'nrepl-current-tooling-session 'cider-current-tooling-session "0.10")

--- a/cider-client.el
+++ b/cider-client.el
@@ -229,13 +229,13 @@ Refreshes EWOC."
 
 (defun cider-nrepl-op-supported-p (op)
   "Check whether the current connection supports the nREPL middleware OP."
-  (nrepl-op-supported-p op (cider-find-relevant-connection)))
+  (nrepl-op-supported-p op (cider-current-connection)))
 
 (defun cider-nrepl-send-request (request callback)
   "Send REQUEST and register response handler CALLBACK.
 REQUEST is a pair list of the form (\"op\" \"operation\" \"par1-name\"
 \"par1\" ... )."
-  (nrepl-send-request request callback (cider-find-relevant-connection)))
+  (nrepl-send-request request callback (cider-current-connection)))
 
 (defun cider-nrepl-send-sync-request (request &optional abort-on-input)
   "Send REQUEST to the nREPL server synchronously.
@@ -243,7 +243,7 @@ Hold till final \"done\" message has arrived and join all response messages
 of the same \"op\" that came along.
 If ABORT-ON-INPUT is non-nil, the function will return nil at the first
 sign of user input, so as not to hang the interface."
-  (nrepl-send-sync-request request (cider-find-relevant-connection) abort-on-input))
+  (nrepl-send-sync-request request (cider-current-connection) abort-on-input))
 
 (defun cider-nrepl-request:eval (input callback &optional ns point)
   "Send the request INPUT and register the CALLBACK as the response handler.
@@ -251,7 +251,7 @@ If NS is non-nil, include it in the request. POINT, if non-nil, is the
 position of INPUT in its buffer."
   (nrepl-request:eval input
                       callback
-                      (cider-find-relevant-connection)
+                      (cider-current-connection)
                       (cider-current-session)
                       ns
                       point))
@@ -261,7 +261,7 @@ position of INPUT in its buffer."
 If NS is non-nil, include it in the request."
   (nrepl-sync-request:eval
    input
-   (cider-find-relevant-connection)
+   (cider-current-connection)
    (cider-current-session)))
 
 (defun cider-tooling-eval (input callback &optional ns)
@@ -270,38 +270,38 @@ NS specifies the namespace in which to evaluate the request."
   ;; namespace forms are always evaluated in the "user" namespace
   (nrepl-request:eval input
                       callback
-                      (cider-find-relevant-connection)
+                      (cider-current-connection)
                       (cider-current-tooling-session)
                       ns))
 
-(declare-function cider-find-relevant-connection "cider-interaction")
-(defalias 'cider-current-repl-buffer #'cider-find-relevant-connection
+(declare-function cider-current-connection "cider-interaction")
+(defalias 'cider-current-repl-buffer #'cider-current-connection
   "The current REPL buffer.
-Return the REPL buffer given by `cider-find-relevant-connection'.")
+Return the REPL buffer given by `cider-current-connection'.")
 
 (declare-function cider-interrupt-handler "cider-interaction")
 (defun cider-interrupt ()
   "Interrupt any pending evaluations."
   (interactive)
-  (with-current-buffer (cider-find-relevant-connection)
+  (with-current-buffer (cider-current-connection)
     (let ((pending-request-ids (cider-util--hash-keys nrepl-pending-requests)))
       (dolist (request-id pending-request-ids)
         (nrepl-request:interrupt
          request-id
          (cider-interrupt-handler (current-buffer))
-         (cider-find-relevant-connection)
+         (cider-current-connection)
          (cider-current-session))))))
 
 (defun cider-current-session ()
   "The REPL session to use for this buffer."
-  (with-current-buffer (cider-find-relevant-connection)
+  (with-current-buffer (cider-current-connection)
     nrepl-session))
 
 (define-obsolete-function-alias 'nrepl-current-session 'cider-current-session "0.10")
 
 (defun cider-current-tooling-session ()
   "Return the current tooling session."
-  (with-current-buffer (cider-find-relevant-connection)
+  (with-current-buffer (cider-current-connection)
     nrepl-tooling-session))
 
 (define-obsolete-function-alias 'nrepl-current-tooling-session 'cider-current-tooling-session "0.10")

--- a/cider-debug.el
+++ b/cider-debug.el
@@ -335,7 +335,7 @@ In order to work properly, this mode must be activated by
     ;; cider-nrepl has a chance to send the next message, and so that the user
     ;; doesn't accidentally hit `n' between two messages (thus editing the code).
     (-when-let (proc (unless nrepl-ongoing-sync-request
-                       (get-buffer-process (cider-default-connection))))
+                       (get-buffer-process (cider-find-relevant-connection))))
       ;; This is for the `:done' sent in reply to the debug-input we provided.
       (when (accept-process-output proc 0.2)
         ;; This is for actually waiting for the next message.

--- a/cider-debug.el
+++ b/cider-debug.el
@@ -120,7 +120,8 @@ This variable must be set before starting the repl connection."
 (defun cider--debug-handle-instrumented-defs (defs ns)
   "Update display of NS according to instrumented DEFS."
   (-when-let (buf (-first (lambda (b) (with-current-buffer b
-                                        (string= ns (cider-current-ns))))
+                                   (and (derived-mode-p 'clojure-mode)
+                                        (string= ns (cider-current-ns)))))
                           (buffer-list)))
     (with-current-buffer buf
       (cider--update-instrumented-defs defs))))
@@ -335,7 +336,7 @@ In order to work properly, this mode must be activated by
     ;; cider-nrepl has a chance to send the next message, and so that the user
     ;; doesn't accidentally hit `n' between two messages (thus editing the code).
     (-when-let (proc (unless nrepl-ongoing-sync-request
-                       (get-buffer-process (cider-find-relevant-connection))))
+                       (get-buffer-process (cider-current-connection))))
       ;; This is for the `:done' sent in reply to the debug-input we provided.
       (when (accept-process-output proc 0.2)
         ;; This is for actually waiting for the next message.

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -297,7 +297,7 @@ Signal an error if it is not supported."
 
 (defun cider--check-required-nrepl-ops ()
   "Check whether all required nREPL ops are present."
-  (let* ((current-connection (cider-find-relevant-connection))
+  (let* ((current-connection (cider-current-connection))
          (missing-ops (-remove (lambda (op) (nrepl-op-supported-p op current-connection)) cider-required-nrepl-ops)))
     (when missing-ops
       (cider-repl-emit-interactive-stderr
@@ -308,7 +308,7 @@ Signal an error if it is not supported."
 ;;; Connection info
 (defun cider--java-version ()
   "Retrieve the underlying connection's Java version."
-  (with-current-buffer (cider-find-relevant-connection "clj")
+  (with-current-buffer (cider-current-connection "clj")
     (when nrepl-versions
       (-> nrepl-versions
           (nrepl-dict-get "java")
@@ -316,7 +316,7 @@ Signal an error if it is not supported."
 
 (defun cider--clojure-version ()
   "Retrieve the underlying connection's Clojure version."
-  (with-current-buffer (cider-find-relevant-connection "clj")
+  (with-current-buffer (cider-current-connection "clj")
     (when nrepl-versions
       (-> nrepl-versions
           (nrepl-dict-get "clojure")
@@ -324,7 +324,7 @@ Signal an error if it is not supported."
 
 (defun cider--nrepl-version ()
   "Retrieve the underlying connection's nREPL version."
-  (with-current-buffer (cider-find-relevant-connection "clj")
+  (with-current-buffer (cider-current-connection "clj")
     (when nrepl-versions
       (-> nrepl-versions
           (nrepl-dict-get "nrepl")
@@ -366,7 +366,7 @@ Signal an error if it is not supported."
       (:version-string @(resolve 'cider.nrepl.version/version))
     (catch Throwable _ \"not installed\"))"
    (cider--check-middleware-compatibility-callback (current-buffer))
-   (cider-find-relevant-connection)
+   (cider-current-connection)
    (cider-current-session)))
 
 (defun cider--connection-info (connection-buffer)
@@ -394,7 +394,7 @@ default connection."
   (interactive "P")
   (message (cider--connection-info (if show-default
                                        (cider-default-connection)
-                                     (cider-find-relevant-connection)))))
+                                     (cider-current-connection)))))
 
 (define-obsolete-function-alias 'cider-display-current-connection-info 'cider-display-connection-info "0.10")
 
@@ -561,7 +561,7 @@ such a link cannot be established automatically."
   (cider-ensure-connected)
   (setq-local cider-buffer-connection nil))
 
-(defun cider-find-relevant-connection (&optional type)
+(defun cider-current-connection (&optional type)
   "Return the REPL buffer relevant for the current Clojure source buffer.
 A REPL is relevant if its `nrepl-project-dir' is compatible with the
 current directory (see `cider-find-connection-buffer-for-project-directory').
@@ -575,8 +575,9 @@ file extension."
    (nrepl-connection-buffer)
    ((= 1 (length cider-connections)) (car cider-connections))
    (t (let* ((project-directory (clojure-project-dir (cider-current-dir)))
-             (repls (cider-find-connection-buffer-for-project-directory project-directory 'all)))
-        (if (not (cdr repls))
+             (repls (and project-directory
+                         (cider-find-connection-buffer-for-project-directory project-directory 'all))))
+        (if (= 1 (length repls))
             ;; Only one match, just return it.
             (car repls)
           ;; OW, find one matching the extension of current file.
@@ -586,7 +587,8 @@ file extension."
                                    (or cider-repl-type "clj"))
                                  type))
                         repls)
-                (car repls))))))))
+                (car repls)
+                (car cider-connections))))))))
 
 (defun cider-switch-to-relevant-repl-buffer (&optional set-namespace)
   "Select the REPL buffer, when possible in an existing window.
@@ -1598,7 +1600,7 @@ evaluation command. Honor `cider-auto-jump-to-error'."
   (with-current-buffer buffer
     (nrepl-request:stdin (concat (read-from-minibuffer "Stdin: ") "\n")
                          (cider-stdin-handler buffer)
-                         (cider-find-relevant-connection)
+                         (cider-current-connection)
                          (cider-current-session))))
 
 
@@ -1718,7 +1720,7 @@ The ns is extracted from the ns form for Clojure buffers and from
 REPL's ns, otherwise fall back to \"user\"."
   (or cider-buffer-ns
       (clojure-find-ns)
-      (-when-let (repl-buf (cider-find-relevant-connection))
+      (-when-let (repl-buf (cider-current-connection))
         (buffer-local-value 'cider-buffer-ns repl-buf))
       "user"))
 
@@ -1745,13 +1747,13 @@ form independently.")
 
 (defun cider--cache-ns-form ()
   "Cache the form in the current buffer for the current connection."
-  (puthash (cider-find-relevant-connection)
+  (puthash (cider-current-connection)
            (cider-ns-form)
            cider--ns-form-cache))
 
 (defun cider--cached-ns-form ()
   "Retrieve the cached ns form for the current buffer & connection."
-  (gethash (cider-find-relevant-connection) cider--ns-form-cache))
+  (gethash (cider-current-connection) cider--ns-form-cache))
 
 (defun cider--prep-interactive-eval (form)
   "Prepares the environment for an interactive eval of FORM.
@@ -1862,7 +1864,7 @@ If invoked with a PREFIX argument, print the result in the current buffer."
 If invoked with a PREFIX argument, switch to the REPL buffer."
   (interactive "P")
   (cider-interactive-eval (cider-last-sexp)
-                          (cider-insert-eval-handler (cider-find-relevant-connection)))
+                          (cider-insert-eval-handler (cider-current-connection)))
   (when prefix
     (cider-switch-to-repl-buffer)))
 
@@ -1938,7 +1940,7 @@ otherwise it's evaluated interactively."
 If EVAL is non-nil the form will also be evaluated."
   (while (string-match "\\`[ \t\n\r]+\\|[ \t\n\r]+\\'" form)
     (setq form (replace-match "" t t form)))
-  (with-current-buffer (cider-find-relevant-connection)
+  (with-current-buffer (cider-current-connection)
     (goto-char (point-max))
     (let ((beg (point)))
       (insert form)
@@ -2324,9 +2326,9 @@ the string contents of the region into a formatted string."
 (defun cider-describe-nrepl-session ()
   "Describe an nREPL session."
   (interactive)
-  (let ((selected-session (completing-read "Describe nREPL session: " (nrepl-sessions (cider-find-relevant-connection)))))
+  (let ((selected-session (completing-read "Describe nREPL session: " (nrepl-sessions (cider-current-connection)))))
     (when (and selected-session (not (equal selected-session "")))
-      (let* ((session-info (nrepl-sync-request:describe (cider-find-relevant-connection) selected-session))
+      (let* ((session-info (nrepl-sync-request:describe (cider-current-connection) selected-session))
              (ops (nrepl-dict-keys (nrepl-dict-get session-info "ops")))
              (session-id (nrepl-dict-get session-info "session"))
              (session-type (cond
@@ -2347,9 +2349,9 @@ the string contents of the region into a formatted string."
 (defun cider-close-nrepl-session ()
   "Close an nREPL session for the current connection."
   (interactive)
-  (let ((selected-session (completing-read "Close nREPL session: " (nrepl-sessions (cider-find-relevant-connection)))))
+  (let ((selected-session (completing-read "Close nREPL session: " (nrepl-sessions (cider-current-connection)))))
     (when selected-session
-      (nrepl-sync-request:close (cider-find-relevant-connection) selected-session)
+      (nrepl-sync-request:close (cider-current-connection) selected-session)
       (message "Closed nREPL session %s" selected-session))))
 
 ;;; quiting
@@ -2358,9 +2360,9 @@ the string contents of the region into a formatted string."
   (when (buffer-live-p buffer)
     (with-current-buffer buffer
       (when nrepl-session
-        (nrepl-sync-request:close (cider-find-relevant-connection) nrepl-session))
+        (nrepl-sync-request:close (cider-current-connection) nrepl-session))
       (when nrepl-tooling-session
-        (nrepl-sync-request:close (cider-find-relevant-connection) nrepl-tooling-session))
+        (nrepl-sync-request:close (cider-current-connection) nrepl-tooling-session))
       (when (get-buffer-process buffer)
         (delete-process (get-buffer-process buffer))))
     (kill-buffer buffer)))
@@ -2394,7 +2396,7 @@ and all ancillary CIDER buffers."
           (dolist (connection cider-connections)
             (cider--quit-connection connection))
           (message "All active nREPL connections were closed"))
-      (cider--quit-connection (cider-find-relevant-connection)))
+      (cider--quit-connection (cider-current-connection)))
     ;; if there are no more connections we can kill all ancillary buffers
     (unless (cider-connected-p)
       (cider-close-ancillary-buffers))))
@@ -2419,7 +2421,7 @@ If RESTART-ALL is t, then restarts all connections."
   (if restart-all
       (dolist (conn cider-connections)
         (cider--restart-connection conn))
-    (cider--restart-connection (cider-find-relevant-connection))))
+    (cider--restart-connection (cider-current-connection))))
 
 (defvar cider--namespace-history nil
   "History of user input for namespace prompts.")

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -44,7 +44,7 @@
   "Return info for the `cider-mode' modeline.
 
 Info contains project name and host:port endpoint."
-  (-if-let (current-connection (ignore-errors (cider-find-relevant-connection)))
+  (-if-let (current-connection (ignore-errors (cider-current-connection)))
       (with-current-buffer current-connection
         (concat
          (when cider-repl-type

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -44,20 +44,19 @@
   "Return info for the `cider-mode' modeline.
 
 Info contains project name and host:port endpoint."
-  (let ((current-connection (cider-find-relevant-connection)))
-    (if current-connection
-        (with-current-buffer current-connection
-          (concat
-           (when cider-repl-type
-             (concat cider-repl-type ":"))
-           (when cider-mode-line-show-connection
-             (format "%s@%s:%s"
-                     (or (cider--project-name nrepl-project-dir) "<no project>")
-                     (pcase (car nrepl-endpoint)
-                       ("localhost" "")
-                       (x x))
-                     (cadr nrepl-endpoint)))))
-      "not connected")))
+  (-if-let (current-connection (ignore-errors (cider-find-relevant-connection)))
+      (with-current-buffer current-connection
+        (concat
+         (when cider-repl-type
+           (concat cider-repl-type ":"))
+         (when cider-mode-line-show-connection
+           (format "%s@%s:%s"
+                   (or (cider--project-name nrepl-project-dir) "<no project>")
+                   (pcase (car nrepl-endpoint)
+                     ("localhost" "")
+                     (x x))
+                   (cadr nrepl-endpoint)))))
+    "not connected"))
 
 ;;;###autoload
 (defcustom cider-mode-line

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -44,7 +44,7 @@
   "Return info for the `cider-mode' modeline.
 
 Info contains project name and host:port endpoint."
-  (let ((current-connection (cider-current-repl-buffer)))
+  (let ((current-connection (cider-find-relevant-connection)))
     (if current-connection
         (with-current-buffer current-connection
           (concat

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -733,7 +733,7 @@ namespace to switch to."
                        (cider-current-ns))))
   (if (and ns (not (equal ns "")))
       (cider-nrepl-request:eval (format "(in-ns '%s)" ns)
-                                (cider-repl-switch-ns-handler (cider-find-relevant-connection))
+                                (cider-repl-switch-ns-handler (cider-current-connection))
                                 nil)
     (error "No namespace selected")))
 

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -733,7 +733,7 @@ namespace to switch to."
                        (cider-current-ns))))
   (if (and ns (not (equal ns "")))
       (cider-nrepl-request:eval (format "(in-ns '%s)" ns)
-                                (cider-repl-switch-ns-handler (cider-current-repl-buffer))
+                                (cider-repl-switch-ns-handler (cider-find-relevant-connection))
                                 nil)
     (error "No namespace selected")))
 

--- a/cider.el
+++ b/cider.el
@@ -194,9 +194,9 @@ REPL."
   "Create a ClojureScript REPL with the same server as CLIENT-BUFFER.
 The new buffer will correspond to the same project as CLIENT-BUFFER, which
 should be the regular Clojure REPL started by the server process filter."
-  (interactive (list (cider-current-repl-buffer)))
+  (interactive (list (cider-find-relevant-connection)))
   (let* ((nrepl-repl-buffer-name-template "*cider-repl CLJS%s*")
-         (nrepl-create-client-buffer-function  #'cider-repl-create)
+         (nrepl-create-client-buffer-function #'cider-repl-create)
          (nrepl-use-this-as-repl-buffer 'new)
          (client-process-args (with-current-buffer client-buffer
                                 (unless (or nrepl-server-buffer nrepl-endpoint)

--- a/cider.el
+++ b/cider.el
@@ -263,14 +263,12 @@ Create REPL buffer and start an nREPL client connection."
   (interactive (cider-select-endpoint))
   (setq cider-current-clojure-buffer (current-buffer))
   (-when-let (repl-buff (nrepl-find-reusable-repl-buffer `(,host ,port) nil))
-    (let ((nrepl-create-client-buffer-function  #'cider-repl-create)
-          (nrepl-use-this-as-repl-buffer repl-buff))
-      (nrepl-start-client-process host port)
+    (let* ((nrepl-create-client-buffer-function  #'cider-repl-create)
+           (nrepl-use-this-as-repl-buffer repl-buff)
+           (conn (process-buffer (nrepl-start-client-process host port))))
       (when (and cider-prompt-for-project-on-connect
                  (y-or-n-p "Do you want to associate the new connection with a local project? "))
-        (cider-assoc-project-with-connection
-         nil
-         (cider-default-connection))))))
+        (cider-assoc-project-with-connection nil conn)))))
 
 (defun cider-current-host ()
   "Retrieve the current host."

--- a/cider.el
+++ b/cider.el
@@ -194,7 +194,7 @@ REPL."
   "Create a ClojureScript REPL with the same server as CLIENT-BUFFER.
 The new buffer will correspond to the same project as CLIENT-BUFFER, which
 should be the regular Clojure REPL started by the server process filter."
-  (interactive (list (cider-find-relevant-connection)))
+  (interactive (list (cider-current-connection)))
   (let* ((nrepl-repl-buffer-name-template "*cider-repl CLJS%s*")
          (nrepl-create-client-buffer-function #'cider-repl-create)
          (nrepl-use-this-as-repl-buffer 'new)

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -873,7 +873,7 @@ server responses."
 (defun nrepl--make-fallback-handler ()
   "Fallback handler which is invoked when no handler is found.
 Handles only stdout and stderr responses."
-  (nrepl-make-response-handler (cider-find-relevant-connection)
+  (nrepl-make-response-handler (cider-current-connection)
                                ;; VALUE
                                '()
                                ;; STDOUT

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -142,8 +142,9 @@ In case of a special value 'new, a new buffer is created.")
 
 ;; These variables are used to track the state of nREPL connections
 (defvar-local nrepl-connection-buffer nil)
+(define-obsolete-variable-alias 'nrepl-repl-buffer
+  'nrepl-connection-buffer "0.10.0")
 (defvar-local nrepl-server-buffer nil)
-(defvar-local nrepl-repl-buffer nil)
 (defvar-local nrepl-endpoint nil)
 (defvar-local nrepl-project-dir nil)
 (defvar-local nrepl-tunnel-buffer nil)
@@ -756,7 +757,6 @@ process."
               nrepl-server-buffer server-buf))
       (setq nrepl-endpoint `(,host ,port)
             nrepl-connection-buffer client-buf
-            nrepl-repl-buffer client-buf
             nrepl-tunnel-buffer (-when-let (tunnel (plist-get endpoint :tunnel))
                                   (process-buffer tunnel))
             nrepl-pending-requests (make-hash-table :test 'equal)
@@ -873,7 +873,7 @@ server responses."
 (defun nrepl--make-fallback-handler ()
   "Fallback handler which is invoked when no handler is found.
 Handles only stdout and stderr responses."
-  (nrepl-make-response-handler (cider-current-repl-buffer)
+  (nrepl-make-response-handler (cider-find-relevant-connection)
                                ;; VALUE
                                '()
                                ;; STDOUT

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -469,13 +469,12 @@
   (with-temp-buffer
     (let* ((connection-buffer (current-buffer))
            (cider-connections (list connection-buffer)))
+      (rename-buffer "*cider-repl bob*")
       (with-temp-buffer
-        (let ((repl-buffer (current-buffer)))
-          (rename-buffer "*cider-repl bob*")
-          (with-temp-buffer
-            (with-current-buffer connection-buffer
-              (setq-local nrepl-repl-buffer repl-buffer))
-            (should (equal "bob" (cider-extract-designation-from-current-repl-buffer)))))))))
+        (should (equal "bob" (cider-extract-designation-from-current-repl-buffer)))
+        (rename-buffer "*cider-repl apa*")
+        (setq cider-buffer-connection (current-buffer))
+        (should (equal "apa" (cider-extract-designation-from-current-repl-buffer)))))))
 
 (ert-deftest cider-extract-designation-from-current-repl-buffer-no-designation ()
   (with-temp-buffer


### PR DESCRIPTION
Streamline connection logic. Dump cider-current-repl and use cider-find-relevant-connection as much as possible.