### PR TITLE
Add company-cider backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add new customization variable `cider-font-lock-reader-conditionals` which toggles syntax highlighting of reader conditional expressions based on the buffer connection.
 * Add new face `cider-reader-conditional-face` which is used to mark unused reader conditional expressions.
 * [#1544](https://github.com/clojure-emacs/cider/issues/1544): Add a new defcustom `nrepl-use-ssh-fallback-for-remote-hosts` to control the behavior of `nrepl-connect` (and in turn that of `cider-connect`) for remote hosts.
+* [#1910](https://github.com/clojure-emacs/cider/issues/1910): Add custom company-mode completion style to show fuzzy completions from Compliment.
 
 ### Changes
 

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -600,6 +600,22 @@ in the buffer."
                                         (cider-eldoc-thing-type eldoc-info))
               (cider-eldoc-format-arglist arglists 0)))))
 
+;; Fuzzy completion for company-mode
+
+(defun cider-company-unfiltered-candidates (string table predicate point)
+  "Return CIDER completion candidates as is, without filtering them by prefix."
+  (cider-complete string))
+
+(add-to-list 'completion-styles-alist
+             '(cider
+               cider-company-unfiltered-candidates
+               cider-company-unfiltered-candidates
+               "CIDER backend-driven completion style."))
+
+(defun cider-company-enable-fuzzy-completion ()
+  "Enable backend-driven fuzzy completion in the current buffer."
+  (setq-local completion-styles '(cider)))
+
 (defun cider-stdin-handler (&optional buffer)
   "Make a stdin response handler for BUFFER."
   (nrepl-make-response-handler (or buffer (current-buffer))

--- a/doc/code_completion.md
+++ b/doc/code_completion.md
@@ -55,13 +55,19 @@ the time of this writing it's still in development).
 By default `company-mode` will provide completion candidates with the assumption
 that whatever you've typed so far (e.g. `map-`) is a completion prefix (meaning
 you'd get only candidates that have `map-` in the beginnings of their names).
+You can get enhanced fuzzy completion with the CIDER-specific completion style
+by adding:
 
-You can get enhanced fuzzy completion with `company-mode` if you install the
-additional package [company-flx](https://github.com/PythonNut/company-flx).
-This is powered internally by [flx](https://github.com/lewang/flx).
+```el
+(add-hook 'cider-repl-mode-hook #'cider-company-enable-fuzzy-completion)
+(add-hook 'cider-mode-hook #'cider-company-enable-fuzzy-completion)
+```
 
-Basically with `company-flx` enabled typing something like `mp` will show you
-`map-indexed` as one of the possible completion candidates.
+Now `company-mode` will accept certain fuzziness when matching candidates
+against the prefix. For example, typing `mp` will show you `map-indexed` as one
+of the possible completion candidates, `cji` will complete to `clojure.java.io`,
+etc. Different completion examples are
+listed [here](https://github.com/alexander-yakushev/compliment/wiki/Examples).
 
 ### Completion annotations
 


### PR DESCRIPTION
#1909 follow-up.

This patch adds `company-cider` backend that for the most part calls directly to the already existing CIDER functions. An update to docs was also made to describe how to enable the backend.

I've made a function that sets `company-cider` a sole completion backend. Is it OK? Maybe it is enough to drop `company-capf` from the list?

Regarding the docs, I also request comments. I took the liberty to drop the mentions of company-flx, but I feel there is a better way to explain the new setup.  