### PR TITLE
Reorder repl init to occur after debugger init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Bugs Fixed
 
+* [#1947](https://github.com/clojure-emacs/cider/issues/1947): Fix error on `cider-jack-in` when `enlighten-mode` is enabled.
 * [#1588](https://github.com/clojure-emacs/cider/issues/1588): Redirect `*err*`, `java.lang.System/out`, and `java.lang.System/err` to REPL buffer on all attached sessions.
 * [#1707](https://github.com/clojure-emacs/cider/issues/1707): Allow to customize line truncating in CIDER's special buffers.
 * [#1876](https://github.com/clojure-emacs/cider/issues/1876): Set pretty-printing width with `cider-repl-pretty-print-width`. If this variable is not set, fall back to `fill-column`.

--- a/cider.el
+++ b/cider.el
@@ -857,16 +857,20 @@ message in the REPL area."
 This function is appended to `nrepl-connected-hook' in the client process
 buffer."
   ;; `nrepl-connected-hook' is run in the connection buffer
-  (cider-make-connection-default (current-buffer))
-  (cider-repl-init (current-buffer))
-  (cider--check-required-nrepl-version)
-  (cider--check-clojure-version-supported)
-  (cider--check-middleware-compatibility)
-  (cider--debug-init-connection)
-  (cider--subscribe-repl-to-server-out)
-  (when cider-auto-mode
-    (cider-enable-on-existing-clojure-buffers))
-  (run-hooks 'cider-connected-hook))
+
+  ;; `cider-enlighten-mode' changes eval to include the debugger, so we inhibit
+  ;; it here as the debugger isn't necessarily initialized yet
+  (let ((cider-enlighten-mode nil))
+    (cider-make-connection-default (current-buffer))
+    (cider-repl-init (current-buffer))
+    (cider--check-required-nrepl-version)
+    (cider--check-clojure-version-supported)
+    (cider--check-middleware-compatibility)
+    (cider--debug-init-connection)
+    (cider--subscribe-repl-to-server-out)
+    (when cider-auto-mode
+      (cider-enable-on-existing-clojure-buffers))
+    (run-hooks 'cider-connected-hook)))
 
 (defun cider--disconnected-handler ()
   "Cleanup after nREPL connection has been lost or closed.


### PR DESCRIPTION
When initializing the repl, we ask what namespace we are in by evaling code,
eg (eval "(str *ns*)"). However, enlighten mode hijacks eval messages in the
middleware and uses the debugger on them which causes an error if the debugger
is not yet initialized.

https://github.com/clojure-emacs/cider/issues/1947
-----------------

- [x] The commits are consistent with our [contribution guidelines][1]
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)
