### PR TITLE
[Fix #1299] Eval in both REPLs for cljc and cljx 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 
 ### Changes
 
+* [#1299]https://github.com/clojure-emacs/cider/issues/1299 <kbd>C-c C-k</kbd> and <kbd> C-c C-l</kbd> now dispatch to both the Clojure and ClojureScript REPL (in the same project) when called from a `.cljc` or `.cljx` file.
 * [#1397](https://github.com/clojure-emacs/cider/issues/1297) <kbd>C-c M-n</kbd> now changes the ns of both the Clojure and ClojureScript REPL (in the same project) when called from a cljc or cljx file.
 * [#1348](https://github.com/clojure-emacs/cider/issues/1348): Drop the dash dependency.
 * The usage of the default connection has been reduced significantly. Now evaluations & related commands will be routed via the connection matching the current project automatically unless there's some ambiguity when determining the connection (like multiple or no matching connections). Simply put you'll no longer have to mess around much with connecting-setting commands (e.g. `nrepl-connection-browser`, `cider-rotate-default-connection`).

--- a/cider-client.el
+++ b/cider-client.el
@@ -421,14 +421,6 @@ Signal an error if it is not supported."
   (unless (cider-nrepl-op-supported-p op)
     (error "Can't find nREPL middleware providing op \"%s\".  Please, install (or update) cider-nrepl %s and restart CIDER" op (upcase cider-version))))
 
-(defun cider--ensure-session (request)
-  "Make sure REQUEST has session.
-
-If the nREPL request lacks a session `cider-current-session' is added."
-  (if (seq-contains request "session")
-      request
-    (append request (list "session" (cider-current-session)))))
-
 (defun cider-nrepl-send-request (request callback &optional connection)
   "Send REQUEST and register response handler CALLBACK.
 REQUEST is a pair list of the form (\"op\" \"operation\" \"par1-name\"
@@ -437,17 +429,16 @@ If CONNECTION is provided dispatch to that connection instead of
 the current connection.
 
 Return the id of the sent message."
-  (nrepl-send-request (cider--ensure-session request) callback
-                      (or connection (cider-current-connection))))
+  (nrepl-send-request request callback (or connection (cider-current-connection))))
 
-(defun cider-nrepl-send-sync-request (request &optional abort-on-input connection)
+(defun cider-nrepl-send-sync-request (request &optional connection abort-on-input)
   "Send REQUEST to the nREPL server synchronously.
 Hold till final \"done\" message has arrived and join all response messages
 of the same \"op\" that came along and return the accumulated response.
 If ABORT-ON-INPUT is non-nil, the function will return nil
 at the first sign of user input, so as not to hang the
 interface."
-  (nrepl-send-sync-request (cider--ensure-session request)
+  (nrepl-send-sync-request request
                            (or connection (cider-current-connection))
                            abort-on-input))
 

--- a/cider-client.el
+++ b/cider-client.el
@@ -226,10 +226,9 @@ from the file extension."
     (car cider-connections)))
 
 (defun cider-other-connection (&optional connection)
-  "Return the first connection of another type than `cider-current-connection', \
-in the same project, or nil.
-
-If CONNECTION is provided act on that connection instead."
+  "Return the first connection of another type than CONNECTION
+Only return connections in the same project or nil.
+CONNECTION defaults to `cider-current-connection'."
   (let* ((connection (or connection (cider-current-connection)))
          (connection-type (cider--connection-type connection))
          (other (if (equal connection-type "clj")
@@ -237,6 +236,17 @@ If CONNECTION is provided act on that connection instead."
                   (cider-current-connection "clj"))))
     (unless (equal connection-type (cider--connection-type other))
       other)))
+
+(defun cider-map-connections (function)
+  "Call FUNCTION once for each appropriate connection.
+The function is called with one argument, the connection buffer.
+The appropriate connections are found by inspecting the current buffer.  If
+the buffer is associated with a .cljc or .cljx file, BODY will be executed
+multiple times."
+  (if-let ((is-cljc (cider--cljc-or-cljx-buffer-p))
+           (other-connection (cider-other-connection)))
+      (mapc function (list (cider-current-connection) other-connection))
+    (funcall function (cider-current-connection))))
 
 
 ;;; Connection Browser

--- a/cider-client.el
+++ b/cider-client.el
@@ -207,21 +207,22 @@ from the file extension."
   (cider-connections) ; Cleanup the connections list.
   (if (eq cider-request-dispatch 'dynamic)
       (cond
-       ((cider--in-connection-buffer-p) (current-buffer))
+       ((and (not type) (cider--in-connection-buffer-p)) (current-buffer))
        ((= 1 (length cider-connections)) (car cider-connections))
-       (t (let ((repls (cider-find-connection-buffer-for-project-directory
-                        nil :all-connections)))
-            (if (= 1 (length repls))
+       (t (let ((project-connections
+                 (cider-find-connection-buffer-for-project-directory
+                  nil :all-connections)))
+            (if (= 1 (length project-connections))
                 ;; Only one match, just return it.
-                (car repls)
+                (car project-connections)
               ;; OW, find one matching the extension of current file.
               (let ((type (or type (file-name-extension (or (buffer-file-name) "")))))
                 (or (seq-find (lambda (conn)
                                 (equal (with-current-buffer conn
                                          cider-repl-type)
                                        type))
-                              (append repls cider-connections))
-                    (car repls)
+                              project-connections)
+                    (car project-connections)
                     (car cider-connections)))))))
     ;; TODO: Add logic to dispatch to a matching Clojure/ClojureScript REPL based on file type
     (car cider-connections)))

--- a/cider-common.el
+++ b/cider-common.el
@@ -224,21 +224,5 @@ existing file ending with URL has been found."
       (16 t) ; empty empty
       (_ nil))))
 
-(defmacro cider-do-connections (var &rest body)
-  "For each appropriate connection, bind it to VAR, and execute BODY.
-
-The appropriate connections are found by inspecting the current buffer.  If
-the buffer is associated with a .cljc or .cljx file, BODY will be executed
-multiple times."
-  (declare (indent 1)
-           (debug (form body)))
-  (let ((other-connection 'oh-my-god-the-linter-wont-let-me-use-gensym))
-    `(if-let ((_ (cider--cljc-or-cljx-buffer-p))
-              (,other-connection (cider-other-connection)))
-         (dolist (,var (list (cider-current-connection) ,other-connection))
-           ,@body)
-       (let ((,var (cider-current-connection)))
-         ,@body))))
-
 (provide 'cider-common)
 ;;; cider-common.el ends here

--- a/cider-common.el
+++ b/cider-common.el
@@ -224,5 +224,21 @@ existing file ending with URL has been found."
       (16 t) ; empty empty
       (_ nil))))
 
+(defmacro cider-do-connections (var &rest body)
+  "For each appropriate connection, bind it to VAR, and execute BODY.
+
+The appropriate connections are found by inspecting the current buffer.  If
+the buffer is associated with a .cljc or .cljx file, BODY will be executed
+multiple times."
+  (declare (indent 1)
+           (debug (form body)))
+  (let ((other-connection 'oh-my-god-the-linter-wont-let-me-use-gensym))
+    `(if-let ((_ (cider--cljc-or-cljx-buffer-p))
+              (,other-connection (cider-other-connection)))
+         (dolist (,var (list (cider-current-connection) ,other-connection))
+           ,@body)
+       (let ((,var (cider-current-connection)))
+         ,@body))))
+
 (provide 'cider-common)
 ;;; cider-common.el ends here

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1373,12 +1373,13 @@ ClojureScript REPL exists for the project, it is evaluated in both REPLs."
     (cider--quit-error-window)
     (cider--cache-ns-form)
     (let ((filename (buffer-file-name)))
-      (cider-do-connections connection
-        (cider-request:load-file
-         (cider-file-string filename)
-         (funcall cider-to-nrepl-filename-function (cider--server-filename filename))
-         (file-name-nondirectory filename)
-         connection))
+      (cider-map-connections
+       (lambda (connection)
+         (cider-request:load-file (cider-file-string filename)
+                                  (funcall cider-to-nrepl-filename-function
+                                           (cider--server-filename filename))
+                                  (file-name-nondirectory filename)
+                                  connection)))
       (message "Loading %s..." filename))))
 
 (defun cider-load-file (filename)

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -409,7 +409,8 @@ namespace itself."
   (interactive)
   (when cider-font-lock-dynamically
     (font-lock-remove-keywords nil cider--dynamic-font-lock-keywords)
-    (when-let ((symbols (cider-resolve-ns-symbols (or ns (cider-current-ns)))))
+    (when-let ((ns (or ns (cider-current-ns)))
+               (symbols (cider-resolve-ns-symbols ns)))
       (setq-local cider--dynamic-font-lock-keywords
                   (cider--compile-font-lock-keywords
                    symbols (cider-resolve-ns-symbols (cider-resolve-core-ns))))

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -790,13 +790,10 @@ namespace to switch to."
                        (cider-current-ns))))
   (when (or (not ns) (equal ns ""))
     (user-error "No namespace selected"))
-  (cider-nrepl-request:eval (format "(in-ns '%s)" ns)
-                            (cider-repl-switch-ns-handler
-                             (cider-current-connection)))
-  (when (cider--cljc-or-cljx-buffer-p)
-    (when-let ((other-connection (cider-other-connection)))
-      (cider-nrepl-request:eval (format "(in-ns '%s)" ns)
-                                (cider-repl-switch-ns-handler other-connection)))))
+  (cider-do-connections connection
+    (cider-nrepl-request:eval (format "(in-ns '%s)" ns)
+                              (cider-repl-switch-ns-handler
+                               connection))))
 
 
 ;;;;; History

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -790,10 +790,10 @@ namespace to switch to."
                        (cider-current-ns))))
   (when (or (not ns) (equal ns ""))
     (user-error "No namespace selected"))
-  (cider-do-connections connection
-    (cider-nrepl-request:eval (format "(in-ns '%s)" ns)
-                              (cider-repl-switch-ns-handler
-                               connection))))
+  (cider-map-connections
+   (lambda (connection)
+     (cider-nrepl-request:eval (format "(in-ns '%s)" ns)
+                               (cider-repl-switch-ns-handler connection)))))
 
 
 ;;;;; History

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -493,7 +493,7 @@ object is a root list or dict."
    ;; else, throw a quiet error
    (t
     (message "Invalid bencode message detected. See %s buffer."
-             nrepl-message-buffer-name)
+             nrepl-message-buffer-name-template)
     (nrepl-log-message
      (format "Decoder error at position %d (`%s'):"
              (point) (buffer-substring (point) (min (+ (point) 10) (point-max)))))
@@ -1140,7 +1140,7 @@ the port, and the client buffer."
 ;;; Messages
 
 (defcustom nrepl-log-messages t
-  "If non-nil, log protocol messages to the `nrepl-message-buffer-name' buffer."
+  "If non-nil, log protocol messages to the `nrepl-message-buffer-name-template' buffer."
   :type 'boolean
   :group 'nrepl)
 
@@ -1184,7 +1184,7 @@ operations.")
     (`response (cons '<- (cdr msg)))))
 
 (defun nrepl-log-message (msg type)
-  "Log the given MSG to the buffer given by `nrepl-message-buffer-name'.
+  "Log the given MSG to the buffer given by `nrepl-message-buffer-name-template'.
 
 TYPE is either request or response."
   (when nrepl-log-messages


### PR DESCRIPTION
This changes the load file request to dispatch to `cider-other-connection` in addition to `cider-current-connection`, when the file is a cljc or cljx file.