### PR TITLE
Improvements to spec browser

### DIFF
--- a/cider-browse-spec.el
+++ b/cider-browse-spec.el
@@ -91,8 +91,7 @@ For example: (\":ring.request/header-name\" \":ring.request/headers\" \":ring/re
 
 (defun cider-browse-spec--propertize-keyword (kw)
   "Add properties to KW text needed by the spec browser."
-  (propertize kw
-              'font-lock-face 'clojure-keyword-face
+  (propertize (cider-font-lock-as-clojure kw)
               'spec-name kw
               'mouse-face 'highlight
               'keymap cider-browse-spec-mouse-map))
@@ -113,9 +112,9 @@ Display TITLE at the top and SPECS are indented underneath."
     (let ((inhibit-read-only t))
       (erase-buffer)
       (goto-char (point-max))
-      (insert (cider-propertize title 'emph) "\n\n")
+      (insert (cider-propertize title 'emph) "\n")
       (dolist (spec-name specs)
-        (insert (format "\t%s\n"
+        (insert (format "  %s\n"
                         (if (char-equal (elt spec-name 0) ?:)
                             (cider-browse-spec--propertize-keyword spec-name)
                           (cider-browse-spec--propertize-fn spec-name)))))

--- a/cider-browse-spec.el
+++ b/cider-browse-spec.el
@@ -230,17 +230,20 @@ Display SPEC as a title and uses `cider-browse-spec--pprint' to display
 a more user friendly representation of SPEC-FORM."
   (with-current-buffer buffer
     (let ((inhibit-read-only t))
+      (cider-browse-spec-mode)
       (erase-buffer)
       (goto-char (point-max))
-      (insert (format "Spec for : %s\n\n" spec))
+      (insert (cider-font-lock-as-clojure spec) "\n\n")
+      (insert (with-temp-buffer
+                (clojure-mode)
+                (insert (cider-browse-spec--pprint spec-form))
+                (indent-region (point-min) (point-max))
+                (font-lock-ensure)
+                (buffer-string)))
+      (insert "\n\n")
       (insert-text-button "[Back]"
                           'action (lambda (b) (call-interactively 'cider-browse-spec--navigate-back))
                           'follow-link t)
-      (insert "\n\n")
-      (insert (cider-browse-spec--pprint spec-form))
-      (clojure-mode)
-      (indent-region (point-min) (point))
-      (cider-browse-spec-mode)
       (goto-char (point-min)))))
 
 (defun cider-browse-spec--browse (spec)

--- a/cider-browse-spec.el
+++ b/cider-browse-spec.el
@@ -114,10 +114,12 @@ Display TITLE at the top and SPECS are indented underneath."
       (goto-char (point-max))
       (insert (cider-propertize title 'emph) "\n")
       (dolist (spec-name specs)
-        (insert (format "  %s\n"
-                        (if (char-equal (elt spec-name 0) ?:)
-                            (cider-browse-spec--propertize-keyword spec-name)
-                          (cider-browse-spec--propertize-fn spec-name)))))
+        (let ((propertize-fn (if (char-equal (elt spec-name 0) ?:)
+                                 #'cider-browse-spec--propertize-keyword
+                               #'cider-browse-spec--propertize-fn)))
+          (thread-first (concat "  " (funcall propertize-fn spec-name) "\n")
+            (propertize 'spec-name spec-name)
+            insert)))
       (goto-char (point-min)))))
 
 (defun cider--qualified-keyword-p (str)
@@ -338,7 +340,8 @@ If FILTER-REGEX is empty, list all specs in the registry."
 (defun cider-browse-spec-handle-mouse (event)
   "Handle mouse click EVENT."
   (interactive "e")
-  (cider-browse-spec--browse-at-point))
+  (when (eq 'highlight (get-text-property (point) 'mouse-face))
+    (cider-browse-spec--browse-at-point)))
 
 (provide 'cider-browse-spec)
 


### PR DESCRIPTION
Some improvements to the spec browser.

All specs:

<img src="https://user-images.githubusercontent.com/1624090/27981787-a3ec0dd4-6346-11e7-80d2-517754238b66.png" width="300" />

Single spec:

<img src="https://user-images.githubusercontent.com/1624090/27981792-c1702250-6346-11e7-8868-54f4e0cac09a.png" width="300"/>

/cc @jpmonettas