### PR TITLE
Add spacing to kbd elements in docs

### DIFF
--- a/doc/css/extra.css
+++ b/doc/css/extra.css
@@ -5,6 +5,7 @@ kbd {
     background-color: #fcfcfc;
     border-radius: 3px;
     box-shadow: inset 0 -1px 0 #bbb;
+    display: inline-block;
 }
 
 /* The default font-size for code blocks is 75% which makes code


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [X] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`make test`)
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [X] You've updated the changelog (if adding/changing user-visible functionality)
- [X] You've updated the readme (if adding/changing user-visible functionality)
- [X] You've updated the refcard (if you made changes to the commands listed there)

Thanks!



This is a simple change that makes the current kbd elements, which look like this: 

<img width="118" alt="using_the_repl_-_cider__the_clojure_interactive_programming_environment_that_rocks" src="https://cloud.githubusercontent.com/assets/320528/14855995/d7bbc3e0-0c5b-11e6-9deb-d24f33bc671b.png">

instead, look like this:

<img width="273" alt="using_the_repl_-_cider__the_clojure_interactive_programming_environment_that_rocks" src="https://cloud.githubusercontent.com/assets/320528/14856013/ecba4b90-0c5b-11e6-98e8-09d171e05fdd.png">

Issue found, and fix tested, on a Macbook using Chrome and Firefox