### PR TITLE
Fix toggle connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#1875](https://github.com/clojure-emacs/cider/issues/1875): Ensure cljc buffers can load buffer into both clj and cljs repls.
 * [#1897](https://github.com/clojure-emacs/cider/issues/1897): Bind TAB in stacktrace buffers in the terminal.
 * [#1895](https://github.com/clojure-emacs/cider/issues/1895): Connect to the same host:port after `cider-restart` if the connection was established with `cider-connect`.
+* [#1913](https://github.com/clojure-emacs/cider/issues/1913): Fix bug in `cider-toggle-buffer-connection` to not delete connections.
 
 ## 0.14.0 (2016-10-13)
 

--- a/cider-client.el
+++ b/cider-client.el
@@ -210,10 +210,9 @@ such a link cannot be established automatically."
   "Toggles the current buffer's connection between Clojure and ClojureScript."
   (interactive)
   (cider-ensure-connected)
-  (let ((other-conn (cider-other-connection)))
-    (if other-conn
-        (setq-local cider-connections (list other-conn))
-      (user-error "No other connection available"))))
+  (when-let ((conns (cider-connections)))
+    (setq-local cider-connections (append (rest conns) (list (car conns))))
+    (message "Repl type default set to: %s" (cider--connection-type (car (cider-connections))))))
 
 (defun cider-clear-buffer-local-connection ()
   "Remove association between the current buffer and a connection."

--- a/cider-client.el
+++ b/cider-client.el
@@ -211,7 +211,7 @@ such a link cannot be established automatically."
   (interactive)
   (cider-ensure-connected)
   (when-let ((conns (cider-connections)))
-    (setq-local cider-connections (append (rest conns) (list (car conns))))
+    (setq-local cider-connections (append (cdr conns) (list (car conns))))
     (message "Repl type default set to: %s" (cider--connection-type (car (cider-connections))))))
 
 (defun cider-clear-buffer-local-connection ()

--- a/cider-client.el
+++ b/cider-client.el
@@ -224,6 +224,8 @@ such a link cannot be established automatically."
 (defun cider-connection-type-for-buffer ()
   "Return the matching connection type (clj or cljs) for the current buffer."
   (cond
+   ;; cljc mode must be first as it derives from clj mode
+   ((derived-mode-p 'clojurec-mode) "cljc")
    ((derived-mode-p 'clojurescript-mode) "cljs")
    ((derived-mode-p 'clojure-mode) "clj")
    (cider-repl-type)
@@ -272,7 +274,12 @@ at all."
                 (guessed-type (or type (cider-connection-type-for-buffer))))
             ;; So we have multiple connections. Look for the connection type we
             ;; want, prioritizing the current project.
-            (or (seq-find (lambda (conn)
+
+            ;; when cljc buffer, use the first connection (you can rotate this
+            ;; to set priority
+            (or (when (string= "cljc" guessed-type)
+                  (car connections))
+                (seq-find (lambda (conn)
                             (equal (cider--connection-type conn) guessed-type))
                           project-connections)
                 (seq-find (lambda (conn)

--- a/cider-scratch.el
+++ b/cider-scratch.el
@@ -66,7 +66,7 @@
   (or (get-buffer cider-scratch-buffer-name)
       (cider-create-scratch-buffer)))
 
-(define-derived-mode cider-clojure-interaction-mode clojure-mode "Clojure Interaction"
+(define-derived-mode cider-clojure-interaction-mode clojurec-mode "Clojure Interaction"
   "Major mode for typing and evaluating Clojure forms.
 Like clojure-mode except that \\[cider-eval-print-last-sexp] evals the Lisp expression
 before point, and prints its value into the buffer, advancing point.


### PR DESCRIPTION
- [x] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

Thanks!
[issue 1913](https://github.com/clojure-emacs/cider/issues/1913)

This introduces a new "type" of cider repl, as returned from `cider-connection-type-for-buffer`. In addition to clj and cljs, we have cljc. This type will use the first connection in `cider-connections`. So we can easily reorder this list to change the default connection.

Previously, since connections were inferred from what was available and what mode you were coming from, this toggle function would create a buffer local var for `cider-connections` and *remove* those connections. The problem was that you could not toggle them again as your list ran out of connections. This keeps all connections around and makes sure that `cider-map-connections` and others work well with multiple connections.