### PR TITLE
option to turn off prompt in nrepl--maybe-kill-server-buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+* Option `nrepl-kill-server-buffer-no-prompt` allows the user to skip the nrepl--maybe-kill-server-buffer prompt
 * [#1672](https://github.com/clojure-emacs/cider/issues/1672): Allow setting a preferred build tool when multiple are found via `cider-preferred-build-tool`.
 * Ensure Clojure version meets minimum supported by CIDER (1.7.0).
 * Fringe indicators highlight which sexps have been loaded. Disable it with `cider-use-fringe-indicators`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
 ## master (unreleased)
+* Add an option `nrepl-prompt-to-kill-server-buffer-on-quit` to control whether killing nrepl server and buffer requires a confirmation prompt.
 
 ### New Features
 
-* Option `nrepl-kill-server-buffer-no-prompt` allows the user to skip the nrepl--maybe-kill-server-buffer prompt
 * [#1672](https://github.com/clojure-emacs/cider/issues/1672): Allow setting a preferred build tool when multiple are found via `cider-preferred-build-tool`.
 * Ensure Clojure version meets minimum supported by CIDER (1.7.0).
 * Fringe indicators highlight which sexps have been loaded. Disable it with `cider-use-fringe-indicators`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
 ## master (unreleased)
-* Add an option `nrepl-prompt-to-kill-server-buffer-on-quit` to control whether killing nrepl server and buffer requires a confirmation prompt.
 
 ### New Features
 
+* Add an option `nrepl-prompt-to-kill-server-buffer-on-quit` to control whether killing nrepl server and buffer requires a confirmation prompt.
 * [#1672](https://github.com/clojure-emacs/cider/issues/1672): Allow setting a preferred build tool when multiple are found via `cider-preferred-build-tool`.
 * Ensure Clojure version meets minimum supported by CIDER (1.7.0).
 * Fringe indicators highlight which sexps have been loaded. Disable it with `cider-use-fringe-indicators`.

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -126,6 +126,11 @@ When true some special buffers like the server buffer will be hidden."
   :type 'boolean
   :group 'nrepl)
 
+(defcustom nrepl-kill-server-buffer-no-prompt nil
+  "Skip user prompt for nrepl-kill-server-buffer confirmation"
+  :type 'boolean
+  :group 'nrepl)
+
 (defvar nrepl-create-client-buffer-function 'nrepl-create-client-buffer-default
   "Name of a function that returns a client process buffer.
 It is called with one argument, a plist containing :host, :port and :proc
@@ -594,7 +599,8 @@ Do nothing if there is a REPL connected to that server."
   (with-current-buffer server-buf
     ;; Don't kill the server if there is a REPL connected to it.
     (when (and (not nrepl-client-buffers)
-               (y-or-n-p "Also kill server process and buffer? "))
+               (or nrepl-kill-server-buffer-no-prompt
+		   (y-or-n-p "Also kill server process and buffer? ")))
       (let ((proc (get-buffer-process server-buf)))
         (when (process-live-p proc)
           (set-process-query-on-exit-flag proc nil)

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -127,7 +127,7 @@ When true some special buffers like the server buffer will be hidden."
   :group 'nrepl)
 
 (defcustom nrepl-prompt-to-kill-server-buffer-on-quit t
-  "If non-nil, prompt the user for confirmation before killing the nrepl server and associated buffer" 
+  "If non-nil, prompt the user for confirmation before killing the nrepl server buffer and associated process." 
   :type 'boolean
   :group 'nrepl)
 

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -126,8 +126,8 @@ When true some special buffers like the server buffer will be hidden."
   :type 'boolean
   :group 'nrepl)
 
-(defcustom nrepl-kill-server-buffer-no-prompt nil
-  "Skip user prompt for nrepl-kill-server-buffer confirmation"
+(defcustom nrepl-prompt-to-kill-server-buffer-on-quit t
+  "If non-nil, prompt the user for confirmation before killing the nrepl server and associated buffer" 
   :type 'boolean
   :group 'nrepl)
 
@@ -599,7 +599,7 @@ Do nothing if there is a REPL connected to that server."
   (with-current-buffer server-buf
     ;; Don't kill the server if there is a REPL connected to it.
     (when (and (not nrepl-client-buffers)
-               (or nrepl-kill-server-buffer-no-prompt
+               (or (not nrepl-prompt-to-kill-server-buffer-on-quit)
 		   (y-or-n-p "Also kill server process and buffer? ")))
       (let ((proc (get-buffer-process server-buf)))
         (when (process-live-p proc)


### PR DESCRIPTION
currently there's no way to avoid the user prompt on nrepl--maybe-kill-server-buffer, this PR adds an option to allow this, defaults to current behavior 

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

Thanks!

[1]: https://github.com/clojure-emacs/cider/blob/master/.github/CONTRIBUTING.md

