### PR TITLE
Cask: Add spinner dependency

### DIFF
--- a/Cask
+++ b/Cask
@@ -6,4 +6,5 @@
 (files "*.el" (:exclude ".dir-locals.el"))
 
 (development
- (depends-on "noflet"))
+ (depends-on "noflet")
+ (depends-on "spinner"))


### PR DESCRIPTION
I'm using CIDER from git. After pulling today, `make` no longer works because of missing `spinner`. This fixes it.
