### PR TITLE
Avoid killed-buffer reference on restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#1450](https://github.com/clojure-emacs/cider/pull/1450): Fix an error in `cider-restart` caused by a reference to a killed buffer.
+
 ## 0.10.0 / 2015-12-03
 
 ### New features

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1553,12 +1553,13 @@ and all ancillary CIDER buffers."
 
 (defun cider--restart-connection (conn)
   "Restart the connection CONN."
-  (let ((project-dir (with-current-buffer conn nrepl-project-dir)))
+  (let ((project-dir (with-current-buffer conn nrepl-project-dir))
+        (buf-name (buffer-name conn)))
     (cider--quit-connection conn)
     ;; Workaround for a nasty race condition https://github.com/clojure-emacs/cider/issues/439
     ;; TODO: Find a better way to ensure `cider-quit' has finished
     (message "Waiting for CIDER connection %s to quit..."
-             (cider-propertize-bold (buffer-name conn)))
+             (cider-propertize-bold buf-name))
     (sleep-for 2)
     (if project-dir
         (let ((default-directory project-dir))


### PR DESCRIPTION
Current version of `cider-restart` seems to cause `(wrong-type-argument stringp nil)` error by trying to get name of killed buffer.

Stacktrace:
```
Debugger entered--Lisp error: (wrong-type-argument stringp nil)
  propertize(nil face bold)
  cider-propertize-bold(nil)
  (message "Waiting for CIDER connection %s to quit..." (cider-propertize-bold (buffer-name conn)))
  (let ((project-dir (save-current-buffer (set-buffer conn) nrepl-project-dir))) (cider--quit-connection conn) (message "Waiting for CIDER connection %s to quit..." (cider-propertize-bold (buffer-name conn))) (sleep-for 2) (if project-dir (let ((default-directory project-dir)) (cider-jack-in)) (error "Can't restart CIDER connection for unknown project")))
  cider--restart-connection(#<killed buffer>)
  (if restart-all (let ((--dolist-tail-- cider-connections)) (while --dolist-tail-- (let ((conn (car --dolist-tail--))) (cider--restart-connection conn) (setq --dolist-tail-- (cdr --dolist-tail--))))) (cider--restart-connection (cider-current-connection)))
  cider-restart(nil)
  call-interactively(cider-restart record nil)
  command-execute(cider-restart record)
  helm-M-x(nil "cider-restart")
  call-interactively(helm-M-x nil nil)
  command-execute(helm-M-x)
```