### PR TITLE
Route stdout/stderr to different buffers based on regexps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * Add an option `cider-inspector-fill-frame` to control whether the cider inspector window fills its frame.
 * [#1893](https://github.com/clojure-emacs/cider/issues/1893): Add negative prefix argument to `cider-refresh` to inhibit invoking of cider-refresh-functions
 * [#1776](https://github.com/clojure-emacs/cider/issues/1776): Add new customization variable `cider-test-defining-forms` allowing new test defining forms to be recognized.
+* [#1525](https://github.com/clojure-emacs/cider/issues/1525): Add the ability to route stdout and stderr to different buffers based on regular expressions
+
 
 ### Changes
 

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -631,14 +631,16 @@ The handler simply inserts the result value in BUFFER."
 The OUTPUT can be sent to either a dedicated output buffer or the current
 REPL buffer.  This is controlled by `cider-interactive-eval-output-destination'.
 REPL-EMIT-FUNCTION emits the OUTPUT."
-  (pcase cider-interactive-eval-output-destination
-    (`output-buffer (let ((output-buffer (or (get-buffer cider-output-buffer)
-                                             (cider-popup-buffer cider-output-buffer t))))
-                      (cider-emit-into-popup-buffer output-buffer output)
-                      (pop-to-buffer output-buffer)))
-    (`repl-buffer (funcall repl-emit-function output))
-    (_ (error "Unsupported value %s for `cider-interactive-eval-output-destination'"
-              cider-interactive-eval-output-destination))))
+  (let ((buffer (cider--interactive-out-buffer output cider-interactive-eval-output-destination)))
+    (pcase buffer
+      (`output-buffer (let ((output-buffer (or (get-buffer cider-output-buffer)
+                                               (cider-popup-buffer cider-output-buffer t))))
+                        (cider-emit-into-popup-buffer output-buffer output)
+                        (pop-to-buffer output-buffer)))
+      (`repl-buffer (funcall repl-emit-function output))
+      (_ (let ((output-buffer (or (get-buffer buffer) (cider-popup-buffer buffer t))))
+           (cider-emit-into-popup-buffer output-buffer output)
+           (pop-to-buffer buffer))))))
 
 (defun cider-emit-interactive-eval-output (output)
   "Emit OUTPUT resulting from interactive code evaluation.

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -137,6 +137,22 @@ More details can be found [here](https://github.com/clojure-emacs/cider/issues/9
 (setq cider-special-mode-truncate-lines nil)
 ```
 
+* You can redirect certain type of output to buffers instead of the REPL.
+  This is configured by adding mappings between regular expressions and
+  buffers in `cider-redirect-output-regexps`. Any output that matches any
+  regular expression will be redirected to the corresponding buffer.
+  Note that if there are multiple matches, the first match is used,
+  and a warning is displayed.
+
+  Consider this example;
+
+```el
+(setq cider-redirect-output-regexps '(("INFO: .*" . "*cider-log*")))
+```
+
+  This would cause all output strings containg "INFO" (logging output)
+  to be redirected to the `*cider-log*` buffer.
+
 ## Configuring eldoc
 
 * Enable `eldoc` in Clojure buffers:


### PR DESCRIPTION
Check out the very short [demo](https://www.youtube.com/watch?v=nhej5XE2THE&feature=youtu.be) (15 sec), with 

`(setq cider-redirect-output-regexps '(("INFO: .*" . "*cider-log*")))`.

If there are multiple matches, we use the first match but display a warning.


-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

Thanks!

[1]: https://github.com/clojure-emacs/cider/blob/master/.github/CONTRIBUTING.md
