### PR TITLE
Make auto scroll work with repl buffer in non-selected frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and try to associate the created connection with this project automatically.
 * Requires Java 7 or newer.
 * Improve stacktrace presentation of compiler errors (readability, DWIM point positioning).
 
+### Bugs fixed
+
+* [#1521](https://github.com/clojure-emacs/cider/pull/1521): Don't assume the repl buffer is in the current frame in `cider-repl--show-maximum-output`.
+
 ## 0.10.1 / 2015-01-05
 
 ### Changes

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -392,7 +392,7 @@ This will not work on non-current prompts."
 (defun cider-repl--show-maximum-output ()
   "Put the end of the buffer at the bottom of the window."
   (when (eobp)
-    (let ((win (get-buffer-window (current-buffer))))
+    (let ((win (get-buffer-window (current-buffer) t)))
       (when win
         (with-selected-window win
           (set-window-point win (point-max))


### PR DESCRIPTION
I noticed `cider-repl--show-maximum-output` doesn't work with non-selected frames.
(Sometimes, I move a repl buffer to sub-monitor, creating a new frame.)

This PR should make it work with non-selected frames.