### PR TITLE
Make cljs repl command configurable again through .dir-locals.el

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -498,6 +498,9 @@ based on PROJECT-TYPE."
 The new buffer will correspond to the same project as CLIENT-BUFFER, which
 should be the regular Clojure REPL started by the server process filter."
   (interactive (list (cider-current-connection)))
+  ;; Load variables in .dir-locals.el into the server process buffer, so
+  ;; cider-cljs-*-repl can be set for each project individually.
+  (hack-local-variables)
   (let* ((nrepl-repl-buffer-name-template "*cider-repl CLJS%s*")
          (nrepl-create-client-buffer-function #'cider-repl-create)
          (nrepl-use-this-as-repl-buffer 'new)


### PR DESCRIPTION
When using `cider-jack-in-clojurescript`, the CLJS repl is started indirectly
from a process handler. The result is that when looking up variables like
`cider-cljs-lein-repl`, it's no longer in the context of a source buffer in the
user's project, and so dir-local (or buffer-local) values no longer apply.

The "fix" is to wrap `cider-create-sibling-cljs-repl` in a lambda which captures
the current buffer.

Would be happy to get feedback on this code.

For more discussion see https://github.com/clojure-emacs/cider/issues/1938 and https://github.com/clojure-emacs/cider/pull/1933
