### PR TITLE
Doc improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ an individual test using `C-c C-t t`.
 
 ### Changes
 
+* Doc buffer splits arglists into several lines.
 * Changed the face of the words “Macro” and “Special form” in the doc buffer to be easier to see.
 * Display multi-line eval overlays at the start of the following line. It looked weird that these overlays started on the middle of a line, but then folded onto the start of following lines.
 * [#1627](https://github.com/clojure-emacs/cider/issues/1627): Align the terminology used by `cider-test` with the one used by lein and boot (use the terms `assertion` and `test`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ an individual test using `C-c C-t t`.
 
 ### Changes
 
+* Changed the face of the words “Macro” and “Special form” in the doc buffer to be easier to see.
 * Display multi-line eval overlays at the start of the following line. It looked weird that these overlays started on the middle of a line, but then folded onto the start of following lines.
 * [#1627](https://github.com/clojure-emacs/cider/issues/1627): Align the terminology used by `cider-test` with the one used by lein and boot (use the terms `assertion` and `test`).
 * Remove the warning about missing nREPl ops.

--- a/cider-doc.el
+++ b/cider-doc.el
@@ -402,7 +402,7 @@ Tables are marked to be ignored by line wrap."
         (when (or forms args)
           (emit (cider-font-lock-as-clojure (or forms args))))
         (when (or special macro)
-          (emit (if special "Special Form" "Macro") 'font-lock-comment-face))
+          (emit (if special "Special Form" "Macro") 'font-lock-variable-name-face))
         (when added
           (emit (concat "Added in " added) 'font-lock-comment-face))
         (when depr

--- a/cider-doc.el
+++ b/cider-doc.el
@@ -400,7 +400,17 @@ Tables are marked to be ignored by line wrap."
         (when (or super ifaces)
           (insert "\n"))
         (when (or forms args)
-          (emit (cider-font-lock-as-clojure (or forms args))))
+          (insert " ")
+          (save-excursion
+            (emit (cider-font-lock-as-clojure (substring (or forms args) 1 -1))))
+          ;; It normally doesn't happen, but it's technically conceivable for
+          ;; the args string to contain unbalanced sexps, so `ignore-errors'.
+          (ignore-errors
+            (forward-sexp 1)
+            (while (not (looking-at "$"))
+              (insert "\n")
+              (forward-sexp 1)))
+          (forward-line 1))
         (when (or special macro)
           (emit (if special "Special Form" "Macro") 'font-lock-variable-name-face))
         (when added


### PR DESCRIPTION
Most important change is that doc buffer splits arglists into several lines.

Instead of this:

    org.httpkit.client/post
    ([url & [opts callback]] [url & [callback]])
      Issues an async HTTP POST request. See `request` for details.

We get this:

    org.httpkit.client/post
     [url & [opts callback]]
     [url & [callback]]
      Issues an async HTTP POST request. See `request` for details.

Which I find much easier to read.