### PR TITLE
[Fix #1881] Add `cider-cljs-*-repl` defcustom and hook `boot-cljs-repl`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [#1875](https://github.com/clojure-emacs/cider/issues/1875): Ensure cljc buffers can load buffer into both clj and cljs repls.
 * [#1897](https://github.com/clojure-emacs/cider/issues/1897): Bind TAB in stacktrace buffers in the terminal.
 * [#1895](https://github.com/clojure-emacs/cider/issues/1895): Connect to the same host:port after `cider-restart` if the connection was established with `cider-connect`.
+* [#1881](https://github.com/clojure-emacs/cider/issues/1881): Add `cider-cljs-boot-repl` and `cider-cljs-gradle-repl` defcustom and hook `boot-cljs-repl`.
 
 ## 0.14.0 (2016-10-13)
 

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -186,9 +186,11 @@ Returns to the buffer in which the command was invoked."
     ("Clojurescript"
      ["Start a Clojure REPL, and a ClojureScript REPL" cider-jack-in-clojurescript
       :help "Starts an nREPL server, connects a Clojure REPL to it, and then a ClojureScript REPL.
-Configure `cider-cljs-lein-repl' to change the ClojureScript REPL to use."]
+Configure `cider-cljs-*-repl' to change the ClojureScript REPL to use for your build tool."]
      ["Create a ClojureScript REPL from a Clojure REPL" cider-create-sibling-cljs-repl]
-     ["Configure the ClojureScript REPL to use" (customize-variable 'cider-cljs-lein-repl)])
+     ["Form for launching a ClojureScript REPL via Leiningen" (customize-variable 'cider-cljs-lein-repl)]
+     ["Form for launching a ClojureScript REPL via Boot" (customize-variable 'cider-cljs-boot-repl)]
+     ["Form for launching a ClojureScript REPL via Gradle" (customize-variable 'cider-cljs-gradle-repl)])
     "--"
     ["Connection info" cider-display-connection-info
      :active cider-connections]
@@ -342,7 +344,7 @@ Configure `cider-cljs-lein-repl' to change the ClojureScript REPL to use."]
         :help "Connects to a REPL that's already running."]
        ["Start a Clojure REPL, and a ClojureScript REPL" cider-jack-in-clojurescript
         :help "Starts an nREPL server, connects a Clojure REPL to it, and then a ClojureScript REPL.
-  Configure `cider-cljs-lein-repl' to change the ClojureScript REPL to use."]
+  Configure `cider-cljs-lein-repl', `cider-cljs-boot-repl' and `cider-cljs-gradle-repl' to change the ClojureScript REPL to use."]
        "--"
        ["View manual online" cider-view-manual])))
 

--- a/doc/up_and_running.md
+++ b/doc/up_and_running.md
@@ -79,8 +79,7 @@ helpful for identifying each host.
 
 ## ClojureScript usage
 
-ClojureScript support relies on the
-[piggieback][] nREPL middleware being
+ClojureScript support relies on the [piggieback][] nREPL middleware being
 present in your REPL session.
 
 Add the following dependencies to your project (`project.clj` in Leiningen based project
@@ -104,8 +103,9 @@ or in `built.boot`:
   repl {:middleware '[cemerick.piggieback/wrap-cljs-repl]})
 ```
 
-Issue <kbd>M-x</kbd> `customize-variable` <kbd>RET</kbd> `cider-cljs-lein-repl` if
-you'd like to change the REPL used (the default is `rhino`).
+Issue <kbd>M-x</kbd> `customize-variable` <kbd>RET</kbd> and either
+`cider-cljs-lein-repl`, `cider-cljs-boot-repl` or `cider-cljs-gradle-repl` if
+you'd like to change the REPL used (the default is `rhino` where possible).
 
 Open a file in your project and issue <kbd>M-x</kbd>
 `cider-jack-in-clojurescript` <kbd>RET</kbd>. This will start up the nREPL
@@ -120,7 +120,8 @@ Using Weasel, you can also have a browser-connected REPL.
 
 1. Add `[weasel "0.7.0"]` to your project's `:dependencies`.
 
-2. Issue <kbd>M-x</kbd> `customize-variable` <kbd>RET</kbd> `cider-cljs-lein-repl`
+2. Issue <kbd>M-x</kbd> `customize-variable` <kbd>RET</kbd> plus either
+   `cider-cljs-lein-repl`, `cider-cljs-boot-repl` or `cider-cljs-gradle-repl`
    and choose the `Weasel` option.
 
 3. Add this to your ClojureScript code:
@@ -156,7 +157,7 @@ and this at the end of `build.boot`:
 ```clojure
 (require
  '[adzerk.boot-cljs :refer [cljs]]
- '[adzerk.boot-cljs-repl :refer [cljs-repl start-repl]]
+ '[adzerk.boot-cljs-repl :refer [cljs-repl]]
  '[pandeiro.boot-http :refer [serve]])
 
 (deftask dev []
@@ -166,11 +167,10 @@ and this at the end of `build.boot`:
         (cljs)))
 ```
 
-2. Start `boot dev` in a terminal.
+2. Issue <kbd>M-x</kbd> `customize-variable` <kbd>RET</kbd> `cider-boot-parameters`
+   and insert `dev`.
 
-3. <kbd>M-x</kbd> `cider-connect` to localhost and select the repl process.
-
-4. Execute `(start-repl)` at the prompt: `boot.user> (start-repl)`.
+3. Open a file in your project and issue <kbd>M-x</kbd> `cider-jack-in-clojurescript`.
 
 5. Connect to the running server with your browser. The address is printed on the terminal, but it's probably `http://localhost:3000`.
 


### PR DESCRIPTION
This patch firstly adds two more defcustoms, `cider-cljs-boot-repl` and
`cider-cljs-gradle-repl`, that will be queried by the
`cider-cljs-repl-form` function on `cider-jack-in-clojurescript`

Secondly, it adds a clause in `cider--cljs-repl-types` that allows to
automatically call `adzerk.boot-cljs-repl/start-repl` in case `boot` is
the project type.

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines][1]
- [X] All tests are passing (`make test`)
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [X] You've updated the changelog (if adding/changing user-visible functionality)
- [X] You've updated the readme (if adding/changing user-visible functionality)
