### PR TITLE
[Fix #467] Improve completion in the repl

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1198,8 +1198,9 @@ The formatting is performed by `cider-annotate-completion-function'."
 
 (defun cider-complete-at-point ()
   "Complete the symbol at point."
-  (let ((sap (symbol-at-point)))
-    (when (and sap (not (nth 3 (syntax-ppss))) (cider-connected-p))
+  (-when-let (sap (cider-symbol-at-point))
+    (when (and (cider-connected-p)
+               (not (or (clojure-in-string-p) (clojure-in-comment-p))))
       (let ((bounds (bounds-of-thing-at-point 'symbol)))
         (list (car bounds) (cdr bounds)
               (completion-table-dynamic #'cider-complete)

--- a/cider-util.el
+++ b/cider-util.el
@@ -60,6 +60,14 @@ Setting this to nil removes the fontification restriction."
       (file-name-directory buffer-file-name)
     default-directory))
 
+(defun cider-in-string-p ()
+  "Return true if point is in a string."
+  (nth 3 (parse-partial-sexp (beginning-of-defun) (point))))
+
+(defun cider-in-comment-p ()
+  "Return true if point is in a comment."
+  (nth 4 (parse-partial-sexp (beginning-of-defun) (point))))
+
 ;;; Text properties
 
 (defun cider-maybe-intern (name)


### PR DESCRIPTION
When investigating #467 I noticed that the test checking if we're in a
string or not had a mostly false positves in the repl.

The previous solution relied on the parse state from point-min up to
point which I think is too large a context.  Furthermore, it's not
reasonable to expect the entire contents of the repl buffer, prompts and
all, to be valid lisp.