### PR TITLE
[Fix #1766] Fix company-mode integration with cider eldoc

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -586,9 +586,9 @@ in the buffer."
 (defun cider-company-docsig (thing)
   "Return signature for THING."
   (let* ((eldoc-info (cider-eldoc-info thing))
-         (ns (nth 0 eldoc-info))
-         (symbol (nth 1 eldoc-info))
-         (arglists (nth 2 eldoc-info)))
+         (ns (lax-plist-get eldoc-info "ns"))
+         (symbol (lax-plist-get eldoc-info "symbol"))
+         (arglists (lax-plist-get eldoc-info "arglists")))
     (when eldoc-info
       (format "%s: %s"
               (cider-eldoc-format-thing ns symbol thing


### PR DESCRIPTION
When the return value of the fn `cider-eldoc-info` was changed from a list to p-list, I missed out making the required changes in this function.

- [ ] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

Thanks!

[1]: https://github.com/clojure-emacs/cider/blob/master/.github/CONTRIBUTING.md

