### PR TITLE
[Fix #1776] Add new customization variable `cider-test-defining-names`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add new customization variable `cider-special-mode-truncate-lines`.
 * Add an option `cider-inspector-fill-frame` to control whether the cider inspector window fills its frame.
 * [#1893](https://github.com/clojure-emacs/cider/issues/1893)Add negative prefix argument to `cider-refresh` to inhibit invoking of cider-refresh-functions
+* [#1776](https://github.com/clojure-emacs/cider/issues/1776)Add new customization variable `cider-test-defining-forms` allowing new test defining forms to be recognized.
 
 ### Changes
 

--- a/cider-test.el
+++ b/cider-test.el
@@ -59,6 +59,15 @@
   :group 'cider-test
   :package-version '(cider . "0.9.0"))
 
+(defcustom cider-test-defining-forms '("deftest" "defspec")
+  "Forms that define individual tests.
+CIDER considers the top-level form around point to define a test if the
+form starts with one of these forms.
+Add to this list to have CIDER recognize additional test defining macros."
+  :type '(repeat string)
+  :group 'cider-test
+  :package-version '(cider . "0.15.0"))
+
 (defvar cider-test-last-summary nil
   "The summary of the last run test.")
 
@@ -680,7 +689,7 @@ is searched."
           (cider-test-execute ns (list var)))
       (let ((ns  (clojure-find-ns))
             (def (clojure-find-def)))
-        (if (and ns (member (car def) '("deftest" "defspec")))
+        (if (and ns (member (car def) cider-test-defining-forms))
             (progn
               (cider-test-update-last-test ns (cdr def))
               (cider-test-execute ns (cdr def)))

--- a/doc/running_tests.md
+++ b/doc/running_tests.md
@@ -35,6 +35,11 @@ customize the variable `cider-test-infer-test-ns`. It should be bound to a
 function that takes the current namespace and returns the matching test
 namespace (which may be the same as the current namespace).
 
+* If your individual tests are not defined by `deftest` or `defspec`, CIDER will
+not recognize them when searching for a test at point in `cider-test-run-test`.
+You can customize the variable `cider-test-defining-forms` to add additional
+forms for CIDER to recognize as individual test definitions.
+
 * If you want to view the test report regardless of whether the tests have
 passed or failed:
 


### PR DESCRIPTION
This fix is strictly simpler than that suggested in
https://github.com/clojure-emacs/cider/issues/1776#issuecomment-223758069.  It
has the advantage of being much more robust.

I partially implemented the suggested fix, and witnessed the following two
issues.  First, full "macroexpand" does not leave a recognizable `deftest` form;
it generally leaves a `(def test-... (fn [] ...))` sexp.  That implies that a
recursive macroexpansion would be required, with each step of the recursion
checking for a recognized form.  Second, even recognizing such a form is tricky,
because the expansion may refer to deftest in an aliased namespace (e.g.,
`t/deftest` or `clojure.test/deftest` rather than bare `deftest`).  One could
then try to identify possible namespaces using the current environment, but this
is getting complicated.

Therefore, I think it better to have the user configure their environment to
help them solve this problem.  (And, of course, future work can implement the
full macroexpansion approach.)

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [n/a] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [n/a] You've updated the readme (if adding/changing user-visible functionality)
- [n/a] You've updated the refcard (if you made changes to the commands listed there)

Thanks!

[1]: https://github.com/clojure-emacs/cider/blob/master/.github/CONTRIBUTING.md
