### PR TITLE
Fix multiple sessions link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ specific CIDER release.**
   - [cider-inspector-mode](#cider-inspector-mode)
   - [cider-test-report-mode](#cider-test-report-mode)
   - [cider-stacktrace-mode](#cider-stacktrace-mode)
-  - [Managing multiple sessions](#managing-multiple-sessions)
+  - [Managing multiple connections](#managing-multiple-connections)
 - [Requirements](#requirements)
 - [Caveats](#caveats)
   - [Var Metadata](#var-metadata)


### PR DESCRIPTION
Fixed broken Internal link for multiple sessions.
Changed the link text to match the section title, assuming section title was the preferred title.