### PR TITLE
Add option to control whether the cider inspector window fills its frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features
 
 * Add new customization variable `cider-special-mode-truncate-lines`.
+* Add an option `cider-inspector-fill-frame` to control whether the cider inspector window fills its frame.
 
 ### Changes
 

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -53,6 +53,12 @@ The page size can be also changed interactively within the inspector."
   :group 'cider-inspector
   :package-version '(cider . "0.10.0"))
 
+(defcustom cider-inspector-fill-frame nil
+  "Controls whether the cider inspector window fills its frame."
+  :type 'boolean
+  :group 'cider-inspector
+  :package-version '(cider . "0.15.0"))
+
 (defvar cider-inspector-mode-map
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map cider-popup-buffer-mode-map)
@@ -242,6 +248,7 @@ Set the page size in paginated view to PAGE-SIZE."
   (cider-make-popup-buffer cider-inspector-buffer 'cider-inspector-mode)
   (cider-inspector-render cider-inspector-buffer value)
   (cider-popup-buffer-display cider-inspector-buffer t)
+  (when cider-inspector-fill-frame (delete-other-windows))
   (with-current-buffer cider-inspector-buffer
     (when (eq cider-inspector-last-command 'cider-inspector-pop)
       (setq cider-inspector-last-command nil)


### PR DESCRIPTION
Added an option to control whether the cider inspector window fills its frame. When non-nil, the cider inspector window will be shown as the only window instead of as a popup.

- [x] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

