### PR TITLE
Apropos special forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+* [#2012](https://github.com/clojure-emacs/cider/pull/2007): Support special forms in `cider-apropos` and `cider-grimoire-lookup`.
 * [#2007](https://github.com/clojure-emacs/cider/pull/2007): Fontify code blocks from `cider-grimoire` if possible.
 * [#1990](https://github.com/clojure-emacs/cider/issues/1990): Add new customation variable `cider-save-files-on-cider-refresh` to allow auto-saving buffers when `cider-refresh` is called.
 * Add new function `cider-load-all-files`, along with menu bar update.

--- a/cider-apropos.el
+++ b/cider-apropos.el
@@ -54,6 +54,15 @@ the symbol found by the apropos search as argument."
   :group 'cider
   :package-version '(cider . "0.13.0"))
 
+(define-button-type 'apropos-special-form
+  'apropos-label "Special form"
+  'apropos-short-label "s"
+  'face 'apropos-misc-button
+  'help-echo "mouse-2, RET: Display more help on this special form"
+  'follow-link t
+  'action (lambda (button)
+            (describe-function (button-get button 'apropos-symbol))))
+
 (defun cider-apropos-doc (button)
   "Display documentation for the symbol represented at BUTTON."
   (cider-doc-lookup (button-get button 'apropos-symbol)))

--- a/cider-grimoire.el
+++ b/cider-grimoire.el
@@ -91,10 +91,13 @@ opposite of what that option dictates."
     (current-buffer)))
 
 (defun cider-grimoire-lookup (symbol)
-  "Look up the grimoire documentation for SYMBOL."
+  "Look up the grimoire documentation for SYMBOL.
+
+If SYMBOL is a special form, the clojure.core ns is used, as is
+Grimoire's convention."
   (if-let ((var-info (cider-var-info symbol)))
       (let ((name (nrepl-dict-get var-info "name"))
-            (ns (nrepl-dict-get var-info "ns"))
+            (ns (nrepl-dict-get var-info "ns" "clojure.core"))
             (url-request-method "GET")
             (url-request-extra-headers `(("Content-Type" . "text/plain"))))
         (url-retrieve (cider-grimoire-url name ns)


### PR DESCRIPTION
These changes are necessary to use clojure-emacs/cider-nrepl#409.

Example of special forms from `cider-apropos`:

![image](https://user-images.githubusercontent.com/1624090/27219691-75979478-5237-11e7-8e72-96c7ee9e24c9.png)
