### PR TITLE
Document case when exec-path does not include non-standard paths

### DIFF
--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -114,6 +114,13 @@ that the order here matters.
 Emacs doesn't load the new files, it only installs them on disk.  To see the
 effect of changes you have to restart Emacs.
 
+## `cider-jack-in` complains about `Wrong type argument: stringp, nil`
+
+Emacs may not be able to locate your `boot` or `lein` command via its `exec-path` variable,
+e.g. if you installed Boot/Leiningen to a home directory. Customize `exec-path` in Emacs to include any
+non-standard paths where you installed the tool.
+
+
 ## CIDER complains of the `cider-nrepl` version
 
 This is a warning displayed on the REPL buffer when it starts, and usually looks like this:


### PR DESCRIPTION
Noting a not-unusual Emacs configuration issue I ran into.

When `boot`/`lein` is not found in `exec-path`, then `cider-jack-in` fails with a cryptic error message. Emacs's stacktrace is enlightening if a user knows or cares to investigate, but this may be worth documenting as a troubleshooting tip anyway.

--

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [X] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`make test`)
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [X] You've updated the changelog (if adding/changing user-visible functionality)
- [X] You've updated the readme (if adding/changing user-visible functionality)
- [X] You've updated the refcard (if you made changes to the commands listed there)

Thanks!