### PR TITLE
Fix a variable name in see-also

### DIFF
--- a/cider-doc.el
+++ b/cider-doc.el
@@ -453,11 +453,11 @@ Tables are marked to be ignored by line wrap."
           (mapc (lambda (ns-sym)
 
                   (let* ((ns-sym-split (split-string ns-sym "/"))
-                         (ns (car ns-sym-split))
-                         (sym (cadr ns-sym-split))
+                         (see-also-ns (car ns-sym-split))
+                         (see-also-sym (cadr ns-sym-split))
                          ;; if the fn belongs to the same ns,
                          ;; don't display the namespace prefixed name
-                         (symbol (if (equal ns ns) sym ns-sym)))
+                         (symbol (if (equal ns see-also-ns) see-also-sym ns-sym)))
                     (insert-button symbol
                                    'type 'help-xref
                                    'help-function (apply-partially #'cider-doc-lookup symbol)))


### PR DESCRIPTION
@bbatsov I've done a stupid thing by using the same variable name as the top level `ns` var here. So the namespace prefixed name will never be shown. I'll be more careful from next time. Please merge this too.

Test case: `clojure.edn/read-string` should link to `clojure.core/prn-str`.