### PR TITLE
Cache namespaceinfo in repl buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#1301](https://github.com/clojure-emacs/cider/issues/1301): CIDER can do dynamic font-locking of defined variables, functions, and macros. This is controlled by the `cider-font-lock-dynamically` custom option.
 * [#1271](https://github.com/clojure-emacs/cider/issues/1271): New possible value (`always-save`) for `cider-prompt-save-file-on-load`.
 * [#1197](https://github.com/clojure-emacs/cider/issues/1197): Display some indication that we're waiting for a result for long-running evaluations.
 * [#1127](https://github.com/clojure-emacs/cider/issues/1127): Make it possible to associate a buffer with a connection (via `cider-assoc-buffer-with-connection`).

--- a/README.md
+++ b/README.md
@@ -466,6 +466,15 @@ font-locked as in `clojure-mode` use the following:
 (setq cider-repl-use-clojure-font-lock t)
 ```
 
+* CIDER can syntax highlight symbols that are known to be defined. By default,
+  this is done on symbols from the `clojure.core` namespace as well as macros
+  from any namespace. If you'd like CIDER to also colorize usages of functions
+  and variables from any namespace, do:
+
+```el
+(setq cider-font-lock-dynamically '(macro core function var))
+```
+
 * You can control the <kbd>C-c C-z</kbd> key behavior of switching to the REPL buffer
 with the `cider-switch-to-repl-command` variable.  While the default command
 `cider-switch-to-relevant-repl-buffer` should be an adequate choice for

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -168,12 +168,16 @@ PROJECT-DIR, HOST and PORT are as in `nrepl-make-buffer-name'."
                "use `nrepl-make-buffer-name' with `nrepl-repl-buffer-name-template' instead."
                "0.10.0")
 
+(defvar-local cider-repl-ns-cache nil
+  "A dict holding information about all currently loaded namespaces.")
+
 (defun cider-repl--state-handler (response)
   "Handle the server STATE.
 Currently, this is only used to keep `cider-repl-type' updated."
   (-when-let (state (nrepl-dict-get response "state"))
-    (nrepl-dbind-response state (repl-type)
-      (setq cider-repl-type repl-type))))
+    (nrepl-dbind-response state (repl-type changed-namespaces)
+      (setq cider-repl-type repl-type)
+      (setq cider-repl-ns-cache (nrepl-dict-merge cider-repl-ns-cache changed-namespaces)))))
 
 (defun cider-repl-create (endpoint)
   "Create a REPL buffer and install `cider-repl-mode'.

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -169,15 +169,24 @@ PROJECT-DIR, HOST and PORT are as in `nrepl-make-buffer-name'."
                "0.10.0")
 
 (defvar-local cider-repl-ns-cache nil
-  "A dict holding information about all currently loaded namespaces.")
+  "A dict holding information about all currently loaded namespaces.
+This cache is stored in the connection buffer.  Other buffer's access it
+via `cider-current-connection'.")
 
 (defun cider-repl--state-handler (response)
   "Handle the server STATE.
 Currently, this is only used to keep `cider-repl-type' updated."
-  (-when-let (state (nrepl-dict-get response "state"))
-    (nrepl-dbind-response state (repl-type changed-namespaces)
-      (setq cider-repl-type repl-type)
-      (setq cider-repl-ns-cache (nrepl-dict-merge cider-repl-ns-cache changed-namespaces)))))
+  (with-demoted-errors "Error in `cider-repl--state-handler': %s"
+    (-when-let (state (nrepl-dict-get response "state"))
+      (nrepl-dbind-response state (repl-type changed-namespaces)
+        (setq cider-repl-type repl-type)
+        (unless (nrepl-dict-empty-p changed-namespaces)
+          (setq cider-repl-ns-cache (nrepl-dict-merge cider-repl-ns-cache changed-namespaces))
+          (dolist (b (buffer-list))
+            (with-current-buffer b
+              (when cider-mode
+                (-when-let (ns-dict (nrepl-dict-get changed-namespaces (cider-current-ns)))
+                  (cider-refresh-font-lock ns-dict))))))))))
 
 (defun cider-repl-create (endpoint)
   "Create a REPL buffer and install `cider-repl-mode'.

--- a/cider-resolve.el
+++ b/cider-resolve.el
@@ -1,0 +1,72 @@
+;;; cider-resolve.el --- Resolve clojure symbols according to current nREPL connection
+
+;; Copyright © 2015 Artur Malabarba
+
+;; Author: Artur Malabarba <bruce.connor.am@gmail.com>
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;; Code:
+
+(require 'nrepl-client)
+(require 'cider-interaction)
+(require 'cider-repl)
+
+(defun cider-resolve--get-in (&rest keys)
+  "Return (nrepl-dict-get-in cider-repl-ns-cache keys)."
+  (when cider-connections
+    (nrepl-dict-get-in
+     (with-current-buffer (cider-current-connection)
+       cider-repl-ns-cache)
+     keys)))
+
+(defun cider-resolve-alias (ns alias)
+  "Return the namespace that ALIAS refers to in namespace NS.
+If it doesn't point anywhere, returns ALIAS."
+  (or (cider-resolve--get-in ns "aliases" alias)
+      alias))
+
+(defun cider-resolve-var (ns var)
+  "Return a dict of the metadata of a clojure var VAR in namespace NS.
+VAR is a string.
+Return nil only if VAR cannot be resolved."
+  (let* ((prefix-regexp "\\`\\([^/]+\\)/")
+         (var-ns (when (string-match prefix-regexp var)
+                   (cider-resolve-alias ns (match-string 1 var))))
+         (name (replace-regexp-in-string prefix-regexp "" var)))
+    (or
+     (cider-resolve--get-in (or var-ns ns) "interns" name)
+     (unless var-ns
+       ;; If the var had no prefix, it might be referred.
+       (-if-let (referal (cider-resolve--get-in ns "refers" name))
+           (cider-resolve-var ns referal)
+         ;; Or it might be from core.
+         (unless (equal ns "clojure.core")
+           (cider-resolve-var "clojure.core" name)))))))
+
+(defun cider-match-instrumented-symbol (n face)
+  "Return a face specification for font-locking.
+If (match-string N) is an instrumented symbol, return 
+    (face cider-instrumented-face FACE)
+otherwise, return (face FACE)."
+  (cons 'face
+        (if (nrepl-dict-get (cider-resolve-var (cider-current-ns) (match-string n))
+                            "cider-instrumented")
+            `((cider-instrumented-face ,face))
+          (list face))))
+
+(provide 'cider-resolve)
+;;; cider-resolve.el ends here

--- a/cider-resolve.el
+++ b/cider-resolve.el
@@ -19,19 +19,61 @@
 
 ;;; Commentary:
 
+;; The ns cache is a dict of namespaces stored in the connection buffer. This
+;; file offers functions to easily get information about variables from this
+;; cache, given the variable's name and the file's namespace.  This
+;; functionality is similar to that offered by the `cider-var-info' function
+;; (and others). The difference is that all functions in this file operate
+;; without contacting the server (they still rely on an active connection
+;; buffer, but no messages are actually exchanged).
+
+;; For this reason, the functions here are well suited for very
+;; performance-sentitive operations, such as font-locking or
+;; indentation. Meanwhile, operations like code-jumping are better off
+;; communicating with the middleware, just in the off chance that the cache is
+;; outdated.
+
+;; Below is a typical entry on this cache dict. Note that clojure.core symbols
+;; are excluded from the refers to save space.
+
+;; "cider.nrepl.middleware.track-state"
+;; (dict "aliases"
+;;       (dict "cljs" "cider.nrepl.middleware.util.cljs"
+;;             "misc" "cider.nrepl.middleware.util.misc"
+;;             "set" "clojure.set")
+;;       "interns" (dict a
+;;                       "assoc-state"    (dict "arglists"
+;;                                              (("response"
+;;                                                (dict "as" "msg" "keys"
+;;                                                      ("session")))))
+;;                       "filter-core"    (dict "arglists"
+;;                                              (("refers")))
+;;                       "make-transport" (dict "arglists"
+;;                                              (((dict "as" "msg" "keys"
+;;                                                      ("transport")))))
+;;                       "ns-as-map"      (dict "arglists"
+;;                                              (("ns")))
+;;                       "ns-cache"       (dict)
+;;                       "relevant-meta"  (dict "arglists"
+;;                                              (("var")))
+;;                       "update-vals"    (dict "arglists"
+;;                                              (("m" "f")))
+;;                       "wrap-tracker"   (dict "arglists"
+;;                                              (("handler"))))
+;;       "refers" (dict "set-descriptor!" "#'clojure.tools.nrepl.middleware/set-descriptor!"))
+
 ;;; Code:
 
 (require 'nrepl-client)
 (require 'cider-interaction)
-(require 'cider-repl)
+
+(defvar cider-repl-ns-cache)
 
 (defun cider-resolve--get-in (&rest keys)
-  "Return (nrepl-dict-get-in cider-repl-ns-cache keys)."
+  "Return (nrepl-dict-get-in cider-repl-ns-cache KEYS)."
   (when cider-connections
-    (nrepl-dict-get-in
-     (with-current-buffer (cider-current-connection)
-       cider-repl-ns-cache)
-     keys)))
+    (with-current-buffer (cider-current-connection)
+      (nrepl-dict-get-in cider-repl-ns-cache keys))))
 
 (defun cider-resolve-alias (ns alias)
   "Return the namespace that ALIAS refers to in namespace NS.
@@ -39,14 +81,15 @@ If it doesn't point anywhere, returns ALIAS."
   (or (cider-resolve--get-in ns "aliases" alias)
       alias))
 
+(defconst cider-resolve--prefix-regexp "\\`\\(?:#'\\)?\\([^/]+\\)/")
+
 (defun cider-resolve-var (ns var)
   "Return a dict of the metadata of a clojure var VAR in namespace NS.
 VAR is a string.
 Return nil only if VAR cannot be resolved."
-  (let* ((prefix-regexp "\\`\\([^/]+\\)/")
-         (var-ns (when (string-match prefix-regexp var)
+  (let* ((var-ns (when (string-match cider-resolve--prefix-regexp var)
                    (cider-resolve-alias ns (match-string 1 var))))
-         (name (replace-regexp-in-string prefix-regexp "" var)))
+         (name (replace-regexp-in-string cider-resolve--prefix-regexp "" var)))
     (or
      (cider-resolve--get-in (or var-ns ns) "interns" name)
      (unless var-ns
@@ -57,16 +100,31 @@ Return nil only if VAR cannot be resolved."
          (unless (equal ns "clojure.core")
            (cider-resolve-var "clojure.core" name)))))))
 
-(defun cider-match-instrumented-symbol (n face)
-  "Return a face specification for font-locking.
-If (match-string N) is an instrumented symbol, return 
-    (face cider-instrumented-face FACE)
-otherwise, return (face FACE)."
-  (cons 'face
-        (if (nrepl-dict-get (cider-resolve-var (cider-current-ns) (match-string n))
-                            "cider-instrumented")
-            `((cider-instrumented-face ,face))
-          (list face))))
+(defun cider-resolve-core-ns ()
+  "Return a dict of the core namespace for current connection.
+This will be clojure.core or cljs.core depending on `cider-repl-type'."
+  (when (cider-connected-p)
+    (with-current-buffer (cider-current-connection)
+      (cider-resolve--get-in (if (equal cider-repl-type "cljs")
+                    "cljs.core"
+                  "clojure.core")))))
+
+(defun cider-resolve-ns-symbols (ns)
+  "Return a dict of all valid symbols in NS.
+Each entry's value is the metadata of the var that the symbol refers to.
+NS can be the namespace name, or a dict of the namespace itself."
+  (-when-let (dict (if (stringp ns)
+                       (cider-resolve--get-in ns)
+                     ns))
+    (nrepl-dbind-response dict (interns refers aliases)
+      (append interns
+              (nrepl-dict-flat-map (lambda (sym var) (list sym (cider-resolve-var ns var)))
+                                   refers)
+              (nrepl-dict-flat-map (lambda (alias namespace)
+                                     (nrepl-dict-flat-map (lambda (sym meta)
+                                                            (list (concat alias "/" sym) meta))
+                                                          (cider-resolve--get-in namespace "interns")))
+                                   aliases)))))
 
 (provide 'cider-resolve)
 ;;; cider-resolve.el ends here

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -348,6 +348,13 @@ any of the values is nil."
       (setq out (nrepl-dict-get out (pop keys))))
     out))
 
+(defun nrepl-dict-flat-map (function dict)
+  "Map FUNCTION over DICT and flatten the result.
+FUNCTION follows the same restrictions as in `nrepl-dict-map', and it must
+also alway return a sequence (since the result will be flattened)."
+  (when dict
+    (apply #'append (nrepl-dict-map function dict))))
+
 (defun nrepl--cons (car list-or-dict)
   "Generic cons of CAR to LIST-OR-DICT."
   (if (eq (car list-or-dict) 'dict)

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -330,6 +330,24 @@ FN must accept two arguments key and value."
                collect (funcall fn (car l) (cadr l)))
     (error "Not a nREPL dict")))
 
+(defun nrepl-dict-merge (dict1 dict2)
+  "Destructively merge DICT2 into DICT1.
+Keys in DICT2 override those in DICT1."
+  (let ((base (or dict1 '(dict))))
+    (nrepl-dict-map (lambda (k v)
+                      (nrepl-dict-put base k v))
+                    (or dict2 '(dict)))
+    base))
+
+(defun nrepl-dict-get-in (dict keys)
+  "Return the value in a nested DICT.
+KEYS is a list of keys.  Return nil if any of the keys is not present or if
+any of the values is nil."
+  (let ((out dict))
+    (while (and keys out)
+      (setq out (nrepl-dict-get out (pop keys))))
+    out))
+
 (defun nrepl--cons (car list-or-dict)
   "Generic cons of CAR to LIST-OR-DICT."
   (if (eq (car list-or-dict) 'dict)

--- a/test/nrepl-dict-tests.el
+++ b/test/nrepl-dict-tests.el
@@ -1,0 +1,11 @@
+(require 'nrepl-client)
+
+(ert-deftest dict-merge ()
+  (let ((input '(dict 2 4 1 2 "10" "90" "a" "b")))
+    (should (equal (nrepl-dict-merge input '(dict 1 3 "10" me))
+                   '(dict 2 4 1 3 "10" me "a" "b")))
+    (should (equal input '(dict 2 4 1 3 "10" me "a" "b"))))
+  (should (equal (nrepl-dict-merge nil '(dict 1 3 "10" me))
+                 '(dict 1 3 "10" me)))
+  (should (equal (nrepl-dict-merge '(dict 1 3 "10" me) nil)
+                 '(dict 1 3 "10" me))))


### PR DESCRIPTION
Must go with https://github.com/clojure-emacs/cider-nrepl/pull/249

- cider-resolve.el has a set of functions for resolving clojure symbols based on what we know in Emacs (without having to query nREPL). These can be used for performance-sensitive contexts, such as indentation and font-locking.

- This PR also displays how to apply that to font-locking. It implements dynamic font-locking of macros, functions, and vars as they are loaded. Here's an example:  
   ![font-lock](https://cloud.githubusercontent.com/assets/453029/9658275/2caec6f8-5240-11e5-918c-04a900a230b5.png)  
   I think the macro font-locking is pretty nice and should be default. Functions and variables are debatable. Some people might find them excessive so they might be better turned off by default. But I'd like to hear opinions.
