### PR TITLE
Fix spelling error in clj-refactor section of documentation

### DIFF
--- a/doc/additional_packages.md
+++ b/doc/additional_packages.md
@@ -6,7 +6,7 @@ experience. The majority of the minor modes listed here should be enabled for bo
 
 [clr-refactor](https://github.com/clojure-emacs/clj-refactor.el) builts on top
 of clojure-mode and CIDER and adds a ton of extra functionality (e.g. the
-ability to thread/untread expression, find and replace usages, introduce let
+ability to thread/unthread expression, find and replace usages, introduce let
 bindings, extract function and so on).
 
 A full list of features is available


### PR DESCRIPTION
Made a mistake in my last PR in clumping together unrelated commits. Changed a small spelling mistake in the explanation of "clj-refactor" in "Additional Packages"