### PR TITLE
Fix nrepl--direct-connect error formatting in the let binding.

### DIFF
--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -554,7 +554,7 @@ If NO-ERROR is non-nil, show messages instead of throwing an error."
         (prog1 (list :proc (open-network-stream "nrepl-connection" nil host port)
                      :host host :port port)
           (message "[nREPL] Direct connection to %s:%s established" host port))
-      (error (let ((msg "[nREPL] Direct connection to %s:%s failed" host port))
+      (error (let ((msg (format "[nREPL] Direct connection to %s:%s failed" host port)))
                (if no-error
                    (message msg)
                  (error msg))


### PR DESCRIPTION
Seems like a bug crawled into 0fb25a8, not even being a valid let form.

The compiled version would have fail like:

    [nREPL] Establishing direct connection to somehost:42 ...
    nrepl--direct-connect: Not enough arguments for format string

Interactively loading `nrepl--direct-connect` function, would
have fail with "let bindings can have only one value form" kind of error.

After this commit the thing fails in a more appropriate way:

    [nREPL] Establishing direct connection to somehost:42 ...
    [nREPL] Direct connection to somehost:42 failed
    nrepl-connect: [nREPL] Cannot connect to somehost:42