### PR TITLE
Integrate ns-vars-with-meta op

### DIFF
--- a/cider-client.el
+++ b/cider-client.el
@@ -892,6 +892,14 @@ CONTEXT represents a completion context for compliment."
     (cider-nrepl-send-sync-request)
     (nrepl-dict-get "ns-vars")))
 
+(defun cider-sync-request:ns-vars-with-meta (ns)
+  "Get a map of the vars in NS to its metadata information."
+  (thread-first (list "op" "ns-vars-with-meta"
+                      "session" (cider-current-session)
+                      "ns" ns)
+    (cider-nrepl-send-sync-request)
+    (nrepl-dict-get "ns-vars-with-meta")))
+
 (defun cider-sync-request:ns-load-all ()
   "Load all project namespaces."
   (thread-first (list "op" "ns-load-all"
@@ -935,6 +943,19 @@ CONTEXT represents a completion context for compliment."
       ;; "clojure.lang.ExceptionInfo: Unmatched delimiter ]"
       (error (car (split-string err "\n"))))
     (nrepl-dict-get response "formatted-edn")))
+
+
+;;; Cache helpers
+
+(declare-function cider-resolve-ns-symbols "cider-resolve")
+
+(defun cider-ns-vars-with-meta (ns)
+  "Return a map of the vars in NS to its metadata information.
+Get the data from `cider-repl-ns-cache' if available.
+Otherwise, perform a middleware call to get the data."
+  (if-let ((ns-symbols (cider-resolve-ns-symbols ns)))
+      (apply #'nrepl-dict ns-symbols)
+    (cider-sync-request:ns-vars-with-meta ns)))
 
 
 ;;; Connection info

--- a/cider-debug.el
+++ b/cider-debug.el
@@ -126,10 +126,16 @@ This variable must be set before starting the repl connection."
         (let ((inhibit-read-only t))
           (erase-buffer)
           (dolist (list all)
-            (let ((ns (car list)))
+            (let* ((ns (car list))
+                   (ns-vars-with-meta (cider-ns-vars-with-meta ns))
+                   ;; seq of metadata maps of the instrumented vars
+                   (instrumented-meta (mapcar (apply-partially #'nrepl-dict-get ns-vars-with-meta)
+                                              (cdr list))))
               (cider-browse-ns--list (current-buffer) ns
-                                     (mapcar (apply-partially #'cider-browse-ns--properties ns)
-                                             (cdr list))
+                                     (seq-mapn #'cider-browse-ns--properties
+                                               (cdr list)
+                                               instrumented-meta)
+
                                      ns 'noerase)
               (goto-char (point-max))
               (insert "\n"))))

--- a/test/cider-browse-ns-tests.el
+++ b/test/cider-browse-ns-tests.el
@@ -2,38 +2,23 @@
 (require 'cider-browse-ns)
 
 (describe "cider-browse-ns--text-face"
-  :var (cider-resolve-var)
-  (describe "when the namespace is not loaded in the REPL"
-    (spy-on 'cider-resolve-var :and-return-value nil)
-    (it "returns font-lock-function-name-face"
-      (expect (cider-browse-ns--text-face "clojure.string" "blank?")
-              :to-equal 'font-lock-function-name-face)))
+  (it "identifies a function"
+    (expect (cider-browse-ns--text-face '(dict "arglists" "fn arg list"))
+            :to-equal 'font-lock-function-name-face))
 
-  (describe "when the namespace is loaded in the REPL"
-    (it "identifies a function"
-      (spy-on 'cider-resolve-var :and-return-value
-              '(dict "arglists" "fn arg list"))
-      (expect (cider-browse-ns--text-face "clojure.core" "reduce")
-              :to-equal 'font-lock-function-name-face))
+  (it "identifies a macro"
+    (expect (cider-browse-ns--text-face '(dict "arglists" "fn arg list" "macro" "true"))
+            :to-equal 'font-lock-keyword-face))
 
-    (it "identifies a macro"
-      (spy-on 'cider-resolve-var :and-return-value
-              '(dict "arglists" "fn arg list" "macro" "true"))
-      (expect (cider-browse-ns--text-face "clojure.core" "defn")
-              :to-equal 'font-lock-keyword-face))
-
-    (it "identifies a variable"
-      (spy-on 'cider-resolve-var :and-return-value
-              '(dict))
-      (expect (cider-browse-ns--text-face "clojure.core" "*clojure-version*")
-              :to-equal 'font-lock-variable-name-face))))
+  (it "identifies a variable"
+    (expect (cider-browse-ns--text-face '(dict))
+            :to-equal 'font-lock-variable-name-face)))
 
 (describe "cider-browse-ns"
   :var (cider-browse-ns-buffer)
   (it "lists out all forms of a namespace with correct font-locks"
-    (spy-on 'cider-sync-request:ns-vars :and-return-value
-            '("blank?"))
-    (spy-on 'cider-resolve-var :and-return-value '(dict "arglists" "fn arg list"))
+    (spy-on 'cider-ns-vars-with-meta :and-return-value
+            '(dict "blank?" (dict "arglists" "fn arg list")))
 
     (with-temp-buffer
       (setq cider-browse-ns-buffer (buffer-name (current-buffer)))

--- a/test/cider-client-tests.el
+++ b/test/cider-client-tests.el
@@ -19,7 +19,6 @@ SYMBOL is locally let-bound to the current buffer."
            (,symbol (current-buffer)))
        ,@body)))
 
-
 (describe "cider-current-connection"
 
   (describe "when there are no active connections"
@@ -29,7 +28,6 @@ SYMBOL is locally let-bound to the current buffer."
       (expect (cider-current-connection) :not :to-be-truthy)
       (expect (cider-current-connection "clj") :not :to-be-truthy)
       (expect (cider-current-connection "cljs") :not :to-be-truthy)))
-
 
   (describe "when active connections are available"
 
@@ -106,7 +104,6 @@ SYMBOL is locally let-bound to the current buffer."
               (setq major-mode 'clojure-mode)
               (expect (cider-current-connection) :to-equal b2))))))))
 
-
 (describe "cider-other-connection"
   (describe "when there are no active connections"
     :var (cider-connections)
@@ -162,3 +159,19 @@ SYMBOL is locally let-bound to the current buffer."
                 ;; older connections still work
                 (expect (cider-other-connection bb1) :to-equal b2)
                 (expect (cider-other-connection bb2) :to-equal b1)))))))))
+
+(describe "cider-ns-vars-with-meta"
+  (describe "when the data is available in the cache"
+    (it "returns the map of the vars in ns to their metadata"
+      (spy-on 'cider-resolve-ns-symbols :and-return-value
+              '("fn1" (dict "arglists" "([x])")))
+      (expect (cider-ns-vars-with-meta "blah")
+              :to-equal '(dict "fn1" (dict "arglists" "([x])")))))
+
+  (describe "when the data is not available in the cache"
+    (it "returns data by calling `ns-vars-with-meta` op on the nREPL middleware"
+      (spy-on 'cider-resolve-ns-symbols :and-return-value nil)
+      (spy-on 'cider-sync-request:ns-vars-with-meta :and-return-value
+              '(dict "fn2" (dict "arglists" "([x y])")))
+      (expect (cider-ns-vars-with-meta "blah")
+              :to-equal '(dict "fn2" (dict "arglists" "([x y])"))))))


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

Thanks!

The current ns-browser relies on the `cider-repl-ns-cache` to decide font-locks.
This gives us incorrect font-locks for namespaces which are present on the classpath,
but not loaded in the REPL.
We change this to get the data from the nREPL middleware op `ns-vars-with-meta`,
in case of a cache miss; clojure-emacs/cider-nrepl#346.