### PR TITLE
Add troubleshooting section about package upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -1270,6 +1270,13 @@ CIDER depends on `clojure-mode` and you should always update them together, as
 the latest CIDER version might depend on functionality present only in the latest
 `clojure-mode` version.
 
+### I upgraded CIDER using `package.el` and it broke
+
+The built-in package manager isn't perfect and sometimes it messes up.  If you
+just updated and encountered an error please go into the `.emacs.d/elpa`
+directory and delete any folders related to CIDER and then re-install before
+opening an issue.
+
 ## Documentation
 
 A single-page quick reference PDF for CIDER commands is available

--- a/README.md
+++ b/README.md
@@ -1277,6 +1277,11 @@ just updated and encountered an error please go into the `.emacs.d/elpa`
 directory and delete any folders related to CIDER and then re-install before
 opening an issue.
 
+### I upgraded CIDER using `package.el` and nothing changed
+
+Emacs doesn't load the new files, it only installs them on disk.  To see the
+effect of changes you have to restart emacs.
+
 ## Documentation
 
 A single-page quick reference PDF for CIDER commands is available


### PR DESCRIPTION
There has been a surge of issues lately, from user's who's just updated
CIDER, which have been resolved after the user has manually deleted
CIDER related folders and then re-installed.  This adds a section in the
readme we can point to.  If we're lucky someone might even see this
prior to opening an issue.