### PR TITLE
Update test-report buffer when tests pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#1402](https://github.com/clojure-emacs/cider/pull/1402): When tests pass after previously failing, update the test-report buffer to show success.
 * [#1373](https://github.com/clojure-emacs/cider/issues/1373): Add gradle support for `cider-jack-in`.
 * Indentation of macros (and functions) [can be specified](https://github.com/clojure-emacs/cider#specifying-indentation) in the var's metadata, via [indent specs](Indent-Spec.md).
 * [Abbreviated printing](https://github.com/clojure-emacs/cider-nrepl/pull/268) for functions multimethods. Instead of seeing `#object[clojure.core$_PLUS_ 0x4e648e99 "clojure.core$_PLUS_@4e648e99"]` you'll see `#function[clojure.core/+]`.

--- a/cider-test.el
+++ b/cider-test.el
@@ -450,12 +450,16 @@ displayed. When test failures/errors occur, their sources are highlighted."
                 (setq cider-test-last-results results)
                 (cider-test-highlight-problems ns results)
                 (cider-test-echo-summary summary)
-                (when (or (not (zerop (+ error fail)))
-                          cider-test-show-report-on-success)
-                  (cider-test-render-report
-                   (cider-popup-buffer cider-test-report-buffer
-                                       cider-auto-select-test-report-buffer)
-                   ns summary results)))))))))
+                (if (or (not (zerop (+ error fail)))
+                        cider-test-show-report-on-success)
+                    (cider-test-render-report
+                     (cider-popup-buffer cider-test-report-buffer
+                                         cider-auto-select-test-report-buffer)
+                     ns summary results)
+                  (when (get-buffer cider-test-report-buffer)
+                    (cider-test-render-report
+                     (cider-popup-buffer cider-test-report-buffer)
+                     ns summary results))))))))))
 
 (defun cider-test-rerun-tests ()
   "Rerun failed and erring tests from the last tested namespace."


### PR DESCRIPTION
If the user has the test-report buffer open. Update the buffer to show
the tests pass instead of keeping previously failed errors. This is less
confusing than seeing previously failed errors despite tests passing.