### PR TITLE
[Fix #1582] Add function names to cheatsheet

### DIFF
--- a/doc/interactive_programming.md
+++ b/doc/interactive_programming.md
@@ -16,54 +16,56 @@ with it.
 
 Here's a list of `cider-mode`'s keybindings:
 
- Keyboard shortcut                    | Description
---------------------------------------|-------------------------------
-<kbd>C-x C-e</kbd> <br/> <kbd>C-c C-e</kbd>| Evaluate the form preceding point and display the result in the echo area and/or in an buffer overlay (according to `cider-use-overlays`).  If invoked with a prefix argument, insert the result into the current buffer.
-<kbd>C-c C-v w</kbd>                   | Evaluate the form preceding point and replace it with its result.
-<kbd>C-c M-e</kbd>                   | Evaluate the form preceding point and output it result to the REPL buffer.  If invoked with a prefix argument, takes you to the REPL buffer after being invoked.
-<kbd>C-c M-p</kbd>                   | Load the form preceding point in the REPL buffer.
-<kbd>C-c C-p</kbd>                   | Evaluate the form preceding point and pretty-print the result in a popup buffer.
-<kbd>C-c C-f</kbd>                   | Evaluate the top level form under point and pretty-print the result in a popup buffer.
-<kbd>C-M-x</kbd> <br/> <kbd>C-c C-c</kbd>  | Evaluate the top level form under point and display the result in the echo area.
-<kbd>C-c C-v v</kbd>                   | Evaluate the form around point.
-<kbd>C-u C-M-x</kbd> <br/> <kbd>C-u C-c C-c</kbd>  | Debug the top level form under point and walk through its evaluation
-<kbd>C-c C-v r</kbd>                   | Evaluate the region and display the result in the echo area.
-<kbd>C-c C-b</kbd>                   | Interrupt any pending evaluations.
-<kbd>C-c C-m</kbd>                   | Invoke `macroexpand-1` on the form at point and display the result in a macroexpansion buffer.  If invoked with a prefix argument, `macroexpand` is used instead of `macroexpand-1`.
-<kbd>C-c M-m</kbd>                   | Invoke `clojure.walk/macroexpand-all` on the form at point and display the result in a macroexpansion buffer.
-<kbd>C-c C-v n</kbd>                   | Eval the ns form.
-<kbd>C-c M-n</kbd>                   | Switch the namespace of the REPL buffer to the namespace of the current buffer.
-<kbd>C-c C-z</kbd>                   | Switch to the relevant REPL buffer. Use a prefix argument to change the namespace of the REPL buffer to match the currently visited source file.
-<kbd>C-u C-u C-c C-z</kbd>           | Switch to the REPL buffer based on a user prompt for a directory.
-<kbd>C-c M-z</kbd>         | Load (eval) the current buffer and switch to the relevant REPL buffer. Use a prefix argument to change the namespace of the REPL buffer to match the currently visited source file.
-<kbd>C-c M-d</kbd>                   | Display default REPL connection details, including project directory name, buffer namespace, host and port.
-<kbd>C-c M-r</kbd>                   | Rotate and display the default nREPL connection.
-<kbd>C-c C-o</kbd>                   | Clear the last output in the REPL buffer. With a prefix argument it will clear the entire REPL buffer, leaving only a prompt. Useful if you're running the REPL buffer in a side by side buffer.
-<kbd>C-c C-k</kbd>                   | Load (eval) the current buffer.
-<kbd>C-c C-l</kbd>                   | Load (eval) a Clojure file.
-<kbd>C-c C-x</kbd>                   | Reload all modified files on the classpath. If invoked with a prefix argument, reload all files on the classpath. If invoked with a double prefix argument, clear the state of the namespace tracker before reloading.
-<kbd>C-c C-d d</kbd> <br/> <kbd>C-c C-d C-d</kbd> | Display doc string for the symbol at point.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.
-<kbd>C-c C-d j</kbd> <br/> <kbd>C-c C-d C-j</kbd> | Display JavaDoc (in your default browser) for the symbol at point.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.
-<kbd>C-c C-d r</kbd> <br/> <kbd>C-c C-d C-r</kbd> | Lookup symbol in Grimoire.
-<kbd>C-c C-d a</kbd> <br/> <kbd>C-c C-d C-a</kbd> | Apropos search for functions/vars.
-<kbd>C-c C-d f</kbd> <br/> <kbd>C-c C-d C-f</kbd> | Apropos search for documentation.
-<kbd>C-c M-i</kbd>                   | Inspect expression. Will act on expression at point if present.
-<kbd>C-c M-t v</kbd>                 | Toggle var tracing.
-<kbd>C-c M-t n</kbd>                 | Toggle namespace tracing.
-<kbd>C-c C-u</kbd>                   | Undefine a symbol. If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.
-<kbd>C-c C-t t</kbd> <br/> <kbd>C-c C-t C-t</kbd> | Run test at point.
-<kbd>C-c C-t g</kbd> <br/> <kbd>C-c C-t C-g</kbd> | Re-run the last test you ran.
-<kbd>C-c C-t n</kbd> <br/> <kbd>C-c C-t C-n</kbd> | Run tests for current namespace.
-<kbd>C-c C-t l</kbd> <br/> <kbd>C-c C-t C-l</kbd> | Run tests for all loaded namespaces.
-<kbd>C-c C-t p</kbd> <br/> <kbd>C-c C-t C-p</kbd> | Run tests for all project namespaces. This loads the additional namespaces.
-<kbd>C-c C-t r</kbd> <br/> <kbd>C-c C-t C-r</kbd> | Re-run test failures/errors.
-<kbd>C-c C-t b</kbd> <br/> <kbd>C-c C-t C-b</kbd> | Show the test report buffer.
-<kbd>M-.</kbd>                       | Jump to the definition of a symbol.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.
-<kbd>C-c M-.</kbd>                   | Jump to the resource referenced by the string at point.
-<kbd>C-c C-.</kbd>                   | Jump to some namespace on the classpath.
-<kbd>M-,</kbd>                       | Return to your pre-jump location.
-<kbd>M-TAB</kbd>                     | Complete the symbol at point.
-<kbd>C-c C-q</kbd>                   | Quit the current nREPL connection. With a prefix argument it will quit all connections.
+ Function                                   | Keyboard shortcut                   | Description
+--------------------------------------------|-------------------------------------|-------------------------------
+cider-eval-last-sexp                        |<kbd>C-x C-e</kbd> <br/> <kbd>C-c C-e</kbd>| Evaluate the form preceding point and display the result in the echo area and/or in an buffer overlay (according to `cider-use-overlays`).  If invoked with a prefix argument, insert the result into the current buffer.
+cider-eval-last-sexp-and-replace            |<kbd>C-c C-v w</kbd>                 | Evaluate the form preceding point and replace it with its result.
+cider-eval-last-sexp-to-repl                |<kbd>C-c M-e</kbd>                   | Evaluate the form preceding point and output it result to the REPL buffer.  If invoked with a prefix argument, takes you to the REPL buffer after being invoked.
+cider-insert-last-sexp-in-repl              |<kbd>C-c M-p</kbd>                   | Load the form preceding point in the REPL buffer.
+cider-pprint-eval-last-sexp                 |<kbd>C-c C-p</kbd>                   | Evaluate the form preceding point and pretty-print the result in a popup buffer.
+cider-pprint-eval-defun-at-point            |<kbd>C-c C-f</kbd>                   | Evaluate the top level form under point and pretty-print the result in a popup buffer.
+cider-eval-defun-at-point                   |<kbd>C-M-x</kbd> <br/> <kbd>C-c C-c</kbd>  | Evaluate the top level form under point and display the result in the echo area.
+cider-eval-sexp-at-point                    |<kbd>C-c C-v v</kbd>                 | Evaluate the form around point.
+                                            |<kbd>C-u C-M-x</kbd> <br/> <kbd>C-u C-c C-c</kbd>  | Debug the top level form under point and walk through its evaluation
+cider-eval-region                           |<kbd>C-c C-v r</kbd>                 | Evaluate the region and display the result in the echo area.
+cider-interrupt                             |<kbd>C-c C-b</kbd>                   | Interrupt any pending evaluations.
+cider-macroexpand-1                         |<kbd>C-c C-m</kbd>                   | Invoke `macroexpand-1` on the form at point and display the result in a macroexpansion buffer.  If invoked with a prefix argument, `macroexpand` is used instead of `macroexpand-1`.
+cider-macroexpand-all                       |<kbd>C-c M-m</kbd>                   | Invoke `clojure.walk/macroexpand-all` on the form at point and display the result in a macroexpansion buffer.
+cider-eval-ns-form                          |<kbd>C-c C-v n</kbd>                 | Eval the ns form.
+cider-repl-set-ns                           |<kbd>C-c M-n</kbd>                   | Switch the namespace of the REPL buffer to the namespace of the current buffer. 
+cider-switch-to-repl-buffer                 |<kbd>C-c C-z</kbd>                   | Switch to the relevant REPL buffer. Use a prefix argument to change the namespace of the REPL buffer to match the currently visited source file.
+                                            |<kbd>C-u C-u C-c C-z</kbd>           | Switch to the REPL buffer based on a user prompt for a directory.
+cider-load-buffer-and-switch-to-repl-buffer |<kbd>C-c M-z</kbd>                   | Load (eval) the current buffer and switch to the relevant REPL buffer. Use a prefix argument to change the namespace of the REPL buffer to match the currently visited source file.
+cider-display-connection-info               |<kbd>C-c M-d</kbd>                   | Display default REPL connection details, including project directory name, buffer namespace, host and port.
+сider-rotate-default-connection             |<kbd>C-c M-r</kbd>                   | Rotate and display the default nREPL connection.
+cider-find-and-clear-repl-output            |<kbd>C-c C-o</kbd>                   | Clear the last output in the REPL buffer. With a prefix argument it will clear the entire REPL buffer, leaving only a prompt. Useful if you're running the REPL buffer in a side by side buffer.
+cider-load-buffer                           |<kbd>C-c C-k</kbd>                   | Load (eval) the current buffer.
+cider-load-file                             |<kbd>C-c C-l</kbd>                   | Load (eval) a Clojure file.
+cider-refresh                               |<kbd>C-c C-x</kbd>                   | Reload all modified files on the classpath. If invoked with a prefix argument, reload all files on the classpath. If invoked with a double prefix argument, clear the state of the namespace tracker before reloading.
+cider-doc                                   |<kbd>C-c C-d d</kbd> <br/> <kbd>C-c C-d C-d</kbd> | Display doc string for the symbol at point.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.
+cider-javadoc                               |<kbd>C-c C-d j</kbd> <br/> <kbd>C-c C-d C-j</kbd> | Display JavaDoc (in your default browser) for the symbol at point.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.
+cider-grimoire                              |<kbd>C-c C-d r</kbd> <br/> <kbd>C-c C-d C-r</kbd> | Lookup symbol in Grimoire.
+cider-grimoire-web                          |<kbd>C-c C-d w</kbd> <br/> <kbd>C-c C-d C-w</kbd> | Open the grimoire documentation for symbol in a web browser.
+cider-apropos                               |<kbd>C-c C-d a</kbd> <br/> <kbd>C-c C-d C-a</kbd> | Apropos search for functions/vars.
+cider-apropos-documentation                 |<kbd>C-c C-d f</kbd> <br/> <kbd>C-c C-d C-f</kbd> | Apropos search for documentation.
+cider-apropos-documentation-select          |<kbd>C-c C-d e</kbd> <br/> <kbd>C-c C-d C-e</kbd> | Apropos search for documentation & select.
+cider-inspect                               |<kbd>C-c M-i</kbd>                   | Inspect expression. Will act on expression at point if present.
+cider-toggle-trace-var                      |<kbd>C-c M-t v</kbd>                 | Toggle var tracing.
+cider-toggle-trace-ns                       |<kbd>C-c M-t n</kbd>                 | Toggle namespace tracing.
+cider-undef                                 |<kbd>C-c C-u</kbd>                   | Undefine a symbol. If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.
+cider-test-run-test                         |<kbd>C-c C-t t</kbd> <br/> <kbd>C-c C-t C-t</kbd> | Run test at point.
+cider-test-rerun-test                       |<kbd>C-c C-t g</kbd> <br/> <kbd>C-c C-t C-g</kbd> | Re-run the last test you ran.
+cider-test-run-ns-tests                     |<kbd>C-c C-t n</kbd> <br/> <kbd>C-c C-t C-n</kbd> | Run tests for current namespace.
+cider-test-run-loaded-tests                 |<kbd>C-c C-t l</kbd> <br/> <kbd>C-c C-t C-l</kbd> | Run tests for all loaded namespaces.
+cider-test-run-project-tests                |<kbd>C-c C-t p</kbd> <br/> <kbd>C-c C-t C-p</kbd> | Run tests for all project namespaces. This loads the additional namespaces.
+cider-test-rerun-failed-tests               |<kbd>C-c C-t r</kbd> <br/> <kbd>C-c C-t C-r</kbd> | Re-run test failures/errors.
+cider-test-show-report                      |<kbd>C-c C-t b</kbd> <br/> <kbd>C-c C-t C-b</kbd> | Show the test report buffer.
+cider-find-var                              |<kbd>M-.</kbd>                       | Jump to the definition of a symbol.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.
+cider-find-resource                         |<kbd>C-c M-.</kbd>                   | Jump to the resource referenced by the string at point.
+cider-find-ns                               |<kbd>C-c C-.</kbd>                   | Jump to some namespace on the classpath.
+cider-pop-back                              |<kbd>M-,</kbd>                       | Return to your pre-jump location.
+complete-symbol                             |<kbd>M-TAB</kbd>                     | Complete the symbol at point.
+cider-quit                                  |<kbd>C-c C-q</kbd>                   | Quit the current nREPL connection. With a prefix argument it will quit all connections.
 
 There's no need to memorize this list. In any Clojure buffer with `cider-mode`
 active you'll have a CIDER menu available, which lists all the most important

--- a/doc/interactive_programming.md
+++ b/doc/interactive_programming.md
@@ -16,56 +16,56 @@ with it.
 
 Here's a list of `cider-mode`'s keybindings:
 
- Function                                   | Keyboard shortcut                   | Description
---------------------------------------------|-------------------------------------|-------------------------------
-cider-eval-last-sexp                        |<kbd>C-x C-e</kbd> <br/> <kbd>C-c C-e</kbd>| Evaluate the form preceding point and display the result in the echo area and/or in an buffer overlay (according to `cider-use-overlays`).  If invoked with a prefix argument, insert the result into the current buffer.
-cider-eval-last-sexp-and-replace            |<kbd>C-c C-v w</kbd>                 | Evaluate the form preceding point and replace it with its result.
-cider-eval-last-sexp-to-repl                |<kbd>C-c M-e</kbd>                   | Evaluate the form preceding point and output it result to the REPL buffer.  If invoked with a prefix argument, takes you to the REPL buffer after being invoked.
-cider-insert-last-sexp-in-repl              |<kbd>C-c M-p</kbd>                   | Load the form preceding point in the REPL buffer.
-cider-pprint-eval-last-sexp                 |<kbd>C-c C-p</kbd>                   | Evaluate the form preceding point and pretty-print the result in a popup buffer.
-cider-pprint-eval-defun-at-point            |<kbd>C-c C-f</kbd>                   | Evaluate the top level form under point and pretty-print the result in a popup buffer.
-cider-eval-defun-at-point                   |<kbd>C-M-x</kbd> <br/> <kbd>C-c C-c</kbd>  | Evaluate the top level form under point and display the result in the echo area.
-cider-eval-sexp-at-point                    |<kbd>C-c C-v v</kbd>                 | Evaluate the form around point.
-                                            |<kbd>C-u C-M-x</kbd> <br/> <kbd>C-u C-c C-c</kbd>  | Debug the top level form under point and walk through its evaluation
-cider-eval-region                           |<kbd>C-c C-v r</kbd>                 | Evaluate the region and display the result in the echo area.
-cider-interrupt                             |<kbd>C-c C-b</kbd>                   | Interrupt any pending evaluations.
-cider-macroexpand-1                         |<kbd>C-c C-m</kbd>                   | Invoke `macroexpand-1` on the form at point and display the result in a macroexpansion buffer.  If invoked with a prefix argument, `macroexpand` is used instead of `macroexpand-1`.
-cider-macroexpand-all                       |<kbd>C-c M-m</kbd>                   | Invoke `clojure.walk/macroexpand-all` on the form at point and display the result in a macroexpansion buffer.
-cider-eval-ns-form                          |<kbd>C-c C-v n</kbd>                 | Eval the ns form.
-cider-repl-set-ns                           |<kbd>C-c M-n</kbd>                   | Switch the namespace of the REPL buffer to the namespace of the current buffer. 
-cider-switch-to-repl-buffer                 |<kbd>C-c C-z</kbd>                   | Switch to the relevant REPL buffer. Use a prefix argument to change the namespace of the REPL buffer to match the currently visited source file.
-                                            |<kbd>C-u C-u C-c C-z</kbd>           | Switch to the REPL buffer based on a user prompt for a directory.
-cider-load-buffer-and-switch-to-repl-buffer |<kbd>C-c M-z</kbd>                   | Load (eval) the current buffer and switch to the relevant REPL buffer. Use a prefix argument to change the namespace of the REPL buffer to match the currently visited source file.
-cider-display-connection-info               |<kbd>C-c M-d</kbd>                   | Display default REPL connection details, including project directory name, buffer namespace, host and port.
-сider-rotate-default-connection             |<kbd>C-c M-r</kbd>                   | Rotate and display the default nREPL connection.
-cider-find-and-clear-repl-output            |<kbd>C-c C-o</kbd>                   | Clear the last output in the REPL buffer. With a prefix argument it will clear the entire REPL buffer, leaving only a prompt. Useful if you're running the REPL buffer in a side by side buffer.
-cider-load-buffer                           |<kbd>C-c C-k</kbd>                   | Load (eval) the current buffer.
-cider-load-file                             |<kbd>C-c C-l</kbd>                   | Load (eval) a Clojure file.
-cider-refresh                               |<kbd>C-c C-x</kbd>                   | Reload all modified files on the classpath. If invoked with a prefix argument, reload all files on the classpath. If invoked with a double prefix argument, clear the state of the namespace tracker before reloading.
-cider-doc                                   |<kbd>C-c C-d d</kbd> <br/> <kbd>C-c C-d C-d</kbd> | Display doc string for the symbol at point.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.
-cider-javadoc                               |<kbd>C-c C-d j</kbd> <br/> <kbd>C-c C-d C-j</kbd> | Display JavaDoc (in your default browser) for the symbol at point.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.
-cider-grimoire                              |<kbd>C-c C-d r</kbd> <br/> <kbd>C-c C-d C-r</kbd> | Lookup symbol in Grimoire.
-cider-grimoire-web                          |<kbd>C-c C-d w</kbd> <br/> <kbd>C-c C-d C-w</kbd> | Open the grimoire documentation for symbol in a web browser.
-cider-apropos                               |<kbd>C-c C-d a</kbd> <br/> <kbd>C-c C-d C-a</kbd> | Apropos search for functions/vars.
-cider-apropos-documentation                 |<kbd>C-c C-d f</kbd> <br/> <kbd>C-c C-d C-f</kbd> | Apropos search for documentation.
-cider-apropos-documentation-select          |<kbd>C-c C-d e</kbd> <br/> <kbd>C-c C-d C-e</kbd> | Apropos search for documentation & select.
-cider-inspect                               |<kbd>C-c M-i</kbd>                   | Inspect expression. Will act on expression at point if present.
-cider-toggle-trace-var                      |<kbd>C-c M-t v</kbd>                 | Toggle var tracing.
-cider-toggle-trace-ns                       |<kbd>C-c M-t n</kbd>                 | Toggle namespace tracing.
-cider-undef                                 |<kbd>C-c C-u</kbd>                   | Undefine a symbol. If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.
-cider-test-run-test                         |<kbd>C-c C-t t</kbd> <br/> <kbd>C-c C-t C-t</kbd> | Run test at point.
-cider-test-rerun-test                       |<kbd>C-c C-t g</kbd> <br/> <kbd>C-c C-t C-g</kbd> | Re-run the last test you ran.
-cider-test-run-ns-tests                     |<kbd>C-c C-t n</kbd> <br/> <kbd>C-c C-t C-n</kbd> | Run tests for current namespace.
-cider-test-run-loaded-tests                 |<kbd>C-c C-t l</kbd> <br/> <kbd>C-c C-t C-l</kbd> | Run tests for all loaded namespaces.
-cider-test-run-project-tests                |<kbd>C-c C-t p</kbd> <br/> <kbd>C-c C-t C-p</kbd> | Run tests for all project namespaces. This loads the additional namespaces.
-cider-test-rerun-failed-tests               |<kbd>C-c C-t r</kbd> <br/> <kbd>C-c C-t C-r</kbd> | Re-run test failures/errors.
-cider-test-show-report                      |<kbd>C-c C-t b</kbd> <br/> <kbd>C-c C-t C-b</kbd> | Show the test report buffer.
-cider-find-var                              |<kbd>M-.</kbd>                       | Jump to the definition of a symbol.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.
-cider-find-resource                         |<kbd>C-c M-.</kbd>                   | Jump to the resource referenced by the string at point.
-cider-find-ns                               |<kbd>C-c C-.</kbd>                   | Jump to some namespace on the classpath.
-cider-pop-back                              |<kbd>M-,</kbd>                       | Return to your pre-jump location.
-complete-symbol                             |<kbd>M-TAB</kbd>                     | Complete the symbol at point.
-cider-quit                                  |<kbd>C-c C-q</kbd>                   | Quit the current nREPL connection. With a prefix argument it will quit all connections.
+ Command                                      | Keyboard shortcut                   | Description
+----------------------------------------------|-------------------------------------|-------------------------------
+`cider-eval-last-sexp`                        |<kbd>C-x C-e</kbd> <br/> <kbd>C-c C-e</kbd>| Evaluate the form preceding point and display the result in the echo area and/or in an buffer overlay (according to `cider-use-overlays`).  If invoked with a prefix argument, insert the result into the current buffer.
+`cider-eval-last-sexp-and-replace`            |<kbd>C-c C-v w</kbd>                 | Evaluate the form preceding point and replace it with its result.
+`cider-eval-last-sexp-to-repl`                |<kbd>C-c M-e</kbd>                   | Evaluate the form preceding point and output it result to the REPL buffer.  If invoked with a prefix argument, takes you to the REPL buffer after being invoked.
+`cider-insert-last-sexp-in-repl`              |<kbd>C-c M-p</kbd>                   | Load the form preceding point in the REPL buffer.
+`cider-pprint-eval-last-sexp`                 |<kbd>C-c C-p</kbd>                   | Evaluate the form preceding point and pretty-print the result in a popup buffer.
+`cider-pprint-eval-defun-at-point`            |<kbd>C-c C-f</kbd>                   | Evaluate the top level form under point and pretty-print the result in a popup buffer.
+`cider-eval-defun-at-point`                   |<kbd>C-M-x</kbd> <br/> <kbd>C-c C-c</kbd>  | Evaluate the top level form under point and display the result in the echo area.
+`cider-eval-sexp-at-point`                    |<kbd>C-c C-v v</kbd>                 | Evaluate the form around point.
+`cider-eval-defun-at-point`                   |<kbd>C-u C-M-x</kbd> <br/> <kbd>C-u C-c C-c</kbd>  | Debug the top level form under point and walk through its evaluation
+`cider-eval-region`                           |<kbd>C-c C-v r</kbd>                 | Evaluate the region and display the result in the echo area.
+`cider-interrupt`                             |<kbd>C-c C-b</kbd>                   | Interrupt any pending evaluations.
+`cider-macroexpand-1`                         |<kbd>C-c C-m</kbd>                   | Invoke `macroexpand-1` on the form at point and display the result in a macroexpansion buffer.  If invoked with a prefix argument, `macroexpand` is used instead of `macroexpand-1`.
+`cider-macroexpand-all`                       |<kbd>C-c M-m</kbd>                   | Invoke `clojure.walk/macroexpand-all` on the form at point and display the result in a macroexpansion buffer.
+`cider-eval-ns-form`                          |<kbd>C-c C-v n</kbd>                 | Eval the ns form.
+`cider-repl-set-ns`                           |<kbd>C-c M-n</kbd>                   | Switch the namespace of the REPL buffer to the namespace of the current buffer. 
+`cider-switch-to-repl-buffer`                 |<kbd>C-c C-z</kbd>                   | Switch to the relevant REPL buffer. Use a prefix argument to change the namespace of the REPL buffer to match the currently visited source file.
+`cider-switch-to-repl-buffer`                 |<kbd>C-u C-u C-c C-z</kbd>           | Switch to the REPL buffer based on a user prompt for a directory.
+`cider-load-buffer-and-switch-to-repl-buffer` |<kbd>C-c M-z</kbd>                   | Load (eval) the current buffer and switch to the relevant REPL buffer. Use a prefix argument to change the namespace of the REPL buffer to match the currently visited source file.
+`cider-display-connection-info`               |<kbd>C-c M-d</kbd>                   | Display default REPL connection details, including project directory name, buffer namespace, host and port.
+`cider-rotate-default-connection`             |<kbd>C-c M-r</kbd>                   | Rotate and display the default nREPL connection.
+`cider-find-and-clear-repl-output`            |<kbd>C-c C-o</kbd>                   | Clear the last output in the REPL buffer. With a prefix argument it will clear the entire REPL buffer, leaving only a prompt. Useful if you're running the REPL buffer in a side by side buffer.
+`cider-load-buffer`                           |<kbd>C-c C-k</kbd>                   | Load (eval) the current buffer.
+`cider-load-file`                             |<kbd>C-c C-l</kbd>                   | Load (eval) a Clojure file.
+`cider-refresh`                               |<kbd>C-c C-x</kbd>                   | Reload all modified files on the classpath. If invoked with a prefix argument, reload all files on the classpath. If invoked with a double prefix argument, clear the state of the namespace tracker before reloading.
+`cider-doc`                                   |<kbd>C-c C-d d</kbd> <br/> <kbd>C-c C-d C-d</kbd> | Display doc string for the symbol at point.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.
+`cider-javadoc`                               |<kbd>C-c C-d j</kbd> <br/> <kbd>C-c C-d C-j</kbd> | Display JavaDoc (in your default browser) for the symbol at point.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.
+`cider-grimoire`                              |<kbd>C-c C-d r</kbd> <br/> <kbd>C-c C-d C-r</kbd> | Lookup symbol in Grimoire.
+`cider-grimoire-web`                          |<kbd>C-c C-d w</kbd> <br/> <kbd>C-c C-d C-w</kbd> | Open the grimoire documentation for symbol in a web browser.
+`cider-apropos`                               |<kbd>C-c C-d a</kbd> <br/> <kbd>C-c C-d C-a</kbd> | Apropos search for functions/vars.
+`cider-apropos-documentation`                 |<kbd>C-c C-d f</kbd> <br/> <kbd>C-c C-d C-f</kbd> | Apropos search for documentation.
+`cider-apropos-documentation-select`          |<kbd>C-c C-d e</kbd> <br/> <kbd>C-c C-d C-e</kbd> | Apropos search for documentation & select.
+`cider-inspect`                               |<kbd>C-c M-i</kbd>                   | Inspect expression. Will act on expression at point if present.
+`cider-toggle-trace-var`                      |<kbd>C-c M-t v</kbd>                 | Toggle var tracing.
+`cider-toggle-trace-ns`                       |<kbd>C-c M-t n</kbd>                 | Toggle namespace tracing.
+`cider-undef`                                 |<kbd>C-c C-u</kbd>                   | Undefine a symbol. If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.
+`cider-test-run-test`                         |<kbd>C-c C-t t</kbd> <br/> <kbd>C-c C-t C-t</kbd> | Run test at point.
+`cider-test-rerun-test`                       |<kbd>C-c C-t g</kbd> <br/> <kbd>C-c C-t C-g</kbd> | Re-run the last test you ran.
+`cider-test-run-ns-tests`                     |<kbd>C-c C-t n</kbd> <br/> <kbd>C-c C-t C-n</kbd> | Run tests for current namespace.
+`cider-test-run-loaded-tests`                 |<kbd>C-c C-t l</kbd> <br/> <kbd>C-c C-t C-l</kbd> | Run tests for all loaded namespaces.
+`cider-test-run-project-tests`                |<kbd>C-c C-t p</kbd> <br/> <kbd>C-c C-t C-p</kbd> | Run tests for all project namespaces. This loads the additional namespaces.
+`cider-test-rerun-failed-tests`               |<kbd>C-c C-t r</kbd> <br/> <kbd>C-c C-t C-r</kbd> | Re-run test failures/errors.
+`cider-test-show-report`                      |<kbd>C-c C-t b</kbd> <br/> <kbd>C-c C-t C-b</kbd> | Show the test report buffer.
+`cider-find-var`                              |<kbd>M-.</kbd>                       | Jump to the definition of a symbol.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.
+`cider-find-resource`                         |<kbd>C-c M-.</kbd>                   | Jump to the resource referenced by the string at point.
+`cider-find-ns`                               |<kbd>C-c C-.</kbd>                   | Jump to some namespace on the classpath.
+`cider-pop-back`                              |<kbd>M-,</kbd>                       | Return to your pre-jump location.
+`complete-symbol`                             |<kbd>M-TAB</kbd>                     | Complete the symbol at point.
+`cider-quit`                                  |<kbd>C-c C-q</kbd>                   | Quit the current nREPL connection. With a prefix argument it will quit all connections.
 
 There's no need to memorize this list. In any Clojure buffer with `cider-mode`
 active you'll have a CIDER menu available, which lists all the most important

--- a/doc/managing_connections.md
+++ b/doc/managing_connections.md
@@ -36,7 +36,7 @@ Command                              |Keyboard shortcut               | Descript
 `cider-connections-close-connection` |<kbd>k</kbd>                    | Close connection at point.
 `cider-connection-browser`           |<kbd>g</kbd>                    | Refresh connection browser.
 `cider-connections-goto-connection`  |<kbd>RET</kbd>                  | Visit connection buffer.
-`cider--close-connection-buffer`     |<kbd>q</kbd>                    | Close window.
+`cider-popup-buffer-quit-function`   |<kbd>q</kbd>                    | Close window.
 
 ## Switch to connection buffer
 

--- a/doc/managing_connections.md
+++ b/doc/managing_connections.md
@@ -30,13 +30,13 @@ REPL buffer.
 You can obtain a list of all active connections using <kbd>M-x</kbd>
 `cider-connection-browser`. This buffer provides a few extra keybindings:
 
-Keyboard shortcut               | Description
---------------------------------|-------------------------------
-<kbd>d</kbd>                    | Make connection at point default.
-<kbd>k</kbd>                    | Close connection at point.
-<kbd>g</kbd>                    | Refresh connection browser.
-<kbd>RET</kbd>                  | Visit connection buffer.
-<kbd>q</kbd>                    | Close window.
+Command                              |Keyboard shortcut               | Description
+-------------------------------------|--------------------------------|-------------------------------
+`cider-connections-make-default`     |<kbd>d</kbd>                    | Make connection at point default.
+`cider-connections-close-connection` |<kbd>k</kbd>                    | Close connection at point.
+`cider-connection-browser`           |<kbd>g</kbd>                    | Refresh connection browser.
+`cider-connections-goto-connection`  |<kbd>RET</kbd>                  | Visit connection buffer.
+`cider--close-connection-buffer`     |<kbd>q</kbd>                    | Close window.
 
 ## Switch to connection buffer
 

--- a/doc/navigating_stacktraces.md
+++ b/doc/navigating_stacktraces.md
@@ -4,24 +4,24 @@ stacktraces.  Stacktraces are presented in a special major mode
 stack frames and some handy ways to navigate causes.  You'll also be able to go
 to the code in question with a single keystroke.
 
-Keyboard shortcut                    | Description
--------------------------------------|-------------------------------
-<kbd>M-p</kbd>                       | Move point to previous cause
-<kbd>M-n</kbd>                       | Move point to next cause
-<kbd>M-.</kbd> or <kbd>Return</kbd>  | Navigate to the source location (if available) for the stacktrace frame
-<kbd>Tab</kbd>                       | Cycle current cause detail
-<kbd>0</kbd> or <kbd>S-Tab</kbd>     | Cycle all cause detail
-<kbd>1</kbd>                         | Cycle cause #1 detail
-<kbd>2</kbd>                         | Cycle cause #2 detail
-<kbd>3</kbd>                         | Cycle cause #3 detail
-<kbd>4</kbd>                         | Cycle cause #4 detail
-<kbd>5</kbd>                         | Cycle cause #5 detail
-<kbd>j</kbd>                         | Toggle display of Java frames
-<kbd>c</kbd>                         | Toggle display of Clojure frames
-<kbd>r</kbd>                         | Toggle display of REPL frames
-<kbd>t</kbd>                         | Toggle display of tooling frames (e.g. compiler, nREPL middleware)
-<kbd>d</kbd>                         | Toggle display of duplicate frames
-<kbd>a</kbd>                         | Toggle display of all frames
+Command                                | Keyboard shortcut                   | Description
+---------------------------------------|-------------------------------------|--------------
+`cider-stacktrace-previous-cause`      |<kbd>M-p</kbd>                       | Move point to previous cause
+`cider-stacktrace-next-cause`          |<kbd>M-n</kbd>                       | Move point to next cause
+`cider-stacktrace-jump`                |<kbd>M-.</kbd> or <kbd>Return</kbd>  | Navigate to the source location (if available) for the stacktrace frame
+`cider-stacktrace-cycle-current-cause` |<kbd>Tab</kbd>                       | Cycle current cause detail
+`cider-stacktrace-cycle-all-causes`    |<kbd>0</kbd> or <kbd>S-Tab</kbd>     | Cycle all cause detail
+`cider-stacktrace-cycle-cause-1`       |<kbd>1</kbd>                         | Cycle cause #1 detail
+`cider-stacktrace-cycle-cause-2`       |<kbd>2</kbd>                         | Cycle cause #2 detail
+`cider-stacktrace-cycle-cause-3`       |<kbd>3</kbd>                         | Cycle cause #3 detail
+`cider-stacktrace-cycle-cause-4`       |<kbd>4</kbd>                         | Cycle cause #4 detail
+`cider-stacktrace-cycle-cause-5`       |<kbd>5</kbd>                         | Cycle cause #5 detail
+`cider-stacktrace-toggle-java`         |<kbd>j</kbd>                         | Toggle display of Java frames
+`cider-stacktrace-toggle-clj`          |<kbd>c</kbd>                         | Toggle display of Clojure frames
+`cider-stacktrace-toggle-repl`         |<kbd>r</kbd>                         | Toggle display of REPL frames
+`cider-stacktrace-toggle-tooling`      |<kbd>t</kbd>                         | Toggle display of tooling frames (e.g. compiler, nREPL middleware)
+`cider-stacktrace-toggle-duplicates`   |<kbd>d</kbd>                         | Toggle display of duplicate frames
+`cider-stacktrace-toggle-all`          |<kbd>a</kbd>                         | Toggle display of all frames
 
 You can configure whether the error buffer with stacktraces should be automatically
 shown on error. By default it will be displayed, but you can change this:


### PR DESCRIPTION
I added a column with the full function names as discussed.
I added two new rows - ```cider-grimoire-web``` and ```cider-apropos-documentation-select```.
I couldn't find the function names for two shortcuts - <kbd>C-u C-u C-c C-z</kbd> and <kbd>C-u C-M-x</kbd> 

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)
- [x] You've updated the refcard (if you made changes to the commands listed there)

Thanks!

[1]: https://github.com/clojure-emacs/cider/blob/master/.github/CONTRIBUTING.md

Closes #1582.