### PR TITLE
[Fix #1297] C-c M-n should act on both repls 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 ### Changes
 
+* [#1397](https://github.com/clojure-emacs/cider/issues/1297) <kbd>C-c M-n</kbd> now changes the ns of both the Clojure and ClojureScript REPL (in the same project) when called from a cljc or cljx file.
 * [#1348](https://github.com/clojure-emacs/cider/issues/1348): Drop the dash dependency.
 * The usage of the default connection has been reduced significantly. Now evaluations & related commands will be routed via the connection matching the current project automatically unless there's some ambiguity when determining the connection (like multiple or no matching connections). Simply put you'll no longer have to mess around much with connecting-setting commands (e.g. `nrepl-connection-browser`, `cider-rotate-default-connection`).
 * [#732](https://github.com/clojure-emacs/cider/issues/732): `cider-quit` and `cider-restart` now operate on the current connection only. With a prefix argument they operate on all connections.

--- a/cider-client.el
+++ b/cider-client.el
@@ -28,6 +28,8 @@
 (require 'spinner)
 (require 'nrepl-client)
 (require 'cider-common)
+(require 'cider-util)
+(require 'clojure-mode)
 
 (require 'cider-compat)
 (require 'seq)
@@ -124,11 +126,15 @@ Also close associated REPL and server buffers."
 (defvar-local cider-repl-type nil
   "The type of this REPL buffer, usually either \"clj\" or \"cljs\".")
 
-(defun cider-find-connection-buffer-for-project-directory (project-directory &optional all-connections)
-  "Return the most appropriate connection-buffer for the given PROJECT-DIRECTORY.
+(defun cider-find-connection-buffer-for-project-directory (&optional project-directory all-connections)
+  "Return the most appropriate connection-buffer for the current project.
+
 By order of preference, this is any connection whose directory matches
-PROJECT-DIRECTORY, followed by any connection whose directory is nil,
+`clojure-project-dir', followed by any connection whose directory is nil,
 followed by any connection at all.
+
+If PROJECT-DIRECTORY is provided act on that project instead.
+
 Only return nil if `cider-connections' is empty (there are no connections).
 
 If more than one connection satisfy a given level of preference, return the
@@ -140,7 +146,9 @@ precedence over other connections associated with the same project.
 
 If ALL-CONNECTIONS is non-nil, the return value is a list and all matching
 connections are returned, instead of just the most recent."
-  (let ((fn (if all-connections #'seq-filter #'seq-find)))
+  (let ((project-directory (or project-directory
+                               (clojure-project-dir (cider-current-dir))))
+        (fn (if all-connections #'seq-filter #'seq-find)))
     (or (funcall fn (lambda (conn)
                       (when-let ((conn-proj-dir (with-current-buffer conn
                                                   nrepl-project-dir)))

--- a/cider-client.el
+++ b/cider-client.el
@@ -202,17 +202,15 @@ such a link cannot be established automatically."
 A REPL is relevant if its `nrepl-project-dir' is compatible with the
 current directory (see `cider-find-connection-buffer-for-project-directory').
 If there is ambiguity, it is resolved by matching TYPE with the REPL
-type (Clojure or ClojureScript).  If TYPE is nil, it is derived from the
-file extension."
-  ;; Cleanup the connections list.
-  (cider-connections)
+type (Clojure or ClojureScript).  TYPE is a string, which when nil is derived
+from the file extension."
+  (cider-connections) ; Cleanup the connections list.
   (if (eq cider-request-dispatch 'dynamic)
       (cond
        ((cider--in-connection-buffer-p) (current-buffer))
        ((= 1 (length cider-connections)) (car cider-connections))
-       (t (let* ((project-directory (clojure-project-dir (cider-current-dir)))
-                 (repls (and project-directory
-                             (cider-find-connection-buffer-for-project-directory project-directory 'all))))
+       (t (let ((repls (cider-find-connection-buffer-for-project-directory
+                        nil :all-connections)))
             (if (= 1 (length repls))
                 ;; Only one match, just return it.
                 (car repls)
@@ -227,6 +225,16 @@ file extension."
                     (car cider-connections)))))))
     ;; TODO: Add logic to dispatch to a matching Clojure/ClojureScript REPL based on file type
     (car cider-connections)))
+
+(defun cider-other-connection (connection)
+  "Return the first connection of another type than CONNECTION, \
+in the same project, or nil."
+  (let* ((connection-type (cider--connection-type connection))
+         (other (if (equal connection-type "clj")
+                    (cider-current-connection "cljs")
+                  (cider-current-connection "clj"))))
+    (unless (equal connection-type (cider--connection-type other))
+      other)))
 
 
 ;;; Connection Browser
@@ -791,9 +799,16 @@ endpoint and Clojure version."
   "Extract the essential properties of CONN-BUFFER."
   (with-current-buffer conn-buffer
     (list
+     :type cider-repl-type
      :host (car nrepl-endpoint)
      :port (cadr nrepl-endpoint)
      :project-dir nrepl-project-dir)))
+
+(defun cider--connection-type (conn-buffer)
+  "Get CONN-BUFFER's type.
+
+Return value matches `cider-repl-type'."
+  (plist-get (cider--connection-properties conn-buffer) :type))
 
 (defun cider--connection-host (conn-buffer)
   "Get CONN-BUFFER's host."

--- a/cider-util.el
+++ b/cider-util.el
@@ -80,6 +80,14 @@ which nREPL uses for temporary evaluation file names."
   (let ((fname (file-name-nondirectory file-name)))
     (string-match-p "^form-init" fname)))
 
+(defun cider--cljc-or-cljx-buffer-p (&optional buffer)
+  "Return true if the current buffer is visiting a cljc or cljx file.
+
+If BUFFER is provided act on that buffer instead."
+  (with-current-buffer (or buffer (current-buffer))
+    (or (derived-mode-p 'clojurec-mode) (derived-mode-p 'clojurex-mode))))
+
+
 ;;; Thing at point
 (defun cider-defun-at-point ()
   "Return the text of the top-level sexp at point."
@@ -131,6 +139,8 @@ which nREPL uses for temporary evaluation file names."
         ""
       str)))
 
+
+;;; sexp navigation
 (defun cider-sexp-at-point ()
   "Return the sexp at point as a string, otherwise nil."
   (let ((bounds (cider-bounds-of-sexp-at-point)))
@@ -171,6 +181,7 @@ Can only error if SKIP is non-nil."
       (forward-sexp 1)
       (cider-start-of-next-sexp))))
 
+
 ;;; Text properties
 
 (defun cider-maybe-intern (name)
@@ -205,6 +216,7 @@ PROP is the name of a text property."
   (when more-text (insert more-text))
   (when break (insert "\n")))
 
+
 ;;; Font lock
 
 (defun cider--font-lock-ensure ()
@@ -283,6 +295,7 @@ Unless you specify a BUFFER it will default to the current one."
       (pkg-info-version-info 'cider)
     (error cider-version)))
 
+
 ;;; Strings
 
 (defun cider-string-join (strings &optional separator)
@@ -333,6 +346,7 @@ Any other value is just returned."
       (mapcar #'cider--deep-vector-to-list x)
     x))
 
+
 ;;; Words of inspiration
 (defun cider-user-first-name ()
   "Find the current user's first name."


### PR DESCRIPTION
In a cljc or cljx buffer hitting `C-c M-n` to switch the repl ns will now act on both repls so they are in sync.