### PR TITLE
[Fix #715] Add jump to error location when clicking on error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## master (unreleased)
 
 ### New features
-
+* [#1325](https://github.com/clojure-emacs/cider/issues/1325): Jump to error location when clicking on the error message in the stack-trace pop-up.
 * [#1301](https://github.com/clojure-emacs/cider/issues/1301): CIDER can do dynamic font-locking of defined variables, functions, and macros. This is controlled by the `cider-font-lock-dynamically` custom option.
 * [#1271](https://github.com/clojure-emacs/cider/issues/1271): New possible value (`always-save`) for `cider-prompt-save-file-on-load`.
 * [#1197](https://github.com/clojure-emacs/cider/issues/1197): Display some indication that we're waiting for a result for long-running evaluations.

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -502,6 +502,26 @@ This associates text properties to enable filtering and source navigation."
             (put-text-property p2 p3 'font-lock-face 'cider-stacktrace-fn-face)))
         (newline)))))
 
+(defun cider-stacktrace--create-go-to-err-button (beg message)
+  "Create a button that jumps to the relevant error.
+
+Buttons span over the region from BEG to current point.
+MESSAGE is parsed to find line, col and buffer name to jump to."
+  (when (string-match "\\([^:]+\\):\\([^:]+\\):\\([^:]+\\):\\([^:]+\\)\\'" message)
+    (let* ((line (string-to-number (match-string 3 message)))
+           (col (string-to-number (match-string 4 message)))
+           (buf-name (car (last (split-string (match-string 2 message) "\\/")))))
+      (when buf-name
+        (make-button (+ beg 3)
+                     (point)
+                     'action (lambda (button)
+                               (let ((the-buf-window (get-buffer-window buf-name)))
+                                 (if the-buf-window
+                                     (select-window the-buf-window)
+                                   (switch-to-buffer buf-name)))
+                               (goto-line line)
+                               (move-to-column col t)))))))
+
 (defun cider-stacktrace-render-cause (buffer cause num note)
   "Emit into BUFFER the CAUSE NUM, exception class, message, data, and NOTE."
   (with-current-buffer buffer
@@ -518,8 +538,10 @@ This associates text properties to enable filtering and source navigation."
             (newline))
           ;; Detail level 1: message + ex-data
           (cider-propertize-region '(detail 1)
-            (cider-stacktrace-emit-indented
-             (propertize (or message "(No message)") 'font-lock-face message-face) indent t)
+            (let ((beg (point)))
+              (cider-stacktrace-emit-indented
+               (propertize (or message "(No message)") 'font-lock-face  message-face) indent t)
+              (cider-stacktrace--create-go-to-err-button beg message))
             (newline)
             (when data
               (cider-stacktrace-emit-indented


### PR DESCRIPTION
Jumps to error location in relevant buffer when you hit enter or click with mouse button 2 on the error message that contains file, line and column information.