### PR TITLE
Ensure cider-jack-in fails gracefully when commands are not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 * Signal an error sooner if the user misconfigured `cider-known-endpoints`.
 * `cider-inspect-read-and-inspect` is obsolete. Use `cider-inspect-expression` instead.
 * Extremely long overlays are truncated and `cider-inspect-last-result` is recommended.
+* Signal `user-error` instead of `error` on jack-in if a project type is not supported.
+* Users with `boot.sh` instead of `boot` should customize `cider-boot-command` instead of relying on automatic detection.
 
 ### Bugs fixed
 
@@ -32,7 +34,7 @@
 * [#1561](https://github.com/clojure-emacs/cider/issues/1561): Use an appropriate font-lock-face for variables, macros and functions in
 the ns-browser.
 * [#1708](https://github.com/clojure-emacs/cider/issues/1708): Fix `cider-popup-buffer-display` when another frame is used for the error buffer.
-* [#1733](https://github.com/clojure-emacs/cider/pull/1733): Better error handling when no boot commands are found in exec-path, by assuming a sensible fallback value.
+* [#1733](https://github.com/clojure-emacs/cider/pull/1733): Better error handling when no boot command is found in exec-path.
 
 ## 0.12.0 (2016-04-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [#1561](https://github.com/clojure-emacs/cider/issues/1561): Use an appropriate font-lock-face for variables, macros and functions in
 the ns-browser.
 * [#1708](https://github.com/clojure-emacs/cider/issues/1708): Fix `cider-popup-buffer-display` when another frame is used for the error buffer.
+* [#1733](https://github.com/clojure-emacs/cider/pull/1733): Better error handling when no boot commands are found in exec-path, by assuming a sensible fallback value.
 
 ## 0.12.0 (2016-04-16)
 

--- a/cider.el
+++ b/cider.el
@@ -215,14 +215,16 @@ Sub-match 1 must be the project path.")
     ("lein" cider-lein-command)
     ("boot" cider-boot-command)
     ("gradle" cider-gradle-command)
-    (_ (error "Unsupported project type `%s'" project-type))))
+    (_ (user-error "Unsupported project type `%s'" project-type))))
 
 (defun cider-jack-in-resolve-command (project-type)
+  "Determine the resolved file path to `cider-jack-in-command' if it can be
+found for the PROJECT-TYPE"
   (pcase project-type
     ("lein" (cider--lein-resolve-command))
     ("boot" (cider--boot-resolve-command))
     ("gradle" (cider--gradle-resolve-command))
-    (_ (error "Unsupported project type `%s'" project-type))))
+    (_ (user-error "Unsupported project type `%s'" project-type))))
     
 (defun cider-jack-in-params (project-type)
   "Determine the commands params for `cider-jack-in' for the PROJECT-TYPE."
@@ -230,8 +232,7 @@ Sub-match 1 must be the project path.")
     ("lein" cider-lein-parameters)
     ("boot" cider-boot-parameters)
     ("gradle" cider-gradle-parameters)
-    (_ (error "Unsupported project type `%s'" project-type))))
-
+    (_ (user-error "Unsupported project type `%s'" project-type))))
 
 
 ;;; Jack-in dependencies injection
@@ -662,7 +663,7 @@ choose."
 
 ;; TODO: Implement a check for `cider-lein-command' over tramp
 (defun cider--lein-resolve-command ()
-  "Check if `cider-lein-command' is on the `exec-path'.
+  "Find `cider-lein-command' on `exec-path' if possible, or return `nil'.
 
 In case `default-directory' is non-local we assume the command is available."
   (or (file-remote-p default-directory)
@@ -670,7 +671,7 @@ In case `default-directory' is non-local we assume the command is available."
       (executable-find (concat cider-lein-command ".bat"))))
 
 (defun cider--boot-resolve-command ()
-  "Check if `cider-boot-command' is on the `exec-path'.
+  "Find `cider-boot-command' on `exec-path' if possible, or return `nil'.
 
 In case `default-directory' is non-local we assume the command is available."
   (or (file-remote-p default-directory)
@@ -678,7 +679,7 @@ In case `default-directory' is non-local we assume the command is available."
       (executable-find (concat cider-boot-command ".exe"))))
 
 (defun cider--gradle-resolve-command ()
-  "Check if `cider-gradle-command' is on the `exec-path'.
+  "Find `cider-gradle-command' on `exec-path' if possible, or return `nil'.
 
 In case `default-directory' is non-local we assume the command is available."
   (or (file-remote-p default-directory)

--- a/cider.el
+++ b/cider.el
@@ -110,7 +110,8 @@ version from the CIDER package or library.")
 
 (defcustom cider-boot-command
   (or (executable-find "boot")
-      (executable-find "boot.sh"))
+      (executable-find "boot.sh")
+      "boot")
   "The command used to execute Boot."
   :type 'string
   :group 'cider


### PR DESCRIPTION
**Problem:** Running `cider-jack-in` with a Boot project when `boot` or `boot.sh` is not found in `exec-path` yields an error like this:

```
Debugger entered--Lisp error: (wrong-type-argument stringp nil)
  locate-file-internal(nil ("/usr/local/bin" "/usr/bin" "/bin" "/usr/local/games" "/usr/games" "/usr/lib/emacs/24.5/x86_64-linux-gnu") ("") 1)
  locate-file(nil ("/usr/local/bin" "/usr/bin" "/bin" "/usr/local/games" "/usr/games" "/usr/lib/emacs/24.5/x86_64-linux-gnu") ("") 1)
  executable-find(nil)
  cider--boot-present-p()
  cider-jack-in(nil)
  call-interactively(cider-jack-in record nil)
  command-execute(cider-jack-in record)
  execute-extended-command(nil "cider-jack-in")
  call-interactively(execute-extended-command nil nil)
  command-execute(execute-extended-command)
```

**Expected:** a more user-friendly message like this:
```The boot executable (specified by `cider-lein-command' or `cider-boot-command') isn't on your `exec-path'```

The source of the bug seems to be that `cider-boot-command` can be nil since it has a non-literal value, whereas `cider--boot-present-p` assumes it is non-nil. I've added a fallback literal value `"boot"` to guard against this causing problems.

Affects cider-20160501.1921 (melpa) and git master.

---

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`make test`)
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [X] You've updated the changelog (if adding/changing user-visible functionality)
- [X] You've updated the readme (if adding/changing user-visible functionality)
- [X] You've updated the refcard (if you made changes to the commands listed there)
