### PR TITLE
Add a keybinding for cider-jack-in-clojurescript

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -517,6 +517,7 @@ process buffer."
 (eval-after-load 'clojure-mode
   '(progn
      (define-key clojure-mode-map (kbd "C-c M-j") #'cider-jack-in)
+     (define-key clojure-mode-map (kbd "C-c M-J") #'cider-jack-in-clojurescript)
      (define-key clojure-mode-map (kbd "C-c M-c") #'cider-connect)))
 
 (provide 'cider)


### PR DESCRIPTION
Hi. I suggest to add binding `C-c M-J` to `jack-in-clojurescript` in addition to `jack-in` (`C-c M-j`).
It might be more convenient for newbies and will make feeling that cider is easy to use out-of-the-box.