### PR TITLE
Let sync op failures use stacktrace viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bugs fixed
 
+
+* [#1420](https://github.com/clojure-emacs/cider/issues/1420): Show stacktrace buffers for sync requests errors.
 * [cider-nrepl#329](https://github.com/clojure-emacs/cider-nrepl/pull/329): Fix error instrumenting functions that call clojure.tools.logging.
 * [#1632](https://github.com/clojure-emacs/cider/pull/1632): Redefining a function correctly updates eldoc.
 * [#1630](https://github.com/clojure-emacs/cider/pull/1630): The debugger no longer gets confused inside `@` redefs.

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -968,11 +968,7 @@ sign of user input, so as not to hang the interface."
         ;; so we have to handle them differently until this is resolved
         (if (member "eval-error" status)
             (funcall nrepl-err-handler)
-          ;; dump the stacktrace in the REPL
-          ;; TODO: This has to be replaced with rendering of the
-          ;; standard stacktrace buffer
-          (cider-repl-emit-interactive-stderr err)
-          (switch-to-buffer-other-window connection)))
+          (cider--render-stacktrace-causes (nrepl-dict-get response "pp-stacktrace"))))
       (when-let ((id (nrepl-dict-get response "id")))
         (with-current-buffer connection
           (nrepl--mark-id-completed id)))


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

Thanks!

This lets sync ops use the stacktrace viewer, just like how async ops
currently do. Requires some changes to the CIDER-nREPL code as well
which were submitted as CIDER-nREPL PR 327
https://github.com/clojure-emacs/cider-nrepl/pull/327.