### PR TITLE
[Fix #1646] Add option to control default apropos act on symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#1572](https://github.com/clojure-emacs/cider/issues/1572): Add support for variables in eldoc.
 * [#1736](https://github.com/clojure-emacs/cider/issues/1736): Show "See Also" links for functions/variables in documentation buffers.
 * [#1767](https://github.com/clojure-emacs/cider/issues/1767): Add a command `cider-read-and-eval-defun-at-point` to insert the defun at point into the minibuffer for evaluation (bound to `C-c C-v .`).
+* [#1646](https://github.com/clojure-emacs/cider/issues/1646): Add an option `cider-apropos-actions` to control the list of actions to be applied on the symbol found by an apropos search.
 
 ### Changes
 

--- a/cider-apropos.el
+++ b/cider-apropos.el
@@ -41,6 +41,17 @@
 
 (push cider-apropos-buffer cider-ancillary-buffers)
 
+(defcustom cider-apropos-actions '(("display-doc" . cider-doc-lookup)
+                                   ("find-def" . cider--find-var)
+                                   ("lookup-on-grimoire" . cider-grimoire-lookup))
+  "Controls the actions to be applied on the symbol found by an apropos search.
+The first action key in the list will be selected as default.  If the list
+contains only one action key, the associated action function will be
+applied automatically.  An action function can be any function that receives
+the symbol found by the apropos search as argument."
+  :type '(alist :key-type string :value-type function)
+  :group 'cider)
+
 (defun cider-apropos-doc (button)
   "Display documentation for the symbol represented at BUTTON."
   (cider-doc-lookup (button-get button 'apropos-symbol)))
@@ -139,17 +150,15 @@ optionally search doc strings (based on DOCS-P), include private vars
 
 (defun cider-apropos-act-on-symbol (symbol)
   "Apply selected action on SYMBOL."
-  (let ((action (completing-read (format "Choose action to apply to `%s`: " symbol)
-                                 '("display-doc"
-                                   "find-def"
-                                   "lookup-on-grimoire"
-                                   "quit"))))
-    (pcase action
-      ("display-doc" (cider-doc-lookup symbol))
-      ("find-def" (cider--find-var symbol))
-      ("lookup-on-grimoire" (cider-grimoire-lookup symbol))
-      ("quit" nil)
-      (_ (user-error "Unknown action `%s`" action)))))
+  (let* ((first-action-key (car (car cider-apropos-actions)))
+         (action-key (if (= 1 (length cider-apropos-actions))
+                     first-action-key
+                   (completing-read (format "Choose action to apply to `%s`: " symbol)
+                                    cider-apropos-actions nil nil nil nil first-action-key)))
+         (action-fn (cdr (assoc action-key cider-apropos-actions))))
+    (if action-fn
+        (funcall action-fn symbol)
+      (user-error "Unknown action `%s`" action-key))))
 
 ;;;###autoload
 (defun cider-apropos-select (query &optional ns docs-p privates-p case-sensitive-p)


### PR DESCRIPTION
Add an option `cider-apropos-default-act-on-symbol` to control the default action to be applied on the symbol found by an apropos search.

-----------------

- [x] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)