### PR TITLE
[Fix #1707] Disable line truncating in cider-test-report-mode

### DIFF
--- a/cider-test.el
+++ b/cider-test.el
@@ -198,7 +198,6 @@
 
 \\{cider-test-report-mode-map}"
   (setq buffer-read-only t)
-  (setq-local truncate-lines t)
   (setq-local electric-indent-chars nil))
 
 ;; Report navigation


### PR DESCRIPTION
This removes setting buffer local variable `truncate-lines` for `cider-test-report` buffer which caused #1707.

Although I don't know if line wrapping in whole report buffer is wanted behaviour?
