### PR TITLE
Handle ANSI REPL evaluation created by Puget.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### Changes
 
+* Handle ANSI REPL evaluation created by Puget.
 * Drop support for Emacs 24.3.
 * Don't try to use ssh automatically when connecting to remote hosts and a direct connection fails. See `nrepl-use-ssh-fallback-for-remote-hosts`.
 * [#1945](https://github.com/clojure-emacs/cider/pull/1945): Start nREPL servers bound to `::` by default using `cider-jack-in`.

--- a/cider-util.el
+++ b/cider-util.el
@@ -258,7 +258,7 @@ This buffer is not designed to display anything to the user.  For that, use
 (defun cider-font-lock-as (mode string)
   "Use MODE to font-lock the STRING."
   (let ((string (if (cider-ansi-color-string-p string)
-                    (ansi-color-apply string)
+                    (substring-no-properties (ansi-color-apply string))
                   string)))
     (if (or (null cider-font-lock-max-length)
             (< (length string) cider-font-lock-max-length))

--- a/cider-util.el
+++ b/cider-util.el
@@ -36,6 +36,7 @@
 (require 'subr-x)
 (require 'cider-compat)
 (require 'nrepl-dict)
+(require 'ansi-color)
 
 (defalias 'cider-pop-back 'pop-tag-mark)
 
@@ -250,16 +251,23 @@ This buffer is not designed to display anything to the user.  For that, use
           (funcall mode))
         b)))
 
+(defun cider-detect-ansi-p (string)
+  "Return non-nil if STRING is an ANSI string."
+  (string-match "^\\[" string))
+
 (defun cider-font-lock-as (mode string)
   "Use MODE to font-lock the STRING."
-  (if (or (null cider-font-lock-max-length)
-          (< (length string) cider-font-lock-max-length))
-      (with-current-buffer (cider--make-buffer-for-mode mode)
-        (erase-buffer)
-        (insert string)
-        (font-lock-fontify-region (point-min) (point-max))
-        (buffer-string))
-    string))
+  (let ((string (if (cider-detect-ansi-p string)
+                    (ansi-color-apply string)
+                  string)))
+    (if (or (null cider-font-lock-max-length)
+            (< (length string) cider-font-lock-max-length))
+        (with-current-buffer (cider--make-buffer-for-mode mode)
+          (erase-buffer)
+          (insert string)
+          (font-lock-fontify-region (point-min) (point-max))
+          (buffer-string))
+      string)))
 
 (defun cider-font-lock-region-as (mode beg end &optional buffer)
   "Use MODE to font-lock text between BEG and END.

--- a/cider-util.el
+++ b/cider-util.el
@@ -257,7 +257,7 @@ This buffer is not designed to display anything to the user.  For that, use
 
 (defun cider-font-lock-as (mode string)
   "Use MODE to font-lock the STRING."
-  (let ((string (if (cider-ansi-color-string-p) string
+  (let ((string (if (cider-ansi-color-string-p string)
                     (ansi-color-apply string)
                   string)))
     (if (or (null cider-font-lock-max-length)

--- a/cider-util.el
+++ b/cider-util.el
@@ -1,4 +1,4 @@
-;;; cider-util.el --- Common utility functions that don't belong anywhere else -*- lexical-binding: t -*-
+;; cider-util.el --- Common utility functions that don't belong anywhere else -*- lexical-binding: t -*-
 
 ;; Copyright © 2012-2013 Tim King, Phil Hagelberg, Bozhidar Batsov
 ;; Copyright © 2013-2017 Bozhidar Batsov, Artur Malabarba and CIDER contributors
@@ -251,13 +251,13 @@ This buffer is not designed to display anything to the user.  For that, use
           (funcall mode))
         b)))
 
-(defun cider-detect-ansi-p (string)
+(defun cider-ansi-color-string-p (string)
   "Return non-nil if STRING is an ANSI string."
   (string-match "^\\[" string))
 
 (defun cider-font-lock-as (mode string)
   "Use MODE to font-lock the STRING."
-  (let ((string (if (cider-detect-ansi-p string)
+  (let ((string (if (cider-ansi-color-string-p) string
                     (ansi-color-apply string)
                   string)))
     (if (or (null cider-font-lock-max-length)

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -191,3 +191,14 @@
       (insert "(test-function arg1 arg2 arg3)")
       (backward-char 2)
       (expect (cider-second-sexp-in-list) :to-equal "arg1"))))
+
+(describe "cider-ansi-color-string-detect"
+  (it "detect ansi color successfully"
+    (expect (cider-ansi-color-string-p "[31man-ansi-str[0m")
+            :to-be-truthy)
+    (expect (cider-ansi-color-string-p "[34m[[0m[31man-ansi-str[0m[34m][0m")
+            :to-be-truthy)
+    (expect (cider-ansi-color-string-p "[an-ansi-str]")
+            :not :to-be-truthy)
+    (expect (cider-ansi-color-string-p "'an-ansi-str")
+            :not :to-be-truthy)))


### PR DESCRIPTION
When `cider-pprint-fn'  is set to `puget' and puget is configured to create color an ANSI string is given in the REPL output after evaluating any expression.  This change uses the (already included by at least 25.1.1 Emacs dist) `ansi-color' library.

## More comprehensive possible future change

By default Puget allows configuration *only* through dynamic variables, which would make configuration hard via Cider so I wrote [this package](https://github.com/plandes/clj-nrepl-puget) to allow this.  I'd be happy to work with someone to get this folded into Cider if that interests the maintainer(s).

I could attempt to do it myself if you'd like.

Thanks and regards,
- Paul

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`make test`)
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [X] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)