### PR TITLE
[Fix #1324] Don't font-lock local variables

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,16 +1,23 @@
 ;;; Directory Local Variables
 ;;; For more information see (info "(emacs) Directory Variables")
-;; The `nameless-*' variables normalize all files to have the same prefix with
-;; the `nameless' package, and instruct the package to not mess with
-;; indentation.
 
 ((nil
+  (bug-reference-url-format . "https://github.com/clojure-emacs/cider/issues/%s")
   (indent-tabs-mode)
   (fill-column . 80)
   (sentence-end-double-space . t)
   (emacs-lisp-docstring-fill-column . 75)
   (checkdoc-arguments-in-order-flag))
  (emacs-lisp-mode
-  (nameless-affect-indentation-and-filling . nil)
+  (bug-reference-bug-regexp . "#\\(?2:[[:digit:]]+\\)")
+  (nameless-affect-indentation-and-filling)
   (nameless-current-name . "cider")))
 
+
+;; The `nameless-*' variables normalize all files to have the same prefix with
+;; the `nameless' package, and instruct the package to not mess with
+;; indentation.
+
+;; To use the bug-reference stuff, do:
+;;     (add-hook 'text-mode-hook #'bug-reference-mode)
+;;     (add-hook 'prog-mode-hook #'bug-reference-prog-mode)

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -428,6 +428,117 @@ namespace itself."
       (with-no-warnings
         (font-lock-fontify-buffer)))))
 
+
+;;; Detecting local variables
+(defun cider--read-locals-from-next-sexp ()
+  "Return a list of all locals inside the next logical sexp."
+  (save-excursion
+    (ignore-errors
+      (clojure-forward-logical-sexp 1)
+      (let ((out nil)
+            (end (point)))
+        (forward-sexp -1)
+        ;; FIXME: This returns locals found inside the :or clause of a
+        ;; destructuring map.
+        (while (search-forward-regexp "\\_<[^:&]\\(\\sw\\|\\s_\\)*\\_>" end 'noerror)
+          (push (match-string-no-properties 0) out))
+        out))))
+
+(defun cider--read-locals-from-bindings-vector ()
+  "Return a list of all locals inside the next bindings vector."
+  (save-excursion
+    (ignore-errors
+      (cider-start-of-next-sexp)
+      (when (eq (char-after) ?\[)
+        (forward-char 1)
+        (let ((out nil))
+          (setq out (append (cider--read-locals-from-next-sexp) out))
+          (while (ignore-errors (clojure-forward-logical-sexp 3)
+                                (unless (eobp)
+                                  (forward-sexp -1)
+                                  t))
+            (setq out (append (cider--read-locals-from-next-sexp) out)))
+          out)))))
+
+(defun cider--read-locals-from-arglist ()
+  "Return a list of all locals in current form's arglist(s)."
+  (let ((out nil))
+    (save-excursion
+      (ignore-errors
+        (cider-start-of-next-sexp)
+        ;; Named fn
+        (when (looking-at-p "\\s_\\|\\sw")
+          (cider-start-of-next-sexp 1))
+        ;; Docstring
+        (when (eq (char-after) ?\")
+          (cider-start-of-next-sexp 1))
+        ;; Attribute map
+        (when (eq (char-after) ?{)
+          (cider-start-of-next-sexp 1))
+        ;; The arglist
+        (pcase (char-after)
+          (?\[ (setq out (cider--read-locals-from-next-sexp)))
+          ;; FIXME: This returns false positives. It takes all arglists of a
+          ;; function and returns all args it finds. The logic should be changed
+          ;; so that each arglist applies to its own scope.
+          (?\( (ignore-errors
+                 (while (eq (char-after) ?\()
+                   (save-excursion
+                     (forward-char 1)
+                     (setq out (append (cider--read-locals-from-next-sexp) out)))
+                   (cider-start-of-next-sexp 1)))))))
+    out))
+
+(defun cider--parse-and-apply-locals (end &optional outer-locals)
+  "Figure out local variables between point and END.
+A list of these variables is set as the `cider-locals' text property over
+the code where they are in scope.
+Optional argument OUTER-LOCALS is used to specify local variables defined
+before point."
+  (while (search-forward-regexp "(\\(ns\\_>\\|def\\|fn\\|for\\b\\|loop\\b\\|with-\\|do[a-z]+\\|\\([a-z]+-\\)?let\\b\\)"
+                                end 'noerror)
+    (goto-char (match-beginning 0))
+    (let ((sym (match-string 1))
+          (sexp-end (save-excursion
+                      (or (ignore-errors (forward-sexp 1)
+                                         (point))
+                          end))))
+      ;; #1324: Don't do dynamic font-lock in `ns' forms, they are special
+      ;; macros where nothing is evaluated, so we'd get a lot of false
+      ;; positives.
+      (if (equal sym "ns")
+          (add-text-properties (point) sexp-end '(cider-block-dynamic-font-lock t))
+        (forward-char 1)
+        (forward-sexp 1)
+        (let ((locals (pcase sym
+                        ((or "fn" "def" "") (cider--read-locals-from-arglist))
+                        (_ (cider--read-locals-from-bindings-vector)))))
+          (add-text-properties (point) sexp-end (list 'cider-locals (append locals outer-locals)))
+          (clojure-forward-logical-sexp 1)
+          (cider--parse-and-apply-locals sexp-end locals)))
+      (goto-char sexp-end))))
+
+(defun cider--wrap-fontify-locals (func)
+  "Return a function that calls FUNC after parsing local variables.
+The local variables are stored in a list under the `cider-locals' text
+property."
+  (lambda (beg end &rest rest)
+    (remove-text-properties beg end '(cider-locals nil cider-block-dynamic-font-lock nil))
+    (when cider-font-lock-dynamically
+      (save-excursion
+        (goto-char beg)
+        ;; If the inside of a `ns' form changed, reparse it from the start.
+        (when (and (not (bobp))
+                   (get-text-property (1- (point)) 'cider-block-dynamic-font-lock))
+          (ignore-errors (beginning-of-defun)))
+        (ignore-errors
+          (cider--parse-and-apply-locals
+           end (unless (bobp)
+                 (get-text-property (1- (point)) 'cider-locals))))))
+    (apply func beg end rest)))
+
+
+;;; Mode definition
 ;; Once a new stable of `clojure-mode' is realeased, we can depend on it and
 ;; ditch this `defvar'.
 (defvar clojure-get-indent-function)
@@ -446,6 +557,8 @@ namespace itself."
                #'cider-complete-at-point)
   (font-lock-add-keywords nil cider--static-font-lock-keywords)
   (cider-refresh-dynamic-font-lock)
+  (setq-local font-lock-fontify-region-function
+              (cider--wrap-fontify-locals font-lock-fontify-region-function))
   (setq-local clojure-get-indent-function #'cider--get-symbol-indent)
   (setq next-error-function #'cider-jump-to-compilation-error))
 

--- a/cider-util.el
+++ b/cider-util.el
@@ -159,6 +159,17 @@ instead."
                  (progn (clojure-forward-logical-sexp 1)
                         (point))))))
 
+(defun cider-start-of-next-sexp (&optional skip)
+  "Move to the start of the next sexp.
+Skip any non-logical sexps like ^metadata or #reader macros.
+If SKIP is an integer, also skip that many logical sexps first.
+Can only error if SKIP is non-nil."
+  (while (clojure--looking-at-non-logical-sexp)
+    (forward-sexp 1))
+  (when (and skip (> skip 0))
+    (dotimes (_ skip)
+      (forward-sexp 1)
+      (cider-start-of-next-sexp))))
 
 ;;; Text properties
 

--- a/test/cider-locals-tests.el
+++ b/test/cider-locals-tests.el
@@ -1,0 +1,97 @@
+;;; cider-locals-tests.el ---                        -*- lexical-binding: t; -*-
+
+;; Author: Artur Malabarba <bruce.connor.am@gmail.com>
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Code:
+
+(require 'cider-mode)
+(require 'cider)
+(require 'ert)
+
+(defmacro cider--test-with-content (content expected &rest body)
+  (declare (indent 2)
+           (debug t))
+  (let ((contents (if (listp content) content
+                    (list content))))
+    `(let ((out))
+       (dolist (this-content ',contents)
+         (with-temp-buffer
+           (clojure-mode)
+           (insert this-content)
+           (goto-char (point-min))
+           (if (search-forward "|" nil 'noerror)
+               (delete-char -1)
+             (goto-char (point-min)))
+           (let ((result (sort (progn ,@body) #'string<)))
+             (setq out
+                   ,(if (eq expected :return)
+                        'result
+                      `(should (equal result ',expected)))))))
+       out)))
+
+(ert-deftest cider--test-read-locals-from-next-sexp ()
+  (cider--test-with-content ("|[a b c]"
+                             "^:type-hint #macro |[a b c]")
+      ("a" "b" "c")
+    (cider--read-locals-from-next-sexp))
+  (cider--test-with-content ("|[a {:keys [my nombre] :as me} c]"
+                             "^:type-hint #macro |[a {:keys [my nombre] :as me} c]")
+      ("a" "c" "me" "my" "nombre")
+    (cider--read-locals-from-next-sexp))
+  (cider--test-with-content ("[a |{:keys [my nombre]} c]"
+                             "[a |^:type-hint #macro {:keys [my nombre]} c]")
+      ("my" "nombre")
+    (cider--read-locals-from-next-sexp))
+  (cider--test-with-content ("[a {:keys [my nombre]} |c]"
+                             " [a {:keys [my nombre]} ^:type-hint #macro |c]")
+      ("c")
+    (cider--read-locals-from-next-sexp)))
+
+(ert-deftest cider--test-read-locals-from-bindings-vector ()
+  (cider--test-with-content ("[the-name (name the-ns) ns 1 [x y & z] 10 {:keys [my nombre]} some-map]"
+                             "^:type-hint #macro [the-name (name the-ns) ns 1 [x y & z] 10 {:keys [my nombre]} some-map]"
+                             "[the-name (name the-ns)\nns 1\n[x y & z] 10\n{:keys [my nombre]} some-map]"
+                             "^:type-hint #macro [the-name (name the-ns)\nns 1\n[x y & z] 10\n{:keys [my nombre]} some-map]")
+      ("my" "nombre" "ns" "the-name" "x" "y" "z")
+    (cider--read-locals-from-bindings-vector)))
+(ert-deftest cider--test-read-locals-from-bindings-vector-unfinished-sexp ()
+  (cider--test-with-content ("[the-name (name the-ns) ns 1 [x y & z] 10 {:keys [my nombre]} some-map"
+                             "^:type-hint #macro [the-name (name the-ns) ns 1 [x y & z] 10 {:keys [my nombre]} some-map"
+                             "[the-name (name the-ns)\nns 1\n[x y & z] 10\n{:keys [my nombre]} some-map"
+                             "^:type-hint #macro [the-name (name the-ns)\nns 1\n[x y & z] 10\n{:keys [my nombre]} some-map")
+      ("my" "nombre" "ns" "the-name" "x" "y" "z")
+    (cider--read-locals-from-bindings-vector)))
+
+(ert-deftest cider--test-read-locals-from-arglist ()
+  (cider--test-with-content ("(defn| requires-ns-by-name ([ a b] (+ a b)) ([the-ns] nil))"
+                             "(defn| requires-ns-by-name \"DOC\" {:data map} (^Value [a b] (+ a b)) ([the-ns] nil))"
+                             "(fn| requires-ns-by-name (^Value [a b] (+ a b)) ([the-ns] nil))"
+                             "(defn| requires-ns-by-name [[a b] the-ns] (+ a b))"
+                             "(defn| requires-ns-by-name \"DOC\" {:data map} ^Value [[a b] the-ns] (+ a b))"
+                             "(fn| requires-ns-by-name ^Value [[a b] the-ns] (+ a b))")
+      ("a" "b" "the-ns")
+    (cider--read-locals-from-arglist))
+  (cider--test-with-content ("(defn| requires-ns-by-name ([ a b] (+ a b)) ([the-ns] nil"
+                             "(defn| requires-ns-by-name \"DOC\" {:data map} (^Value [a b] (+ a b)) ([the-ns] nil"
+                             "(fn| requires-ns-by-name (^Value [a b] (+ a b)) ([the-ns] nil"
+                             "(defn| requires-ns-by-name [[a b] the-ns] (+ a b"
+                             "(defn| requires-ns-by-name \"DOC\" {:data map} ^Value [[a b] the-ns] (+ a b"
+                             "(fn| requires-ns-by-name ^Value [[a b] the-ns] (+ a b")
+      ("a" "b" "the-ns")
+    (cider--read-locals-from-arglist)))
+
+(provide 'cider-locals-tests)
+;;; cider-locals-tests.el ends here

--- a/test/cider-locals-tests.el
+++ b/test/cider-locals-tests.el
@@ -93,5 +93,17 @@
       ("a" "b" "the-ns")
     (cider--read-locals-from-arglist)))
 
+(ert-deftest cider--test-unless-local ()
+  (with-temp-buffer
+    (clojure-mode)
+    (insert (propertize "the-ns inc lalala" 'cider-locals '("inc" "x")))
+    (goto-char (point-min))
+    (search-forward-regexp "\\(\\sw\\|\\s_\\)+" nil 'noerror)
+    (should (cider--unless-local-match t))
+    (search-forward-regexp "\\(\\sw\\|\\s_\\)+" nil 'noerror)
+    (should-not (cider--unless-local-match t))
+    (search-forward-regexp "\\(\\sw\\|\\s_\\)+" nil 'noerror)
+    (should (cider--unless-local-match t))))
+
 (provide 'cider-locals-tests)
 ;;; cider-locals-tests.el ends here


### PR DESCRIPTION
This detects local variables as part of font-locking, and records them
to a cider-locals text property.

Note this is a bit of a hack, and has known issues, but a proper
solution would involve implementing a reader of Clojure code.

Known issues:

1. False positive for multi-arity functions. The args of all possible
   arities are gathered and applied to all scopes in the function.
2. False positives when a destructuting map has an :or clause.