### PR TITLE
Make local Javadoc lookup paths configurable

### DIFF
--- a/cider-doc.el
+++ b/cider-doc.el
@@ -86,6 +86,11 @@
   :group 'cider-docview-mode
   :package-version '(cider . "0.7.0"))
 
+(defcustom cider-docview-javadoc-path ()
+  "List of directories where CIDER looks for Javadoc HTML files."
+  :type '(repeat string)
+  :group 'cider-docview-mode
+  :package-version '(cider . "0.7.0"))
 
 
 ;; Faces
@@ -181,9 +186,13 @@
   (when symbol-name
     (cider-ensure-op-supported "info")
     (let* ((info (cider-var-info symbol-name))
-           (url (nrepl-dict-get info "javadoc")))
-      (if url
-          (browse-url url)
+           (url (nrepl-dict-get info "javadoc"))
+           (f-expand (lambda (dir) (concat (file-name-as-directory dir) url)))
+           (candidates (mapcar f-expand cider-docview-javadoc-path))
+           (files (remove-if-not 'file-exists-p candidates))
+           (target (car `(,@files ,url))))
+      (if target
+          (browse-url target)
         (user-error "No Javadoc available for %s" symbol-name)))))
 
 (defun cider-javadoc (arg)


### PR DESCRIPTION
If I do `cider-javadoc` on e.g. `javafx.stage.Stage`, it results in an elisp call to `(browse-url "javafx.stage.Stage")`, which doesn't even open a browser tab, presumably because `browse-url` doesn't know what protocol that relative URL has.

If I do the same for e.g. `java.lang.String` it results in a full url to the Oracle website, so that works. I tried to figure out where in cider-nrepl that URL is coming from, but I only find code there to build a relative URL, so I may be missing something.

What I really want is to have the JDK and JavaFX javadocs locally, and have CIDER open the right file from those local docs.

This commits adds a customizable search path for Javadoc directories, so you can easily do just that. If it doesn't find the file in any of the configured locations, it falls back to the old behavior.

I may be missing something here, or this may not be the best approach, so it's more a starting point for discussion. This is my first PR here, I'm happy to take any feedback into consideration.

```
; CIDER 0.11.0snapshot (package: 20160121.1400) (Java 1.8.0_66, Clojure 1.7.0, nREPL 0.2.12)
```