### PR TITLE
Added cider-doc-auto-select-buffer custom variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#1726](https://github.com/clojure-emacs/cider/issues/1726): Order keys in printed nrepl message objects.
 * [#1832](https://github.com/clojure-emacs/cider/issues/1832): Add new customization variable `cider-eldoc-display-context-dependent-info` to control showing eldoc info for datomic query input parameters.
 * Make it possible to disable auto-evaluation of changed ns forms via the defcustom `cider-auto-track-ns-form-changes`.
+* [#1995](https://github.com/clojure-emacs/cider/pull/1995): Add new customization variable `cider-doc-auto-select-buffer` to control cider-doc popup buffer auto selection.
 
 ### Changes
 

--- a/cider-doc.el
+++ b/cider-doc.el
@@ -96,6 +96,11 @@
   :group 'cider-docview-mode
   :package-version '(cider . "0.7.0"))
 
+(defcustom cider-doc-auto-select-buffer t
+  "Controls whether to auto-select the doc popup buffer."
+  :type 'boolean
+  :group 'cider-doc
+  :package-version  '(cider . "0.15.0"))
 
 
 ;; Faces
@@ -263,7 +268,7 @@ opposite of what that option dictates."
 (defun cider-doc-lookup (symbol)
   "Look up documentation for SYMBOL."
   (if-let ((buffer (cider-create-doc-buffer symbol)))
-      (cider-popup-buffer-display buffer t)
+      (cider-popup-buffer-display buffer cider-doc-auto-select-buffer)
     (user-error "Symbol %s not resolved" symbol)))
 
 (defun cider-doc (&optional arg)


### PR DESCRIPTION
Added cider-doc-auto-select-buffer custom variable to control if the documentation viewer popup will be autoselected after opening.
