### PR TITLE
Resolve ambiguous build system with preferred choice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+* Allow setting a preffered-build-tool when multiple are found in `cider-preferred-build-tool`.
 * Ensure Clojure version meets minimum supported by CIDER (1.7.0).
 * Fringe indicators highlight which sexps have been loaded. Disable it with `cider-use-fringe-indicators`.
 * New command: `cider-inspect-last-result`.

--- a/cider.el
+++ b/cider.el
@@ -146,6 +146,19 @@ project.clj for leiningen or build.boot for boot, could be found."
   :group 'cider
   :package-version '(cider . "0.9.0"))
 
+(defcustom cider-preferred-build-tool
+  nil
+  "Allow choosing a build system when there are many.
+When there are artifacts from multiple build systems (\"lein\", \"boot\",
+\"gradle\") the user is prompted to select one of them.  When non-nil, this
+variable will suppress this behavior and will select whatever build system
+is indicated by the variable if present.  Note, this is only when CIDER
+cannot decide which of many build systems to use and will never override a
+command when there is no ambiguity."
+  :type '(choice "lein" "boot" "gradle")
+  :group 'cider
+  :package-version '(cider . "0.13.0"))
+
 (defcustom cider-known-endpoints nil
   "A list of connection endpoints where each endpoint is a list.
 For example: \\='((\"label\" \"host\" \"port\")).
@@ -562,24 +575,35 @@ Use `cider-ps-running-nrepls-command' and `cider-ps-running-nrepl-path-regexp-li
           (setq paths (cons (match-string 1) paths)))))
     (seq-uniq paths)))
 
+(defun cider--identify-buildtools-present ()
+  "Identify build systems present by their build files."
+  (let* ((default-directory (clojure-project-dir (cider-current-dir)))
+         (build-files '(("lein" . "project.clj")
+                        ("boot" . "build.boot")
+                        ("gradle" . "build.gradle"))))
+    (delq nil
+          (mapcar (lambda (candidate)
+                    (when (file-exists-p (cdr candidate))
+                      (car candidate)))
+                  build-files))))
+
 (defun cider-project-type ()
   "Determine the type, either leiningen, boot or gradle, of the current project.
-If more than one project file types are present, prompt the user to choose."
-  (let* ((default-directory (clojure-project-dir (cider-current-dir)))
-         (choices (delq nil
-                        (mapcar (lambda (candidate)
-                                  (when (file-exists-p (cdr candidate))
-                                    (car candidate)))
-                                '(("lein" . "project.clj")
-                                  ("boot" . "build.boot")
-                                  ("gradle" . "build.gradle")))))
+If more than one project file types are present, check for a preferred
+build tool in `cider-preferred-build-tool`, otherwise prompt the user to
+choose."
+  (let* ((choices (cider--identify-buildtools-present))
+         (multiple-project-choices (> (length choices) 1))
          (default (car choices)))
-    (or (if (> (length choices) 1)
-            (completing-read (format "Which command shoud be used (default %s)? "
-                                     default)
-                             choices nil t nil nil default)
-          (car choices))
-        cider-default-repl-command)))
+    (cond ((and multiple-project-choices
+                (member cider-preferred-build-tool choices))
+           cider-preferred-build-tool)
+          (multiple-project-choices
+           (completing-read (format "Which command should be used (default %s)" default)
+                            choices nil t nil nil default))
+          (choices
+           (car choices))
+          (t cider-default-repl-command))))
 
 ;; TODO: Implement a check for `cider-lein-command' over tramp
 (defun cider--lein-present-p ()

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -834,3 +834,29 @@
            (clojure-expected-ns (path) "clojure-expected-ns"))
     (should (string= (cider-expected-ns "foo")
                      "clojure-expected-ns"))))
+
+(ert-deftest cider-project-type-single-project ()
+  (noflet ((cider--identify-buildtools-present () '("lein")))
+    (should (string= (cider-project-type) "lein"))))
+
+(ert-deftest cider-project-type-multiple-projects ()
+  (noflet ((cider--identify-buildtools-present () '("build1" "build2"))
+           (completing-read (r a n d o m s) "build2")) ; user choice build2
+    (should (string= (cider-project-type) "build2"))
+
+    (let ((cider-preferred-build-tool "build1"))
+      (should (string= (cider-project-type) "build1")))
+
+    (let ((cider-preferred-build-tool "invalid choice"))
+      (should (string= (cider-project-type) "build2")))
+
+    (let ((cider-preferred-build-tool "build3"))
+      (should (string= (cider-project-type) "build2")))))
+
+(ert-deftest cider-project-type-no-choices ()
+  (noflet ((cider--identify-buildtools-present () '()))
+    (should (string= (cider-project-type) cider-default-repl-command))))
+
+(provide 'cider-tests)
+
+;;; cider-tests.el ends here


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings (4 preexisting)
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)
- [x] You've updated the refcard (if you made changes to the commands listed there)

Thanks!

When there are artifacts from multiple build systems, eg: lein, boot,
etc, look in `cider-preferred-build-system`.

Allow setting a variable to resolve conflicts when multiple build systems are found. Ensure valid choice, otherwise do the current behavior: ask the user.

[associated issue 1672](https://github.com/clojure-emacs/cider/issues/1672)