### PR TITLE
Update seq dependency to 2.14

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -12,7 +12,7 @@
 ;; Maintainer: Bozhidar Batsov <bozhidar@batsov.com>
 ;; URL: http://www.github.com/clojure-emacs/cider
 ;; Version: 0.12.0-cvs
-;; Package-Requires: ((emacs "24.3") (clojure-mode "5.3.0") (pkg-info "0.4") (queue "0.1.1") (spinner "1.7") (seq "1.9"))
+;; Package-Requires: ((emacs "24.3") (clojure-mode "5.3.0") (pkg-info "0.4") (queue "0.1.1") (spinner "1.7") (seq "2.14"))
 ;; Keywords: languages, clojure, cider
 
 ;; This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
Updating seq.el to v 2.14 has the following benefits:

- The 2.x branch of seq now provides the same API for Emacs 25.1, Emacs master and Emacs 24.x.
- This version adds `seq-map-indexed` and `seq-sort-by`, which removes the need for `cider-map-indexed`.