### PR TITLE
Add cider-load-all-files and clojure-files-in-directory functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+* Add new function `cider-load-all-files` (and helper `clojure-files-in-directory`).
 * Add new customization variable `cider-special-mode-truncate-lines`.
 * Add an option `cider-inspector-fill-frame` to control whether the cider inspector window fills its frame.
 * [#1893](https://github.com/clojure-emacs/cider/issues/1893): Add negative prefix argument to `cider-refresh` to inhibit invoking of cider-refresh-functions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
-* Add new function `cider-load-all-files` (and helper `clojure-files-in-directory`), along with menu bar update.
+* Add new function `cider-load-all-files`, along with menu bar update.
 * Add new customization variable `cider-special-mode-truncate-lines`.
 * Add an option `cider-inspector-fill-frame` to control whether the cider inspector window fills its frame.
 * [#1893](https://github.com/clojure-emacs/cider/issues/1893): Add negative prefix argument to `cider-refresh` to inhibit invoking of cider-refresh-functions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
-* Add new function `cider-load-all-files` (and helper `clojure-files-in-directory`).
+* Add new function `cider-load-all-files` (and helper `clojure-files-in-directory`), along with menu bar update.
 * Add new customization variable `cider-special-mode-truncate-lines`.
 * Add an option `cider-inspector-fill-frame` to control whether the cider inspector window fills its frame.
 * [#1893](https://github.com/clojure-emacs/cider/issues/1893): Add negative prefix argument to `cider-refresh` to inhibit invoking of cider-refresh-functions

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1612,7 +1612,7 @@ The heavy lifting is done by `cider-load-buffer'."
     (cider-load-buffer (current-buffer))))
 
 (defun cider-load-all-files (directory)
-  "Load all files in DIRECTORY (recursively). Useful when the running nREPL on remote host"
+  "Load all files in DIRECTORY (recursively).  Useful when the running nREPL on remote host."
   (interactive "DLoad files beneath directory: ")
   (mapcar #'cider-load-file
           (directory-files-recursively directory ".clj$")))

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1611,54 +1611,16 @@ The heavy lifting is done by `cider-load-buffer'."
     (find-file filename)
     (cider-load-buffer (current-buffer))))
 
-(defun clojure-files-in-directory (directory)
-  "List of all .clj files found recursively in DIRECTORY.
-
-Fork of function at: https://www.gnu.org/software/emacs/manual/html_node/eintr/Files-List.html"
-  (interactive "DDirectory name: ")
-  (cider-ensure-connected)
-  (let (clj-files-list
-        (current-directory-list
-         (directory-files-and-attributes directory t)))
-    ;; while we are in the current directory
-    (while current-directory-list
-      (cond
-       ;; check to see whether filename ends in '.clj'
-       ;; and if so, add its name to a list.
-       ((equal ".clj" (substring (car (car current-directory-list)) -4))
-        (setq clj-files-list
-              (cons (car (car current-directory-list)) clj-files-list)))
-       ;; check whether filename is that of a directory
-       ((eq t (car (cdr (car current-directory-list))))
-        ;; decide whether to skip or recurse
-        (if
-            (equal "."
-                   (substring (car (car current-directory-list)) -1))
-            ;; then do nothing since filename is that of
-            ;;   current directory or parent, "." or ".."
-            ()
-          ;; else descend into the directory and repeat the process
-          (setq clj-files-list
-                (append
-                 (clojure-files-in-directory
-                  (car (car current-directory-list)))
-                 clj-files-list)))))
-      ;; move to the next filename in the list; this also
-      ;; shortens the list so the while loop eventually comes to an end
-      (setq current-directory-list (cdr current-directory-list)))
-    ;; return the filenames
-    clj-files-list))
-
 (defun cider-load-all-files (directory)
   "Load all files in DIRECTORY (recursively)."
   (interactive "DDirectory name: ")
   (mapcar #'cider-load-file
-          (clojure-files-in-directory directory)))
+          (directory-files-recursively directory ".clj$")))
 
 (defalias 'cider-eval-file 'cider-load-file
   "A convenience alias as some people are confused by the load-* names.")
 
-(defalias 'cider-eval-all-files 'cider-load-file
+(defalias 'cider-eval-all-files 'cider-load-all-files
   "A convenience alias as some people are confused by the load-* names.")
 
 (defalias 'cider-eval-buffer 'cider-load-buffer

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1612,7 +1612,7 @@ The heavy lifting is done by `cider-load-buffer'."
     (cider-load-buffer (current-buffer))))
 
 (defun cider-load-all-files (directory)
-  "Load all files in DIRECTORY (recursively)."
+  "Load all files in DIRECTORY (recursively). Useful when the running nREPL on remote host"
   (interactive "DDirectory name: ")
   (mapcar #'cider-load-file
           (directory-files-recursively directory ".clj$")))

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1613,7 +1613,7 @@ The heavy lifting is done by `cider-load-buffer'."
 
 (defun cider-load-all-files (directory)
   "Load all files in DIRECTORY (recursively). Useful when the running nREPL on remote host"
-  (interactive "DDirectory name: ")
+  (interactive "DLoad files beneath directory: ")
   (mapcar #'cider-load-file
           (directory-files-recursively directory ".clj$")))
 

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1611,7 +1611,54 @@ The heavy lifting is done by `cider-load-buffer'."
     (find-file filename)
     (cider-load-buffer (current-buffer))))
 
+(defun clojure-files-in-directory (directory)
+  "List of all .clj files found recursively in DIRECTORY.
+
+Fork of function at: https://www.gnu.org/software/emacs/manual/html_node/eintr/Files-List.html"
+  (interactive "DDirectory name: ")
+  (cider-ensure-connected)
+  (let (clj-files-list
+        (current-directory-list
+         (directory-files-and-attributes directory t)))
+    ;; while we are in the current directory
+    (while current-directory-list
+      (cond
+       ;; check to see whether filename ends in '.clj'
+       ;; and if so, add its name to a list.
+       ((equal ".clj" (substring (car (car current-directory-list)) -4))
+        (setq clj-files-list
+              (cons (car (car current-directory-list)) clj-files-list)))
+       ;; check whether filename is that of a directory
+       ((eq t (car (cdr (car current-directory-list))))
+        ;; decide whether to skip or recurse
+        (if
+            (equal "."
+                   (substring (car (car current-directory-list)) -1))
+            ;; then do nothing since filename is that of
+            ;;   current directory or parent, "." or ".."
+            ()
+          ;; else descend into the directory and repeat the process
+          (setq clj-files-list
+                (append
+                 (clojure-files-in-directory
+                  (car (car current-directory-list)))
+                 clj-files-list)))))
+      ;; move to the next filename in the list; this also
+      ;; shortens the list so the while loop eventually comes to an end
+      (setq current-directory-list (cdr current-directory-list)))
+    ;; return the filenames
+    clj-files-list))
+
+(defun cider-load-all-files (directory)
+  "Load all files in DIRECTORY (recursively)."
+  (interactive "DDirectory name: ")
+  (mapcar #'cider-load-file
+          (clojure-files-in-directory directory)))
+
 (defalias 'cider-eval-file 'cider-load-file
+  "A convenience alias as some people are confused by the load-* names.")
+
+(defalias 'cider-eval-all-files 'cider-load-file
   "A convenience alias as some people are confused by the load-* names.")
 
 (defalias 'cider-eval-buffer 'cider-load-buffer

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -315,6 +315,7 @@ Configure `cider-cljs-*-repl' to change the ClojureScript REPL to use for your b
     (define-key map (kbd "C-c C-o") #'cider-find-and-clear-repl-output)
     (define-key map (kbd "C-c C-k") #'cider-load-buffer)
     (define-key map (kbd "C-c C-l") #'cider-load-file)
+    (define-key map (kbd "C-c C-M-l") #'cider-load-all-files)
     (define-key map (kbd "C-c C-b") #'cider-interrupt)
     (define-key map (kbd "C-c ,")   'cider-test-commands-map)
     (define-key map (kbd "C-c C-t") 'cider-test-commands-map)

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -235,6 +235,7 @@ Configure `cider-cljs-*-repl' to change the ClojureScript REPL to use for your b
     "--"
     ["Load this buffer" cider-load-buffer]
     ["Load another file" cider-load-file]
+    ["Recursively load all files in directory" cider-load-all-files]
     ["Load all project files" cider-load-all-project-ns]
     ["Refresh loaded code" cider-refresh]
     ["Run project (-main function)" cider-run])

--- a/doc/cider-refcard.tex
+++ b/doc/cider-refcard.tex
@@ -79,6 +79,7 @@
 \begin{keylist}[labelwidth=\widthof{\keyify{C-c RET}}]
   \item[C-c C-k] cider-load-buffer
   \item[C-c C-l] cider-load-file
+  \item[C-c C-M-l] cider-load-all-files
   \item[C-c C-r] cider-eval-region
   \item[C-c C-n] cider-eval-ns-form
   \item[C-x C-e] \ns{cider-eval-last-sexp}

--- a/doc/interactive_programming.md
+++ b/doc/interactive_programming.md
@@ -41,6 +41,7 @@ Here's a list of `cider-mode`'s keybindings:
 `cider-find-and-clear-repl-output`            |<kbd>C-c C-o</kbd>                   | Clear the last output in the REPL buffer. With a prefix argument it will clear the entire REPL buffer, leaving only a prompt. Useful if you're running the REPL buffer in a side by side buffer.
 `cider-load-buffer`                           |<kbd>C-c C-k</kbd>                   | Load (eval) the current buffer.
 `cider-load-file`                             |<kbd>C-c C-l</kbd>                   | Load (eval) a Clojure file.
+`cider-load-all-files`                        |<kbd>C-c C-M-l</kbd>                 | Load (eval) all Clojure files below a directory.
 `cider-refresh`                               |<kbd>C-c C-x</kbd>                   | Reload all modified files on the classpath. If invoked with a prefix argument, reload all files on the classpath. If invoked with a double prefix argument, clear the state of the namespace tracker before reloading.
 `cider-doc`                                   |<kbd>C-c C-d d</kbd> <br/> <kbd>C-c C-d C-d</kbd> | Display doc string for the symbol at point.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.
 `cider-javadoc`                               |<kbd>C-c C-d j</kbd> <br/> <kbd>C-c C-d C-j</kbd> | Display JavaDoc (in your default browser) for the symbol at point.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.


### PR DESCRIPTION
Useful when the nrepl host is on another machine, and you wish to "force" the
state of your local file system onto that remote nrepl all at once. 

For this use case `cider-load-all-project-ns` will not do as it runs on the nrepl server machine (unless I've misunderstood). 

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [N/A] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [N/A] You've updated the readme (if adding/changing user-visible functionality)
- [N/A] You've updated the refcard (if you made changes to the commands listed there)