### PR TITLE
[Fix #1320] Update cider-repl--state-handler with the new syntax

### DIFF
--- a/cider-repl.el
+++ b/cider-repl.el
@@ -180,8 +180,8 @@ via `cider-current-connection'.")
   "Handle the server STATE.
 Currently, this is only used to keep `cider-repl-type' updated."
   (with-demoted-errors "Error in `cider-repl--state-handler': %s"
-    (-when-let (state (nrepl-dict-get response "state"))
-      (nrepl-dbind-response state (repl-type changed-namespaces)
+    (when (member "state" (nrepl-dict-get response "status"))
+      (nrepl-dbind-response response (repl-type changed-namespaces)
         (setq cider-repl-type repl-type)
         (unless (nrepl-dict-empty-p changed-namespaces)
           (setq cider-repl-ns-cache (nrepl-dict-merge cider-repl-ns-cache changed-namespaces))

--- a/cider-resolve.el
+++ b/cider-resolve.el
@@ -118,8 +118,6 @@ NS can be the namespace name, or a dict of the namespace itself."
                      ns))
     (nrepl-dbind-response dict (interns refers aliases)
       (append (cdr interns)
-              (nrepl-dict-flat-map (lambda (sym var) (list sym (cider-resolve-var ns var)))
-                                   refers)
               (nrepl-dict-flat-map (lambda (alias namespace)
                                      (nrepl-dict-flat-map (lambda (sym meta)
                                                             (list (concat alias "/" sym) meta))


### PR DESCRIPTION
Relies on https://github.com/clojure-emacs/cider-nrepl/pull/255