### PR TITLE
Add basic gradle support

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -413,19 +413,20 @@ Use `cider-ps-running-nrepls-command' and `cider-ps-running-nrepl-path-regexp-li
     (-distinct paths)))
 
 (defun cider-project-type ()
-  "Determine the type, either leiningen or boot, of the current project.
-If both project file types are present, prompt the user to choose."
+  "Determine the type, either leiningen, boot or gradle, of the current project.
+If more than one project file types are present, prompt the user to choose."
   (let* ((default-directory (clojure-project-dir (cider-current-dir)))
-         (lein-project-exists (file-exists-p "project.clj"))
-         (boot-project-exists (file-exists-p "build.boot"))
-         (gradle-project-exists (file-exists-p "build.gradle")))
-    ;; FIXME: multiple-choice
-    (cond ((and lein-project-exists boot-project-exists)
-           (completing-read "Which command should be used? "
-                            '("lein" "boot") nil t "lein"))
-          (lein-project-exists "lein")
-          (boot-project-exists "boot")
-          (gradle-project-exists "gradle"))))
+         (choices (delq nil
+                        (mapcar (lambda (candidate)
+                                  (when (file-exists-p (cdr candidate))
+                                    (car candidate)))
+                                '(("lein" . "project.clj")
+                                  ("boot" . "build.boot")
+                                  ("gradle" . "build.gradle"))))))
+    (if (< 1 (length choices))
+        (completing-read "Which command shoud be used? " choices
+                         nil t (car choices))
+      (car choices))))
 
 ;; TODO: Implement a check for `cider-lein-command' over tramp
 (defun cider--lein-present-p ()

--- a/cider.el
+++ b/cider.el
@@ -106,6 +106,20 @@ version from the CIDER package or library.")
   :group 'cider
   :package-version '(cider . "0.9.0"))
 
+(defcustom cider-gradle-command
+  "gradle"
+  "The command used to execute Gradle."
+  :type 'string
+  :group 'cider
+  :package-version '(cider . "0.9.0"))
+
+(defcustom cider-gradle-parameters
+  "clojureRepl"
+  "Params passed to gradle to start an nREPL server via `cider-jack-in'."
+  :type 'string
+  :group 'cider
+  :package-version '(cider . "0.9.0"))
+
 (defcustom cider-default-repl-command
   "lein"
   "The default command and parameters to use when connecting to nREPL.
@@ -162,19 +176,22 @@ Sub-match 1 must be the project path.")
   "Check if the command matching PROJECT-TYPE is present."
   (pcase project-type
     ("lein" 'cider--lein-present-p)
-    ("boot" 'cider--boot-present-p)))
+    ("boot" 'cider--boot-present-p)
+    ("gradle" 'cider--gradle-present-p)))
 
 (defun cider-jack-in-command (project-type)
   "Determine the command `cider-jack-in' needs to invoke for the PROJECT-TYPE."
   (pcase project-type
     ("lein" cider-lein-command)
-    ("boot" cider-boot-command)))
+    ("boot" cider-boot-command)
+    ("gradle" cider-gradle-command)))
 
 (defun cider-jack-in-params (project-type)
   "Determine the commands params for `cider-jack-in' for the PROJECT-TYPE."
   (pcase project-type
     ("lein" cider-lein-parameters)
-    ("boot" cider-boot-parameters)))
+    ("boot" cider-boot-parameters)
+    ("gradle" cider-gradle-parameters)))
 
 (defcustom cider-cljs-repl "(cemerick.piggieback/cljs-repl (cljs.repl.rhino/repl-env))"
   "Clojure form that returns a ClojureScript REPL environment.
@@ -400,12 +417,15 @@ Use `cider-ps-running-nrepls-command' and `cider-ps-running-nrepl-path-regexp-li
 If both project file types are present, prompt the user to choose."
   (let* ((default-directory (clojure-project-dir (cider-current-dir)))
          (lein-project-exists (file-exists-p "project.clj"))
-         (boot-project-exists (file-exists-p "build.boot")))
+         (boot-project-exists (file-exists-p "build.boot"))
+         (gradle-project-exists (file-exists-p "build.gradle")))
+    ;; FIXME: multiple-choice
     (cond ((and lein-project-exists boot-project-exists)
            (completing-read "Which command should be used? "
                             '("lein" "boot") nil t "lein"))
           (lein-project-exists "lein")
-          (boot-project-exists "boot"))))
+          (boot-project-exists "boot")
+          (gradle-project-exists "gradle"))))
 
 ;; TODO: Implement a check for `cider-lein-command' over tramp
 (defun cider--lein-present-p ()
@@ -423,6 +443,14 @@ In case `default-directory' is non-local we assume the command is available."
   (or (file-remote-p default-directory)
       (executable-find cider-boot-command)
       (executable-find (concat cider-boot-command ".exe"))))
+
+(defun cider--gradle-present-p ()
+  "Check if `cider-gradle-command' is on the `exec-path'.
+
+In case `default-directory' is non-local we assume the command is available."
+  (or (file-remote-p default-directory)
+      (executable-find cider-gradle-command)
+      (executable-find (concat cider-gradle-command ".exe"))))
 
 
 ;;; Check that the connection is working well

--- a/cider.el
+++ b/cider.el
@@ -111,14 +111,14 @@ version from the CIDER package or library.")
   "The command used to execute Gradle."
   :type 'string
   :group 'cider
-  :package-version '(cider . "0.9.0"))
+  :package-version '(cider . "0.10.0"))
 
 (defcustom cider-gradle-parameters
   "clojureRepl"
   "Params passed to gradle to start an nREPL server via `cider-jack-in'."
   :type 'string
   :group 'cider
-  :package-version '(cider . "0.9.0"))
+  :package-version '(cider . "0.10.0"))
 
 (defcustom cider-default-repl-command
   "lein"


### PR DESCRIPTION
Judging from where "lein" and "boot" is used, this should be a first guess to add gradle support for `cider-jack-in`. This is not ready for pull, yet. I'm not sure the changes are sufficient and complete.

https://github.com/clojure-emacs/cider/issues/1373