### PR TITLE
Exclude Clojure dependency when injecting deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ specific CIDER release.**
     - [REPL Configuration](#repl-configuration)
       - [REPL history](#repl-history)
   - [ClojureScript usage](#clojurescript-usage)
+  - [Using CIDER with Clojure forks](#fork-usage)
 - [Extended Workflow](#extended-workflow)
   - [Macroexpansion](#macroexpansion)
   - [Value Inspection](#value-inspection)
@@ -731,6 +732,18 @@ CIDER will determine which to use based on the type of file you're editing.
 You should also check out
 [Figwheel](https://github.com/bhauman/lein-figwheel/wiki/Using-the-Figwheel-REPL-within-NRepl)'s
 wiki.
+
+### Clojure fork usage (Leiningen-only)
+
+Ordinarily CIDER relies on having a recent build of Clojure around.  However, if
+for some reason you want to use your own build of Clojure this can be achieved
+by customizing the var `cider-jack-in-exclusions`. When CIDER starts a REPL, it
+will automatically inject appropriate dependencies. This var lets you exclude
+transitive dependencies such as Clojure so that you can provide your own.
+
+**Warning**: By doing this you circumvent CIDER's ability to provide an
+appropriate version of Clojure or other libraries for itself, and you could very
+easily break something. Proceed with caution.
 
 ## Extended workflow
 

--- a/cider.el
+++ b/cider.el
@@ -183,6 +183,12 @@ This variable is used by `cider-connect'."
   "Regexp list to extract project paths from output of `cider-ps-running-nrepls-command'.
 Sub-match 1 must be the project path.")
 
+(defcustom cider-jack-in-exclusions nil
+  "List of artifact names which will be excluded when injecting dependencies."
+  :type '(repeat string)
+  :group 'cider
+  :package-version '(cider . "0.12.0"))
+
 (defvar cider-host-history nil
   "Completion history for connection hosts.")
 
@@ -258,11 +264,20 @@ string is quoted for passing as argument to an inferior shell."
   (concat (boot-command-prefix (append dependencies plugins))
           (boot-repl-task-params params middlewares)))
 
+(defun cider--list-as-lein-exclusions (list)
+  (if list
+      (concat " :exclusions [" (mapconcat 'identity list " ") "]")
+    ""))
+
 (defun cider--list-as-lein-artifact (list)
   "Return an artifact string described by the elements of LIST.
 LIST should have the form (ARTIFACT-NAME ARTIFACT-VERSION).  The returned
 string is quoted for passing as argument to an inferior shell."
-  (shell-quote-argument (format "[%s %S]" (car list) (cadr list))))
+  (shell-quote-argument
+   (format "[%s %S%s]"
+           (car list)
+           (cadr list)
+           (cider--list-as-lein-exclusions cider-jack-in-exclusions))))
 
 (defun cider-lein-jack-in-dependencies (params dependencies lein-plugins)
   (concat


### PR DESCRIPTION
This change allows users to make use of Clojure forks, without having CIDER clobber everything when starting a REPL.

Maybe a more general structure such as a `cider-excluded-dependencies` var is in order, but it's worth talking about and this is what I'm rolling locally.