### PR TITLE
cider-auto-test-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ an individual test using `C-c C-t t`.
 
 ### New Features
 
+* [#1636](https://github.com/clojure-emacs/cider/pull/1636): New minor-mode `cider-auto-test-mode` for test-driven-development. When activated, tests are rerun after every load-file.
 * Javadoc commands take into account the variable `clojure.java.javadoc/*remote-javadocs*`.
 * Javadoc also works on classes of the AmazonAWS Java SDK.
 * Apropos commands now accept lists of space-separated words as arguments, in addition to regular expressions (similar to Emacs's own apropos commands).

--- a/cider-test.el
+++ b/cider-test.el
@@ -646,6 +646,29 @@ is searched."
             (cider-test-execute ns (cdr def))
           (message "No test at point"))))))
 
+;;; Auto-test mode
+(defun cider--test-silently ()
+  "Like `cider-test-run-tests', but with less feedback.
+Only notify the user if there actually were any tests to run and only after
+the results are received."
+  (when (cider-connected-p)
+    (let ((cider-auto-select-test-report-buffer nil)
+          (cider-test-show-report-on-success nil))
+      (cider-test-run-ns-tests nil 'soft))))
+
+;;;###autoload
+(define-minor-mode cider-auto-test-mode
+  "Toggle automatic testing of Clojure files.
+
+When enabled this reruns tests every time a Clojure file is loaded.
+Only runs tests corresponding to the loaded file's namespace and does
+nothing if no tests are defined or if the file failed to load."
+  nil (cider-mode " Test") nil
+  :global t
+  (if cider-auto-test-mode
+      (add-hook 'cider-file-loaded-hook #'cider--test-silently)
+    (remove-hook 'cider-file-loaded-hook #'cider--test-silently)))
+
 (provide 'cider-test)
 
 ;;; cider-test.el ends here

--- a/doc/extended_workflow.md
+++ b/doc/extended_workflow.md
@@ -101,6 +101,20 @@ passed or failed:
 (setq cider-test-show-report-on-success t)
 ```
 
+#### Running tests automatically (test-driven development)
+
+CIDER provides a minor-mode that automatically runs all tests for a namespace
+whenever you load a file (with <kbd>C-c C-k</kbd>). You can toggle it
+manually with <kbd>M-x</kbd> `cider-auto-test-mode`, or you can use:
+
+```el
+(cider-auto-test-mode 1)
+```
+
+This is completely equivalent to manually typing <kbd>C-c C-t C-n</kbd> every
+time you load a Clojure buffer. Also, as described above before, CIDER is smart
+enough to figure out the namespace containing the tests.
+
 #### Using cider-test with alternative test libraries
 
 The `clojure.test` machinery is designed to be pluggable. Any test library


### PR DESCRIPTION
A minor mode that runs tests after every successful load-file op.
I've been using this a lot lately, and I'm quite happy with it now.

It might make sense to also let the user run tests after every eval op (instead of just load-file). But I actually like that I can play around small code snippets with `C-x C-e` and `C-M-x` without accidentally reruning all tests, so I'm leaving this as is for now.