### PR TITLE
Fix orphaned nrepl-messages buffer after cider-quit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 the ns-browser.
 * [#1708](https://github.com/clojure-emacs/cider/issues/1708): Fix `cider-popup-buffer-display` when another frame is used for the error buffer.
 * [#1733](https://github.com/clojure-emacs/cider/pull/1733): Better error handling when no boot command is found in exec-path.
+* Fix orphaned nrepl-messages buffer after `cider-quit'.
 
 ## 0.12.0 (2016-04-16)
 

--- a/cider-client.el
+++ b/cider-client.el
@@ -118,21 +118,21 @@ Moves CONNECTION-BUFFER to the front of variable `cider-connections'."
 (defun cider--close-connection-buffer (conn-buffer)
   "Close CONN-BUFFER, removing it from variable `cider-connections'.
 Also close associated REPL and server buffers."
-  (let ((buffer (get-buffer conn-buffer)))
+  (let ((buffer (get-buffer conn-buffer))
+        (nrepl-messages-buffer (and nrepl-log-messages
+                                    (nrepl-messages-buffer conn-buffer))))
     (setq cider-connections
           (delq buffer cider-connections))
     (when (buffer-live-p buffer)
-      ;; close the matching nREPL messages buffer
-      (when nrepl-log-messages
-        (when-let ((nrepl-messages-buffer (nrepl-messages-buffer conn-buffer)))
-          (kill-buffer nrepl-messages-buffer)))
       (with-current-buffer buffer
         (when spinner-current (spinner-stop))
         (when nrepl-tunnel-buffer
           (cider--close-buffer nrepl-tunnel-buffer)))
       ;; If this is the only (or last) REPL connected to its server, the
       ;; kill-process hook will kill the server.
-      (cider--close-buffer buffer))))
+      (cider--close-buffer buffer)
+      (when nrepl-messages-buffer
+        (kill-buffer nrepl-messages-buffer)))))
 
 
 ;;; Current connection logic


### PR DESCRIPTION
Hi all

My observation after cider-quit and answering both questions with yes
is that in the function cider--close-connection-buffer: First the
buffer *nrepl-messages [...]* is killed and then it is recreated
during killing the buffer *cider-repl [...]*.

The attached patch solves the problem for me by killing nrepl-messages
after cider-repl on master and 0.12.0. "make test" succeeds.

Michael