### PR TITLE
Fix cider-popup-buffer-display with multiple frames.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Use `cider-apropos-select` instead of `cider-apropos` in `cider-apropos-documentation-select`.
 * [#1561](https://github.com/clojure-emacs/cider/issues/1561): Use an appropriate font-lock-face for variables, macros and functions in
 the ns-browser.
+* [#1708] Fix cider-popup-buffer-display when another frame is used for the error buffer.
 
 ## 0.12.0 (2016-04-16)
 

--- a/cider-popup.el
+++ b/cider-popup.el
@@ -65,6 +65,8 @@ If SELECT is non-nil, select the BUFFER."
     ;; bound to that).
     (unless (eq window (selected-window))
       ;; Non nil `inhibit-same-window' ensures that current window is not covered
+      ;; Non nil `inhibit-switch-frame' ensures that the other frame is not selected
+      ;; if that's where the buffer is being shown.
       (funcall (if select #'pop-to-buffer #'display-buffer)
                buffer `(nil . ((inhibit-same-window . ,pop-up-windows)
                                (reusable-frames . visible))))))


### PR DESCRIPTION
If you set cider-popup-buffer-display to nil, but are using multiple
frames, the call to display-buffer doesn't currently set the required
extra parameter in the alist to stop Emacs from switching to that
frame. This small PR fixes that.

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`make test`)
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)
