### PR TITLE
Add default value to nrepl-dict-get

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -620,8 +620,7 @@ Retrieve the underlying connection's CIDER-nREPL version and checks if the
 middleware used is compatible with CIDER.  If not, will display a warning
 message in the REPL area."
   (let* ((version-dict        (nrepl-aux-info "cider-version" (cider-current-connection)))
-         (middleware-version  (or (nrepl-dict-get version-dict "version-string")
-                                  "not installed")))
+         (middleware-version  (nrepl-dict-get version-dict "version-string" "not installed")))
     (unless (equal cider-version middleware-version)
       (cider-repl-manual-warning "installation/#ciders-nrepl-middleware"
                                  "CIDER's version (%s) does not match cider-nrepl's version (%s). Things will break!"

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -301,12 +301,22 @@ Bind the value of the provided KEYS and execute BODY."
   "Return t if nREPL dict DICT is empty."
   (null (cdr dict)))
 
-(defun nrepl-dict-get (dict key)
-  "Get from DICT value associated with KEY.
-If dict is nil, return nil."
+(defun nrepl-dict-contains (dict key)
+  "Return nil if nREPL dict DICT doesn't contain KEY.
+If DICT does contain KEY, then a non-nil value is returned.  Due to the
+current implementation, this return value is the tail of DICT's key-list
+whose car is KEY.  Comparison is done with `equal'."
+  (member key (nrepl-dict-keys dict)))
+
+(defun nrepl-dict-get (dict key &optional default)
+  "Get from DICT value associated with KEY, optional DEFAULT if KEY not in DICT.
+If dict is nil, return nil.  If DEFAULT not provided, and KEY not in DICT,
+return nil.  If DICT is not an nREPL dict object, an error is thrown."
   (when dict
     (if (nrepl-dict-p dict)
-        (lax-plist-get (cdr dict) key)
+        (if (nrepl-dict-contains dict key)
+            (lax-plist-get (cdr dict) key)
+          default)
       (error "Not an nREPL dict object: %s" dict))))
 
 (defun nrepl-dict-put (dict key value)

--- a/test/nrepl-dict-tests.el
+++ b/test/nrepl-dict-tests.el
@@ -9,3 +9,72 @@
                  '(dict 1 3 "10" me)))
   (should (equal (nrepl-dict-merge '(dict 1 3 "10" me) nil)
                  '(dict 1 3 "10" me))))
+
+(ert-deftest nrepl-dict-contains-successful ()
+  "Tests `nrepl-dict-contains' on inputs where this predicate function
+should return non-nil. Of note, the `nil' value itself is allowed to be a
+key in the nREPL dict."
+  (let ((input '(dict 1 "a" 2 "B" "3" "d" 4 nil sym yes nil nil-val)))
+    (should (nrepl-dict-contains input 1))
+    (should (nrepl-dict-contains input 2))
+    (should (nrepl-dict-contains input "3"))
+    (should (nrepl-dict-contains input 4))
+    (should (nrepl-dict-contains input 'sym))
+    (should (nrepl-dict-contains input nil))))
+
+(ert-deftest nrepl-dict-contains-failure ()
+  "Tests `nrepl-dict-contains' on inputs where this predicate function
+should return nil."
+  (let ((input '(dict 1 "a" 2 "B" "3" "d" 4 nil sym yes)))
+    (should (equal (nrepl-dict-contains input 11) nil))
+    (should (equal (nrepl-dict-contains input 12) nil))
+    (should (equal (nrepl-dict-contains input "13") nil))
+    (should (equal (nrepl-dict-contains input 14) nil))
+    (should (equal (nrepl-dict-contains input 'missing) nil))
+    (should (equal (nrepl-dict-contains input nil) nil))))
+
+(ert-deftest nrepl-dict-get-found ()
+  "Tests `nrepl-dict-get' on inputs where the keys exist in the nREPL
+dict. The `nil' value itself can be used as either a value or a key in the
+nrepl-dict."
+  (let ((input '(dict 1 "a" 2 "B" "3" "d" 4 nil sym yes nil nil-val)))
+    (should (equal (nrepl-dict-get input 1) "a"))
+    (should (equal (nrepl-dict-get input 2) "B"))
+    (should (equal (nrepl-dict-get input "3") "d"))
+    (should (equal (nrepl-dict-get input 4) nil))
+    (should (equal (nrepl-dict-get input 'sym) 'yes))
+    (should (equal (nrepl-dict-get input nil) 'nil-val))))
+
+(ert-deftest nrepl-dict-get-missing ()
+  "Tests `nrepl-dict-get' on inputs where the keys do not exist in the
+nREPL dict."
+  (let ((input '(dict 1 "a" 2 "B" "3" "d" 4 nil sym yes)))
+    (should (equal (nrepl-dict-get input 11) nil))
+    (should (equal (nrepl-dict-get input "13") nil))
+    (should (equal (nrepl-dict-get input 14) nil))
+    (should (equal (nrepl-dict-get input 'missing) nil))
+    (should (equal (nrepl-dict-get input nil) nil))))
+
+(ert-deftest nrepl-dict-get-found-with-default ()
+  "Tests `nrepl-dict-get' on inputs where the keys exist in the nREPL dict,
+while also passing in a default value. The `nil' value itself can be used
+as either a key or a value in the nrepl-dict, but in these cases
+`nrepl-dict-get' should NOT return the `default' value."
+  (let ((input '(dict 1 "a" 2 "B" "3" "d" 4 nil sym yes nil nil-val)))
+    (should (equal (nrepl-dict-get input 1 "default") "a"))
+    (should (equal (nrepl-dict-get input 2 "default") "B"))
+    (should (equal (nrepl-dict-get input "3" "default") "d"))
+    (should (equal (nrepl-dict-get input 4 "default") nil))
+    (should (equal (nrepl-dict-get input 'sym "default") 'yes))
+    (should (equal (nrepl-dict-get input nil "default") 'nil-val))))
+
+(ert-deftest nrepl-dict-get-missing-with-default ()
+  "Tests `nrepl-dict-get' on inputs where the keys do not exist in the
+nREPL dict, while also passing in a default value."
+  (let ((input '(dict 1 "a" 2 "B" "3" "d" 4 nil sym yes)))
+    (should (equal (nrepl-dict-get input 11 "default") "default"))
+    (should (equal (nrepl-dict-get input 21 "default") "default"))
+    (should (equal (nrepl-dict-get input "31" "default") "default"))
+    (should (equal (nrepl-dict-get input 41 "default") "default"))
+    (should (equal (nrepl-dict-get input 'missing "default") "default"))
+    (should (equal (nrepl-dict-get input nil "default") "default"))))


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

Thanks!

Make the nrepl-dict hashes act similarly to the Clojure maps by giving
them an optional default return value. If the provided key is not found
in the dict, then the optional default value will be returned. Notably,
the nil value is allowed as both a key and a value in nrepl-dict's.