### PR TITLE
Mute user-specified middleware errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ an individual test using `C-c C-t t`.
 * Display eldoc for keywords used to get map keys.
 * Display eldoc for `Classname.`.
 * Display namespace in eldoc.
+* [cider-nrepl#313](https://github.com/clojure-emacs/cider-nrepl/issues/313): Selectively suppress user-specified categories of middleware errors from foregrounding stacktrace buffers via the `cider-stacktrace-suppressed-errors` variable.
 
 ### Changes
 

--- a/doc/extended_workflow.md
+++ b/doc/extended_workflow.md
@@ -166,8 +166,24 @@ shown on error. By default it will be displayed, but you can change this:
 (setq cider-show-error-buffer nil)
 ```
 
-Independently of the value of `cider-show-error-buffer`, the error buffer is
-always generated in the background. Use `cider-visit-error-buffer` to visit
+At times, the error being displayed will originate from a bug in the
+CIDER code itself. These internal errors might frequently occur and
+interrupt your workflow, but you might not want to suppress **all**
+stacktrace buffers via the `cider-show-error-buffer` variable as
+above; instead, you might only want to suppress *this specific type*
+of internal error. The stacktrace buffers provide such an option when
+displaying an internal error. A toggle button will be displayed with
+the error type's name, and you can toggle whether this particular type
+of error will cause the stacktrace buffer to automatically show
+itself.  The toggle button controls this behavior only during the
+current Emacs session, but if you would like to make the suppression
+more permanent, you can do so by customizing the
+`cider-stacktrace-suppressed-errors` variable.  The buffer will also
+provide a direct link to the bug reporting page to help facilitate its
+diagnosis and repair.
+
+Independently of the value of `cider-show-error-buffer` or `cider-stacktrace-suppressed-errors`,
+the error buffer is always generated in the background. Use `cider-visit-error-buffer` to visit
 this buffer.
 
 There are two more selective strategies for the error buffer:

--- a/test/cider-stacktrace-tests.el
+++ b/test/cider-stacktrace-tests.el
@@ -1,0 +1,33 @@
+(require 'cider)
+(require 'cider-stacktrace)
+(require 'ert)
+
+;;; cider-stacktrace tests
+
+;;; Internal/Middleware error suppression
+(ert-deftest test-cider-stacktrace-some-suppressed-errors-p ()
+  (let ((cider-stacktrace-suppressed-errors '()))
+    (should-not (cider-stacktrace-some-suppressed-errors-p '("a")))
+    (should-not (cider-stacktrace-some-suppressed-errors-p '())))
+
+  (let ((cider-stacktrace-suppressed-errors '("a" "b" "c" "d")))
+    (should (equal '("a") (cider-stacktrace-some-suppressed-errors-p '("a"))))
+    (should (equal '("a" "c") (cider-stacktrace-some-suppressed-errors-p '("a" "c" "e"))))
+    (should-not (cider-stacktrace-some-suppressed-errors-p '("g" "f" "e")))))
+
+(ert-deftest test-cider-stacktrace-suppress-error ()
+  (let ((cider-stacktrace-suppressed-errors '("a" "b" "c")))
+    (should-not (cl-set-exclusive-or '("a" "b" "z" "c") (cider-stacktrace-suppress-error "z") :test 'equal))))
+
+(ert-deftest test-cider-stacktrace-promote-error ()
+  (let ((cider-stacktrace-suppressed-errors '("a" "b" "x" "c")))
+    (should-not (cl-set-exclusive-or '("a" "b" "c") (cider-stacktrace-promote-error "x")
+                                     :test 'equal))))
+
+(ert-deftest test-cider-stacktrace-suppressed-error-p ()
+  (let ((cider-stacktrace-suppressed-errors '("a" "b" "g" "j")))
+    (should (cider-stacktrace-suppressed-error-p "a"))
+    (should (cider-stacktrace-suppressed-error-p "b"))
+    (should (cider-stacktrace-suppressed-error-p "g"))
+    (should (cider-stacktrace-suppressed-error-p "j"))
+    (should-not (cider-stacktrace-suppressed-error-p "c"))))


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

Thanks!

These changes allow the user to more finely tune the 'mute-ability' of
stacktrace buffers from popping up and stealing focus. The selectivity
of the muting used to be pretty broad, defined by the variable
`cider-show-error-buffer`, but now the user can mute errors with a
specific error type. These error types live in the response's
status. The mute list is `cider-mute-error-types`. We allow short-term
(ie, until Emacs is restarted) muting directely from the stacktrace buffer.