### PR TITLE
[Fix #1482] Clear nREPL sessions when connection is closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and try to associate the created connection with this project automatically.
 * [#1452](https://github.com/clojure-emacs/cider/issues/1452): Prevent ANSI color overlays in the REPL buffer from being extended.
 * [#1486](https://github.com/clojure-emacs/cider/issues/1486): Complete a partial fix in stacktrace font-locking.
 * [#1488](https://github.com/clojure-emacs/cider/pull/1488): Delete zombie overlays in the REPL buffer.
+* [#1482](https://github.com/clojure-emacs/cider/issues/1482): Clear nREPL sessions when a connection is closed.
 
 ## 0.10.0 / 2015-12-03
 

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -615,6 +615,7 @@ and kill the process buffer."
              (substring message 0 -1)))
   (when (equal (process-status process) 'closed)
     (when-let ((client-buffer (process-buffer process)))
+      (nrepl--clear-client-sessions client-buffer)
       (with-current-buffer client-buffer
         (run-hooks 'nrepl-disconnected-hook)
         (when (buffer-live-p nrepl-server-buffer)
@@ -799,6 +800,12 @@ values of *1, *2, etc."
       (with-current-buffer conn-buffer
         (setq nrepl-ops ops)
         (setq nrepl-versions versions)))))
+
+(defun nrepl--clear-client-sessions (conn-buffer)
+  "Clear client nREPL sessions in CONN-BUFFER."
+  (with-current-buffer conn-buffer
+    (setq nrepl-session nil)
+    (setq nrepl-tooling-session nil)))
 
 (define-obsolete-function-alias 'nrepl-close 'cider--close-connection-buffer "0.10.0")
 


### PR DESCRIPTION
Fix for #1482.
Following @Malabarba's suggestion, I put the clearing sessions code into nrepl-client-sentinel.