### PR TITLE
Try to handle CIDER mistakes more gracefully

### DIFF
--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -965,16 +965,11 @@ sign of user input, so as not to hang the interface."
     (when (member "done" status)
       (when-let ((ex (nrepl-dict-get response "ex"))
                  (err (nrepl-dict-get response "err")))
-        ;; non-eval requests currently don't set the *e var
-        ;; which is required by the stacktrace middleware
-        ;; so we have to handle them differently until this is resolved
-        (if (member "eval-error" status)
-            (funcall nrepl-err-handler)
-          ;; dump the stacktrace in the REPL
-          ;; TODO: This has to be replaced with rendering of the
-          ;; standard stacktrace buffer
-          (cider-repl-emit-interactive-stderr err)
-          (switch-to-buffer-other-window connection)))
+        ;; Non-eval requests currently don't set the *e var
+        ;; but instead get stored in util/storage, the storage-key
+        ;; lets us retrieve these errors. If there's no storage-key,
+        ;; then this will end up returning *e.
+        (funcall nrepl-err-handler (nrepl-dict-get response "storage-key")))
       (when-let ((id (nrepl-dict-get response "id")))
         (with-current-buffer connection
           (nrepl--mark-id-completed id)))


### PR DESCRIPTION
Not ready yet, but thought I'd see what you guys thought before going any further

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

Thanks!

Unless specifically coded into the sync request, errors result in
stacktraces being thrown onto the REPL and focus changing to the REPL
buffer. These changes just log the exception info into a buffer and
notify the user of this in the message area. Easiest way to see how this
works is to select a region with unbalanced parens and then call a
cider-format-region-edn.