### PR TITLE
Show value of locals in debugger tooltip (#1737)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Extremely long overlays are truncated and `cider-inspect-last-result` is recommended.
 * Signal `user-error` instead of `error` on jack-in if a project type is not supported.
 * Users with `boot.sh` instead of `boot` should customize `cider-boot-command` instead of relying on automatic detection.
+* [#1737](https://github.com/clojure-emacs/cider/issues/1737): Show value of locals in debugger tooltip.
 
 ### Bugs fixed
 

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -659,6 +659,9 @@ before point."
   :type 'boolean
   :package-version '(cider "0.12.0"))
 
+(defvar cider--debug-mode-response)
+(defvar cider--debug-mode)
+
 (defun cider--help-echo (_ obj pos)
   "Return the help-echo string for OBJ at POS.
 See \(info \"(elisp) Special Properties\")"
@@ -671,7 +674,11 @@ See \(info \"(elisp) Special Properties\")"
             (goto-char pos)
             (when-let ((sym (cider-symbol-at-point)))
               (if (member sym (get-text-property (point) 'cider-locals))
-                  (format "`%s' is a local" sym)
+                  (concat (format "`%s' is a local" sym)
+                          (when cider--debug-mode
+                            (let* ((locals (nrepl-dict-get cider--debug-mode-response "locals"))
+                                   (local-val (cadr (assoc sym locals))))
+                                (format " with value:\n%s" local-val))))
                 (let* ((info (cider-sync-request:info sym))
                        (candidates (nrepl-dict-get info "candidates")))
                   (if candidates


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

Added the value of the local to the mouse tooltip in the debugger.

