### PR TITLE
Hook boot cider-middleware task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add new face `cider-reader-conditional-face` which is used to mark unused reader conditional expressions.
 * [#1544](https://github.com/clojure-emacs/cider/issues/1544): Add a new defcustom `nrepl-use-ssh-fallback-for-remote-hosts` to control the behavior of `nrepl-connect` (and in turn that of `cider-connect`) for remote hosts.
 * [#1910](https://github.com/clojure-emacs/cider/issues/1910): Add custom company-mode completion style to show fuzzy completions from Compliment.
+* Introduce `cider-*-global-options` for customizing options that are not related to tasks.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#1544](https://github.com/clojure-emacs/cider/issues/1544): Add a new defcustom `nrepl-use-ssh-fallback-for-remote-hosts` to control the behavior of `nrepl-connect` (and in turn that of `cider-connect`) for remote hosts.
 * [#1910](https://github.com/clojure-emacs/cider/issues/1910): Add custom company-mode completion style to show fuzzy completions from Compliment.
 * Introduce `cider-*-global-options` for customizing options that are not related to tasks.
+* [#1731](https://github.com/clojure-emacs/cider/issues/1731): Change code in order to use the new `cider.tasks/add-middleware` boot tasks.
 
 ### Changes
 

--- a/doc/up_and_running.md
+++ b/doc/up_and_running.md
@@ -38,6 +38,15 @@ in it.
 
 In Clojure(Script) buffers the command `cider-jack-in` is bound to <kbd>C-c M-j</kbd>.
 
+For further customizing the command line used for `cider-jack-in`, you can
+change the following (all string options):
+
+ * `cider-[TOOL]-global-options`: these are passed to the command directly, in
+   first position (e.g. `-o` to `lein` enables offline mode).
+ * `cider-[TOOL]-parameters`: these are usually tasks names and their parameters
+   (e.g.: `dev` for launching boot's dev task instead of the standard `repl -s
+   wait`).
+
 ## Connect to a running nREPL server
 
 You can go to your project's directory in a terminal and type there

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -84,25 +84,25 @@
       (setq-local cider-jack-in-dependencies-exclusions '()))
 
     (it "can inject dependencies in a lein project"
-      (expect (cider-inject-jack-in-dependencies "repl :headless" "lein")
-              :to-equal"update-in :dependencies conj \\[org.clojure/tools.nrepl\\ \\\"0.2.12\\\"\\] -- update-in :plugins conj \\[cider/cider-nrepl\\ \\\"0.10.0-SNAPSHOT\\\"\\] -- repl :headless"))
+      (expect (cider-inject-jack-in-dependencies "" "repl :headless" "lein")
+              :to-equal "update-in :dependencies conj \\[org.clojure/tools.nrepl\\ \\\"0.2.12\\\"\\] -- update-in :plugins conj \\[cider/cider-nrepl\\ \\\"0.10.0-SNAPSHOT\\\"\\] -- repl :headless"))
 
     (it "can inject dependencies in a lein project with an exclusion"
         (setq-local cider-jack-in-dependencies-exclusions '(("org.clojure/tools.nrepl" ("org.clojure/clojure"))))
-        (expect (cider-inject-jack-in-dependencies "repl :headless" "lein")
-                :to-equal"update-in :dependencies conj \\[org.clojure/tools.nrepl\\ \\\"0.2.12\\\"\\ \\:exclusions\\ \\[org.clojure/clojure\\]\\] -- update-in :plugins conj \\[cider/cider-nrepl\\ \\\"0.10.0-SNAPSHOT\\\"\\] -- repl :headless"))
+        (expect (cider-inject-jack-in-dependencies "" "repl :headless" "lein")
+                :to-equal "update-in :dependencies conj \\[org.clojure/tools.nrepl\\ \\\"0.2.12\\\"\\ \\:exclusions\\ \\[org.clojure/clojure\\]\\] -- update-in :plugins conj \\[cider/cider-nrepl\\ \\\"0.10.0-SNAPSHOT\\\"\\] -- repl :headless"))
 
     (it "can inject dependencies in a lein project with multiple exclusions"
         (setq-local cider-jack-in-dependencies-exclusions '(("org.clojure/tools.nrepl" ("org.clojure/clojure" "foo.bar/baz"))))
-        (expect (cider-inject-jack-in-dependencies "repl :headless" "lein")
-                :to-equal"update-in :dependencies conj \\[org.clojure/tools.nrepl\\ \\\"0.2.12\\\"\\ \\:exclusions\\ \\[org.clojure/clojure\\ foo.bar/baz\\]\\] -- update-in :plugins conj \\[cider/cider-nrepl\\ \\\"0.10.0-SNAPSHOT\\\"\\] -- repl :headless"))
+        (expect (cider-inject-jack-in-dependencies "" "repl :headless" "lein")
+                :to-equal "update-in :dependencies conj \\[org.clojure/tools.nrepl\\ \\\"0.2.12\\\"\\ \\:exclusions\\ \\[org.clojure/clojure\\ foo.bar/baz\\]\\] -- update-in :plugins conj \\[cider/cider-nrepl\\ \\\"0.10.0-SNAPSHOT\\\"\\] -- repl :headless"))
 
     (it "can inject dependencies in a boot project"
-      (expect (cider-inject-jack-in-dependencies "repl -s wait" "boot")
+      (expect (cider-inject-jack-in-dependencies "" "repl -s wait" "boot")
               :to-equal "-d org.clojure/tools.nrepl\\:0.2.12 -d cider/cider-nrepl\\:0.10.0-SNAPSHOT repl -m cider.nrepl/cider-middleware -s wait"))
 
     (it "can inject dependencies in a gradle project"
-      (expect (cider-inject-jack-in-dependencies "--no-daemon clojureRepl" "gradle")
+      (expect (cider-inject-jack-in-dependencies "" "--no-daemon clojureRepl" "gradle")
               :to-equal "--no-daemon clojureRepl")))
 
   (describe "when there are multiple dependencies"
@@ -111,12 +111,28 @@
       (setq-local cider-jack-in-nrepl-middlewares '("refactor-nrepl.middleware/wrap-refactor" "cider.nrepl/cider-middleware"))
       (setq-local cider-jack-in-dependencies-exclusions '()))
     (it "can inject dependencies in a lein project"
-      (expect (cider-inject-jack-in-dependencies "repl :headless" "lein")
+      (expect (cider-inject-jack-in-dependencies "" "repl :headless" "lein")
               :to-equal "update-in :dependencies conj \\[org.clojure/tools.nrepl\\ \\\"0.2.12\\\"\\] -- update-in :plugins conj \\[refactor-nrepl\\ \\\"2.0.0\\\"\\] -- update-in :plugins conj \\[cider/cider-nrepl\\ \\\"0.11.0\\\"\\] -- repl :headless"))
 
     (it "can inject dependencies in a boot project"
-      (expect (cider-inject-jack-in-dependencies "repl -s wait" "boot")
-              :to-equal "-d org.clojure/tools.nrepl\\:0.2.12 -d refactor-nrepl\\:2.0.0 -d cider/cider-nrepl\\:0.11.0 repl -m refactor-nrepl.middleware/wrap-refactor -m cider.nrepl/cider-middleware -s wait"))))
+      (expect (cider-inject-jack-in-dependencies "" "repl -s wait" "boot")
+              :to-equal "-d org.clojure/tools.nrepl\\:0.2.12 -d refactor-nrepl\\:2.0.0 -d cider/cider-nrepl\\:0.11.0 repl -m refactor-nrepl.middleware/wrap-refactor -m cider.nrepl/cider-middleware -s wait")))
+
+  (describe "when there are global options"
+    (before-each
+      (setq-local cider-jack-in-dependencies '(("org.clojure/tools.nrepl" "0.2.12")))
+      (setq-local cider-jack-in-nrepl-middlewares '("cider.nrepl/cider-middleware"))
+      (setq-local cider-jack-in-lein-plugins '(("cider/cider-nrepl" "0.11.0")))
+      (setq-local cider-jack-in-dependencies-exclusions '()))
+    (it "can concat in a lein project"
+        (expect (cider-inject-jack-in-dependencies "-o -U" "repl :headless" "lein")
+                :to-equal "-o -U update-in :dependencies conj \\[org.clojure/tools.nrepl\\ \\\"0.2.12\\\"\\] -- update-in :plugins conj \\[cider/cider-nrepl\\ \\\"0.11.0\\\"\\] -- repl :headless"))
+    (it "can concat in a boot project"
+        (expect (cider-inject-jack-in-dependencies "-C -o" "repl -s wait" "boot")
+                :to-equal "-C -o -d org.clojure/tools.nrepl\\:0.2.12 -d cider/cider-nrepl\\:0.11.0 repl -m cider.nrepl/cider-middleware -s wait"))
+    (it "can concat in a gradle project"
+        (expect (cider-inject-jack-in-dependencies "-m" "--no-daemon clojureRepl" "gradle")
+                :to-equal "-m --no-daemon clojureRepl"))))
 
 (describe "cider-jack-in-auto-inject-clojure"
   (it "injects `cider-minimum-clojure-version' when `cider-jack-in-auto-inject-clojure' is set to minimal"

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -99,7 +99,7 @@
 
     (it "can inject dependencies in a boot project"
       (expect (cider-inject-jack-in-dependencies "" "repl -s wait" "boot")
-              :to-equal "-d org.clojure/tools.nrepl\\:0.2.12 -d cider/cider-nrepl\\:0.10.0-SNAPSHOT repl -m cider.nrepl/cider-middleware -s wait"))
+              :to-equal "-i \"(require 'cider.tasks)\" -d org.clojure/tools.nrepl\\:0.2.12 -d cider/cider-nrepl\\:0.10.0-SNAPSHOT cider.tasks/add-middleware -m cider.nrepl/cider-middleware repl -s wait"))
 
     (it "can inject dependencies in a gradle project"
       (expect (cider-inject-jack-in-dependencies "" "--no-daemon clojureRepl" "gradle")
@@ -116,7 +116,7 @@
 
     (it "can inject dependencies in a boot project"
       (expect (cider-inject-jack-in-dependencies "" "repl -s wait" "boot")
-              :to-equal "-d org.clojure/tools.nrepl\\:0.2.12 -d refactor-nrepl\\:2.0.0 -d cider/cider-nrepl\\:0.11.0 repl -m refactor-nrepl.middleware/wrap-refactor -m cider.nrepl/cider-middleware -s wait")))
+              :to-equal "-i \"(require 'cider.tasks)\" -d org.clojure/tools.nrepl\\:0.2.12 -d refactor-nrepl\\:2.0.0 -d cider/cider-nrepl\\:0.11.0 cider.tasks/add-middleware -m refactor-nrepl.middleware/wrap-refactor -m cider.nrepl/cider-middleware repl -s wait")))
 
   (describe "when there are global options"
     (before-each
@@ -129,7 +129,7 @@
                 :to-equal "-o -U update-in :dependencies conj \\[org.clojure/tools.nrepl\\ \\\"0.2.12\\\"\\] -- update-in :plugins conj \\[cider/cider-nrepl\\ \\\"0.11.0\\\"\\] -- repl :headless"))
     (it "can concat in a boot project"
         (expect (cider-inject-jack-in-dependencies "-C -o" "repl -s wait" "boot")
-                :to-equal "-C -o -d org.clojure/tools.nrepl\\:0.2.12 -d cider/cider-nrepl\\:0.11.0 repl -m cider.nrepl/cider-middleware -s wait"))
+                :to-equal "-C -o -i \"(require 'cider.tasks)\" -d org.clojure/tools.nrepl\\:0.2.12 -d cider/cider-nrepl\\:0.11.0 cider.tasks/add-middleware -m cider.nrepl/cider-middleware repl -s wait"))
     (it "can concat in a gradle project"
         (expect (cider-inject-jack-in-dependencies "-m" "--no-daemon clojureRepl" "gradle")
                 :to-equal "-m --no-daemon clojureRepl"))))


### PR DESCRIPTION
## Custom boot task for middleware injection 
> This patch also introduces cider-*-global-options defcustoms for
directly setting up global option parameters to lein, boot and gradle.
> An example of global option would be -o for offline execution in lein.

How to try it out:

 - Clone https://github.com/arichiardi/cider-nrepl/tree/boot-middleware
 - `cd cider-nrepl && lein install`
 - Clone https://github.com/arichiardi/cider/tree/boot-middleware branch in your emacs
 - Restart emacs
 - Jack in

You should see `-i \"(require 'cider.tasks)\" ...` in the mini buffer and of course `cider` should work as expected.

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):
- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test` -> not all but mine)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)

Thanks!
