### PR TITLE
[Fix #1407] Jack-in with existing connections

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -261,11 +261,11 @@ be reused."
                                 (and project-directory
                                      (equal project-directory nrepl-project-dir)))))
                         repl-buffers)))
-      (if (and (get-buffer-process exact-buff)
-               (y-or-n-p (format "REPL buffer already exists (%s).  \
+      (if (get-buffer-process exact-buff)
+          (when (y-or-n-p (format "REPL buffer already exists (%s).  \
 Do you really want to create a new one? "
-                                 exact-buff)))
-          (or (cider--select-zombie-buffer repl-buffers) 'new)
+                                  exact-buff))
+            'new)
         exact-buff)
     (or (cider--select-zombie-buffer repl-buffers) 'new)))
 


### PR DESCRIPTION
The branch where the user is asked whether to create a new REPL in the
face of an existing REPL erroneously ignored the user's answer and
always created a new REPL.

The return value of this code branch, has been changed to be nil, as
described in the docstring.