### PR TITLE
Check major mode first when choosing connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and try to associate the created connection with this project automatically.
 
 ### Changes
 
+* `cider-current-connection` considers major mode before `cider-repl-type`.
 * `cider-inspect` now operates by default on the last sexp. Its behavior can be altered via prefix arguments.
 * Requires Clojure(Script) 1.7 or newer.
 * Requires Java 7 or newer.

--- a/cider-client.el
+++ b/cider-client.el
@@ -197,6 +197,14 @@ such a link cannot be established automatically."
   (cider-ensure-connected)
   (kill-local-variable 'cider-connections))
 
+(defun cider-connection-type-for-buffer ()
+  "Return the matching connection type (clj or cljs) for the current buffer."
+  (cond
+   ((derived-mode-p 'clojurescript-mode) "cljs")
+   ((derived-mode-p 'clojure-mode) "clj")
+   (cider-repl-type)
+   (t "clj")))
+
 (defun cider-current-connection (&optional type)
   "Return the REPL buffer relevant for the current Clojure source buffer.
 A REPL is relevant if its `nrepl-project-dir' is compatible with the
@@ -218,9 +226,7 @@ from the file extension."
                 ;; Only one match, just return it.
                 (car project-connections)
               ;; OW, find one matching the language of the current buffer.
-              (let ((type (or type cider-repl-type
-                              (if (derived-mode-p 'clojurescript-mode)
-                                  "cljs" "clj"))))
+              (let ((type (or type (cider-connection-type-for-buffer))))
                 (or (seq-find (lambda (conn)
                                 (equal (cider--connection-type conn) type))
                               project-connections)

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -254,6 +254,21 @@
   (should (string= (cider--var-namespace "a-two/var") "a-two"))
   (should (string= (cider--var-namespace "a.two-three.b/var-c") "a.two-three.b")))
 
+(ert-deftest test-cider-connection-type-for-buffer ()
+  (with-temp-buffer
+    (clojurescript-mode)
+    (should (string= (cider-connection-type-for-buffer) "cljs")))
+  (with-temp-buffer
+    (clojure-mode)
+    (should (string= (cider-connection-type-for-buffer) "clj")))
+  (with-temp-buffer
+    (let ((cider-repl-type nil))
+      (should (string= (cider-connection-type-for-buffer) "clj")))
+    (let ((cider-repl-type "clj"))
+      (should (string= (cider-connection-type-for-buffer) "clj")))
+    (let ((cider-repl-type "cljs"))
+      (should (string= (cider-connection-type-for-buffer) "cljs")))))
+
 
 ;;; response handling
 (ert-deftest test-cider-dbind-response ()


### PR DESCRIPTION
Emacs version: `24.5.1`
`; CIDER 0.11.0snapshot (package: 20151214.1327) (Java 1.8.0_05, Clojure 1.7.0, nREPL 0.2.12)`

`cider-repl-type` does not initially get set differently for the two
repls created by `cider-jack-in-clojurescript`.  If the major mode of
the current buffer is definitely Clojure or ClojureScript, use the
matching REPL connection for that type, if there is one open.  If the
major mode is not either of those modes, only then determine the
appropriate connection by looking at `cider-repl-type`.

Thanks to @rfkm for the suggestion for the change
(https://github.com/clojure-emacs/cider/commit/003adaa11c7b417486f58a7265e85c5e4c6d188b#commitcomment-15082109)!