### PR TITLE
Reconnect to the same host:port after cider-restart if the connection was established with `cider-connect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#1876](https://github.com/clojure-emacs/cider/issues/1876): Set pretty-printing width with `cider-repl-pretty-print-width`. If this variable is not set, fall back to `fill-column`.
 * [#1875](https://github.com/clojure-emacs/cider/issues/1875): Ensure cljc buffers can load buffer into both clj and cljs repls.
 * [#1897](https://github.com/clojure-emacs/cider/issues/1897): Bind TAB in stacktrace buffers in the terminal.
+* [#1895](https://github.com/clojure-emacs/cider/issues/1895): Connect to the same host:port after `cider-restart` if the connection was established with `cider-connect`.
 
 ## 0.14.0 (2016-10-13)
 

--- a/cider.el
+++ b/cider.el
@@ -562,6 +562,8 @@ gets associated with it."
     (let* ((nrepl-create-client-buffer-function  #'cider-repl-create)
            (nrepl-use-this-as-repl-buffer repl-buff)
            (conn (process-buffer (nrepl-start-client-process host port))))
+      (with-current-buffer conn
+        (setq cider-connection-created-with 'connect))
       (if project-dir
           (cider-assoc-project-with-connection project-dir conn)
         (let ((project-dir (clojure-project-dir)))

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -952,9 +952,8 @@ Used by `nrepl-start-server-process'.")
 Return a newly created process.
 Set `nrepl-server-filter' as the process filter, which starts REPL process
 with its own buffer once the server has started.
-If CALLBACK is non-nil, it should be function of 3 arguments.  Once the
-client process is started, the function is called with the server process,
-the port, and the client buffer."
+If CALLBACK is non-nil, it should be function of 1 argument.  Once the
+client process is started, the function is called with the client buffer."
   (let* ((default-directory (or directory default-directory))
          (serv-buf (get-buffer-create (generate-new-buffer-name
                                        (nrepl-server-buffer-name directory))))


### PR DESCRIPTION
It's been a while since I've worked on anything in CIDER. Feels good to be back :-)

This PR fixes #1895.

@bbatsov, the approach is the same as what you outlined in the comment.

1. Create a new buffer-local var `cider-connection-created-with` to track how the connection was created. It defaults to `'jack-in`, and we set it to `'connect` in `cider-connect`.
2. In `cider--restart-connection`, we do the right thing based on the type of  `conn`.

- [ ] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

Thanks!

[1]: https://github.com/clojure-emacs/cider/blob/master/.github/CONTRIBUTING.md
