### PR TITLE
cider-interaction: Allow full project refreshes with c.t.namespace

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1429,6 +1429,22 @@ ClojureScript REPL exists for the project, it is evaluated in both REPLs."
        :both)
       (message "Loading %s..." filename))))
 
+(defun cider-refresh-project ()
+  "Refresh te project. This relies on clojure.tools.namespace being available in
+   the classpath."
+  (interactive)
+  (check-parens)
+  (cider-ensure-connected)
+  (cider--clear-compilation-highlights)
+  (cider--quit-error-window)
+  (cider--cache-ns-form)
+  (remove-overlays nil nil 'cider-type 'instrumented-defs)
+  (cider-nrepl-request:eval
+   "(do (require 'clojure.tools.namespace) (clojure.tools.namespace/refresh))"
+   (lambda (_response) nil))
+  (message "Refreshing all namespaces..."))
+
+
 (defun cider-load-file (filename)
   "Load (eval) the Clojure file FILENAME in nREPL.
 

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1440,7 +1440,7 @@ ClojureScript REPL exists for the project, it is evaluated in both REPLs."
   (cider--cache-ns-form)
   (remove-overlays nil nil 'cider-type 'instrumented-defs)
   (cider-nrepl-request:eval
-   "(do (require 'clojure.tools.namespace) (clojure.tools.namespace/refresh))"
+   "(do (require 'clojure.tools.namespace.repl) (clojure.tools.namespace.repl/refresh))"
    (lambda (_response) nil))
   (message "Refreshing all namespaces..."))
 

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -204,6 +204,7 @@ Returns to the buffer in which the command was invoked."
     (define-key map (kbd "C-c M-z") #'cider-load-buffer-and-switch-to-repl-buffer)
     (define-key map (kbd "C-c C-o") #'cider-find-and-clear-repl-output)
     (define-key map (kbd "C-c C-k") #'cider-load-buffer)
+    (define-key map (kbd "C-c M-k") #'cider-refresh-project)
     (define-key map (kbd "C-c C-l") #'cider-load-file)
     (define-key map (kbd "C-c C-b") #'cider-interrupt)
     (define-key map (kbd "C-c ,")   'cider-test-commands-map)

--- a/doc/cider-refcard.tex
+++ b/doc/cider-refcard.tex
@@ -78,6 +78,7 @@
 \subsection{Evaluation}
 \begin{keylist}[labelwidth=\widthof{\keyify{C-c RET}}]
   \item[C-c C-k] cider-load-buffer
+  \item[C-c M-k] cider-refresh-project
   \item[C-c C-l] cider-load-file
   \item[C-c C-r] cider-eval-region
   \item[C-c C-n] cider-eval-ns-form


### PR DESCRIPTION
When clojure.tools.namespace is available, usually by having
a `~/.lein/profiles.clj` containing something along the lines of:

```clojure
{:repl {:plugins [[cider/cider-nrepl "0.11.0-SNAPSHOT"]]
        :dependencies [[org.clojure/tools.nrepl "0.2.12"]
                       [org.clojure/tools.namespace "0.3.0-alpha3"]]}}
```

It is useful to be able to trigger full project refreshes by calling
`clojure.tools.namespace/refresh`. The rationale for refresh can
be found here: https://github.com/clojure/tools.namespace#reloading-code-motivation

My workflow for testing emacs-lisp code isn't perfect, so bear with
me on this PR, :-).