### PR TITLE
Add markdown support in the grimmoire buffer

### DIFF
--- a/cider-grimoire.el
+++ b/cider-grimoire.el
@@ -79,6 +79,8 @@ opposite of what that option dictates."
     (read-only-mode -1)
     (insert content)
     (read-only-mode +1)
+    (when (fboundp 'markdown-mode)
+      (markdown-mode))
     (goto-char (point-min))
     (current-buffer)))
 


### PR DESCRIPTION
* cider-grimoire.el (cider-create-grimoire-buffer): Activate markdown-mode when
  found.

The `http://conj.io/` gives documentation in the markdown format. I thought it would be nice to get font-lock working. It's a really simple PR.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](https://github.com/clojure-emacs/cider/blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)