### PR TITLE
Fix bug in cider-expected-ns; make tests run again

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -675,12 +675,12 @@ active nREPL connection."
       (let* ((path (or path (file-truename (buffer-file-name))))
              (relpath (thread-last (cider-sync-request:classpath)
                         (seq-map
-                         (lambda (p)
-                           ;; when path starts with p
-                           (when (string-match (rx-to-string `(: bos ,p)) path)
-                             (substring path (length p)))))
+                         (lambda (cp)
+                           (when (string-prefix-p cp path)
+                             (substring path (length cp)))))
                         (seq-filter #'identity)
-                        (seq-sort #'string<)
+                        (seq-sort (lambda (a b)
+                                    (< (length a) (length b))))
                         (car))))
         (when relpath
           (thread-last (substring relpath 1) ; remove leading /

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -782,8 +782,9 @@
     (should-error (cider-find-ns) :type 'user-error)))
 
 (ert-deftest cider-expected-ns ()
-  (noflet ((cider-ensure-connected () t)
-           (cider-sync-request:classpath () '("/a" "/b" "/c" "/c/inner")))
+  (noflet ((cider-connected-p () t)
+           (cider-sync-request:classpath () '("/a" "/b" "/c" "/c/inner"
+                                              "/base/clj" "/base/clj-dev")))
     (should (string= (cider-expected-ns "/a/foo/bar/baz_utils.clj")
                      "foo.bar.baz-utils"))
     (should (string= (cider-expected-ns "/b/foo.clj")
@@ -794,4 +795,6 @@
                      ;; NOT inner.foo.bar
                      "foo.bar"))
     (should (string= (cider-expected-ns "/c/foo/bar/baz")
-                     "foo.bar.baz"))))
+                     "foo.bar.baz"))
+    (should (string= (cider-expected-ns "/base/clj-dev/foo/bar.clj")
+                     "foo.bar"))))


### PR DESCRIPTION
Oops, my previous PR sorted the seq incorrectly.  This PR fixes the bug and adds a test case for it.

I also discovered the `string-prefix-p` function, which makes the classpath prefix test simpler.

Side note 1: I think 3f345bfd8 broke `make test`, so this fixes the tests also.

Side note 2: is there an elisp seq equivalant to clojure's `sort-by`?  Such a function would make things a little simpler.