### PR TITLE
Use sync requests in inspector-*

### DIFF
--- a/cider-debug.el
+++ b/cider-debug.el
@@ -636,7 +636,7 @@ needed.  It is expected to contain at least \"key\", \"input-type\", and
              (setq cider--debug-mode-response response)
              (cider--debug-mode 1)))
           (when inspect
-            (cider-inspector--value-handler nil inspect)))
+            (cider-inspector--render-value inspect)))
       ;; If something goes wrong, we send a "quit" or the session hangs.
       (error (cider-debug-mode-send-reply ":quit" key)
              (message "Error encountered while handling the debug message: %S" e)))))


### PR DESCRIPTION
As discussed in https://github.com/clojure-emacs/cider/pull/1807#issuecomment-234760146, the inspector-* fn's use callbacks to interact with the middleware. This PR changes those fn's to use the `cider-sync-request:*`.

- [ ] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

Thanks!

[1]: https://github.com/clojure-emacs/cider/blob/master/.github/CONTRIBUTING.md

