### PR TITLE
Keyboard shortcuts for macroexpansion mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changes
 
+* Simpler keybindings in macroexpand buffer. Expand one step with `m` and all expansions with `a`. Previously was `C-c C-m` and `C-c M-m`.
 * Signal an error sooner if the user misconfigured `cider-known-endpoints`.
 * `cider-inspect-read-and-inspect` is obsolete. Use `cider-inspect-expression` instead.
 * Extremely long overlays are truncated and `cider-inspect-last-result` is recommended.

--- a/cider-macroexpansion.el
+++ b/cider-macroexpansion.el
@@ -177,23 +177,21 @@ and point is placed after the expanded form."
     (define-key map (kbd "d") #'cider-doc)
     (define-key map (kbd "j") #'cider-javadoc)
     (define-key map (kbd ".") #'cider-find-var)
+    (define-key map (kbd "m") #'cider-macroexpand-1-inplace)
+    (define-key map (kbd "a") #'cider-macroexpand-all-inplace)
+    (define-key map (kbd "u") #'cider-macroexpand-undo)
+    (define-key map [remap undo] #'cider-macroexpand-undo)
     (easy-menu-define cider-macroexpansion-mode-menu map
       "Menu for CIDER's doc mode"
       '("Macroexpansion"
         ["Restart expansion" cider-macroexpand-again]
         ["Macroexpand-1" cider-macroexpand-1-inplace]
         ["Macroexpand-all" cider-macroexpand-all-inplace]
+        ["Macroexpand-undo" cider-macroexpand-undo]
         ["Go to source" cider-find-var]
         ["Go to doc" cider-doc]
         ["Go to Javadoc" cider-docview-javadoc]
         ["Quit" cider-popup-buffer-quit-function]))
-    (cl-labels ((redefine-key (from to)
-                              (dolist (mapping (where-is-internal from cider-mode-map))
-                                (define-key map mapping to))))
-      (redefine-key 'cider-macroexpand-1 #'cider-macroexpand-1-inplace)
-      (redefine-key 'cider-macroexpand-all #'cider-macroexpand-all-inplace)
-      (redefine-key 'advertised-undo #'cider-macroexpand-undo)
-      (redefine-key 'undo #'cider-macroexpand-undo))
     map))
 
 (define-minor-mode cider-macroexpansion-mode

--- a/doc/miscellaneous_features.md
+++ b/doc/miscellaneous_features.md
@@ -39,12 +39,12 @@ result in a new buffer, showing the macroexpansion of the form in
 question. You'll have access to additional keybindings in the macroexpansion
 buffer (which is internally using `cider-macroexpansion-mode`):
 
-Keyboard shortcut               | Description
---------------------------------|-------------------------------
-<kbd>C-c C-m</kbd>              | Invoke `macroexpand-1` on the form at point and replace the original form with its expansion.  If invoked with a prefix argument, `macroexpand` is used instead of `macroexpand-1`.
-<kbd>C-c M-m</kbd>              | Invoke `clojure.walk/macroexpand-all` on the form at point and replace the original form with its expansion.
-<kbd>g</kbd>                    | The prior macroexpansion is performed again and the current contents of the macroexpansion buffer are replaced with the new expansion.
-<kbd>C-/</kbd> <br/> <kbd>C-x u</kbd> | Undo the last inplace expansion performed in the macroexpansion buffer.
+Keyboard shortcut                 | Description
+----------------------------------|-------------------------------
+<kbd>m</kbd>                      | Invoke `macroexpand-1` on the form at point and replace the original form with its expansion.  If invoked with a prefix argument, `macroexpand` is used instead of `macroexpand-1`.
+<kbd>a</kbd>                      | Invoke `clojure.walk/macroexpand-all` on the form at point and replace the original form with its expansion.
+<kbd>g</kbd>                      | The prior macroexpansion is performed again and the current contents of the macroexpansion buffer are replaced with the new expansion.
+<kbd>C-/</kbd> <br/> <kbd>u</kbd> | Undo the last inplace expansion performed in the macroexpansion buffer.
 
 ## Value inspection
 


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
    - not applicable
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)
    - was not included before, was not added
- [x] You've updated the refcard (if you made changes to the commands listed there)
    - macroexpansion-mode keybindings not previously included and not now added.

Thanks!

Change keyboard shortcuts for `cider-macroexpand-1-inplace` to `m` and
`cider-macroexpand-all-inplace` to `a` from previous `C-c C-m` and `C-c
M-m` respectively.

References [issue 1685](https://github.com/clojure-emacs/cider/issues/1685)