### PR TITLE
Fix performance in fringe overlay placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Bugs Fixed
 
+* [#1962](https://github.com/clojure-emacs/cider/issues/1962): Fix performance in fringe overlay placement
 * [#1947](https://github.com/clojure-emacs/cider/issues/1947): Fix error on `cider-jack-in` when `enlighten-mode` is enabled.
 * [#1588](https://github.com/clojure-emacs/cider/issues/1588): Redirect `*err*`, `java.lang.System/out`, and `java.lang.System/err` to REPL buffer on all attached sessions.
 * [#1707](https://github.com/clojure-emacs/cider/issues/1707): Allow to customize line truncating in CIDER's special buffers.

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -693,6 +693,7 @@ REPL buffer.  This is controlled via
                          (current-buffer))
     (save-excursion
       (goto-char beg)
+      (remove-overlays beg end 'cider-fringe-indicator)
       (condition-case nil
           (while (progn (clojure-forward-logical-sexp)
                         (and (<= (point) end)
@@ -709,11 +710,14 @@ or it can be a list with (START END) of the evaluated region."
          (beg (car-safe place))
          (end (or (car-safe (cdr-safe place)) place))
          (beg (when beg (copy-marker beg)))
-         (end (when end (copy-marker end))))
+         (end (when end (copy-marker end)))
+         (fringed nil))
     (nrepl-make-response-handler (or buffer eval-buffer)
                                  (lambda (_buffer value)
                                    (if beg
-                                       (cider--make-fringe-overlays-for-region beg end)
+                                       (unless fringed
+                                         (cider--make-fringe-overlays-for-region beg end)
+                                         (setq fringed t))
                                      (cider--make-fringe-overlay end))
                                    (cider--display-interactive-eval-result value end))
                                  (lambda (_buffer out)


### PR DESCRIPTION
Multiple identical fringe overlays were being placed by overlays were being
added to the entire region for every interactive eval in that region.

Add check in cider-interactive-eval-handler, so only first value adds fringe
overlays. Remove all fringe overlays in region before placing new ones.

Addresses #1962

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][2] extremely useful.*

[1]: https://github.com/clojure-emacs/cider/blob/master/.github/CONTRIBUTING.md
[2]: https://cider.readthedocs.io/en/latest/hacking_on_cider/
