### PR TITLE
Accompanying changes to  clojure-emacs/cider-nrepl#405

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 ### Bugs Fixed
 
+* [#1699](https://github.com/clojure-emacs/cider/issues/1699): Fix "Method code too large!" error that occurred during instrumentation for debugging.
 * [#1987](https://github.com/clojure-emacs/cider/issues/1987): Fix: Update faces when disabling a theme
 * [#1962](https://github.com/clojure-emacs/cider/issues/1962): Fix performance in fringe overlay placement.
 * [#1947](https://github.com/clojure-emacs/cider/issues/1947): Fix error on `cider-jack-in` when `enlighten-mode` is enabled.

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -557,11 +557,11 @@ with the given LIMIT."
                    (while plist
                      (let ((sym (pop plist))
                            (meta (pop plist)))
-                       (pcase (nrepl-dict-get meta "cider.nrepl.middleware.util.instrument/breakfunction")
+                       (pcase (nrepl-dict-get meta "cider/instrumented")
                          (`nil nil)
-                         (`"#'cider.nrepl.middleware.debug/breakpoint-if-interesting"
+                         (`"\"breakpoint-if-interesting\""
                           (push sym instrumented))
-                         (`"#'cider.nrepl.middleware.enlighten/light-form"
+                         (`"\"light-form\""
                           (push sym enlightened)))
                        ;; The ::traced keywords can be inlined by MrAnderson, so
                        ;; we catch that case too.


### PR DESCRIPTION
Adjustments needed for clojure-emacs/cider-nrepl#405.

So far there is only one change - simplification of instrumentation metadata received from the server. I cut simplified metadata on the clojure side as it inflates the method side considerably. Also removing the namespace qualification which looks like a spill over of internals from clojure side. 