### PR TITLE
Fix image link in miscellaneous_features.md

### DIFF
--- a/doc/miscellaneous_features.md
+++ b/doc/miscellaneous_features.md
@@ -85,8 +85,8 @@ That's it! Once your code executes, the regular old buffer on the left will turn
 into the brilliant show of lights on the right.
 
 <p align="center">
-  <img src="../images/enlighten_disabled.png" width="300" />
-  <img src="../images/enlighten_enabled.png" width="300" />
+  <img src="images/enlighten_disabled.png" height="300" />
+  <img src="images/enlighten_enabled.png" height="300" />
 </p>
 
 To stop displaying the locals you'll have to disable `cider-enlighten-mode`


### PR DESCRIPTION
Broken image link is fixed.  Image size adjust to same height (not to same width).