### PR TITLE
Font-lock vars, macros, and functions in the ns-browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 
 * Use `cider-apropos-select` instead of `cider-apropos` in `cider-apropos-documentation-select`.
 
+* [#1561] Use an appropriate font-lock-face for variables, macros and functions in
+the ns-browser.
+
+
 ## 0.12.0 (2016-04-16)
 
 ### New Features

--- a/cider-client.el
+++ b/cider-client.el
@@ -908,7 +908,7 @@ CONTEXT represents a completion context for compliment."
     (nrepl-dict-get "resource-path")))
 
 (defun cider-sync-request:resources-list ()
-  "Perform nREPL \"resource\" op with resource name NAME."
+  "Return a list of all resources on the classpath."
   (thread-first (list "op" "resources-list"
                       "session" (cider-current-session))
     (cider-nrepl-send-sync-request)

--- a/cider-debug.el
+++ b/cider-debug.el
@@ -128,7 +128,8 @@ This variable must be set before starting the repl connection."
           (dolist (list all)
             (let ((ns (car list)))
               (cider-browse-ns--list (current-buffer) ns
-                                     (mapcar #'cider-browse-ns--properties (cdr list))
+                                     (mapcar (apply-partially #'cider-browse-ns--properties ns)
+                                             (cdr list))
                                      ns 'noerase)
               (goto-char (point-max))
               (insert "\n"))))

--- a/test/cider-browse-ns-tests.el
+++ b/test/cider-browse-ns-tests.el
@@ -1,0 +1,44 @@
+(require 'buttercup)
+(require 'cider-browse-ns)
+
+(describe "cider-browse-ns--text-face"
+  :var (cider-resolve-var)
+  (describe "when the namespace is not loaded in the REPL"
+    (spy-on 'cider-resolve-var :and-return-value nil)
+    (it "returns font-lock-function-name-face"
+      (expect (cider-browse-ns--text-face "clojure.string" "blank?")
+              :to-equal 'font-lock-function-name-face)))
+
+  (describe "when the namespace is loaded in the REPL"
+    (it "identifies a function"
+      (spy-on 'cider-resolve-var :and-return-value
+              '(dict "arglists" "fn arg list"))
+      (expect (cider-browse-ns--text-face "clojure.core" "reduce")
+              :to-equal 'font-lock-function-name-face))
+
+    (it "identifies a macro"
+      (spy-on 'cider-resolve-var :and-return-value
+              '(dict "arglists" "fn arg list" "macro" "true"))
+      (expect (cider-browse-ns--text-face "clojure.core" "defn")
+              :to-equal 'font-lock-keyword-face))
+
+    (it "identifies a variable"
+      (spy-on 'cider-resolve-var :and-return-value
+              '(dict))
+      (expect (cider-browse-ns--text-face "clojure.core" "*clojure-version*")
+              :to-equal 'font-lock-variable-name-face))))
+
+(describe "cider-browse-ns"
+  :var (cider-browse-ns-buffer)
+  (it "lists out all forms of a namespace with correct font-locks"
+    (spy-on 'cider-sync-request:ns-vars :and-return-value
+            '("blank?"))
+    (spy-on 'cider-resolve-var :and-return-value '(dict "arglists" "fn arg list"))
+
+    (with-temp-buffer
+      (setq cider-browse-ns-buffer (buffer-name (current-buffer)))
+      (cider-browse-ns "clojure.string")
+      (search-forward "clojure")
+      (expect (get-text-property (point) 'face) :to-equal 'font-lock-type-face)
+      (search-forward "blank")
+      (expect (get-text-property (point) 'font-lock-face) :to-equal 'font-lock-function-name-face))))


### PR DESCRIPTION
For #1561 
I still have to write the tests, but does this make sense ?

Before vs after:
<img width="665" alt="ns-browser" src="https://cloud.githubusercontent.com/assets/5201497/14635957/5ce19c78-0646-11e6-82a9-6dc32061d8e8.png">

Also, should `nrepl-dict*` be their own thing ? 
