### PR TITLE
Fix arity of `cider-change-buffers-designation'

### DIFF
--- a/cider-client.el
+++ b/cider-client.el
@@ -1066,14 +1066,13 @@ If CONN is not provided the user will be prompted to select a connection."
                   repl-buffer-name)
     (or (match-string 1 repl-buffer-name) "<no designation>")))
 
-(defun cider-change-buffers-designation ()
-  "Change the designation in cider buffer names.
+(defun cider-change-buffers-designation (designation)
+  "Change the DESIGNATION in cider buffer names.
 Buffer names changed are cider-repl and nrepl-server."
-  (interactive)
+  (interactive (list (read-string (format "Change CIDER buffer designation from '%s': "
+					  (cider-extract-designation-from-current-repl-buffer)))))
   (cider-ensure-connected)
-  (let* ((designation (read-string (format "Change CIDER buffer designation from '%s': "
-                                           (cider-extract-designation-from-current-repl-buffer))))
-         (new-repl-buffer-name (nrepl-format-buffer-name-template
+  (let ((new-repl-buffer-name (nrepl-format-buffer-name-template
                                 nrepl-repl-buffer-name-template designation)))
     (with-current-buffer (cider-current-repl-buffer)
       (rename-buffer new-repl-buffer-name)

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -356,10 +356,9 @@
         (let* ((connection-buffer (current-buffer))
                (cider-connections (list connection-buffer)))
           (setq-local nrepl-server-buffer server-buffer)
-          (noflet ((read-string (dontcare) "bob"))
-            (cider-change-buffers-designation)
-            (should (equal "*cider-repl bob*" (buffer-name connection-buffer)))
-            (should (equal "*nrepl-server bob*" (buffer-name server-buffer))))
+          (cider-change-buffers-designation "bob")
+          (should (equal "*cider-repl bob*" (buffer-name connection-buffer)))
+          (should (equal "*nrepl-server bob*" (buffer-name server-buffer)))
           (with-current-buffer connection-buffer
             (should (equal "*cider-repl bob*" (buffer-name)))))))))
 
@@ -381,12 +380,11 @@
                   (setq-local nrepl-repl-buffer repl-buffer)
                   (setq-local nrepl-server-buffer server-buffer))
 
-                (noflet ((read-string (dontcare) "bob"))
-                  (should-error
-                   (cider-change-buffers-designation))
-                  (should (equal before-repl-buffer-name (buffer-name repl-buffer)))
-                  (should (equal before-connection-buffer-name (buffer-name connection-buffer)))
-                  (should (equal before-server-buffer-name (buffer-name server-buffer))))))))))))
+                (should-error
+                 (cider-change-buffers-designation "bob"))
+                (should (equal before-repl-buffer-name (buffer-name repl-buffer)))
+                (should (equal before-connection-buffer-name (buffer-name connection-buffer)))
+                (should (equal before-server-buffer-name (buffer-name server-buffer)))))))))))
 
 (ert-deftest cider-extract-designation-from-current-repl-buffer ()
   (with-temp-buffer


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

Thanks!

* Allow user to set the argument of `cider-change-buffers-designation'
  in a non-interactive call (programmatically).