### PR TITLE
[Fix #943] Make cider-repl-result-prefix work for multiline strings

### DIFF
--- a/cider-repl.el
+++ b/cider-repl.el
@@ -613,12 +613,14 @@ If BOL is non-nil insert at the beginning of the line."
           (goto-char cider-repl-input-start-mark)
           (when (and bol (not (bolp)))
             (insert-before-markers "\n"))
-          (insert-before-markers (propertize cider-repl-result-prefix 'font-lock-face 'font-lock-comment-face))
-          (if cider-repl-use-clojure-font-lock
-              (insert-before-markers (cider-font-lock-as-clojure string))
-            (cider-propertize-region
-                '(font-lock-face cider-repl-result-face rear-nonsticky (font-lock-face))
-              (insert-before-markers string))))))
+          (let ((prefixed-string (mapconcat (lambda (s) (concat cider-repl-result-prefix s))
+                                            (butlast (split-string string "\n") 1)
+                                            "\n")))
+            (if cider-repl-use-clojure-font-lock
+                (insert-before-markers (cider-font-lock-as-clojure prefixed-string))
+              (cider-propertize-region
+                  '(font-lock-face cider-repl-result-face rear-nonsticky (font-lock-face))
+                (insert-before-markers prefixed-string)))))))
     (cider-repl--show-maximum-output)))
 
 (defun cider-repl-newline-and-indent ()


### PR DESCRIPTION
This commit fixes issue where only first line of multilne string
returned by repl was prefixed.

As it changes repl output string, font locking prefix and repl output
separately would not work and was removed.

--
This means that `cider-repl-result-prefix` won't be font locked as comment and rest of output will by font loced with `cider-font-lock-as-clojure`. This looks nice if prefix is someting like `;; => ` and not so bad with other values :)

If old behaviour is something necessary it can be done with some more work, let me know if this is good enough.