### PR TITLE
[Fix #1707] Add customization for line truncating in special buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## master (unreleased)
 
+### New Features
+
+* Add new customization variable `cider-special-mode-truncate-lines`.
+
+### Bugs Fixed
+
+* [#1707](https://github.com/clojure-emacs/cider/issues/1707): Allow to customize line truncating in CIDER's special buffers.
+
 ## 0.14.0 (2016-10-13)
 
 ### New Features

--- a/cider-browse-ns.el
+++ b/cider-browse-ns.el
@@ -71,7 +71,8 @@
 \\{cider-browse-ns-mode-map}"
   (setq buffer-read-only t)
   (setq-local electric-indent-chars nil)
-  (setq-local truncate-lines t)
+  (when cider-special-mode-truncate-lines
+    (setq-local truncate-lines t))
   (setq-local cider-browse-ns-current-ns nil))
 
 (defun cider-browse-ns--text-face (var-meta)

--- a/cider-classpath.el
+++ b/cider-classpath.el
@@ -50,7 +50,8 @@
 \\{cider-classpath-mode-map}"
   (setq buffer-read-only t)
   (setq-local electric-indent-chars nil)
-  (setq-local truncate-lines t))
+  (when cider-special-mode-truncate-lines
+    (setq-local truncate-lines t)))
 
 (defun cider-classpath-list (buffer items)
   "Populate BUFFER with ITEMS."

--- a/cider-client.el
+++ b/cider-client.el
@@ -388,7 +388,8 @@ connection but can be invoked from any buffer (like `cider-refresh')."
   "CIDER Connections Buffer Mode.
 \\{cider-connections-buffer-mode-map}
 \\{cider-popup-buffer-mode-map}"
-  (setq-local truncate-lines t))
+  (when cider-special-mode-truncate-lines
+    (setq-local truncate-lines t)))
 
 (defvar cider--connection-ewoc)
 (defconst cider--connection-browser-buffer-name "*cider-connections*")

--- a/cider-common.el
+++ b/cider-common.el
@@ -42,6 +42,13 @@ prompt if that throws an error."
   :group 'cider
   :package-version '(cider . "0.9.0"))
 
+(defcustom cider-special-mode-truncate-lines t
+  "If non-nil, contents of CIDER's special buffers will be line-truncated.
+Should be set before loading CIDER."
+  :type 'boolean
+  :group 'cider
+  :package-version '(cider . "0.15.0"))
+
 (defun cider--should-prompt-for-symbol (&optional invert)
   "Return the value of the variable `cider-prompt-for-symbol'.
 Optionally invert the value, if INVERT is truthy."

--- a/cider-doc.el
+++ b/cider-doc.el
@@ -168,7 +168,8 @@
 
 \\{cider-docview-mode-map}"
   (setq buffer-read-only t)
-  (setq-local truncate-lines t)
+  (when cider-special-mode-truncate-lines
+    (setq-local truncate-lines t))
   (setq-local electric-indent-chars nil)
   (setq-local cider-docview-symbol nil)
   (setq-local cider-docview-javadoc-url nil)

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -81,7 +81,8 @@ The page size can be also changed interactively within the inspector."
   (set-syntax-table clojure-mode-syntax-table)
   (setq buffer-read-only t)
   (setq-local electric-indent-chars nil)
-  (setq-local truncate-lines t))
+  (when cider-special-mode-truncate-lines
+    (setq-local truncate-lines t)))
 
 ;;;###autoload
 (defun cider-inspect-last-sexp ()

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -225,7 +225,8 @@ The error types are represented as strings."
 
 \\{cider-stacktrace-mode-map}"
   (setq buffer-read-only t)
-  (setq-local truncate-lines t)
+  (when cider-special-mode-truncate-lines
+    (setq-local truncate-lines t))
   (setq-local electric-indent-chars nil)
   (setq-local cider-stacktrace-prior-filters nil)
   (setq-local cider-stacktrace-hidden-frame-count 0)

--- a/cider-test.el
+++ b/cider-test.el
@@ -198,7 +198,8 @@
 
 \\{cider-test-report-mode-map}"
   (setq buffer-read-only t)
-  (setq-local truncate-lines t)
+  (when cider-special-mode-truncate-lines
+    (setq-local truncate-lines t))
   (setq-local electric-indent-chars nil))
 
 ;; Report navigation

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -125,6 +125,17 @@ More details can be found [here](https://github.com/clojure-emacs/cider/issues/9
 (setq cider-filter-regexps '(".*nrepl"))
 ```
 
+* By default contents of CIDER's special buffers such as `*cider-test-report*`
+  or `*cider-doc*` are line truncated. You can set
+  `cider-special-mode-truncate-lines` to `nil` to make those buffers use word
+  wrapping instead of line truncating.
+
+  This variable should be set before loading CIDER.
+
+``` el
+(setq cider-special-mode-truncate-lines nil)
+```
+
 ## Configuring eldoc
 
 * Enable `eldoc` in Clojure buffers:

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -70,6 +70,7 @@
 ;;; Code:
 (require 'seq)
 (require 'cider-compat)
+(require 'cider-common)
 (require 'cl-lib)
 (require 'nrepl-dict)
 (require 'queue)
@@ -1072,7 +1073,8 @@ operations.")
 
 \\{nrepl-messages-mode-map}"
   (setq buffer-read-only t)
-  (setq-local truncate-lines t)
+  (when cider-special-mode-truncate-lines
+    (setq-local truncate-lines t))
   (setq-local electric-indent-chars nil)
   (setq-local comment-start ";")
   (setq-local comment-end "")


### PR DESCRIPTION
As proposed in #1863 this commit allows to customize line truncating in CIDER's special buffers such as `cider-test-report` and `cider-doc`.

As most of those buffers (except `cidet-test-report-mode` and `cider-connections-buffer-mode`) use modes deriving `special-mode` I named it `cider-special-mode-truncate-lines`, if you can think of better name please let me know.

Side note: shouldn't `cider-test-report-mode` derive `special-mode` instead of `fundamental-mode`?
Also setting `buffer-read-only t` is redundant when deriving `special-mode`.

-----------------

- [x] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)