### PR TITLE
Fix occasional error when indenting namespace-qualified function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and try to associate the created connection with this project automatically.
 * [#1450](https://github.com/clojure-emacs/cider/pull/1450): Fix an error in `cider-restart` caused by a reference to a killed buffer.
 * [#1459](https://github.com/clojure-emacs/cider/issues/1459): Add support for dynamic dispatch in scratch buffers.
 * [#1466](https://github.com/clojure-emacs/cider/issues/1466): Correctly font-lock pretty-printed results in the REPL.
+* [#1475](https://github.com/clojure-emacs/cider/pull/1475): Fix `args-out-of-range` error in `cider--get-symbol-indent`.
 
 ## 0.10.0 / 2015-12-03
 

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -289,7 +289,8 @@ Returns to the buffer in which the command was invoked."
       ;; There's no indent metadata, but there might be a clojure-mode
       ;; indent-spec with fully-qualified namespace.
       (when (string-match cider-resolve--prefix-regexp symbol-name)
-        (when-let ((sym (intern-soft (replace-match (cider-resolve-alias ns (match-string 1 symbol-name))
+        (when-let ((sym (intern-soft (replace-match (save-match-data
+                                                      (cider-resolve-alias ns (match-string 1 symbol-name)))
                                                     t t symbol-name 1))))
           (get sym 'clojure-indent-function))))))
 


### PR DESCRIPTION


I got `(args-out-of-range -1 -1)` error when I tried to indent a namespace-qualified function call in a CLJS buffer which is associated with browser REPL connection.

Stacktrace:

```
Debugger entered--Lisp error: (args-out-of-range -1 -1)
  replace-match(#("foo" 0 3 (face font-lock-type-face fontified t)) t t #("foo/bar" 0 3 (fontified t face font-lock-type-face) 3 4 (fontified t face default) 4 7 (fontified t)) 1)
  cider--get-symbol-indent(#("foo/bar" 0 3 (fontified t face font-lock-type-face) 3 4 (fontified t face default) 4 7 (fontified t)))
  clojure--get-indent-method(#("foo/bar" 0 3 (fontified t face font-lock-type-face) 3 4 (fontified t face default) 4 7 (fontified t)))
  clojure--find-indent-spec-backtracking()
  clojure--find-indent-spec()
  clojure-indent-function(142 (1 133 134 nil nil nil 0 nil nil (133)))
  calculate-lisp-indent()
  lisp-indent-line()
  clojure-indent-line()
  indent-according-to-mode()
  electric-indent-post-self-insert-function()
  self-insert-command(1)
  newline(nil 1)
  call-interactively(newline nil nil)
  command-execute(newline)
```

I haven't found minimal steps to reproduce it yet, but the cause is clear.
It is because `cider-resolve-alias` is called between `string-match` and `replace-match` in `cider--get-symbol-indent` <sup>1</sup>.
`cider-resolve-alias` can also call `string-match` <sup>2</sup> , so the match data can be replaced with another one.

This PR should fix it by backing up the match data with `save-match-data` macro.

[1] https://github.com/clojure-emacs/cider/blob/491d5e5510668b17566acfa0e8357b8e6486fdfb/cider-mode.el#L291-L292
[2] E.g. `cider-resolve-alias` -> `cider-resolve--get-in` -> `cider-current-connection` -> `cider-find-connection-buffer-for-project-directory` -> `file-truename` -> `string-match`
