### PR TITLE
Show the project directory as default when picking

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -532,7 +532,7 @@ such a link cannot be established automatically."
   (interactive)
   (cider-ensure-connected)
   (let ((conn-buf (or connection (completing-read "Connection: " (cider-connections))))
-        (project-dir (or project (read-directory-name "Project directory: " nil (clojure-project-dir)))))
+        (project-dir (or project (read-directory-name "Project directory: " nil (clojure-project-dir) nil (clojure-project-dir)))))
     (when conn-buf
       (with-current-buffer conn-buf
         (setq nrepl-project-dir project-dir)))))


### PR DESCRIPTION
`read-directory-name` takes a default directory name as its 3rd
argument, `default-dirname`, but this is merely the value which is
returned if the user doesn't change the value when prompted. It's not
the value which is initially *displayed*. That value is the 5th
argument, `initial`.

Without specifying an `initial`, the apparent initial value is the 2nd
argument `dir`, and when `dir` is nil (as it is here), it defaults to
the buffer's `default-directory`. Thus, before this change, the default
value of this prompt would *appear* to be the buffer's
`default-directory`, but accepting the initial value would in fact
return `(clojure-project-dir)`, the given `default-dirname`.

Providing `(clojure-project-dir)` as the `initial` as well matches the
initial apparent value in the prompt to the actual value that will be
returned if the user accepts what is displayed. Why this is not inherent
to the way `read-directory-name`/`read-file-name` works is beyond me.

---

All of the above is derived from my experience with Helm. It's possible that this doesn't actually apply outside of Helm, and that this is a Helm bug, but given the Emacs documentation the story outlined above sounds correct to me. If not, I'd love to hear why, and I'll be happy to file an issue against Helm instead.