### PR TITLE
Remove gratuitous use of CL rest function

### DIFF
--- a/cider-test.el
+++ b/cider-test.el
@@ -475,7 +475,7 @@ is searched."
       (let ((ns  (clojure-find-ns))
             (def (clojure-find-def)))
         (if (and ns (member (car def) '("deftest" "defspec")))
-            (cider-test-execute ns nil (rest def))
+            (cider-test-execute ns nil (cdr def))
           (message "No test at point"))))))
 
 (provide 'cider-test)


### PR DESCRIPTION
The `rest` function appears to be part of the "cl" package which does not appear to be required by the cider-test package. Alternatively we could just require it but since this particular one is just an alias to an existing emacs function, I figured I'd just use `cdr`.