### PR TITLE
Use text properties instead of overlays for ANSI coloring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and try to associate the created connection with this project automatically.
 
 ### Changes
 
+* [#1500](https://github.com/clojure-emacs/cider/pull/1500): Improve the performance of REPL buffers by using text properties instead of overlays for ANSI coloring.
 * `cider-current-connection` considers major mode before `cider-repl-type`.
 * `cider-inspect` now operates by default on the last sexp. Its behavior can be altered via prefix arguments.
 * Requires Clojure(Script) 1.7 or newer.
@@ -24,9 +25,8 @@ and try to associate the created connection with this project automatically.
 * [#1466](https://github.com/clojure-emacs/cider/issues/1466): Correctly font-lock pretty-printed results in the REPL.
 * [#1475](https://github.com/clojure-emacs/cider/pull/1475): Fix `args-out-of-range` error in `cider--get-symbol-indent`.
 * [#1479](https://github.com/clojure-emacs/cider/pull/1479): Make paredit and `cider-repl-mode` play nice.
-* [#1452](https://github.com/clojure-emacs/cider/issues/1452): Prevent ANSI color overlays in the REPL buffer from being extended.
+* [#1452](https://github.com/clojure-emacs/cider/issues/1452): Fix wrong ANSI coloring in the REPL buffer.
 * [#1486](https://github.com/clojure-emacs/cider/issues/1486): Complete a partial fix in stacktrace font-locking.
-* [#1488](https://github.com/clojure-emacs/cider/pull/1488): Delete zombie overlays in the REPL buffer.
 * [#1482](https://github.com/clojure-emacs/cider/issues/1482): Clear nREPL sessions when a connection is closed.
 * [#1435](https://github.com/clojure-emacs/cider/issues/1435): Improve error display in cider-test.
 * [#1379](https://github.com/clojure-emacs/cider/issues/1379): Fix test highlighting at start of line.

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -532,6 +532,23 @@
   (should (equal (cider-repl-prompt-abbreviated "some.pretty.long.namespace.name")
                  "s.p.l.n.name> ")))
 
+(ert-deftest test-cider-repl--emit-output-at-pos-with-ansi-code ()
+  (with-temp-buffer
+    (let* ((ansi-color-names-vector ["black" "red3" "green3" "yellow3" "blue2" "magenta3" "cyan3" "gray90"])
+           (ansi-color-map (ansi-color-make-color-map)))
+      (cider-repl-reset-markers)
+
+      (cider-repl--emit-output-at-pos (current-buffer) "[30ma[0m" 'cider-repl-stdout-face (point))
+      (cider-repl--emit-output-at-pos (current-buffer) "b" 'cider-repl-stdout-face (point))
+      (cider-repl--emit-output-at-pos (current-buffer) "[31mc" 'cider-repl-stdout-face (point))
+      (cider-repl--emit-output-at-pos (current-buffer) "d[0m" 'cider-repl-stdout-face (point))
+
+      (should (string= (buffer-string) "a\nb\nc\nd\n"))
+      (should (equal (get-text-property 1 'font-lock-face) '(foreground-color . "black")))
+      (should (equal (get-text-property 3 'font-lock-face) 'cider-repl-stdout-face))
+      (should (equal (get-text-property 5 'font-lock-face) '(foreground-color . "red3")))
+      (should (equal (get-text-property 7 'font-lock-face) '(foreground-color . "red3"))))))
+
 (ert-deftest test-cider--url-to-file ()
   (should (equal "/space test" (cider--url-to-file "file:/space%20test")))
   (should (equal "C:/space test" (cider--url-to-file "file:/C:/space%20test"))))


### PR DESCRIPTION
### TL;DR

This PR improves the performance of REPL buffers by using text properties instead of overlays for ANSI coloring.
Also, this fixes #1452 while removing the hacky workaround introduced by #1455.

---

I recently sent some PRs related to overlays in the REPL buffer,
but I've finally realized we should avoid using overlays for ANSI coloring in the first place.
It's simply because overlays are pretty slow. I improved the performance a bit in #1488, but it's not radical.

So, in this PR, I remove all code related to overlays and use text properties instead.


I measured the performance by calling `cider-repl--emit-interactive-output` repeatedly.
The complete benchmark code is [here](https://gist.github.com/rfkm/c28f0e35965bcebe3e37), and the version of my Emacs is `GNU Emacs 24.4.1 (x86_64-apple-darwin14.0.0, NS apple-appkit-1343.14)`.

![active](https://cloud.githubusercontent.com/assets/857162/12069428/6520b1d2-b072-11e5-914b-536ec23da79a.png)

As this figure shows, the overlay version (current master) is getting slower and slower as the number of lines in the REPL buffer increases.

![total](https://cloud.githubusercontent.com/assets/857162/12069432/fe855832-b072-11e5-9fe3-d8adf4be0b94.png)

Total time the overlay version spent on inserting 1000 lines is about 5 seconds. As for the text property version, it's about 0.6 seconds.

If no window displays the REPL buffer, it is much faster in the both cases:

![hidden](https://cloud.githubusercontent.com/assets/857162/12069434/0dc1b3ae-b073-11e5-9cd2-4c0e77a53796.png)

![total_hidden](https://cloud.githubusercontent.com/assets/857162/12069435/138ed000-b073-11e5-8496-f8dfc822467a.png)

---

I keep my changes in #1488 as is because they are harmless, but I can remove them if it is necessary.

I also wonder whether I should remove my old changelog entries related to overlays.
Since this PR removes old PRs' changes, it looks a bit strange that these changelog entries appears in the same release.


P.S.

While I had not intended that, the PR #1455 seems to have improved the performance significantly ;)

![active_old](https://cloud.githubusercontent.com/assets/857162/12069438/64297ba0-b073-11e5-87b3-e07a4425503d.png)
(This is the worst case, that is, all outputs have a trailing overlay.)