### PR TITLE
Fontify Grimoire code blocks if possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+* [#2007](https://github.com/clojure-emacs/cider/pull/2007): Fontify code blocks from `cider-grimoire` if possible.
 * [#1990](https://github.com/clojure-emacs/cider/issues/1990): Add new customation variable `cider-save-files-on-cider-refresh` to allow auto-saving buffers when `cider-refresh` is called.
 * Add new function `cider-load-all-files`, along with menu bar update.
 * Add new customization variable `cider-special-mode-truncate-lines`.

--- a/Cask
+++ b/Cask
@@ -6,4 +6,5 @@
 (files "*.el" (:exclude ".dir-locals.el"))
 
 (development
- (depends-on "buttercup"))
+ (depends-on "buttercup")
+ (depends-on "markdown-mode"))

--- a/cider-grimoire.el
+++ b/cider-grimoire.el
@@ -35,6 +35,9 @@
 
 (require 'url-vars)
 
+(declare-function markdown-mode "markdown-mode.el")
+(declare-function markdown-toggle-fontify-code-blocks-natively "markdown-mode.el")
+
 (defconst cider-grimoire-url "http://conj.io/")
 
 (defconst cider-grimoire-buffer "*cider-grimoire*")
@@ -78,6 +81,11 @@ opposite of what that option dictates."
   (with-current-buffer (cider-popup-buffer cider-grimoire-buffer t)
     (read-only-mode -1)
     (insert content)
+    (when (require 'markdown-mode nil 'noerror)
+      (markdown-mode)
+      (cider-popup-buffer-mode 1)
+      (when (fboundp 'markdown-toggle-fontify-code-blocks-natively)
+        (markdown-toggle-fontify-code-blocks-natively 1)))
     (read-only-mode +1)
     (goto-char (point-min))
     (current-buffer)))


### PR DESCRIPTION
Follow-up on #1959 and the [discussion](https://github.com/clojure-emacs/cider/pull/1959#issuecomment-291918454) with @bbatsov r.e. fontifying code blocks in the markdown buffer returned by `cider-grimoire`.

Thanks to @jrblevin for addressing jrblevin/markdown-mode#185.