### PR TITLE
Make mouse-over tooltips less intrusive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ the ns-browser.
 * [#1708](https://github.com/clojure-emacs/cider/issues/1708): Fix `cider-popup-buffer-display` when another frame is used for the error buffer.
 * [#1733](https://github.com/clojure-emacs/cider/pull/1733): Better error handling when no boot command is found in `exec-path`.
 * Fix orphaned nrepl-messages buffer after `cider-quit`.
+* [#1782](https://github.com/clojure-emacs/cider/issues/1782): Disable mouse-over tooltips when `help-at-pt-display-when-idle` is non-nil.
 
 ## 0.12.0 (2016-04-16)
 

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -668,7 +668,7 @@ before point."
 See \(info \"(elisp) Special Properties\")"
   (while-no-input
     (when (and (bufferp obj) (cider-connected-p)
-               cider-use-tooltips)
+               cider-use-tooltips (not help-at-pt-display-when-idle))
       (with-current-buffer obj
         (ignore-errors
           (save-excursion


### PR DESCRIPTION
We disable the tooltips when `help-at-pt-display-when-idle` is non-nil.

The Emacs customization interface also allows us to set this to `In certain situations`; which sets it to a list `(keymap local-map button kbd-help help-echo)` by default.

> If the value is a list, the help only gets printed if there is a text or overlay property at point that is included in this list.

I have not added any special consideration for this, as both `help-echo` and `kbd-help` are in this list by default. I don't think any special handling is required, and we'll just skip the messages unless the value is nil. Is this ok ? 


- [ ] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)

