### PR TITLE
[#1990] Adds option to auto-save buffers when calling cider-refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+* [#1990](https://github.com/clojure-emacs/cider/issues/1990): Add new customation variable `cider-prompt-save-file-on-cider-refresh` to allow auto-saving buffers when `cider-refresh` is called.
 * Add new function `cider-load-all-files`, along with menu bar update.
 * Add new customization variable `cider-special-mode-truncate-lines`.
 * Add an option `cider-inspector-fill-frame` to control whether the cider inspector window fills its frame.

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -111,6 +111,17 @@ If the symbol `always-save', save the file without confirmation."
   :group 'cider
   :package-version '(cider . "0.6.0"))
 
+(defcustom cider-prompt-save-file-on-cider-refresh t
+  "Controls whether to prompt to save clojure file when calling ‘cider-refresh’.
+If nil, files are not saved.
+If t, the user is prompted to save files if it's been modified.
+If the symbol `always-save', save the files without confirmation."
+  :type '(choice (const t :tag "Prompt to save files if it's been modified")
+                 (const nil :tag "Don't save the files")
+                 (const always-save :tag "Save the files without confirmation"))
+  :group 'cider
+  :package-version '(cider . "0.15.0"))
+
 (defcustom cider-completion-use-context t
   "When true, uses context at point to improve completion suggestions."
   :type 'boolean
@@ -1541,6 +1552,9 @@ refresh functions (defined in `cider-refresh-before-fn' and
   (let ((clear? (member mode '(clear 16)))
         (refresh-all? (member mode '(refresh-all 4)))
         (inhibit-refresh-fns (member mode '(inhibit-fns -1))))
+    (when cider-prompt-save-file-on-cider-refresh
+      (save-some-buffers (eq cider-prompt-save-file-on-cider-refresh 'always-save)
+                         (lambda () (derived-mode-p 'clojure-mode))))
     (cider-map-connections
      (lambda (conn)
        ;; Inside the lambda, so the buffer is not created if we error out.

--- a/doc/miscellaneous_features.md
+++ b/doc/miscellaneous_features.md
@@ -145,6 +145,9 @@ and
 (setq cider-refresh-show-log-buffer t)
 ```
 
+* By default, all Clojure buffers are prompted to be saved. This behaviour can be
+  customized using `cider-prompt-save-file-on-refresh`. 
+
 ## Tracing function execution
 
 You can trace the results produced by functions using <kbd>C-c M-t v</kbd>.  The


### PR DESCRIPTION
Fixes #1990. Adds an option to auto-save buffers when calling cider-refresh. There is an option `cider-prompt-save-file-on-cider-refresh` which allows users to customize this behaviour. By default, the user is prompted for each clojure buffer to save.

- [ ] The commits are consistent with our [contribution guidelines][1]
- [ ] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)