### PR TITLE
Allow auto-display of REPL without cursor focusing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ within the scope of your current Emacs session.
 * [#1789](https://github.com/clojure-emacs/cider/issues/1789): Make it easy to change the connection of the cider-scratch buffer from the mode's menu.
 * New interactive command `cider-toggle-buffer-connection`.
 * [#1861](https://github.com/clojure-emacs/cider/issues/1861): New interactive commands in message log buffer `nrepl-log-expand-button` and `nrepl-log-expand-all-buttons`.
+* [#1872](https://github.com/clojure-emacs/cider/issues/1872): Add new value `display-only` for option `cider-repl-pop-to-buffer-on-connect` that allows for showing the REPL buffer without focusing it.
 
 ### Changes
 

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -84,8 +84,13 @@
 (defcustom cider-repl-pop-to-buffer-on-connect t
   "Controls whether to pop to the REPL buffer on connect.
 
-When set to nil the buffer will only be created."
-  :type 'boolean
+When set to nil the buffer will only be created, and not displayed.  When
+set to `display-only' the buffer will be displayed, but it will not become
+focused.  Otherwise the buffer is displayed and focused."
+  :type '(choice (const :tag "Create the buffer, but don't display it" nil)
+                 (const :tag "Create and display the buffer, but don't focus it"
+                   display-only)
+                 (const :tag "Create, display, and focus the buffer" t))
   :group 'cider-repl)
 
 (defcustom cider-repl-display-in-current-window nil
@@ -290,8 +295,9 @@ client process connection.  Unless NO-BANNER is non-nil, insert a banner."
     (cider-repl--insert-banner-and-prompt buffer))
   (when cider-repl-display-in-current-window
     (add-to-list 'same-window-buffer-names (buffer-name buffer)))
-  (when cider-repl-pop-to-buffer-on-connect
-    (pop-to-buffer buffer))
+  (pcase cider-repl-pop-to-buffer-on-connect
+    ('display-only (display-buffer buffer))
+    ((pred identity) (pop-to-buffer buffer)))
   (cider-remember-clojure-buffer cider-current-clojure-buffer)
   buffer)
 

--- a/doc/using_the_repl.md
+++ b/doc/using_the_repl.md
@@ -70,6 +70,13 @@ Normally, the REPL buffer is auto-displayed in a separate window after
 (setq cider-repl-pop-to-buffer-on-connect nil)
 ```
 
+If you want the REPL buffer to be auto-displayed, but don't want it to be
+focused, use this:
+
+```el
+(setq cider-repl-pop-to-buffer-on-connect 'display-only)
+```
+
 #### Behavior on switch
 
 By default <kbd>C-c C-z</kbd> will display the REPL buffer in a different window.


### PR DESCRIPTION
Resolves #1872. I updated all of the places where
`cider-repl-pop-to-buffer-on-connect` was used. This should be perfectly
reverse-compatible, since the only new behavior happens if you specifically set
the variable to `display-only`.