### PR TITLE
Handle lone carriage returns as newline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## master (unreleased)
 
+### New Features
+### Changes
+### Bugs Fixed
+* [#1677](https://github.com/clojure-emacs/cider/issues/1677): Interpret `\r` as a newline
+
+
 ## 0.13.0 (2016-07-25)
 
 ### New Features

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -356,7 +356,10 @@ object is a root list or dict."
         (goto-char end)
         ;; normalise any platform-specific newlines
         (let* ((original (buffer-substring-no-properties beg end))
-               (result (replace-regexp-in-string "\r" "" original)))
+               ;; handle both \n\r and \r\n
+               (result (replace-regexp-in-string "\r\n\\|\n\r" "\n" original))
+               ;; we don't handle single carriage returns, insert newline
+               (result (replace-regexp-in-string "\r" "\n" result)))
           (cons nil (nrepl--push result stack))))))
    ;; integer
    ((looking-at "i\\(-?[0-9]+\\)e")

--- a/test/nrepl-bencode-tests.el
+++ b/test/nrepl-bencode-tests.el
@@ -55,7 +55,9 @@ If object is incomplete, return a decoded path."
 
     (it "handles platform specific newlines"
       (expect (nrepl-bdecode-string "5:spam\n") :to-equal '("spam\n"))
-      (expect (nrepl-bdecode-string "6:spam\n") :to-equal '("spam\n")))
+      (expect (nrepl-bdecode-string "6:spam\n") :to-equal '("spam\n"))
+      (expect (nrepl-bdecode-string "6:spam\n") :to-equal '("spam\n"))
+      (expect (nrepl-bdecode-string "5:spam\r") :to-equal '("spam\n")))
 
     (it "decodes integers"
       (expect (nrepl-bdecode-string "i3e") :to-equal '(3))


### PR DESCRIPTION
- [x] The commits are consistent with our [contribution guidelines][1]
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)
- [x] You've updated the refcard (if you made changes to the commands listed there)

Substitute newline for single carriage returns

https://github.com/clojure-emacs/cider/issues/1677

this doesn't totally solve the issue actually. The issue poster was hoping that "foo\rbar" would right foo, return to the beginning of the same line, and then write bar. However, we were stripping carriage returns with no action. We now act as lein repl does, replacing this lone carriage returns with newlines.

The fundamental issue was that text-based status bars didn't work, and it sounds like we don't have plans to fix this, or at least not at the moment. There are lots of things to consider like markers, how we parse up the bencoded string to know when to move to next line, when to zap over current line, etc, and that would be a much larger change.