### PR TITLE
Require cider-classpath

### DIFF
--- a/cider-repl.el
+++ b/cider-repl.el
@@ -40,6 +40,7 @@
 (require 'cider-compat)
 (require 'cider-util)
 (require 'cider-resolve)
+(require 'cider-classpath)
 
 (require 'clojure-mode)
 (require 'easymenu)


### PR DESCRIPTION
Require `cider-classpath` in cider-repl.el.

This file accesses or references the cider-classpath functionality, but it's not required by this file, or by any file that requires this one.  I found that with a vanilla setup, doing `,` and then `classpath` did not work, without explicitly the explicit `require`.
