### PR TITLE
[Fix #1859] In message log insert large objects on request only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ within the scope of your current Emacs session.
 * Add option to define exclusions for injected dependecies. Fixes [#1824](https://github.com/clojure-emacs/cider/issues/1824): Can no longer jack-in to an inherited clojure version.
 * [#1820](https://github.com/clojure-emacs/cider/issues/1820): Don't try to display eldoc in EDN buffers.
 * [#1823](https://github.com/clojure-emacs/cider/issues/1823): Fix column location metadata set by interactive evaluation.
-* [#1859](https://github.com/clojure-emacs/cider/issues/1859): Remove the overhead of nREPL message log.
+* [#1859](https://github.com/clojure-emacs/cider/issues/1859): Make nREPL message log much faster. `nrepl-dict-max-message-size` custom variable was removed.
 
 ## 0.13.0 (2016-07-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ within the scope of your current Emacs session.
 * [#1748](https://github.com/clojure-emacs/cider/issues/1748): Add new interactive command `cider-pprint-eval-last-sexp-to-repl`.
 * [#1789](https://github.com/clojure-emacs/cider/issues/1789): Make it easy to change the connection of the cider-scratch buffer from the mode's menu.
 * New interactive command `cider-toggle-buffer-connection`.
+* [#1861](https://github.com/clojure-emacs/cider/issues/1861): New interactive commands in message log buffer `nrepl-log-expand-button` and `nrepl-log-expand-all-buttons`.
 
 ### Changes
 
@@ -27,6 +28,7 @@ within the scope of your current Emacs session.
 * [#1820](https://github.com/clojure-emacs/cider/issues/1820): Don't try to display eldoc in EDN buffers.
 * [#1823](https://github.com/clojure-emacs/cider/issues/1823): Fix column location metadata set by interactive evaluation.
 * [#1859](https://github.com/clojure-emacs/cider/issues/1859): Make nREPL message log much faster. `nrepl-dict-max-message-size` custom variable was removed.
+
 
 ## 0.13.0 (2016-07-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ within the scope of your current Emacs session.
 * Add option to define exclusions for injected dependecies. Fixes [#1824](https://github.com/clojure-emacs/cider/issues/1824): Can no longer jack-in to an inherited clojure version.
 * [#1820](https://github.com/clojure-emacs/cider/issues/1820): Don't try to display eldoc in EDN buffers.
 * [#1823](https://github.com/clojure-emacs/cider/issues/1823): Fix column location metadata set by interactive evaluation.
+* [#1859](https://github.com/clojure-emacs/cider/issues/1859): Remove the overhead of nREPL message log.
 
 ## 0.13.0 (2016-07-25)
 

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -1099,8 +1099,8 @@ The message is logged to a buffer described by
         (re-search-forward "^(" nil t)
         (delete-region (point-min) (- (point) 1)))
       (goto-char (point-max))
-      (nrepl--pp (nrepl-decorate-msg msg type)
-                 (nrepl--message-color (lax-plist-get (cdr msg) "id"))
+      (nrepl-log-pp-object (nrepl-decorate-msg msg type)
+                 (nrepl-log--message-color (lax-plist-get (cdr msg) "id"))
                  t)
       (when-let ((win (get-buffer-window)))
         (set-window-point win (point-max)))
@@ -1135,7 +1135,7 @@ BUTTON defaults the button at point."
           (goto-char start)
           (delete-overlay button)
           (delete-region start end)
-          (nrepl--pp obj)
+          (nrepl-log-pp-object obj)
           (delete-char -1)))
     (error "No button at point")))
 
@@ -1152,7 +1152,7 @@ BUTTON defaults the button at point."
           (nrepl-log-expand-button button)
           (setq button (next-button pos)))))))
 
-(defun nrepl--expand-button-mouse (event)
+(defun nrepl-log--expand-button-mouse (event)
   "Expand the text hidden under overlay button.
 EVENT gives the button position on window."
   (interactive "e")
@@ -1169,10 +1169,10 @@ EVENT gives the button position on window."
                  'face 'link
                  'help-echo "RET: Expand object."
                  ;; Workaround for bug#1568.
-                 'local-map '(keymap (mouse-1 . nrepl--expand-button-mouse)))
+                 'local-map '(keymap (mouse-1 . nrepl-log--expand-button-mouse)))
   (insert "\n"))
 
-(defun nrepl--message-color (id)
+(defun nrepl-log--message-color (id)
   "Return the color to use when pretty-printing the nREPL message with ID.
 If ID is nil, return nil."
   (when id
@@ -1180,9 +1180,9 @@ If ID is nil, return nil."
       (mod (length nrepl-message-colors))
       (nth nrepl-message-colors))))
 
-(defun nrepl--pp-listlike (object &optional foreground button)
+(defun nrepl-log--pp-listlike (object &optional foreground button)
   "Pretty print nREPL list like OBJECT.
-FOREGROUND and BUTTON are as in `nrepl--pp'."
+FOREGROUND and BUTTON are as in `nrepl-log-pp-object'."
   (cl-flet ((color (str)
                    (propertize str 'face
                                (append '(:weight ultra-bold)
@@ -1201,12 +1201,12 @@ FOREGROUND and BUTTON are as in `nrepl--pp'."
                                                      (unless (eq (car object) 'dict)
                                                        'font-lock-keyword-face)))))
                         (insert str)
-                        (nrepl--pp (cadr l) nil button)))
+                        (nrepl-log-pp-object (cadr l) nil button)))
           (when (eq (car object) 'dict)
             (delete-char -1))
           (insert (color ")\n")))))))
 
-(defun nrepl--pp (object &optional foreground button)
+(defun nrepl-log-pp-object (object &optional foreground button)
   "Pretty print nREPL OBJECT, delimited using FOREGROUND.
 If BUTTON is non-nil, try making a button from OBJECT instead of inserting
 it into the buffer."
@@ -1218,12 +1218,12 @@ it into the buffer."
         (cond
          ;; top level dicts (always expanded)
          ((memq head '(<-- -->))
-          (nrepl--pp-listlike object foreground button))
+          (nrepl-log--pp-listlike object foreground button))
          ;; inner dicts
          ((eq head 'dict)
           (if (and button (> (length object) min-dict-fold-size))
               (nrepl-log-insert-button "(dict ...)" object)
-            (nrepl--pp-listlike object foreground button)))
+            (nrepl-log--pp-listlike object foreground button)))
          ;; lists
          (t
           (if (and button (> (length object) min-list-fold-size))

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -1058,11 +1058,12 @@ operations.")
 
 (defvar nrepl-messages-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "n") #'next-line)
-    (define-key map (kbd "p") #'previous-line)
+    (define-key map (kbd "n")   #'next-line)
+    (define-key map (kbd "p")   #'previous-line)
     (define-key map (kbd "TAB") #'forward-button)
-    (define-key map (kbd "e")  #'nrepl-log-expand-button)
-    (define-key map (kbd "E")  #'nrepl-log-expand-all-buttons)
+    (define-key map (kbd "RET") #'nrepl-log-expand-button)
+    (define-key map (kbd "e")   #'nrepl-log-expand-button)
+    (define-key map (kbd "E")   #'nrepl-log-expand-all-buttons)
     (define-key map (kbd "<backtab>") #'backward-button)
     map))
 
@@ -1086,11 +1087,8 @@ operations.")
 
 (defun nrepl-log-message (msg type)
   "Log the nREPL MSG.
-
-TYPE is either request or response.
-
-The message is logged to a buffer described by
-`nrepl-message-buffer-name-template'."
+TYPE is either request or response.  The message is logged to a buffer
+described by `nrepl-message-buffer-name-template'."
   (when nrepl-log-messages
     (with-current-buffer (nrepl-messages-buffer (current-buffer))
       (setq buffer-read-only nil)
@@ -1100,8 +1098,8 @@ The message is logged to a buffer described by
         (delete-region (point-min) (- (point) 1)))
       (goto-char (point-max))
       (nrepl-log-pp-object (nrepl-decorate-msg msg type)
-                 (nrepl-log--message-color (lax-plist-get (cdr msg) "id"))
-                 t)
+                           (nrepl-log--message-color (lax-plist-get (cdr msg) "id"))
+                           t)
       (when-let ((win (get-buffer-window)))
         (set-window-point win (point-max)))
       (setq buffer-read-only t))))
@@ -1168,8 +1166,9 @@ EVENT gives the button position on window."
                  'action #'nrepl-log-expand-button
                  'face 'link
                  'help-echo "RET: Expand object."
-                 ;; Workaround for bug#1568.
-                 'local-map '(keymap (mouse-1 . nrepl-log--expand-button-mouse)))
+                 ;; Workaround for bug#1568 (don't use local-map here; it
+                 ;; overwrites major mode map.)
+                 'keymap `(keymap (mouse-1 . nrepl-log--expand-button-mouse)))
   (insert "\n"))
 
 (defun nrepl-log--message-color (id)


### PR DESCRIPTION
Instead of removing the pp logic I have moved it to a different place. The pp print of big dicts, lists and strings now happens on requests only, i.e. when the user clicks the expansion button. This completely removes logger overhead. In my tests I don't see `nrepl-message-log` in the profiler tree anymore. 

Not closing the #1758 as there seem to be much more going on there.