### PR TITLE
cider-repl-closing-return completes { and [

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 * Rebind `cider-eval-region` to `C-c C-v r`.
 * Rebind `cider-eval-ns-form` to `C-c C-v n`.
 * [#1577](https://github.com/clojure-emacs/cider/issues/1577): Show first line of docstring in ns browser.
-* cider-repl-closing-return (`C-<Return>`) now also completes brackets (`[]`) and curly braces (`{}`) in an expression.
+* `cider-repl-closing-return` (`C-<Return>`) now also completes brackets (`[]`) and curly braces (`{}`) in an expression.
 
 ### Bugs fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Rebind `cider-eval-region` to `C-c C-v r`.
 * Rebind `cider-eval-ns-form` to `C-c C-v n`.
 * [#1577](https://github.com/clojure-emacs/cider/issues/1577): Show first line of docstring in ns browser.
+* cider-repl-closing-return (`C-<Return>`) now also completes brackets (`[]`) and curly braces (`{}`) in an expression.
 
 ### Bugs fixed
 

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -760,7 +760,7 @@ text property `cider-old-input'."
       (forward-char offset))))
 
 (defun cider-repl-closing-return ()
-  "Evaluate the current input string after closing all open lists."
+  "Evaluate the current input string after closing all open parenthesized or bracketed expressions."
   (interactive)
   (goto-char (point-max))
   (save-restriction

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -765,8 +765,11 @@ text property `cider-old-input'."
   (goto-char (point-max))
   (save-restriction
     (narrow-to-region cider-repl-input-start-mark (point))
-    (while (ignore-errors (save-excursion (backward-up-list 1)) t)
-      (insert ")")))
+    (let ((matched-delimiter nil)))
+      (while (ignore-errors (save-excursion
+	   		       (backward-up-list 1)
+			       (setq matched-delimiter (string (following-char)))) t)
+      (insert (cdr (assoc matched-delimiter '(("(" . ")") ("[" . "]") ("{" . "}")))))))
   (cider-repl-return))
 
 (defun cider-repl-toggle-pretty-printing ()

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -765,11 +765,11 @@ text property `cider-old-input'."
   (goto-char (point-max))
   (save-restriction
     (narrow-to-region cider-repl-input-start-mark (point))
-    (let ((matched-delimiter nil)))
+    (let ((matching-delimiter nil))
       (while (ignore-errors (save-excursion
-	   		       (backward-up-list 1)
-			       (setq matched-delimiter (string (following-char)))) t)
-      (insert (cdr (assoc matched-delimiter '(("(" . ")") ("[" . "]") ("{" . "}")))))))
+			      (backward-up-list 1)
+			      (setq matching-delimiter (cdr (syntax-after (point))))) t)
+        (insert-char matching-delimiter))))
   (cider-repl-return))
 
 (defun cider-repl-toggle-pretty-printing ()


### PR DESCRIPTION
This pull request edits `cider-repl-closing-return` (`C-<return>`) so that it inserts `]` and `}` where necessary, instead of completing every braced expression with a `)`.

Observe: say you've typed this out at the REPL:
```clojure
user> (def foo {:bar ['baz 'qux
```

If you hit `C-<return>`, you'd expect it to complete your expression and eval it:

````clojure
user> (def foo {:bar [baz qux)))
RuntimeException Unmatched delimiter: )  clojure.lang.Util.runtimeException (Util.java:221)
````

With this edit, `cider-repl-closing-return` works as expected, inserting `}` and `]` to match their respective braces. Because emacs is treating all three of these brace types as expression delimiters, the auto-complete should work with each of them.

-----------------

- [x] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

[1]: https://github.com/clojure-emacs/cider/blob/master/.github/CONTRIBUTING.md

