### PR TITLE
[Fix #1577] Show first line of docstring in ns browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Rebind `cider-eval-last-sexp-and-replace` to `C-c C-v w`.
 * Rebind `cider-eval-region` to `C-c C-v r`.
 * Rebind `cider-eval-ns-form` to `C-c C-v n`.
+* [#1577](https://github.com/clojure-emacs/cider/issues/1577): Show first line of docstring in ns browser.
 
 ### Bugs fixed
 


### PR DESCRIPTION
Show the first line of the docstring in the ns browser after the var name.
-----------------
- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)
