### PR TITLE
[Fix #1659] Add fringe indicators for evaluated forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New Features
+
+* Fringe indicators highlight which sexps have been loaded. Disable it with `cider-use-fringe-indicators`.
+
 ### Changes
 
 * Signal an error sooner if the user misconfigured `cider-known-endpoints`.

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -649,6 +649,7 @@ can be used to display the evaluation result."
         (point (when point (copy-marker point))))
     (nrepl-make-response-handler (or buffer eval-buffer)
                                  (lambda (_buffer value)
+                                   (cider--make-fringe-overlay point)
                                    (cider--display-interactive-eval-result value point))
                                  (lambda (_buffer out)
                                    (cider-emit-interactive-eval-output out))
@@ -663,8 +664,14 @@ can be used to display the evaluation result."
     (nrepl-make-response-handler (or buffer eval-buffer)
                                  (lambda (buffer value)
                                    (cider--display-interactive-eval-result value)
-                                   (with-current-buffer buffer
-                                     (run-hooks 'cider-file-loaded-hook)))
+                                   (when (buffer-live-p buffer)
+                                     (with-current-buffer buffer
+                                       (save-excursion
+                                         (goto-char (point-min))
+                                         (while (progn (clojure-forward-logical-sexp)
+                                                       (not (eobp)))
+                                           (cider--make-fringe-overlay (point))))
+                                       (run-hooks 'cider-file-loaded-hook))))
                                  (lambda (_buffer value)
                                    (cider-emit-interactive-eval-output value))
                                  (lambda (_buffer err)


### PR DESCRIPTION
Out of all the fringe bitmap options, these 4 are the ones that seem most appropriate.
Not sure which one to use though.
![screenshot-2016-04-18--194945-0300](https://cloud.githubusercontent.com/assets/453029/14622246/fc7f4670-059e-11e6-9d60-40ba737d0148.png)

