### PR TITLE
Add font-lock-variable-name-face in cider-propertize

### DIFF
--- a/cider-eldoc.el
+++ b/cider-eldoc.el
@@ -121,8 +121,8 @@ is non-nil.  Else format it as a variable."
                             symbol
                           thing))
            (propertized-method-name (if (equal type 'function)
-                                        (cider-propertize method-name 'var)
-                                      (cider-propertize method-name 'font-lock-variable-name-face)))
+                                        (cider-propertize method-name 'fn)
+                                      (cider-propertize method-name 'var)))
            (ns-or-class (if (and ns (stringp ns))
                             (funcall cider-eldoc-ns-function ns)
                           (cider--eldoc-format-class-names ns))))

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1328,9 +1328,9 @@ See `cider-mode'."
          (var-name (nrepl-dict-get trace-response "var-name"))
          (var-status (nrepl-dict-get trace-response "var-status")))
     (pcase var-status
-      ("not-found" (error "Var %s not found" (cider-propertize sym 'var)))
-      ("not-traceable" (error "Var %s can't be traced because it's not bound to a function" (cider-propertize var-name 'var)))
-      (_ (message "Var %s %s" (cider-propertize var-name 'var) var-status)))))
+      ("not-found" (error "Var %s not found" (cider-propertize sym 'fn)))
+      ("not-traceable" (error "Var %s can't be traced because it's not bound to a function" (cider-propertize var-name 'fn)))
+      (_ (message "Var %s %s" (cider-propertize var-name 'fn) var-status)))))
 
 (defun cider-toggle-trace-var (arg)
   "Toggle var tracing.
@@ -1753,7 +1753,7 @@ With a prefix argument, prompt for function to run instead of -main."
                                         completions nil t nil
                                         'cider--namespace-history def)
                        name))))
-        (user-error "No %s var defined in any namespace" (cider-propertize name 'var))))))
+        (user-error "No %s var defined in any namespace" (cider-propertize name 'fn))))))
 
 (provide 'cider-interaction)
 

--- a/cider-util.el
+++ b/cider-util.el
@@ -602,9 +602,10 @@ Return buffer column number at position POS."
 
 (defun cider-propertize (text kind)
   "Propertize TEXT as KIND.
-KIND can be the symbols `ns', `var', `emph', or a face name."
+KIND can be the symbols `ns', `var', `emph', `fn', or a face name."
   (propertize text 'face (pcase kind
-                           (`var 'font-lock-function-name-face)
+                           (`fn 'font-lock-function-name-face)
+                           (`var 'font-lock-variable-name-face)
                            (`ns 'font-lock-type-face)
                            (`emph 'font-lock-keyword-face)
                            (face face))))


### PR DESCRIPTION
Add an option `'var` to `cider-propertize` which would propertize the text as a variable. This is not compulsory, as the method also accepts any `face`. But it currently maps `'var` to `font-lock-function-name-face` which could be confusing. So the mapping is changed to `var -> font-lock-variable-name-face` and `fn -> font-lock-function-name-face`

- [ ] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
