### PR TITLE
[Fix #1288] REPL eval with pprint not working

### DIFF
--- a/cider-repl.el
+++ b/cider-repl.el
@@ -591,8 +591,8 @@ If NEWLINE is true then add a newline at the end of the input."
     (cider-repl--mark-input-start)
     (cider-repl--mark-output-start)
     (when cider-show-eval-spinner
-        (spinner-start cider-eval-spinner-type nil
-                       cider-eval-spinner-delay))
+      (spinner-start cider-eval-spinner-type nil
+                     cider-eval-spinner-delay))
     (if (and (not (string-match-p "\\`[ \t\r\n]*\\'" input))
              cider-repl-use-pretty-printing)
         (nrepl-request:pprint-eval
@@ -600,8 +600,9 @@ If NEWLINE is true then add a newline at the end of the input."
          (cider-eval-spinner-handler
           (current-buffer)
           (cider-repl-handler (current-buffer)))
+         (cider-current-repl-buffer)
+         (cider-current-session)
          (cider-current-ns)
-         nil
          (1- (window-width)))
       (cider-nrepl-request:eval
        input

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -1019,7 +1019,7 @@ The request is dispatched via CONNECTION and SESSION.
 If NS is non-nil, include it in the request.
 RIGHT-MARGIN specifies the maximum column width of the
 pretty-printed result, and is included in the request if non-nil."
-  (nrepl-send-request (nrepl--pprint-eval-request input ns session right-margin)
+  (nrepl-send-request (nrepl--pprint-eval-request input connection session ns right-margin)
                       callback
                       connection))
 


### PR DESCRIPTION
I don't feel 100% confident in the changes I made here.  Is the `connection` equivalent with `cider-current-repl-buffer`?

Is `cider-current-session` the right thing, or should I be using `cider-current-tooling-session`?

Re-ordering parameters like that is a pretty gross refactoring without any test coverage...Next time perhaps rename to a new function, with a generous amount of assertions, and remove the old name.  Then once we're sure the re-ordering went OK we can reclaim the old name and remove all the type assertions.