### PR TITLE
Always fetch ns-vars-with-meta from nREPL middleware

### DIFF
--- a/cider-browse-ns.el
+++ b/cider-browse-ns.el
@@ -124,7 +124,7 @@ contents of the buffer are not reset before inserting TITLE and ITEMS."
     (cider-browse-ns--list (current-buffer)
                            namespace
                            (nrepl-dict-map #'cider-browse-ns--properties
-                                           (cider-ns-vars-with-meta namespace)))
+                                           (cider-sync-request:ns-vars-with-meta namespace)))
     (setq-local cider-browse-ns-current-ns namespace)))
 
 ;;;###autoload

--- a/cider-client.el
+++ b/cider-client.el
@@ -945,19 +945,6 @@ CONTEXT represents a completion context for compliment."
     (nrepl-dict-get response "formatted-edn")))
 
 
-;;; Cache helpers
-
-(declare-function cider-resolve-ns-symbols "cider-resolve")
-
-(defun cider-ns-vars-with-meta (ns)
-  "Return a map of the vars in NS to its metadata information.
-Get the data from `cider-repl-ns-cache' if available.
-Otherwise, perform a middleware call to get the data."
-  (if-let ((ns-symbols (cider-resolve-ns-symbols ns)))
-      (apply #'nrepl-dict ns-symbols)
-    (cider-sync-request:ns-vars-with-meta ns)))
-
-
 ;;; Connection info
 (defun cider--java-version ()
   "Retrieve the underlying connection's Java version."

--- a/cider-debug.el
+++ b/cider-debug.el
@@ -127,7 +127,7 @@ This variable must be set before starting the repl connection."
           (erase-buffer)
           (dolist (list all)
             (let* ((ns (car list))
-                   (ns-vars-with-meta (cider-ns-vars-with-meta ns))
+                   (ns-vars-with-meta (cider-sync-request:ns-vars-with-meta ns))
                    ;; seq of metadata maps of the instrumented vars
                    (instrumented-meta (mapcar (apply-partially #'nrepl-dict-get ns-vars-with-meta)
                                               (cdr list))))

--- a/test/cider-browse-ns-tests.el
+++ b/test/cider-browse-ns-tests.el
@@ -17,7 +17,7 @@
 (describe "cider-browse-ns"
   :var (cider-browse-ns-buffer)
   (it "lists out all forms of a namespace with correct font-locks"
-    (spy-on 'cider-ns-vars-with-meta :and-return-value
+    (spy-on 'cider-sync-request:ns-vars-with-meta :and-return-value
             '(dict "blank?" (dict "arglists" "fn arg list")))
 
     (with-temp-buffer

--- a/test/cider-client-tests.el
+++ b/test/cider-client-tests.el
@@ -159,19 +159,3 @@ SYMBOL is locally let-bound to the current buffer."
                 ;; older connections still work
                 (expect (cider-other-connection bb1) :to-equal b2)
                 (expect (cider-other-connection bb2) :to-equal b1)))))))))
-
-(describe "cider-ns-vars-with-meta"
-  (describe "when the data is available in the cache"
-    (it "returns the map of the vars in ns to their metadata"
-      (spy-on 'cider-resolve-ns-symbols :and-return-value
-              '("fn1" (dict "arglists" "([x])")))
-      (expect (cider-ns-vars-with-meta "blah")
-              :to-equal '(dict "fn1" (dict "arglists" "([x])")))))
-
-  (describe "when the data is not available in the cache"
-    (it "returns data by calling `ns-vars-with-meta` op on the nREPL middleware"
-      (spy-on 'cider-resolve-ns-symbols :and-return-value nil)
-      (spy-on 'cider-sync-request:ns-vars-with-meta :and-return-value
-              '(dict "fn2" (dict "arglists" "([x y])")))
-      (expect (cider-ns-vars-with-meta "blah")
-              :to-equal '(dict "fn2" (dict "arglists" "([x y])"))))))


### PR DESCRIPTION
As discussed in https://github.com/clojure-emacs/cider/pull/1710

/cc @Malabarba 