### PR TITLE
Update kbd for running test in current buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -720,8 +720,8 @@ Keyboard shortcut                       | Description
 
 ### Running tests
 
-You can run `clojure.test` tests pretty quickly in CIDER. Pressing <kbd>C-c
-,</kbd> in a source buffer or a REPL buffer will run the tests for the namespace
+You can run `clojure.test` tests pretty quickly in CIDER. Pressing <kbd>C-c C-t n</kbd>
+in a source buffer or a REPL buffer will run the tests for the namespace
 you're currently in. CIDER is smart enough to figure out the namespace
 containing the tests.
 


### PR DESCRIPTION
`C-c ,` is no longer supported - this PR updates its README with the new kbd.