### PR TITLE
Suppress eldoc when the current sexp seems to be too large

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and try to associate the created connection with this project automatically.
 
 ### Changes
 
+* Suppress eldoc when the current sexp seems to be too large.
 * [#1500](https://github.com/clojure-emacs/cider/pull/1500): Improve the performance of REPL buffers by using text properties instead of overlays for ANSI coloring.
 * `cider-current-connection` considers major mode before `cider-repl-type`.
 * `cider-inspect` now operates by default on the last sexp. Its behavior can be altered via prefix arguments.

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -553,6 +553,33 @@
   (should (equal "/space test" (cider--url-to-file "file:/space%20test")))
   (should (equal "C:/space test" (cider--url-to-file "file:/C:/space%20test"))))
 
+(ert-deftest test-cider-eldoc-beginning-of-sexp ()
+  (with-temp-buffer
+    (save-excursion
+      (insert "(a (b b) (c c) d)"))
+    (search-forward "d")
+
+    (let ((cider-eldoc-max-num-sexps-to-skip nil))
+      (save-excursion
+        (should (eq (cider-eldoc-beginning-of-sexp) 4))
+        (should (eq (point) 2))))
+
+    (let ((cider-eldoc-max-num-sexps-to-skip 4))
+      (save-excursion
+        (should (eq (cider-eldoc-beginning-of-sexp) 4))
+        (should (eq (point) 2))))
+
+    (let ((cider-eldoc-max-num-sexps-to-skip 3))
+      (save-excursion
+        (should (eq (cider-eldoc-beginning-of-sexp) nil))
+        (should (eq (point) 2))))
+
+    (let ((cider-eldoc-max-num-sexps-to-skip 2))
+      (save-excursion
+        (should (eq (cider-eldoc-beginning-of-sexp) nil))
+        (should (eq (point) 4))))))
+
+
 
 ;;; Cygwin tests
 


### PR DESCRIPTION
This PR restricts the range of searching the beginning of the current sexps for eldoc.

Current version of eldoc could be slow in a large buffer because `cider-eldoc-beginning-of-sexp` could traverse the whole buffer.
Such a situation is especially prone to happen in the REPL buffer.

In the following example, if the cursor is located at the right of the prompt,
`cider-eldoc-beginning-of-sexp` calls `(forward-sexp -1)` about 15 times (`user> -> line -> a -> is -> ...`).

```
This is a line
This is a line
This is a line
user>
```

When the REPL buffer has 4k lines and 35k sexp-like objects (this means `(forward-sexp -1)` will be called 35k times),
`cider-eldoc-beginning-of-sexp` takes about 4 seconds in my environment.
With my fix, it takes less than 0.001 seconds.

This might be related to #1361.