### PR TITLE
Change priority for guessing proper type of conn

### DIFF
--- a/cider-client.el
+++ b/cider-client.el
@@ -215,6 +215,8 @@ such a link cannot be established automatically."
   "Return the matching connection type (clj or cljs) for the current buffer."
   (cond
    ((derived-mode-p 'clojurescript-mode) "cljs")
+   ((derived-mode-p 'clojurec-mode) cider-repl-type)
+   ((derived-mode-p 'clojurex-mode) cider-repl-type)
    ((derived-mode-p 'clojure-mode) "clj")
    (cider-repl-type)
    (t "clj")))


### PR DESCRIPTION
Existing code have a problem that `clojurec-mode` is always having `"clj"` type of connection.

now it can have a either `"cljs"` or `"clj"` type of connection by `(setq cider-repl-type ...)` in target buffer