### PR TITLE
Position point correctly when debugging forms with metadata

### DIFF
--- a/cider-debug.el
+++ b/cider-debug.el
@@ -460,6 +460,8 @@ key of a map, and it means \"go to the value associated with this key\". "
       ;; Navigate through sexps inside the sexp.
       (let ((in-syntax-quote nil))
         (while coordinates
+          (while (clojure--looking-at-non-logical-sexp)
+            (forward-sexp))
           (down-list)
           ;; Are we entering a syntax-quote?
           (when (looking-back "`\\(#{\\|[{[(]\\)" (line-beginning-position))

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -102,6 +102,27 @@
     (cider--debug-move-point '(2 1 1 1))
     (should (string= (buffer-substring (point-min) (point)) "`[(~d)"))))
 
+(ert-deftest test-debug-move-point-metadata ()
+  (with-temp-buffer
+    (clojure-mode)
+    (save-excursion (insert "(defn a [] (let [x 1] ^{:y z} (inc x))"))
+    (cider--debug-move-point '(3 2 1))
+    (should (string= (thing-at-point 'symbol) "x"))))
+
+(ert-deftest test-debug-move-point-data-reader ()
+  (with-temp-buffer
+    (clojure-mode)
+    (save-excursion (insert "(defn a [] (let [x 1] #bar (inc #foo x))"))
+    (cider--debug-move-point '(3 2 1))
+    (should (string= (thing-at-point 'symbol) "x"))))
+
+(ert-deftest test-debug-move-point-data-reader-and-metadata ()
+  (with-temp-buffer
+    (clojure-mode)
+    (save-excursion (insert "(defn a [] (let [x 1] #break ^{foo (foo x)} (inc x))"))
+    (cider--debug-move-point '(3 2 1))
+    (should (string= (thing-at-point 'symbol) "x"))))
+
 (ert-deftest test-cider-connection-buffer-name ()
   (setq-local nrepl-endpoint '("localhost" 1))
   (let ((nrepl-hide-special-buffers nil))


### PR DESCRIPTION
`cider--debug-move-point` would position the point incorrectly when
debugging a form with a metadata map attached via the reader, because
the call to `down-list` would descend into the metadata map.