### PR TITLE
Require cider-test in cider-repl

### DIFF
--- a/cider-repl.el
+++ b/cider-repl.el
@@ -36,6 +36,7 @@
 (require 'cider-common)
 (require 'cider-compat)
 (require 'cider-util)
+(require 'cider-test)
 
 (require 'clojure-mode)
 (require 'easymenu)


### PR DESCRIPTION
When loading cider the following error occurs:

`Symbol's value as variable is void: cider-test-menu`

This happens because the `cider-repl.el` file uses the symbol
`cider-test-menu` from the `cider-test.el` file, but doesn't require
it. This patch fixes the problem.