### PR TITLE
Use elisp cywin functions. Refs #735

### DIFF
--- a/cider-common.el
+++ b/cider-common.el
@@ -127,14 +127,10 @@ otherwise, nil."
     name))
 
 (defvar cider-from-nrepl-filename-function
-  (if (eq system-type 'cygwin)
-      (lambda (resource)
-        (let ((fixed-resource (replace-regexp-in-string "^/" "" resource)))
-          (replace-regexp-in-string
-           "\n"
-           ""
-           (shell-command-to-string (format "cygpath --unix '%s'" fixed-resource)))))
-    #'identity)
+  (with-no-warnings
+    (if (eq system-type 'cygwin)
+        #'cygwin-convert-file-name-from-windows
+      #'identity))
   "Function to translate nREPL namestrings to Emacs filenames.")
 
 (defcustom cider-prefer-local-resources nil

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -932,14 +932,10 @@ evaluation command. Honor `cider-auto-jump-to-error'."
 ;;; Evaluation
 
 (defvar cider-to-nrepl-filename-function
-  (if (eq system-type 'cygwin)
-      (lambda (filename)
-        (->> (expand-file-name filename)
-             (format "cygpath.exe --windows '%s'")
-             (shell-command-to-string)
-             (replace-regexp-in-string "\n" "")
-             (replace-regexp-in-string "\\\\" "/")))
-    #'identity)
+  (with-no-warnings
+    (if (eq system-type 'cygwin)
+        #'cygwin-convert-file-name-to-windows
+      #'identity))
   "Function to translate Emacs filenames to nREPL namestrings.")
 
 (defvar-local cider--ns-form-cache (make-hash-table :test 'equal)


### PR DESCRIPTION
Use `cygwin-convert-file-name-to-windows' and
`cygwin-convert-file-name-from-windows' instead of executing external
"cygpath" commands.

I wasn't aware this functions exist, when creating the origin cygwin support.