### PR TITLE
Allow specifying connection for load buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 * [#1707](https://github.com/clojure-emacs/cider/issues/1707): Allow to customize line truncating in CIDER's special buffers.
 * [#1876](https://github.com/clojure-emacs/cider/issues/1876): Set pretty-printing width with `cider-repl-pretty-print-width`. If this variable is not set, fall back to `fill-column`.
+* [#1875](https://github.com/clojure-emacs/cider/issues/1875): Ensure cljc buffers can load buffer into both clj and cljs repls.
 
 ## 0.14.0 (2016-10-13)
 

--- a/cider-client.el
+++ b/cider-client.el
@@ -766,7 +766,10 @@ Return the REPL buffer given by `cider-current-connection'.")
 
 (defun cider-current-session ()
   "Return the eval nREPL session id of the current connection."
-  (with-current-buffer (cider-current-connection)
+  (cider-session-for-connection (cider-current-connection)))
+
+(defun cider-session-for-connection (connection)
+  (with-current-buffer connection
     nrepl-session))
 
 (defun cider-current-messages-buffer ()
@@ -852,7 +855,9 @@ loaded.
 If CONNECTION is nil, use `cider-current-connection'.
 If CALLBACK is nil, use `cider-load-file-handler'."
   (cider-nrepl-send-request (list "op" "load-file"
-                                  "session" (cider-current-session)
+                                  "session" (if connection
+                                                (cider-session-for-connection connection)
+                                              (cider-current-session))
                                   "file" file-contents
                                   "file-path" file-path
                                   "file-name" file-name)


### PR DESCRIPTION
When running a cljc buffer, you can load the code into more than just a
single connection. This is managed by cider-map-connections. However,
the load buffer command was reaching out to the current connection for
the session id, leading the entire mechanism working correctly except
that it would talk to the OTHER repl session inside of the repl.

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

Thanks!

[1]: https://github.com/clojure-emacs/cider/blob/master/.github/CONTRIBUTING.md
Fix for [Issue 1875](https://github.com/clojure-emacs/cider/issues/1875)