### PR TITLE
Feature/multiline eldoc

### DIFF
--- a/cider-browse-ns.el
+++ b/cider-browse-ns.el
@@ -120,7 +120,7 @@ If the first line of the DOC string contains multiple sentences, only
 the first sentence is returned.  If the DOC string is nil, a Not documented
 string is returned."
   (if doc
-      (let* ((split-newline (split-string (read doc) "\n"))
+      (let* ((split-newline (split-string doc "\n"))
              (first-line (car split-newline)))
         (cond
          ((string-match "\\. " first-line) (substring first-line 0 (match-end 0)))
@@ -135,6 +135,9 @@ Each item consists of a ns-var and the first line of its docstring."
          (propertized-ns-vars (nrepl-dict-map #'cider-browse-ns--properties ns-vars-with-meta)))
     (mapcar (lambda (ns-var)
               (let* ((doc (nrepl-dict-get-in ns-vars-with-meta (list ns-var "doc")))
+                     ;; to avoid (read nil)
+                     ;; it prompts the user for a Lisp expression
+                     (doc (when doc (read doc)))
                      (first-doc-line (cider-browse-ns--first-doc-line doc)))
                 (concat ns-var " " (propertize first-doc-line 'font-lock-face 'font-lock-doc-face))))
             propertized-ns-vars)))

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -4,22 +4,6 @@ experience.
 
 ## Basic configuration
 
-* Enable `eldoc` in Clojure buffers:
-
-```el
-(add-hook 'cider-mode-hook #'eldoc-mode)
-```
-
-![Eldoc](images/eldoc.png)
-
-CIDER also would show the eldoc for the symbol at point. So in (map inc ...)
-when the cursor is over inc its eldoc would be displayed. You can turn off this
-behaviour by:
-
-```el
-(setq cider-eldoc-display-for-symbol-at-point nil)
-```
-
 * Suppress auto-enabling of `cider-mode` in `clojure-mode` buffers, when starting
   CIDER:
 
@@ -139,6 +123,34 @@ More details can be found [here](https://github.com/clojure-emacs/cider/issues/9
 ```el
 (setq cider-filter-regexps '(".*nrepl"))
 ```
+
+## Configuring eldoc
+
+* Enable `eldoc` in Clojure buffers:
+
+```el
+(add-hook 'cider-mode-hook #'eldoc-mode)
+```
+
+![Eldoc](images/eldoc.png)
+
+* CIDER also would show the eldoc for the symbol at point. So in (map inc ...)
+when the cursor is over inc its eldoc would be displayed. You can turn off this
+behaviour by:
+
+```el
+(setq cider-eldoc-display-for-symbol-at-point nil)
+```
+
+* CIDER respects the value of `eldoc-echo-area-use-multiline-p` when
+displaying documentation in the minibuffer. You can customize this variable to change
+its behaviour.
+
+| eldoc-echo-area-use-multiline-p | Behaviour |
+| ------------- | ------------- |
+| `t`  | Never attempt to truncate messages. Complete symbol name and function arglist or variable documentation will be displayed even if echo area must be resized to fit.|
+| `nil`  | Messages are always truncated to fit in a single line of display in the echo area.  |
+| `truncate-sym-name-if-fit` or anything non-nil | Symbol name may be truncated if it will enable the function arglist or documentation string to fit on a single line. Otherwise, behavior is just like `t` case. |
 
 ## Overlays
 

--- a/test/cider-browse-ns-tests.el
+++ b/test/cider-browse-ns-tests.el
@@ -67,13 +67,13 @@
             :to-equal "Not documented."))
 
   (it "returns the first line of the doc string"
-      (expect (cider-browse-ns--first-doc-line "\"True if s is nil, empty, or contains only whitespace.\"")
-              :to-equal "True if s is nil, empty, or contains only whitespace."))
+    (expect (cider-browse-ns--first-doc-line "True if s is nil, empty, or contains only whitespace.")
+            :to-equal "True if s is nil, empty, or contains only whitespace."))
 
   (it "returns the first sentence of the doc string if the first line contains multiple sentences"
-      (expect (cider-browse-ns--first-doc-line "\"First sentence. Second sentence.\"")
-              :to-equal "First sentence. "))
+    (expect (cider-browse-ns--first-doc-line "First sentence. Second sentence.")
+            :to-equal "First sentence. "))
 
   (it "returns the first line of the doc string if the first sentence spans multiple lines"
-      (expect (cider-browse-ns--first-doc-line "\"True if s is nil, empty, or\n contains only whitespace.\"")
-              :to-equal "True if s is nil, empty, or...")))
+    (expect (cider-browse-ns--first-doc-line "True if s is nil, empty, or\n contains only whitespace.")
+            :to-equal "True if s is nil, empty, or...")))


### PR DESCRIPTION
For #1782. We now consider the value of `eldoc-echo-area-use-multiline-p` while formatting the docstring for a var. It's semantics are;

| eldoc-echo-area-use-multiline-p | Behaviour |
| ------------- | ------------- |
| `t`  | never attempt to truncate messages  |
| `nil`  | messages are always truncated to fit in a single line  |
| `truncate-sym-name-if-fit` or anything else | symbol name may be truncated if it will enable the function arglist or documentation string to fit on a single line |

This PR does not implement the last case. Any ideas on how to ? We could use `cider-abbreviate-ns`, or `cider-last-ns-segment`. But I'm not sure if truncating the name this way is right. The name may be more important than eldoc.

- [x] The commits are consistent with our [contribution guidelines][1]
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

Thanks!