### PR TITLE
Correctly font-lock pretty-printed results at the REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 * [#1450](https://github.com/clojure-emacs/cider/pull/1450): Fix an error in `cider-restart` caused by a reference to a killed buffer.
 * [#1459](https://github.com/clojure-emacs/cider/issues/1459): Add support for dynamic dispatch in scratch buffers.
+* [#1466](https://github.com/clojure-emacs/cider/issues/1466): Correctly font-lock pretty-printed results in the REPL.
 
 ## 0.10.0 / 2015-12-03
 

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -606,7 +606,10 @@ the symbol."
                                (lambda (buffer err)
                                  (cider-repl-emit-stderr buffer err))
                                (lambda (buffer)
-                                 (cider-repl-emit-prompt buffer))))
+                                 (cider-repl-emit-prompt buffer))
+                               nrepl-err-handler
+                               (lambda (buffer pprint-out)
+                                 (cider-repl-emit-result buffer pprint-out nil))))
 
 (defun cider-repl--send-input (&optional newline)
   "Go to the end of the input and send the current input.

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -599,8 +599,7 @@ the symbol."
   "Make a nREPL evaluation handler for the REPL BUFFER."
   (nrepl-make-response-handler buffer
                                (lambda (buffer value)
-                                 (unless cider-repl-use-pretty-printing
-                                   (cider-repl-emit-result buffer value t)))
+                                 (cider-repl-emit-result buffer value t))
                                (lambda (buffer out)
                                  (cider-repl-emit-stdout buffer out))
                                (lambda (buffer err)

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -824,7 +824,8 @@ It is safe to call this function multiple times on the same ID."
 
 (defun nrepl-make-response-handler (buffer value-handler stdout-handler
                                            stderr-handler done-handler
-                                           &optional eval-error-handler)
+                                           &optional eval-error-handler
+                                           pprint-out-handler)
   "Make a response handler for connection BUFFER.
 A handler is a function that takes one argument - response received from
 the server process.  The response is an alist that contains at least 'id'
@@ -855,8 +856,8 @@ server responses."
              (when stdout-handler
                (funcall stdout-handler buffer out)))
             (pprint-out
-             (when stdout-handler
-               (funcall stdout-handler buffer pprint-out)))
+             (cond (pprint-out-handler (funcall pprint-out-handler buffer pprint-out))
+                   (stdout-handler (funcall stdout-handler buffer pprint-out))))
             (err
              (when stderr-handler
                (funcall stderr-handler buffer err)))


### PR DESCRIPTION
Adding another argument to `nrepl-make-response-handler` is regrettable, but we have #1099 logged for untangling that. I'm going to take a look at fixing that soon - it will make it easier to solve the problem where `out` and `pprint-out` responses are interleaved (e.g. in the face of concurrency or laziness).