### PR TITLE
[Fix #1735] Display eldoc only for valid forms

### DIFF
--- a/cider-util.el
+++ b/cider-util.el
@@ -124,16 +124,6 @@ find a symbol if there isn't one at point."
               (forward-sexp -1)))
           (cider-symbol-at-point)))))
 
-(defun cider-ns-thing-at-point ()
-  "Return destructured `cider-symbol-at-point'.
-If the symbol at point is of the form ns-name/thing-name, returns a dict
-\(\"ns\" \"ns-name\" \"thing\" \"thing-name\")."
-  (if-let ((sym (cider-symbol-at-point))
-           (ns-thing (split-string sym "/")))
-      (if (< (length ns-thing) 2)
-          (nrepl-dict "thing" (car ns-thing))
-        (nrepl-dict "ns" (car ns-thing) "thing" (cadr ns-thing)))))
-
 
 ;;; sexp navigation
 (defun cider-sexp-at-point (&optional bounds)

--- a/test/cider-eldoc-tests.el
+++ b/test/cider-eldoc-tests.el
@@ -146,3 +146,14 @@
       (let ((cider-eldoc-max-num-sexps-to-skip 2))
         (expect (cider-eldoc-beginning-of-sexp) :to-equal nil)
         (expect (point) :to-equal 4)))))
+
+(describe "cider--eldoc-remove-dot-sym"
+  (it "removes the \".\" from the namespace qualified symbols"
+    (expect (cider--eldoc-remove-dot-sym "java.lang.String/.length")
+            :to-equal "java.lang.String/length")
+    (expect (cider--eldoc-remove-dot-sym "clojure.string/blank?")
+            :to-equal "clojure.string/blank?")
+    (expect (cider--eldoc-remove-dot-sym ".length")
+            :to-equal ".length")
+    (expect (cider--eldoc-remove-dot-sym "map")
+            :to-equal "map")))

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -86,23 +86,6 @@
     (spy-on 'thing-at-point :and-return-value "boogie>")
     (expect (cider-symbol-at-point) :to-equal "boogie>")))
 
-(describe "cider-ns-thing-at-point"
-  (it "destructures the symbol at point into ns and thing"
-    (with-temp-buffer
-      (clojure-mode)
-      (insert "java.lang.String/.length")
-      (search-backward "S")
-      (expect (cider-ns-thing-at-point) :to-equal
-              (nrepl-dict "ns" "java.lang.String" "thing" ".length"))))
-
-  (it "handles a non namespace qualified form"
-    (with-temp-buffer
-      (clojure-mode)
-      (insert "map")
-      (search-backward "m")
-      (expect (cider-ns-thing-at-point) :to-equal
-              (nrepl-dict "thing" "map")))))
-
 (describe "cider-sexp-at-point"
   (describe "when the param 'bounds is not given"
     (it "returns the sexp at point"


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

Thanks!

If the user has entered invalid class/ns name, like `(X/.length)` or `(X/defn)`, the eldoc is not displayed.