### PR TITLE
Suggest just using `.lein/profiles.d/repl.clj` for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,8 +245,28 @@ Much of CIDER's functionality depends on the presence of CIDER's own
 
 #### Using Leiningen
 
-Use the convenient plugin for defaults, either in your project's
-`project.clj` file or in the :repl profile in `~/.lein/profiles.clj`.
+To install CIDER globally in Leiningen, you should add the cider-nrepl plugin
+into your `:repl` profile. If you have not set up the `:repl` profile before,
+you can download
+[repl.clj](https://raw.githubusercontent.com/clojure-emacs/cider/master/repl.clj)
+and move it so that is located at `~/.lein/profiles.d/repl.clj`. The directory
+`~/.lein/profiles.d/` is not usually created, so you may have to create it
+yourself.
+
+These terminal commands will do that for you:
+
+```shell
+mkdir -p ~/.lein/profiles.d
+if [ -f ~/.lein/profiles.d/repl.clj ]; then
+    echo 'repl.clj already exists!'
+else
+    curl https://raw.githubusercontent.com/clojure-emacs/cider/master/repl.clj \
+      > ~/.lein/profiles.d/repl.clj
+fi
+```
+
+You can also put the plugin in your project's `project.clj` file or in the :repl
+profile in `~/.lein/profiles.clj`.
 
 ```clojure
 :plugins [[cider/cider-nrepl "x.y.z"]]

--- a/repl.clj
+++ b/repl.clj
@@ -1,0 +1,2 @@
+;; Default cider-nrepl repl.clj profile for Leiningen.
+{:plugins [[cider/cider-nrepl "0.10.2"]]}


### PR DESCRIPTION
After some feedback from technomancy/leiningen#2074, I realised that it may be easier for newcomers to Clojure and CIDER to just use a default provided `:repl` profile. Leiningen supports putting different profiles in `.lein/profiles.d` (for example `.lein/profiles.d/repl.clj`), and it may be an idea to provide steps to just download a profile file and put it in the right place.

I'm not sure if the way I've written this makes it easier or not, but at least now you know about the option. (I will also take a look into and see if we can make it easier to support more "automatic" kind of setups for tools that use Leiningen.)

Pinging @phillord for this, since he brought it up in the first place.