### PR TITLE
Revert "Drop support for Emacs 24.3"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: true
 language: emacs-lisp
 env:
+  - EMACS_BINARY=emacs-24.3-bin PATH=$HOME/.evm/bin:$PATH MAKE_TEST=test
   - EMACS_BINARY=emacs-24.4-bin PATH=$HOME/.evm/bin:$PATH MAKE_TEST=test
   - EMACS_BINARY=emacs-24.5-bin PATH=$HOME/.evm/bin:$PATH MAKE_TEST=test
   - EMACS_BINARY=emacs-25.1-bin PATH=$HOME/.evm/bin:$PATH MAKE_TEST=test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@
 
 * Add new customization variable `cider-special-mode-truncate-lines`.
 
-### Changes
-
-* Drop support for Emacs 24.3.
-
 ### Bugs Fixed
 
 * [#1707](https://github.com/clojure-emacs/cider/issues/1707): Allow to customize line truncating in CIDER's special buffers.

--- a/cider-apropos.el
+++ b/cider-apropos.el
@@ -27,7 +27,7 @@
 
 (require 'cider-doc)
 (require 'cider-util)
-(require 'subr-x)
+(require 'cider-compat)
 
 (require 'cider-client)
 (require 'cider-popup)

--- a/cider-browse-ns.el
+++ b/cider-browse-ns.el
@@ -37,7 +37,7 @@
 
 (require 'cider-interaction)
 (require 'cider-client)
-(require 'subr-x)
+(require 'cider-compat)
 (require 'cider-util)
 (require 'nrepl-dict)
 

--- a/cider-classpath.el
+++ b/cider-classpath.el
@@ -25,7 +25,7 @@
 
 (require 'cider-client)
 (require 'cider-popup)
-(require 'subr-x)
+(require 'cider-compat)
 
 (defvar cider-classpath-buffer "*cider-classpath*")
 

--- a/cider-client.el
+++ b/cider-client.el
@@ -32,7 +32,7 @@
 (require 'cider-util)
 (require 'clojure-mode)
 
-(require 'subr-x)
+(require 'cider-compat)
 (require 'seq)
 
 ;;; Connection Buffer Management

--- a/cider-common.el
+++ b/cider-common.el
@@ -24,7 +24,7 @@
 
 ;;; Code:
 
-(require 'subr-x)
+(require 'cider-compat)
 (require 'nrepl-dict)
 (require 'cider-util)
 (require 'tramp)

--- a/cider-compat.el
+++ b/cider-compat.el
@@ -1,0 +1,157 @@
+;;; cider-compat.el --- Functions from newer Emacs versions for compatibility -*- lexical-binding: t -*-
+
+;; Copyright © 2012-2013 Tim King, Phil Hagelberg, Bozhidar Batsov
+;; Copyright © 2013-2016 Bozhidar Batsov, Artur Malabarba and CIDER contributors
+;;
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+
+;; Pretty much everything here's copied from subr-x for compatibility with
+;; Emacs 24.3 and 24.4.
+
+;;; Code:
+
+(eval-and-compile
+
+  (unless (fboundp 'internal--thread-argument)
+    (defmacro internal--thread-argument (first? &rest forms)
+      "Internal implementation for `thread-first' and `thread-last'.
+When Argument FIRST? is non-nil argument is threaded first, else
+last.  FORMS are the expressions to be threaded."
+      (pcase forms
+        (`(,x (,f . ,args) . ,rest)
+         `(internal--thread-argument
+           ,first? ,(if first? `(,f ,x ,@args) `(,f ,@args ,x)) ,@rest))
+        (`(,x ,f . ,rest) `(internal--thread-argument ,first? (,f ,x) ,@rest))
+        (_ (car forms)))))
+
+  (unless (fboundp 'thread-first)
+    (defmacro thread-first (&rest forms)
+      "Thread FORMS elements as the first argument of their successor.
+Example:
+    (thread-first
+      5
+      (+ 20)
+      (/ 25)
+      -
+      (+ 40))
+Is equivalent to:
+    (+ (- (/ (+ 5 20) 25)) 40)
+Note how the single `-' got converted into a list before
+threading."
+      (declare (indent 1)
+               (debug (form &rest [&or symbolp (sexp &rest form)])))
+      `(internal--thread-argument t ,@forms)))
+
+  (unless (fboundp 'thread-last)
+    (defmacro thread-last (&rest forms)
+      "Thread FORMS elements as the last argument of their successor.
+Example:
+    (thread-last
+      5
+      (+ 20)
+      (/ 25)
+      -
+      (+ 40))
+Is equivalent to:
+    (+ 40 (- (/ 25 (+ 20 5))))
+Note how the single `-' got converted into a list before
+threading."
+      (declare (indent 1) (debug thread-first))
+      `(internal--thread-argument nil ,@forms))))
+
+
+(eval-and-compile
+
+  (unless (fboundp 'internal--listify)
+
+    (defsubst internal--listify (elt)
+      "Wrap ELT in a list if it is not one."
+      (if (not (listp elt))
+          (list elt)
+        elt)))
+
+  (unless (fboundp 'internal--check-binding)
+
+    (defsubst internal--check-binding (binding)
+      "Check BINDING is properly formed."
+      (when (> (length binding) 2)
+        (signal
+         'error
+         (cons "`let' bindings can have only one value-form" binding)))
+      binding))
+
+  (unless (fboundp 'internal--build-binding-value-form)
+
+    (defsubst internal--build-binding-value-form (binding prev-var)
+      "Build the conditional value form for BINDING using PREV-VAR."
+      `(,(car binding) (and ,prev-var ,(cadr binding)))))
+
+  (unless (fboundp 'internal--build-binding)
+
+    (defun internal--build-binding (binding prev-var)
+      "Check and build a single BINDING with PREV-VAR."
+      (thread-first
+          binding
+        internal--listify
+        internal--check-binding
+        (internal--build-binding-value-form prev-var))))
+
+  (unless (fboundp 'internal--build-bindings)
+
+    (defun internal--build-bindings (bindings)
+      "Check and build conditional value forms for BINDINGS."
+      (let ((prev-var t))
+        (mapcar (lambda (binding)
+                  (let ((binding (internal--build-binding binding prev-var)))
+                    (setq prev-var (car binding))
+                    binding))
+                bindings)))))
+
+(eval-and-compile
+
+  (unless (fboundp 'if-let)
+    (defmacro if-let (bindings then &rest else)
+      "Process BINDINGS and if all values are non-nil eval THEN, else ELSE.
+Argument BINDINGS is a list of tuples whose car is a symbol to be
+bound and (optionally) used in THEN, and its cadr is a sexp to be
+evalled to set symbol's value.  In the special case you only want
+to bind a single value, BINDINGS can just be a plain tuple."
+      (declare (indent 2)
+               (debug ([&or (&rest (symbolp form)) (symbolp form)] form body)))
+      (when (and (<= (length bindings) 2)
+                 (not (listp (car bindings))))
+        ;; Adjust the single binding case
+        (setq bindings (list bindings)))
+      `(let* ,(internal--build-bindings bindings)
+         (if ,(car (internal--listify (car (last bindings))))
+             ,then
+           ,@else))))
+
+  (unless (fboundp 'when-let)
+    (defmacro when-let (bindings &rest body)
+      "Process BINDINGS and if all values are non-nil eval BODY.
+Argument BINDINGS is a list of tuples whose car is a symbol to be
+bound and (optionally) used in BODY, and its cadr is a sexp to be
+evalled to set symbol's value.  In the special case you only want
+to bind a single value, BINDINGS can just be a plain tuple."
+      (declare (indent 1) (debug if-let))
+      (list 'if-let bindings (macroexp-progn body)))))
+
+(provide 'cider-compat)
+;;; cider-compat.el ends here

--- a/cider-debug.el
+++ b/cider-debug.el
@@ -33,7 +33,7 @@
 (require 'cider-inspector)
 (require 'cider-browse-ns)
 (require 'cider-common)
-(require 'subr-x)
+(require 'cider-compat)
 (require 'seq)
 (require 'spinner)
 

--- a/cider-doc.el
+++ b/cider-doc.el
@@ -26,7 +26,7 @@
 ;;; Code:
 
 (require 'cider-common)
-(require 'subr-x)
+(require 'cider-compat)
 (require 'cider-util)
 (require 'cider-popup)
 (require 'cider-client)

--- a/cider-eldoc.el
+++ b/cider-eldoc.el
@@ -33,7 +33,7 @@
 
 (require 'cider-client)
 (require 'cider-common) ; for cider-symbol-at-point
-(require 'subr-x)
+(require 'cider-compat)
 (require 'cider-util)
 (require 'nrepl-dict)
 

--- a/cider-grimoire.el
+++ b/cider-grimoire.el
@@ -27,7 +27,7 @@
 
 (require 'cider-client)
 (require 'cider-common)
-(require 'subr-x)
+(require 'cider-compat)
 (require 'cider-popup)
 
 (require 'nrepl-dict)

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -41,7 +41,7 @@
 (require 'cider-doc)
 (require 'cider-eldoc)
 (require 'cider-overlays)
-(require 'subr-x)
+(require 'cider-compat)
 
 (require 'clojure-mode)
 (require 'thingatpt)

--- a/cider-macroexpansion.el
+++ b/cider-macroexpansion.el
@@ -32,7 +32,7 @@
 ;;; Code:
 
 (require 'cider-mode)
-(require 'subr-x)
+(require 'cider-compat)
 
 (defconst cider-macroexpansion-buffer "*cider-macroexpansion*")
 

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -37,7 +37,7 @@
 (require 'cider-eldoc)
 (require 'cider-resolve)
 (require 'cider-doc)
-(require 'subr-x)
+(require 'cider-compat)
 
 (defcustom cider-mode-line-show-connection t
   "If the mode-line lighter should detail the connection."

--- a/cider-overlays.el
+++ b/cider-overlays.el
@@ -26,7 +26,7 @@
 ;;; Code:
 
 (require 'cider-common)
-(require 'subr-x)
+(require 'cider-compat)
 (require 'cl-lib)
 
 
@@ -141,7 +141,7 @@ END is the position where the sexp ends, and defaults to point."
     (with-current-buffer (if (markerp end)
                              (marker-buffer end)
                            (current-buffer))
-      (save-excursion
+      (save-excursion 
         (if end
             (goto-char end)
           (setq end (point)))

--- a/cider-popup.el
+++ b/cider-popup.el
@@ -23,7 +23,7 @@
 
 ;;; Code:
 
-(require 'subr-x)
+(require 'cider-compat)
 
 (define-minor-mode cider-popup-buffer-mode
   "Mode for CIDER popup buffers"

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -36,7 +36,7 @@
 (require 'cider-test)
 (require 'cider-eldoc) ; for cider-eldoc-setup
 (require 'cider-common)
-(require 'subr-x)
+(require 'cider-compat)
 (require 'cider-util)
 (require 'cider-resolve)
 

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -30,7 +30,7 @@
 (require 'button)
 (require 'easymenu)
 (require 'cider-common)
-(require 'subr-x)
+(require 'cider-compat)
 (require 'cider-client)
 (require 'cider-util)
 

--- a/cider-test.el
+++ b/cider-test.el
@@ -32,7 +32,7 @@
 (require 'cider-client)
 (require 'cider-popup)
 (require 'cider-stacktrace)
-(require 'subr-x)
+(require 'cider-compat)
 (require 'cider-overlays)
 
 (require 'button)

--- a/cider-util.el
+++ b/cider-util.el
@@ -34,7 +34,7 @@
 (require 'seq)
 (require 'cl-lib)
 (require 'clojure-mode)
-(require 'subr-x)
+(require 'cider-compat)
 (require 'nrepl-dict)
 
 (defalias 'cider-pop-back 'pop-tag-mark)

--- a/cider.el
+++ b/cider.el
@@ -12,7 +12,7 @@
 ;; Maintainer: Bozhidar Batsov <bozhidar@batsov.com>
 ;; URL: http://www.github.com/clojure-emacs/cider
 ;; Version: 0.15.0-snapshot
-;; Package-Requires: ((emacs "24.4") (clojure-mode "5.6.0") (pkg-info "0.4") (queue "0.1.1") (spinner "1.7") (seq "2.16"))
+;; Package-Requires: ((emacs "24.3") (clojure-mode "5.5.2") (pkg-info "0.4") (queue "0.1.1") (spinner "1.7") (seq "2.16"))
 ;; Keywords: languages, clojure, cider
 
 ;; This program is free software: you can redistribute it and/or modify
@@ -82,7 +82,7 @@ project inference will take place."
 (require 'cider-repl)
 (require 'cider-mode)
 (require 'cider-common)
-(require 'subr-x)
+(require 'cider-compat)
 (require 'cider-debug)
 (require 'tramp-sh)
 

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -8,7 +8,7 @@ Yes.
 
 ## What are CIDER's installation prerequisites?
 
-CIDER officially supports Emacs 24.4+, Java 7+ and Clojure(Script) 1.7+.
+CIDER officially supports Emacs 24.3+, Java 7+ and Clojure(Script) 1.7+.
 CIDER 0.10 was the final release which supported Java 6 and Clojure 1.5 and 1.6.
 
 ## What's the relationship between CIDER and nrepl.el?

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -9,7 +9,7 @@ release). If you're new to Emacs you might want to go through
 [the guided tour of Emacs](https://www.gnu.org/software/emacs/tour/index.html)
 and the built-in tutorial (just press <kbd>C-h t</kbd>).
 
-CIDER officially supports Emacs 24.4+, Java 7+ and Clojure(Script) 1.7+.
+CIDER officially supports Emacs 24.3+, Java 7+ and Clojure(Script) 1.7+.
 CIDER 0.10 was the final release which supported Java 6 and Clojure 1.5 and 1.6.
 
 You'll also need a recent version of your favorite build tool (Leiningen, Boot

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -69,7 +69,7 @@
 
 ;;; Code:
 (require 'seq)
-(require 'subr-x)
+(require 'cider-compat)
 (require 'cl-lib)
 (require 'nrepl-dict)
 (require 'queue)

--- a/test/cider-tests--no-auto.el
+++ b/test/cider-tests--no-auto.el
@@ -32,7 +32,7 @@
 
 (require 'buttercup)
 (require 'cider)
-(require 'subr-x)
+(require 'cider-compat)
 (require 'cl-lib)
 
 ;;; Docs


### PR DESCRIPTION
- [x] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)



This reverts commit 70971d0a918053d86e76e4ff8248b25a8646940e.

Should be a fix for [1882](https://github.com/clojure-emacs/cider/issues/1882)