### PR TITLE
[Fix #1767] Read and eval defun at point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#1725](https://github.com/clojure-emacs/cider/issues/1725): Display class names in eldoc for interop forms.
 * [#1572](https://github.com/clojure-emacs/cider/issues/1572): Add support for variables in eldoc.
 * [#1736](https://github.com/clojure-emacs/cider/issues/1736): Show "See Also" links for functions/variables in documentation buffers.
+* [#1767](https://github.com/clojure-emacs/cider/issues/1767): Add a command `cider-read-and-eval-defun-at-point` to insert the defun at point into the minibuffer for evaluation (bound to `C-c C-v .`).
 
 ### Changes
 

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1223,10 +1223,11 @@ otherwise it's evaluated interactively."
             (cider-nrepl-sync-request:eval (cider-defun-at-point)))
         (cider-eval-defun-at-point)))))
 
-(defun cider-read-and-eval ()
-  "Read a sexp from the minibuffer and output its result to the echo area."
+(defun cider-read-and-eval (&optional value)
+  "Read a sexp from the minibuffer and output its result to the echo area.
+If VALUE is non-nil, it is inserted into the minibuffer as initial input."
   (interactive)
-  (let* ((form (cider-read-from-minibuffer "Clojure Eval: "))
+  (let* ((form (cider-read-from-minibuffer "Clojure Eval: " value))
          (override cider-interactive-eval-override)
          (ns-form (if (cider-ns-form-p form) "" (format "(ns %s)" (cider-current-ns)))))
     (with-current-buffer (get-buffer-create cider-read-eval-buffer)
@@ -1237,6 +1238,15 @@ otherwise it's evaluated interactively."
       (insert form)
       (let ((cider-interactive-eval-override override))
         (cider-interactive-eval form)))))
+
+(defun cider-read-and-eval-defun-at-point ()
+  "Insert the toplevel form at point in the minibuffer and output its result.
+The point is placed next to the function name in the minibuffer to allow
+passing arguments."
+  (interactive)
+  (let* ((fn-name (cadr (split-string (cider-defun-at-point))))
+         (form (concat "(" fn-name ")")))
+    (cider-read-and-eval (cons form (length form)))))
 
 
 ;; Connection and REPL

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -291,6 +291,7 @@ Configure `cider-cljs-lein-repl' to change the ClojureScript REPL to use."]
     (define-key map (kbd "C-c C-v r") #'cider-eval-region)
     (define-key map (kbd "C-c C-v n") #'cider-eval-ns-form)
     (define-key map (kbd "C-c C-v v") #'cider-eval-sexp-at-point)
+    (define-key map (kbd "C-c C-v .") #'cider-read-and-eval-defun-at-point)
     (define-key map (kbd "C-c M-;") #'cider-eval-defun-to-comment)
     (define-key map (kbd "C-c M-e") #'cider-eval-last-sexp-to-repl)
     (define-key map (kbd "C-c M-p") #'cider-insert-last-sexp-in-repl)

--- a/doc/miscellaneous_features.md
+++ b/doc/miscellaneous_features.md
@@ -7,8 +7,12 @@ something.
 
 You can evaluate Clojure code in the minibuffer from pretty much everywhere by
 using <kbd>M-x</kbd> `cider-read-and-eval` (bound in `cider-mode` buffers to
-<kbd>C-c C-:</kbd>).  <kbd>TAB</kbd> completion will work in the minibuffer,
+<kbd>C-c M-:</kbd>).  <kbd>TAB</kbd> completion will work in the minibuffer,
 just as in a REPL/source buffer.
+
+Pressing <kbd>C-c C-v .</kbd> in a Clojure buffer will insert the defun 
+at point into the minibuffer for evaluation. This way you can pass arguments 
+to the function and evaluate it and see the result in the minibuffer.
 
 You can also enable `eldoc-mode` in the minibuffer by adding the following to your
 config:


### PR DESCRIPTION
Insert the defun at point in the minibuffer and place the point next to the function name to allow passing arguments. Output the result of the function call to the minibuffer or as overlay in the buffer.

- [x] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

