### PR TITLE
Bugfix: (pcase) accepts only backquote in Emacs 24.5.1

### DIFF
--- a/cider-repl.el
+++ b/cider-repl.el
@@ -296,7 +296,7 @@ client process connection.  Unless NO-BANNER is non-nil, insert a banner."
   (when cider-repl-display-in-current-window
     (add-to-list 'same-window-buffer-names (buffer-name buffer)))
   (pcase cider-repl-pop-to-buffer-on-connect
-    ('display-only (display-buffer buffer))
+    (`display-only (display-buffer buffer))
     ((pred identity) (pop-to-buffer buffer)))
   (cider-remember-clojure-buffer cider-current-clojure-buffer)
   buffer)


### PR DESCRIPTION
Introduced in ce349eb24f2, caused error like:

    error in process filter: pcase--u1: Unknown upattern `(quote display-only)'

- [x] The commits are consistent with our [contribution guidelines][1]
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)
- [x] You've updated the refcard (if you made changes to the commands listed there)
