### PR TITLE
Docs update - fix link and spelling

### DIFF
--- a/doc/additional_packages.md
+++ b/doc/additional_packages.md
@@ -4,7 +4,7 @@ experience. The majority of the minor modes listed here should be enabled for bo
 
 ## clj-refactor
 
-[clr-refactor](https://github.com/clojure-emacs/clj-refactor.el) builts on top
+[clr-refactor](https://github.com/clojure-emacs/clj-refactor.el) builds on top
 of clojure-mode and CIDER and adds a ton of extra functionality (e.g. the
 ability to thread/unthread expression, find and replace usages, introduce let
 bindings, extract function and so on).

--- a/doc/caveats.md
+++ b/doc/caveats.md
@@ -73,7 +73,7 @@ it's not actively maintained and it doesn't behave like the Clojure nREPL.
 * `cider-nrepl` uses a lot of Java code internally itself.
 
 Those issues are not insurmountable, but are beyond the scope of our current roadmap.
-If someone would like to tackle them, we'd be happy to provide assitance.
+If someone would like to tackle them, we'd be happy to provide assistance.
 
 ## Injecting dependencies and Leiningen pedantic: abort mode
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -15,7 +15,8 @@ so on.
 CIDER is the successor to the now deprecated combination of using [SLIME][] +
 [swank-clojure][] for Clojure development.
 
-If you like the project, please consider [supporting its ongoing development](contributing.md#donations).
+If you like the project, please consider
+[supporting its ongoing development](about/contributing.md#donations).
 
 ## Overview
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -66,7 +66,7 @@ Much of CIDER's functionality depends on the presence of CIDER's own
 [nREPL middleware](https://github.com/clojure-emacs/cider-nrepl). Starting with version 0.11, When `cider-jack-in` (<kbd>C-c M-j</kbd>) is
 used, CIDER takes care of injecting it and its other dependencies.
 
-**`profiles.clj` or `profile.boot` don't need to be modified anymore for the above usecase!**
+**`profiles.clj` or `profile.boot` don't need to be modified anymore for the above use case!**
 
 If you don't want `cider-jack-in` to inject dependencies automatically, set
 `cider-inject-dependencies-at-jack-in` to `nil`. Note that you'll have to setup

--- a/doc/miscellaneous_features.md
+++ b/doc/miscellaneous_features.md
@@ -184,4 +184,4 @@ Keyboard shortcut               | Description
 <kbd>s</kbd>                    | Go to definition for item at point.
 <kbd>^</kbd>                    | Browse all namespaces.
 <kbd>n</kbd>                    | Go to next line.
-<kbd>p</kbd>                    | Go to previos line.
+<kbd>p</kbd>                    | Go to previous line.

--- a/doc/up_and_running.md
+++ b/doc/up_and_running.md
@@ -6,7 +6,7 @@ command).
 
 ## Setting up a Leiningen or Boot project (optional)
 
-[Leiningen][] is the de facto standard build/project
+[Leiningen][] is the de-facto standard build/project
 management tool for Clojure. [Boot][] is a newer build tool
 offering abstractions and libraries to construct more complex build
 scenarios. Both have a similar scope to the Maven build tool favoured by Java

--- a/doc/using_the_repl.md
+++ b/doc/using_the_repl.md
@@ -17,7 +17,7 @@ Keyboard shortcut                    | Description
 <kbd>C-c M-o</kbd>    | Switch between the Clojure and ClojureScript REPLs for the current project.
 <kbd>C-c C-u</kbd>    | Kill all text from the prompt to the current point.
 <kbd>C-c C-b</kbd> <br/> <kbd>C-c C-c</kbd>| Interrupt any pending evaluations.
-<kbd>C-up</kbd> <br/> <kbd>C-down</kbd> | Goto to previous/next input in history.
+<kbd>C-up</kbd> <br/> <kbd>C-down</kbd> | Go to to previous/next input in history.
 <kbd>M-p</kbd> <br/> <kbd>M-n</kbd> | Search the previous/next item in history using the current input as search pattern. If <kbd>M-p/M-n</kbd> is typed two times in a row, the second invocation uses the same search pattern (even if the current input has changed).
 <kbd>M-s</kbd> <br/> <kbd>M-r</kbd> | Search forward/reverse through command history with regex.
 <kbd>C-c C-n</kbd> <br/> <kbd>C-c C-p</kbd> | Move between the current and previous prompts in the REPL buffer. Pressing <kbd>RET</kbd> on a line with old input copies that line to the newest prompt.


### PR DESCRIPTION
A few small fixes for issues in the new docs. 

Contributing link on the index page was missing the leading `about` path - now `mkdocs build` does not issue an error about the broken link.

Also, there were a handful of spelling errors in the docs that have been fixed.

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [X] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`make test`)
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [X] You've updated the changelog (if adding/changing user-visible functionality)
- [X] You've updated the readme (if adding/changing user-visible functionality)
- [X] You've updated the refcard (if you made changes to the commands listed there)

Thanks!
