### PR TITLE
[Fix #1824] Cider-jack-in dependency exclusions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * [#1677](https://github.com/clojure-emacs/cider/issues/1677): Interpret `\r` as a newline.
 * [#1819](https://github.com/clojure-emacs/cider/issues/1819): Handle properly missing commands on `cider-jack-in`.
+* Add option to define exclusions for injected dependecies. Fixes [#1824](https://github.com/clojure-emacs/cider/issues/1824): Can no longer jack-in to an inherited clojure version.
 
 ## 0.13.0 (2016-07-25)
 


### PR DESCRIPTION
- [x] The commits are consistent with our [contribution guidelines][1]
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)
- [x] You've updated the refcard (if you made changes to the commands listed there)

Add option to define exclusions for injected dependecies. Add
`org.cloure/clojure` exclusion to `org.clojure/tools.nrepl` to mitigate
problem with tools.nrepl clojure dependency.

Note about boot: the latest stable release does not support defining
depedency exclusions on the command line. However, this feature is
available in the upcoming 2.7.x release. This feature will be added
for boot when 2.7.x is released.