### PR TITLE
Use new format for forms-str and arglists-str

### DIFF
--- a/cider-apropos.el
+++ b/cider-apropos.el
@@ -57,7 +57,7 @@ the symbol found by the apropos search as argument."
 (define-button-type 'apropos-special-form
   'apropos-label "Special form"
   'apropos-short-label "s"
-  'face 'apropos-misc-button
+  'face 'font-lock-keyword-face
   'help-echo "mouse-2, RET: Display more help on this special form"
   'follow-link t
   'action (lambda (button)


### PR DESCRIPTION
Depends on clojure-emacs/cider-nrepl#412.

Using the new forms-str and arglists-str formats simplifies code for
`cider-docview-render-info`.

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)