### PR TITLE
Fix usage of RET in several keymaps

### DIFF
--- a/cider-browse-ns.el
+++ b/cider-browse-ns.el
@@ -54,7 +54,7 @@
     (set-keymap-parent map cider-popup-buffer-mode-map)
     (define-key map "d" #'cider-browse-ns-doc-at-point)
     (define-key map "s" #'cider-browse-ns-find-at-point)
-    (define-key map [return] #'cider-browse-ns-operate-at-point)
+    (define-key map (kbd "RET") #'cider-browse-ns-operate-at-point)
     (define-key map "^" #'cider-browse-ns-all)
     (define-key map "n" #'next-line)
     (define-key map "p" #'previous-line)

--- a/cider-classpath.el
+++ b/cider-classpath.el
@@ -34,7 +34,7 @@
 (defvar cider-classpath-mode-map
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map cider-popup-buffer-mode-map)
-    (define-key map [return] #'cider-classpath-operate-on-point)
+    (define-key map (kbd "RET") #'cider-classpath-operate-on-point)
     (define-key map "n" #'next-line)
     (define-key map "p" #'previous-line)
     map))

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -56,8 +56,7 @@ The page size can be also changed interactively within the inspector."
 (defvar cider-inspector-mode-map
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map cider-popup-buffer-mode-map)
-    (define-key map [return] #'cider-inspector-operate-on-point)
-    (define-key map "\C-m"   #'cider-inspector-operate-on-point)
+    (define-key map (kbd "RET") #'cider-inspector-operate-on-point)
     (define-key map [mouse-1] #'cider-inspector-operate-on-click)
     (define-key map "l" #'cider-inspector-pop)
     (define-key map "g" #'cider-inspector-refresh)


### PR DESCRIPTION
Replace occurrences of `[return]` in keymap definitions with
`(kbd "RET")`.