### PR TITLE
Make cider global and parameters option explicit in the doc

### DIFF
--- a/doc/up_and_running.md
+++ b/doc/up_and_running.md
@@ -42,8 +42,8 @@ In Clojure(Script) buffers the command `cider-jack-in` is bound to <kbd>C-c M-j<
 For further customizing the command line used for `cider-jack-in`, you can
 change the following (all string options):
 
- * `cider-[TOOL]-global-options`: these are passed to the command directly, in first position (e.g. `-o` to `lein` enables offline mode).
- * `cider-[TOOL]-parameters`: these are usually tasks names and their parameters (e.g.: `dev` for launching boot's dev task instead of the standard `repl -s  wait`).
+ * `cider-lein-global-options`, `cider-boot-global-options`, `cider-gradle-global-options`: these are passed to the command directly, in first position (e.g. `-o` to `lein` enables offline mode).
+ * `cider-lein-parameters`, `cider-boot-parameters`, `cider-gradle-parameters`: these are usually tasks names and their parameters (e.g.: `dev` for launching boot's dev task instead of the standard `repl -s  wait`).
 
 ## Connect to a running nREPL server
 


### PR DESCRIPTION
As per the other PR, makes `defcustom` explicit in the doc.