### PR TITLE
Indicate both special form and macro in doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### New Features
 
-* [#2012](https://github.com/clojure-emacs/cider/pull/2007): Support special forms in `cider-apropos` and `cider-grimoire-lookup`.
+* [#2015](https://github.com/clojure-emacs/cider/pull/2015): Show symbols as special forms *and* macros in `cider-doc`
+* [#2012](https://github.com/clojure-emacs/cider/pull/2012): Support special forms in `cider-apropos` and `cider-grimoire-lookup`.
 * [#2007](https://github.com/clojure-emacs/cider/pull/2007): Fontify code blocks from `cider-grimoire` if possible.
 * [#1990](https://github.com/clojure-emacs/cider/issues/1990): Add new customation variable `cider-save-files-on-cider-refresh` to allow auto-saving buffers when `cider-refresh` is called.
 * Add new function `cider-load-all-files`, along with menu bar update.

--- a/cider-doc.el
+++ b/cider-doc.el
@@ -432,8 +432,10 @@ Tables are marked to be ignored by line wrap."
           (dolist (form forms)
             (insert " ")
             (emit (cider-font-lock-as-clojure form))))
-        (when (or special macro)
-          (emit (if special "Special Form" "Macro") 'font-lock-variable-name-face))
+        (when special
+          (emit "Special Form" 'font-lock-keyword-face))
+        (when macro
+          (emit "Macro" 'font-lock-variable-name-face))
         (when added
           (emit (concat "Added in " added) 'font-lock-comment-face))
         (when depr


### PR DESCRIPTION
Some symbols, like `clojure.core/let`, are special forms AND macros. `cider-doc` should indicate this.