### PR TITLE
[#1804] Remember location after cider-inspector-pop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [#1767](https://github.com/clojure-emacs/cider/issues/1767): Add a command `cider-read-and-eval-defun-at-point` to insert the defun at point into the minibuffer for evaluation (bound to `C-c C-v .`).
 * [#1646](https://github.com/clojure-emacs/cider/issues/1646): Add an option `cider-apropos-actions` to control the list of actions to be applied on the symbol found by an apropos search.
 * [#1783](https://github.com/clojure-emacs/cider/issues/1783): Put eval commands onto single map bound to `C-c C-v`.
+* [#1804](https://github.com/clojure-emacs/cider/issues/1804): Remember cursor position between `cider-inspector-*` operations.
 
 ### Changes
 


### PR DESCRIPTION
We push our current location in the buffer i.e`(point)`, onto a stack, before every `cider-inspector-push` operation. Then when we're navigation back using `cider-inspector-pop`,
we just `goto-char` to that location.

I've not used this feature of CIDER much. But does it make sense to do something like this for `next-page` and `prev-page` too ?

![out](https://cloud.githubusercontent.com/assets/5201497/16940947/b7fc4558-4daa-11e6-9d54-2483a3772322.gif)


/cc @mallt 

- [ ] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)