### PR TITLE
Remove session from nrepl interaction

### DIFF
--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -192,52 +192,46 @@ Current page will be reset to zero."
 ;; nREPL interactions
 (defun cider-sync-request:inspect-pop ()
   "Move one level up in the inspector stack."
-  (thread-first (list "op" "inspect-pop"
-                      "session" (cider-current-session))
+  (thread-first (list "op" "inspect-pop")
     (cider-nrepl-send-sync-request)
     (nrepl-dict-get "value")))
 
 (defun cider-sync-request:inspect-push (idx)
   "Inspect the inside value specified by IDX."
   (thread-first (list "op" "inspect-push"
-                      "idx" idx
-                      "session" (cider-current-session))
+                      "idx" idx)
     (cider-nrepl-send-sync-request)
     (nrepl-dict-get "value")))
 
 (defun cider-sync-request:inspect-refresh ()
   "Re-render the currently inspected value."
-  (thread-first (list "op" "inspect-refresh"
-                      "session" (cider-current-session))
+  (thread-first (list "op" "inspect-refresh")
     (cider-nrepl-send-sync-request)
     (nrepl-dict-get "value")))
 
 (defun cider-sync-request:inspect-next-page ()
   "Jump to the next page in paginated collection view."
-  (thread-first (list "op" "inspect-next-page"
-                      "session" (cider-current-session))
+  (thread-first (list "op" "inspect-next-page")
     (cider-nrepl-send-sync-request)
     (nrepl-dict-get "value")))
 
 (defun cider-sync-request:inspect-prev-page ()
   "Jump to the previous page in paginated collection view."
-  (thread-first (list "op" "inspect-prev-page"
-                      "session" (cider-current-session))
+  (thread-first (list "op" "inspect-prev-page")
     (cider-nrepl-send-sync-request)
     (nrepl-dict-get "value")))
 
 (defun cider-sync-request:inspect-set-page-size (page-size)
   "Set the page size in paginated view to PAGE-SIZE."
   (thread-first (list "op" "inspect-set-page-size"
-                      "page-size" page-size
-                      "session" (cider-current-session))
+                      "page-size" page-size)
     (cider-nrepl-send-sync-request)
     (nrepl-dict-get "value")))
 
 (defun cider-sync-request:inspect-expr (expr ns page-size)
   "Evaluate EXPR in context of NS and inspect its result.
 Set the page size in paginated view to PAGE-SIZE."
-  (thread-first (append (nrepl--eval-request expr (cider-current-session) ns)
+  (thread-first (append (nrepl--eval-request expr ns)
                         (list "inspect" "true"
                               "page-size" page-size))
     (cider-nrepl-send-sync-request)

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1662,7 +1662,7 @@ START and END represent the region's boundaries."
   (cider-ensure-connected)
   (let ((selected-session (completing-read "Describe nREPL session: " (nrepl-sessions (cider-current-connection)))))
     (when (and selected-session (not (equal selected-session "")))
-      (let* ((session-info (nrepl-sync-request:describe (cider-current-connection) selected-session))
+      (let* ((session-info (nrepl-sync-request:describe (cider-current-connection)))
              (ops (nrepl-dict-keys (nrepl-dict-get session-info "ops")))
              (session-id (nrepl-dict-get session-info "session"))
              (session-type (cond

--- a/cider-test.el
+++ b/cider-test.el
@@ -262,7 +262,7 @@ prompt and whether to use a new window.  Similar to `cider-find-var'."
   (let (causes)
     (cider-nrepl-send-request
      (append
-      (list "op" "test-stacktrace" "session" (cider-current-session)
+      (list "op" "test-stacktrace"
             "ns" ns "var" var "index" index)
       (when (cider--pprint-fn)
         (list "pprint-fn" (cider--pprint-fn)))
@@ -594,8 +594,7 @@ If SILENT is non-nil, suppress all messages other then test results."
             "tests"  (when (stringp ns) tests)
             "load?"  (when (or (stringp ns)
                                (eq :project ns))
-                       "true")
-            "session" (cider-current-session))
+                       "true"))
       (lambda (response)
         (nrepl-dbind-response response (summary results status out err)
           (cond ((member "namespace-not-found" status)

--- a/cider.el
+++ b/cider.el
@@ -456,7 +456,6 @@ should be the regular Clojure REPL started by the server process filter."
       (cider-nrepl-send-request
        (list "op" "eval"
              "ns" (cider-current-ns)
-             "session" nrepl-session
              "code" cider-cljs-lein-repl)
        (cider-repl-handler (current-buffer)))
       (cider--offer-to-open-app-in-browser nrepl-server-buffer))))

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -799,7 +799,8 @@ REQUEST is a pair list of the form (\"op\" \"operation\" \"par1-name\"
 `nrepl-request:stdin', etc. This expects that the REQUEST does not have a
 session already in it. This code will add it as appropriate to prevent
 connection/session drift.
-Return the ID of the sent message."
+Return the ID of the sent message.
+Optional argument TOOLING Set to t if desiring the tooling session rather than the standard session."
   (with-current-buffer connection
     (when-let ((session (if tooling nrepl-tooling-session nrepl-session)))
       (setq request (append request
@@ -904,8 +905,8 @@ If LINE and COLUMN are non-nil and current buffer is a file buffer, \"line\",
   "Send the request INPUT and register the CALLBACK as the response handler.
 The request is dispatched via CONNECTION.  If NS is non-nil,
 include it in the request.  LINE and COLUMN, if non-nil, define the position
-of INPUT in its buffer. A CONNECTION uniquely determines two connections
-available: the standard interaction one and the tooling session. If the
+of INPUT in its buffer.  A CONNECTION uniquely determines two connections
+available: the standard interaction one and the tooling session.  If the
 tooling is desired, set TOOLING to true.
 ADDITIONAL-PARAMS is a plist to be appended to the request message."
   (nrepl-send-request (append (nrepl--eval-request input ns line column) additional-params)
@@ -915,7 +916,8 @@ ADDITIONAL-PARAMS is a plist to be appended to the request message."
 
 (defun nrepl-sync-request:clone (connection &optional tooling)
   "Sent a :clone request to create a new client session.
-The request is dispatched via CONNECTION."
+The request is dispatched via CONNECTION.
+Optional argument TOOLING Tooling is set to t if wanting the tooling session from CONNECTION."
   (nrepl-send-sync-request '("op" "clone")
                            connection
                            nil tooling))

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -801,7 +801,7 @@ session already in it. This code will add it as appropriate to prevent
 connection/session drift.
 Return the ID of the sent message."
   (with-current-buffer connection
-    (let ((session (if tooling nrepl-tooling-session nrepl-session)))
+    (when-let ((session (if tooling nrepl-tooling-session nrepl-session)))
       (setq request (append request
                             (list "session" session))))
     (let* ((id (nrepl-next-request-id connection))

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -792,16 +792,18 @@ corresponding type of response."
   (with-current-buffer connection
     (number-to-string (cl-incf nrepl-request-counter))))
 
-(defun nrepl-send-request (request callback connection)
+(defun nrepl-send-request (request callback connection &optional tooling)
   "Send REQUEST and register response handler CALLBACK using CONNECTION.
 REQUEST is a pair list of the form (\"op\" \"operation\" \"par1-name\"
 \"par1\" ... ). See the code of `nrepl-request:clone',
-`nrepl-request:stdin', etc.
+`nrepl-request:stdin', etc. This expects that the REQUEST does not have a
+session already in it. This code will add it as appropriate to prevent
+connection/session drift.
 Return the ID of the sent message."
   (with-current-buffer connection
-    (when (and (not (lax-plist-get request "session"))
-               nrepl-session)
-      (setq request (append request (list "session" nrepl-session))))
+    (let ((session (if tooling nrepl-tooling-session nrepl-session)))
+      (setq request (append request
+                            (list "session" session))))
     (let* ((id (nrepl-next-request-id connection))
            (request (cons 'dict (lax-plist-put request "id" id)))
            (message (nrepl-bencode request)))
@@ -816,19 +818,21 @@ Return the ID of the sent message."
 (declare-function cider-repl-emit-interactive-stderr "cider-repl")
 (declare-function cider--render-stacktrace-causes "cider-interaction")
 
-(defun nrepl-send-sync-request (request connection &optional abort-on-input)
+(defun nrepl-send-sync-request (request connection &optional abort-on-input tooling)
   "Send REQUEST to the nREPL server synchronously using CONNECTION.
 Hold till final \"done\" message has arrived and join all response messages
 of the same \"op\" that came along.
 If ABORT-ON-INPUT is non-nil, the function will return nil at the first
-sign of user input, so as not to hang the interface."
+sign of user input, so as not to hang the interface.
+If TOOLING, use the tooling session rather than the standard session."
   (let* ((time0 (current-time))
          (response (cons 'dict nil))
          (nrepl-ongoing-sync-request t)
          status)
     (nrepl-send-request request
                         (lambda (resp) (nrepl--merge response resp))
-                        connection)
+                        connection
+                        tooling)
     (while (and (not (member "done" status))
                 (not (and abort-on-input
                           (input-pending-p))))
@@ -860,21 +864,19 @@ sign of user input, so as not to hang the interface."
             (nrepl--mark-id-completed id)))
         response))))
 
-(defun nrepl-request:stdin (input callback connection session)
-  "Send a :stdin request with INPUT using CONNECTION and SESSION.
+(defun nrepl-request:stdin (input callback connection)
+  "Send a :stdin request with INPUT using CONNECTION.
 Register CALLBACK as the response handler."
   (nrepl-send-request (list "op" "stdin"
-                            "stdin" input
-                            "session" session)
+                            "stdin" input)
                       callback
                       connection))
 
-(defun nrepl-request:interrupt (pending-request-id callback connection session)
+(defun nrepl-request:interrupt (pending-request-id callback connection)
   "Send an :interrupt request for PENDING-REQUEST-ID.
-The request is dispatched using CONNECTION and SESSION.
+The request is dispatched using CONNECTION.
 Register CALLBACK as the response handler."
   (nrepl-send-request (list "op" "interrupt"
-                            "session" session
                             "interrupt-id" pending-request-id)
                       callback
                       connection))
@@ -882,14 +884,13 @@ Register CALLBACK as the response handler."
 (define-minor-mode cider-enlighten-mode nil nil (cider-mode " light")
   :global t)
 
-(defun nrepl--eval-request (input session &optional ns line column)
+(defun nrepl--eval-request (input &optional ns line column)
   "Prepare :eval request message for INPUT.
-SESSION and NS provide context for the request.
+NS provides context for the request.
 If LINE and COLUMN are non-nil and current buffer is a file buffer, \"line\",
 \"column\" and \"file\" are added to the message."
   (append (and ns (list "ns" ns))
           (list "op" "eval"
-                "session" session
                 "code" input)
           (when cider-enlighten-mode
             (list "enlighten" "true"))
@@ -899,15 +900,18 @@ If LINE and COLUMN are non-nil and current buffer is a file buffer, \"line\",
                     "line" line
                     "column" column)))))
 
-(defun nrepl-request:eval (input callback connection &optional session ns line column additional-params)
+(defun nrepl-request:eval (input callback connection &optional ns line column additional-params tooling)
   "Send the request INPUT and register the CALLBACK as the response handler.
-The request is dispatched via CONNECTION and SESSION.  If NS is non-nil,
+The request is dispatched via CONNECTION.  If NS is non-nil,
 include it in the request.  LINE and COLUMN, if non-nil, define the position
-of INPUT in its buffer.
+of INPUT in its buffer. A CONNECTION uniquely determines two connections
+available: the standard interaction one and the tooling session. If the
+tooling is desired, set TOOLING to true.
 ADDITIONAL-PARAMS is a plist to be appended to the request message."
-  (nrepl-send-request (append (nrepl--eval-request input session ns line column) additional-params)
+  (nrepl-send-request (append (nrepl--eval-request input ns line column) additional-params)
                       callback
-                      connection))
+                      connection
+                      tooling))
 
 (defun nrepl-sync-request:clone (connection)
   "Sent a :clone request to create a new client session.
@@ -915,29 +919,28 @@ The request is dispatched via CONNECTION."
   (nrepl-send-sync-request '("op" "clone")
                            connection))
 
-(defun nrepl-sync-request:close (connection session)
+(defun nrepl-sync-request:close (connection)
   "Sent a :close request to close CONNECTION's SESSION."
-  (nrepl-send-sync-request (list "op" "close" "session" session)
-                           connection))
+  (nrepl-send-sync-request (list "op" "close")
+                           connection)
+  (nrepl-send-sync-request (list "op" "close")
+                           t)) ;; close tooling session
 
-(defun nrepl-sync-request:describe (connection &optional session)
+(defun nrepl-sync-request:describe (connection)
   "Perform :describe request for CONNECTION and SESSION."
-  (if session
-      (nrepl-send-sync-request (list "session" session "op" "describe")
-                               connection)
-    (nrepl-send-sync-request '("op" "describe")
-                             connection)))
+  (nrepl-send-sync-request '("op" "describe")
+                           connection))
 
 (defun nrepl-sync-request:ls-sessions (connection)
   "Perform :ls-sessions request for CONNECTION."
   (nrepl-send-sync-request '("op" "ls-sessions") connection))
 
-(defun nrepl-sync-request:eval (input connection session &optional ns)
+(defun nrepl-sync-request:eval (input connection &optional ns)
   "Send the INPUT to the nREPL server synchronously.
-The request is dispatched via CONNECTION and SESSION.
+The request is dispatched via CONNECTION.
 If NS is non-nil, include it in the request."
   (nrepl-send-sync-request
-   (nrepl--eval-request input session ns)
+   (nrepl--eval-request input ns)
    connection))
 
 (defun nrepl-sessions (connection)

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -674,7 +674,7 @@ eval requests for functionality like pretty-printing won't clobber the
 values of *1, *2, etc."
   (let* ((client-conn (process-buffer client))
          (response-main (nrepl-sync-request:clone client-conn))
-         (response-tooling (nrepl-sync-request:clone client-conn)))
+         (response-tooling (nrepl-sync-request:clone client-conn t))) ; t for tooling
     (nrepl-dbind-response response-main (new-session err)
       (if new-session
           (with-current-buffer client-conn
@@ -913,11 +913,12 @@ ADDITIONAL-PARAMS is a plist to be appended to the request message."
                       connection
                       tooling))
 
-(defun nrepl-sync-request:clone (connection)
+(defun nrepl-sync-request:clone (connection &optional tooling)
   "Sent a :clone request to create a new client session.
 The request is dispatched via CONNECTION."
   (nrepl-send-sync-request '("op" "clone")
-                           connection))
+                           connection
+                           nil tooling))
 
 (defun nrepl-sync-request:close (connection)
   "Sent a :close request to close CONNECTION's SESSION."


### PR DESCRIPTION
The most fundamental notion of CIDER interaction is the connection, which is the repl (or process connected to it). These each hold two sessions, the tooling and standard sessions. The important part is that you always know which session to use if you have a connection: you want the standard one mostly and sometimes the tooling connection. 

However, we keep registering the two independently. The importance of this is that we don't take care to make sure they go in lockstep. The end result is that we'll say something like do this request (with session number) in the clojure connection, and then do it in the clojurescript connection. This causes the _same session_ to be used in two different connections. This can cause the same code to happen in the two different repls, but handled by the same clojure backend, rather than ever hitting the clojurescript one. Worse, when returning results, the tooling reports that it is a clojure repl and we record this. This is what causes cljs repls to be marked as clojure repls.

This is a tangible bug because when we evaluate clojurescript code, we dont ask for a clojurescript repl, we look for buffers named with clojurescript in them! To wit,

    (defun cider--guess-cljs-connection ()
      "Hacky way to find a ClojureScript REPL.
    DO NOT USE THIS FUNCTION.
    It was written only to be used in `cider-map-connections', as a workaround
    to a still-undetermined bug in the state-stracker backend."
      (when-let ((project-connections (cider-find-connection-buffer-for-project-directory
                                       nil :all-connections))
                 (cljs-conn
                  ;; So we have multiple connections. Look for the connection type we
                  ;; want, prioritizing the current project.
                  (or (seq-find (lambda (c) (string-match "\\bCLJS\\b" (buffer-name c)))
                                project-connections)
                      (seq-find (lambda (c) (string-match "\\bCLJS\\b" (buffer-name c)))
                                (cider-connections)))))
        (unless cider--has-warned-about-bad-repl-type
          (setq cider--has-warned-about-bad-repl-type t)
          (read-key
           (concat "The ClojureScript REPL seems to be is misbehaving."
                   (substitute-command-keys
                    "\nWe have applied a workaround, but please also file a bug report with `\\[cider-report-bug]'.")
                   "\nPress any key to continue.")))
        cljs-conn))

Further, this is the first step on the roadmap to making connections first class objects. The plan is to make connections aware of their client buffers and buffers aware of all potential connections and have a preference. Then, when receiving results from the backend, we pick out the session, find the associated connection, and we again have a connection that flows through all code. This allows us to be very flexible in the number and type of connections we handle. It also allows us to update any associated buffers to connections when appropriate (ie, font lock, etc).

This should increase the usability of cljs and cljc cuffers in CIDER, and move to give them first class citizenship alongside clojure buffers.




- [x] The commits are consistent with our [contribution guidelines][1]
- [x] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

**Caveats**

I haven't tested much of it. There are many things I don't know about in CIDER, killing sessions, describing sessions, etc. Everything should work, again, because connections uniquely (up to tooling) determine which session to use, and I have allowed us to mark tooling uses.

Also, specifically, the session browser needs some work. We need a new interface, and I'll begin working on this. But in a cljc project, it shows four UUID's. No one could find this useful as no one knows session ids. We need to group them by connection (clj cljs) and then mark them as tooling and standard. Once we do this, then we just describe them and pass along the connection selected, and mark it tooling or not and we are good to go. 