### PR TITLE
fix `find-file-noselect: Wrong type argument: stringp, nil` 

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1590,12 +1590,10 @@ ClojureScript REPL exists for the project, it is evaluated in both REPLs."
                (or (eq cider-prompt-save-file-on-load 'always-save)
                    (y-or-n-p (format "Save file %s? " buffer-file-name))))
       (save-buffer))
-
     (remove-overlays nil nil 'cider-temporary t)
     (cider--clear-compilation-highlights)
     (cider--quit-error-window)
     (cider--cache-ns-form)
-
     (let ((filename (buffer-file-name buffer)))
       (cider-map-connections
        (lambda (connection)

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1590,11 +1590,12 @@ ClojureScript REPL exists for the project, it is evaluated in both REPLs."
                (or (eq cider-prompt-save-file-on-load 'always-save)
                    (y-or-n-p (format "Save file %s? " buffer-file-name))))
       (save-buffer))
-    (remove-overlays nil nil 'cider-temporary t)
-    (cider--clear-compilation-highlights)
-    (cider--quit-error-window)
-    (cider--cache-ns-form)
     (let ((filename (buffer-file-name)))
+      (remove-overlays nil nil 'cider-temporary t)
+      (cider--clear-compilation-highlights)
+      (cider--quit-error-window)
+      (cider--cache-ns-form)
+
       (cider-map-connections
        (lambda (connection)
          (cider-request:load-file (cider-file-string filename)

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1590,12 +1590,13 @@ ClojureScript REPL exists for the project, it is evaluated in both REPLs."
                (or (eq cider-prompt-save-file-on-load 'always-save)
                    (y-or-n-p (format "Save file %s? " buffer-file-name))))
       (save-buffer))
-    (let ((filename (buffer-file-name)))
-      (remove-overlays nil nil 'cider-temporary t)
-      (cider--clear-compilation-highlights)
-      (cider--quit-error-window)
-      (cider--cache-ns-form)
 
+    (remove-overlays nil nil 'cider-temporary t)
+    (cider--clear-compilation-highlights)
+    (cider--quit-error-window)
+    (cider--cache-ns-form)
+
+    (let ((filename (buffer-file-name buffer)))
       (cider-map-connections
        (lambda (connection)
          (cider-request:load-file (cider-file-string filename)


### PR DESCRIPTION

- fix a bug that losing `buffer-file-name` after call `(cider--quit-error-window)`
The bug yields an error message `find-file-noselect: Wrong type argument: stringp, nil'  that prevents from loading buffer.
-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][2] extremely useful.*

[1]: https://github.com/clojure-emacs/cider/blob/master/.github/CONTRIBUTING.md
[2]: https://cider.readthedocs.io/en/latest/hacking_on_cider/
