### PR TITLE
Simplify middleware version compatibility check

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -606,29 +606,18 @@ In case `default-directory' is non-local we assume the command is available."
                                "Can't determine nREPL's version.\nPlease, update nREPL to %s."
                                cider-required-nrepl-version)))
 
-(defun cider--check-middleware-compatibility-callback (buffer)
-  "A callback to check if the middleware used is compatible with CIDER.
-BUFFER specifies the connection buffer to be used."
-  (nrepl-make-response-handler
-   buffer
-   (lambda (_buffer result)
-     (let ((middleware-version (read result)))
-       (unless (and middleware-version (equal cider-version middleware-version))
-         (cider-repl-manual-warning "installation/#ciders-nrepl-middleware"
-                                    "CIDER's version (%s) does not match cider-nrepl's version (%s). Things will break!"
-                                    cider-version middleware-version))))
-   '()
-   '()
-   '()))
-
 (defun cider--check-middleware-compatibility ()
-  "Retrieve the underlying connection's CIDER nREPL version."
-  (cider-nrepl-request:eval
-   "(try
-      (require 'cider.nrepl.version)
-      (:version-string @(resolve 'cider.nrepl.version/version))
-    (catch Throwable _ \"not installed\"))"
-   (cider--check-middleware-compatibility-callback (current-buffer))))
+  "CIDER frontend/backend compatibility check.
+Retrieve the underlying connection's CIDER-nREPL version and checks if the
+middleware used is compatible with CIDER.  If not, will display a warning
+message in the REPL area."
+  (let* ((version-dict        (nrepl-aux-info "cider-version" (cider-current-connection)))
+         (middleware-version  (or (nrepl-dict-get version-dict "version-string")
+                                  "not installed")))
+    (unless (equal cider-version middleware-version)
+      (cider-repl-manual-warning "installation/#ciders-nrepl-middleware"
+                                 "CIDER's version (%s) does not match cider-nrepl's version (%s). Things will break!"
+                                 cider-version middleware-version))))
 
 (defun cider--subscribe-repl-to-server-out ()
   "Subscribe to the server's *out*."

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -172,6 +172,9 @@ To be used for tooling calls (i.e. completion, eldoc, etc)")
 (defvar-local nrepl-versions nil
   "Version information received from the describe op.")
 
+(defvar-local nrepl-aux nil
+  "Auxillary information received from the describe op.")
+
 
 ;;; nREPL Buffer Names
 
@@ -259,6 +262,11 @@ Bind the value of the provided KEYS and execute BODY."
   "Return t iff the given operation OP is supported by the nREPL CONNECTION."
   (with-current-buffer connection
     (and nrepl-ops (nrepl-dict-get nrepl-ops op))))
+
+(defun nrepl-aux-info (key connection)
+  "Return KEY's aux info, as returned via the :describe op for CONNECTION."
+  (with-current-buffer connection
+    (and nrepl-aux (nrepl-dict-get nrepl-aux key))))
 
 (defun nrepl-local-host-p (host)
   "Return t if HOST is local."
@@ -797,10 +805,11 @@ values of *1, *2, etc."
 (defun nrepl--init-capabilities (conn-buffer)
   "Store locally in CONN-BUFFER the capabilities of nREPL server."
   (let ((description (nrepl-sync-request:describe conn-buffer)))
-    (nrepl-dbind-response description (ops versions)
+    (nrepl-dbind-response description (ops versions aux)
       (with-current-buffer conn-buffer
         (setq nrepl-ops ops)
-        (setq nrepl-versions versions)))))
+        (setq nrepl-versions versions)
+        (setq nrepl-aux aux)))))
 
 (defun nrepl--clear-client-sessions (conn-buffer)
   "Clear information about nREPL sessions in CONN-BUFFER.


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

Thanks!

This mostly addresses CIDER-nREPL issue #202
https://github.com/clojure-emacs/cider-nrepl/issues/202. We can now
check for CIDER -> CIDER-nREPL compatibility without having to perform
an eval request and set up a callback handler to process that request.