### PR TITLE
Inject minimal clojure version as a dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Fringe indicators highlight which sexps have been loaded. Disable it with `cider-use-fringe-indicators`.
 * New command: `cider-inspect-last-result`.
 * `cider-cljs-lein-repl` now also supports figwheel.
+* Option `cider-jack-in-auto-inject-clojure` enables the user to specify a
+  version of Clojure for CIDER. This allows the user to override the version
+  used in a project, particular if it is lower than minimum required for CIDER.
 
 ### Changes
 

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -220,8 +220,14 @@ namespace-qualified function of zero arity."
   "Face used to highlight compilation warnings in Clojure buffers."
   :group 'cider)
 
+(defconst cider-clojure-artifact-id "org.clojure/clojure"
+  "Artifact identifier for Clojure.")
+
 (defconst cider-minimum-clojure-version "1.7.0"
   "Minimum supported version of Clojure.")
+
+(defconst cider-latest-clojure-version "1.8.0"
+  "Latest supported version of Clojure.")
 
 (defconst cider-required-nrepl-version "0.2.12"
   "The minimum nREPL version that's known to work properly with CIDER.")

--- a/cider.el
+++ b/cider.el
@@ -229,6 +229,23 @@ Sub-match 1 must be the project path.")
 (cider-add-to-alist 'cider-jack-in-dependencies
                     "org.clojure/tools.nrepl" "0.2.12")
 
+(defcustom cider-jack-in-auto-inject-clojure nil
+  "Version of clojure to auto-inject into REPL.
+
+If nil, do not inject clojure into the REPL.  If `latest', inject
+`cider-latest-clojure-version', which should approximate to the most recent
+version of clojure.  If `minimal', inject `cider-minimum-clojure-version',
+which will be the lowest version cider supports.  If a string, use this as
+the version number.  If it is a list, the first element should be a string,
+specifying the artifact ID, and the second element the version number."
+  :type '(choice (const :tag "None" nil)
+                 (const :tag "Latest" 'latest)
+                 (const :tag "Minimal" 'minimal)
+                 (string :tag "Specific Version")
+                 (list :tag "Artifact ID and Version"
+                       (string :tag "Artifact ID")
+                       (string :tag "Version"))))
+
 (defvar cider-jack-in-lein-plugins nil
   "List of Leiningen plugins where elements are lists of artifact name and version.")
 (put 'cider-jack-in-lein-plugins 'risky-local-variable t)
@@ -288,6 +305,24 @@ string is quoted for passing as argument to an inferior shell."
    " -- "
    params))
 
+(defun cider-add-clojure-dependencies-maybe (dependencies)
+  "Return DEPENDENCIES with an added Clojure dependency if requested.
+
+See also `cider-jack-in-auto-inject-clojure'."
+  (if cider-jack-in-auto-inject-clojure
+      (if (consp cider-jack-in-auto-inject-clojure)
+          (cons cider-jack-in-auto-inject-clojure dependencies)
+        (cons (list cider-clojure-artifact-id
+                    (cond
+                     ((stringp cider-jack-in-auto-inject-clojure)
+                      cider-jack-in-auto-inject-clojure)
+                     ((eq cider-jack-in-auto-inject-clojure 'minimal)
+                      cider-minimum-clojure-version)
+                     ((eq cider-jack-in-auto-inject-clojure 'latest)
+                      cider-latest-clojure-version)))
+              dependencies))
+    dependencies))
+
 (defun cider-inject-jack-in-dependencies (params project-type)
   "Return PARAMS with injected REPL dependencies.
 These are set in `cider-jack-in-dependencies', `cider-jack-in-lein-plugins' and
@@ -298,11 +333,13 @@ dependencies."
   (pcase project-type
     ("lein" (cider-lein-jack-in-dependencies
              params
-             cider-jack-in-dependencies
+             (cider-add-clojure-dependencies-maybe
+              cider-jack-in-dependencies)
              cider-jack-in-lein-plugins))
     ("boot" (cider-boot-jack-in-dependencies
              params
-             cider-jack-in-dependencies
+             (cider-add-clojure-dependencies-maybe
+              cider-jack-in-dependencies)
              cider-jack-in-lein-plugins
              cider-jack-in-nrepl-middlewares))
     ("gradle" params)

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -72,6 +72,11 @@ If you don't want `cider-jack-in` to inject dependencies automatically, set
 `cider-inject-dependencies-at-jack-in` to `nil`. Note that you'll have to setup
 the dependencies yourself (see the section below), just as in CIDER 0.10 and older.
 
+CIDER can also inject a Clojure dependency into your project, which is useful,
+for example, if your project defaults to an older version of Clojure than that
+supported by the CIDER middleware. Set `cider-jack-in-auto-inject-clojure`
+appropriately to enable this.
+
 If a standalone REPL is preferred, you need to invoke `cider-connect` (instead
 of `cider-jack-in`) and you'll need to manually add the dependencies to your
 Clojure project (explained in the following section).

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -584,6 +584,34 @@
                      "-d org.clojure/tools.nrepl\\:0.2.12 -d cider/cider-nrepl\\:0.10.2 repl -m cider.nrepl/cider-middleware -s wait"))
     (should (string= (cider-inject-jack-in-dependencies "--no-daemon clojureRepl" "gradle") "--no-daemon clojureRepl"))))
 
+(ert-deftest cider-inject-clojure-dependency ()
+  (should
+   (equal
+    `((,cider-clojure-artifact-id ,cider-minimum-clojure-version))
+    (let ((cider-jack-in-auto-inject-clojure 'minimal))
+      (cider-add-clojure-dependencies-maybe nil))))
+  (should
+   (equal
+    `((,cider-clojure-artifact-id "bob"))
+    (let ((cider-jack-in-auto-inject-clojure "bob"))
+      (cider-add-clojure-dependencies-maybe nil))))
+  (should
+   (equal
+    `((,cider-clojure-artifact-id ,cider-latest-clojure-version))
+    (let ((cider-jack-in-auto-inject-clojure 'latest))
+      (cider-add-clojure-dependencies-maybe nil))))
+  (should
+   (equal
+    '(("Hello, I love you" "won't you tell me your name"))
+    (let ((cider-jack-in-auto-inject-clojure
+           '("Hello, I love you" "won't you tell me your name")))
+      (cider-add-clojure-dependencies-maybe nil))))
+  (should
+   (eq
+    'nil
+    (let ((cider-jack-in-auto-inject-clojure nil))
+      (cider-add-clojure-dependencies-maybe nil)))))
+
 (ert-deftest cider-inject-jack-in-dependencies-add-refactor-nrepl ()
   (let ((cider-jack-in-lein-plugins '(("refactor-nrepl" "2.0.0") ("cider/cider-nrepl" "0.11.0")))
         (cider-jack-in-nrepl-middlewares '("refactor-nrepl.middleware/wrap-refactor" "cider.nrepl/cider-middleware")))


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)
- [x] You've updated the refcard (if you made changes to the commands listed there)

Thanks!

Haven't done all of that -- this is just a starter-for-ten, as it explains the idea better than raising an issue. Happy to add all of it, if you think the idea is sound.

Given that cider requires 1.7, when not inject it? At the moment, if you open a project which requires less than 1.7, the middleware fails to load, and cider fails with an unhelpful error message. I don't want to require a latter version of clojure in my project (although I don't mind running inside one).

Other options: make the error message better; change cider-nrepl from a provided dependency (which I think would cause lein to load 1.7 when cider-nrepl is injected. That's all I can think of.



Cider-nrepl has a provided dependency of Clojure 1.7. Projects can now
have a Clojure version lower than 1.7 therefore fail to run cider
correctly, unless this dependency is added. Injection means that cider
can support these projects without requiring them to update.