### PR TITLE
check clojure version from running jvm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+* Ensure Clojure version meets minimum supported by CIDER (1.7.0).
 * Fringe indicators highlight which sexps have been loaded. Disable it with `cider-use-fringe-indicators`.
 * New command: `cider-inspect-last-result`.
 

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -220,6 +220,9 @@ namespace-qualified function of zero arity."
   "Face used to highlight compilation warnings in Clojure buffers."
   :group 'cider)
 
+(defvar cider-minimum-clojure-version "1.7.0"
+  "Minimum supported version of Clojure.")
+
 (defvar cider-required-nrepl-version "0.2.12"
   "The minimum nREPL version that's known to work properly with CIDER.")
 

--- a/cider.el
+++ b/cider.el
@@ -621,6 +621,17 @@ In case `default-directory' is non-local we assume the command is available."
                                "Can't determine nREPL's version.\nPlease, update nREPL to %s."
                                cider-required-nrepl-version)))
 
+(defun cider--check-clojure-version-supported ()
+  "Ensure that we are meeting the minimum supported version of Clojure."
+  (if-let ((clojure-version (cider--clojure-version)))
+      (when (version< clojure-version cider-minimum-clojure-version)
+        (cider-repl-manual-warning "installation/#prerequisites"
+                                   "Clojure version (%s) is not supported (minimum %s). CIDER will not work."
+                                   clojure-version cider-minimum-clojure-version))
+    (cider-repl-manual-warning "installation/#prerequisites"
+                               "Clojure version information could not be determined. Requires a minimum version %s."
+                               cider-minimum-clojure-version)))
+
 (defun cider--check-middleware-compatibility ()
   "CIDER frontend/backend compatibility check.
 Retrieve the underlying connection's CIDER-nREPL version and checks if the
@@ -646,6 +657,7 @@ buffer."
   (cider-make-connection-default (current-buffer))
   (cider-repl-init (current-buffer))
   (cider--check-required-nrepl-version)
+  (cider--check-clojure-version-supported)
   (cider--check-middleware-compatibility)
   (cider--debug-init-connection)
   (cider--subscribe-repl-to-server-out)


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md) 
- [x] You've added tests (if possible) to cover your change(s)
    - difficult since i'm calling out to nrepl. Willing if there's a straightforward way to mock these calls and check what repl message was generated.
- [x] All tests are passing (`make test`) 
    - 107 of 107
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
    - 4 preexisting issues
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
    - doesn't feel applicable but willing to add
- [ ] You've updated the refcard (if you made changes to the commands listed there)
    - not applicable


Add a version check of clojure during the pre-flight checks of setting up the repl. This has become an issue because of the recent minimum supported version of clojure went to 1.7.0 with the seattle release. However, it prints only a cryptic message about nrepl mismatch rather than the real cause of the error.

New version:
![image](https://cloud.githubusercontent.com/assets/6377293/14695092/566f051c-0734-11e6-8240-e21e150bf88f.png)


versus previous behavior:

![image](https://cloud.githubusercontent.com/assets/6377293/14695070/18f9cfd2-0734-11e6-8078-ca75490a69c3.png)
