### PR TITLE
Fix eldoc error

### DIFF
--- a/cider-eldoc.el
+++ b/cider-eldoc.el
@@ -261,9 +261,9 @@ Then go back to the point and return its eldoc."
 (defun cider-eldoc-info-at-sexp-beginning ()
   "Return eldoc info for first symbol in the sexp."
   (save-excursion
-    (let* ((beginning-of-sexp (cider-eldoc-beginning-of-sexp))
-           ;; If we are at the beginning of function name, this will be -1
-           (argument-index (max 0 (1- beginning-of-sexp))))
+    (when-let ((beginning-of-sexp (cider-eldoc-beginning-of-sexp))
+               ;; If we are at the beginning of function name, this will be -1
+               (argument-index (max 0 (1- beginning-of-sexp))))
       (unless (or (memq (or (char-before (point)) 0)
                         '(?\" ?\{ ?\[))
                   (cider-in-comment-p))


### PR DESCRIPTION
This is something I missed out in my initial testing. Sorry about that.
This fixes `eldoc error: (wrong-type-argument number-or-marker-p nil)` error in minibuffer.

- [ ] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings