### PR TITLE
Filter stacktrace to just project frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+* Filter stacktrace to just frames from your project.
 * [#1918](https://github.com/clojure-emacs/cider/issues/1918): Add new commands `cider-browse-spec` and `cider-browse-spec-all` which start a spec browser.
 * [#2015](https://github.com/clojure-emacs/cider/pull/2015): Show symbols as special forms *and* macros in `cider-doc`
 * [#2012](https://github.com/clojure-emacs/cider/pull/2012): Support special forms in `cider-apropos` and `cider-grimoire-lookup`.

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -117,23 +117,17 @@ The error types are represented as strings."
   :group 'cider-stacktrace
   :package-version '(cider . "0.7.0"))
 
-(defface cider-stacktrace-filter-shown-face
+(defface cider-stacktrace-filter-active-face
   '((t (:inherit button :underline t :weight normal)))
   "Face for filter buttons representing frames currently visible"
   :group 'cider-stacktrace
   :package-version '(cider . "0.6.0"))
 
-(defface cider-stacktrace-filter-hidden-face
+(defface cider-stacktrace-filter-inactive-face
   '((t (:inherit button :underline nil :weight normal)))
   "Face for filter buttons representing frames currently filtered out"
   :group 'cider-stacktrace
   :package-version '(cider . "0.6.0"))
-
-(defface cider-stacktrace-filter-positive-face
-  '((t (:inherit button :underline t :weight normal)))
-  "Face for filter buttons representing frames currently filtered out"
-  :group 'cider-stacktrace
-  :package-version '(cider . "0.15.0"))
 
 (defface cider-stacktrace-face
   '((t (:inherit default)))
@@ -253,11 +247,18 @@ The error types are represented as strings."
 
 (defun cider-stacktrace--face-for-filter (filter neg-filters pos-filters)
   "Return whether we should mark the filter is active or not."
-  (cond ((member filter neg-filters) 'cider-stacktrace-filter-hidden-face)
-        ((member filter pos-filters) 'cider-stacktrace-filter-positive-face)
-        ((member filter '(project)) 'cider-stacktrace-filter-hidden-face)
-        ((null filter) 'cider-stacktrace-filter-hidden-face)
-        (t 'cider-stacktrace-filter-shown-face)))
+  (cond ((member filter '(clj java repl tooling dup)) ; negative filter
+         (if (member filter neg-filters)
+             'cider-stacktrace-filter-active-face
+           'cider-stacktrace-filter-inactive-face))
+        ((member filter '(project))                   ; positive filter
+         (if (member filter pos-filters)
+             'cider-stacktrace-filter-active-face
+           'cider-stacktrace-filter-inactive-face))
+        ((null filter)                               ; "all" filter
+         (if (null neg-filters)
+             'cider-stacktrace-filter-active-face
+           'cider-stacktrace-filter-inactive-face))))
 
 (defun cider-stacktrace-indicate-filters (filters pos-filters)
   "Update enabled state of filter buttons.
@@ -595,17 +596,20 @@ prompt and whether to use a new window.  Similar to `cider-find-var'."
       (setq-local fill-prefix indent)
       (fill-region beg (point)))))
 
-(defun cider-stacktrace-render-filters (buffer filters)
+(defun cider-stacktrace-render-filters (buffer special-filters filters)
   "Emit into BUFFER toggle buttons for each of the FILTERS."
   (with-current-buffer buffer
     (insert "  Show: ")
-    (insert-text-button "Project-Only"
-                        'filter 'project
-                        'follow-link t
-                        'action 'cider-stacktrace-show-only-project
-                        'help-echo "Project frames only")
-    (insert " ") ;; if you put the space after project-only the button
-                 ;; highlighting spills into the next button
+    (dolist (filter special-filters)
+      (insert-text-button (car filter)
+                          'filter (cadr filter)
+                          'follow-link t
+                          'action (or (nth 3 filter) 'cider-stacktrace-filter)
+                          'help-echo (format "Toggle %s stack frames"
+                                             (car filter)))
+      (insert " "))
+    (insert "\n")
+    (insert "  Hide: ")
     (dolist (filter filters)
       (insert-text-button (car filter)
                           'filter (cadr filter)
@@ -769,8 +773,9 @@ through the `cider-stacktrace-suppressed-errors' variable."
       ;; Stacktrace filters
       (cider-stacktrace-render-filters
        buffer
+       `(("Project-Only" project cider-stacktrace-show-only-project) ("All" ,nil))
        `(("Clojure" clj) ("Java" java) ("REPL" repl)
-         ("Tooling" tooling) ("Duplicates" dup) ("All" ,nil)))
+         ("Tooling" tooling) ("Duplicates" dup)))
       (insert "\n")
       ;; Option to suppress internal/middleware errors
       (when error-types

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -129,6 +129,12 @@ The error types are represented as strings."
   :group 'cider-stacktrace
   :package-version '(cider . "0.6.0"))
 
+(defface cider-stacktrace-filter-positive-face
+  '((t (:inherit button :underline t :weight normal)))
+  "Face for filter buttons representing frames currently filtered out"
+  :group 'cider-stacktrace
+  :package-version '(cider . "0.15.0"))
+
 (defface cider-stacktrace-face
   '((t (:inherit default)))
   "Face for stack frame text"
@@ -194,6 +200,7 @@ The error types are represented as strings."
     (define-key map "r" #'cider-stacktrace-toggle-repl)
     (define-key map "t" #'cider-stacktrace-toggle-tooling)
     (define-key map "d" #'cider-stacktrace-toggle-duplicates)
+    (define-key map "p" #'cider-stacktrace-show-only-project)
     (define-key map "a" #'cider-stacktrace-toggle-all)
     (define-key map "1" #'cider-stacktrace-cycle-cause-1)
     (define-key map "2" #'cider-stacktrace-cycle-cause-2)
@@ -224,6 +231,7 @@ The error types are represented as strings."
         ["Show/hide REPL frames" cider-stacktrace-toggle-repl]
         ["Show/hide tooling frames" cider-stacktrace-toggle-tooling]
         ["Show/hide duplicate frames" cider-stacktrace-toggle-duplicates]
+        ["Show only project frames" cider-stacktrace-show-only-project]
         ["Show/hide all frames" cider-stacktrace-toggle-all]))
     map))
 
@@ -243,29 +251,34 @@ The error types are represented as strings."
 
 ;; Stacktrace filtering
 
-(defun cider-stacktrace-indicate-filters (filters)
+(defun cider-stacktrace--face-for-filter (filter neg-filters pos-filters)
+  "Return whether we should mark the filter is active or not."
+  (cond ((member filter neg-filters) 'cider-stacktrace-filter-hidden-face)
+        ((member filter pos-filters) 'cider-stacktrace-filter-positive-face)
+        ((member filter '(project)) 'cider-stacktrace-filter-hidden-face)
+        ((null filter) 'cider-stacktrace-filter-hidden-face)
+        (t 'cider-stacktrace-filter-shown-face)))
+
+(defun cider-stacktrace-indicate-filters (filters pos-filters)
   "Update enabled state of filter buttons.
 
 Find buttons with a 'filter property; if filter is a member of FILTERS, or
 if filter is nil ('show all') and the argument list is non-nil, fontify the
 button as disabled.  Upon finding text with a 'hidden-count property, stop
-searching and update the hidden count text."
+searching and update the hidden count text. POS-FILTERS is the list of
+positive filters to always include."
   (with-current-buffer cider-error-buffer
     (save-excursion
       (goto-char (point-min))
-      (let ((inhibit-read-only t)
-            (get-face (lambda (hide)
-                        (if hide
-                            'cider-stacktrace-filter-hidden-face
-                          'cider-stacktrace-filter-shown-face))))
+      (let ((inhibit-read-only t))
         ;; Toggle buttons
         (while (not (or (get-text-property (point) 'hidden-count) (eobp)))
           (let ((button (button-at (point))))
             (when button
               (let* ((filter (button-get button 'filter))
-                     (face (funcall get-face (if filter
-                                                 (member filter filters)
-                                               filters))))
+                     (face (cider-stacktrace--face-for-filter filter
+                                                              filters
+                                                              pos-filters)))
                 (button-put button 'face face)))
             (goto-char (or (next-property-change (point))
                            (point-max)))))
@@ -466,6 +479,21 @@ When it reaches 3, it wraps to 0."
            (cons flag cider-stacktrace-filters)))
    cider-stacktrace-positive-filters))
 
+(defun cider-stacktrace-show-only-project (&optional button)
+  "Display only the stackframes from the project.
+BUTTON is the button at the top of the error buffer as the button calls
+with the button."
+  (interactive)
+  (if (null cider-stacktrace-positive-filters)
+      (progn
+        (setq-local cider-stacktrace-prior-filters cider-stacktrace-filters)
+        (setq-local cider-stacktrace-filters '(java clj repl tooling dup))
+        (setq-local cider-stacktrace-positive-filters '(project)))
+    (progn
+      (setq-local cider-stacktrace-filters cider-stacktrace-prior-filters)
+      (setq-local cider-stacktrace-positive-filters nil)))
+  (cider-stacktrace-apply-filters cider-stacktrace-filters
+                                  cider-stacktrace-positive-filters))
 
 (defun cider-stacktrace-toggle-java ()
   "Toggle display of Java stack frames."
@@ -571,6 +599,13 @@ prompt and whether to use a new window.  Similar to `cider-find-var'."
   "Emit into BUFFER toggle buttons for each of the FILTERS."
   (with-current-buffer buffer
     (insert "  Show: ")
+    (insert-text-button "Project-Only"
+                        'filter 'project
+                        'follow-link t
+                        'action 'cider-stacktrace-show-only-project
+                        'help-echo "Project frames only")
+    (insert " ") ;; if you put the space after project-only the button
+                 ;; highlighting spills into the next button
     (dolist (filter filters)
       (insert-text-button (car filter)
                           'filter (cadr filter)
@@ -579,6 +614,7 @@ prompt and whether to use a new window.  Similar to `cider-find-var'."
                           'help-echo (format "Toggle %s stack frames"
                                              (car filter)))
       (insert " "))
+    
     (let ((hidden "(0 frames hidden)"))
       (put-text-property 0 (length hidden) 'hidden-count t hidden)
       (insert " " hidden "\n"))))
@@ -748,7 +784,6 @@ through the `cider-stacktrace-suppressed-errors' variable."
             (setq num (1- num))))))
     (cider-stacktrace-initialize causes)
     (font-lock-refresh-defaults)))
-
 
 (provide 'cider-stacktrace)
 

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -91,6 +91,7 @@ cyclical data structures."
 (defvar-local cider-stacktrace-filters nil)
 (defvar-local cider-stacktrace-prior-filters nil)
 (defvar-local cider-stacktrace-cause-visibility nil)
+(defvar-local cider-stacktrace-positive-filters nil)
 
 (defconst cider-error-buffer "*cider-error*")
 (add-to-list 'cider-ancillary-buffers cider-error-buffer)
@@ -275,16 +276,31 @@ searching and update the hidden count text."
            (number-to-string cider-stacktrace-hidden-frame-count)))))))
 
 (defun cider-stacktrace-frame-p ()
+  "Indicate if the text at point is a stack frame."
   (get-text-property (point) 'cider-stacktrace-frame))
 
 (defun cider-stacktrace-collapsed-p ()
+  "Indicate if the stackframe was collapsed."
   (get-text-property (point) 'collapsed))
 
-(defun cider-stacktrace-apply-filters (filters)
-  "Set visibility on stack frames using FILTERS.
+(defun cider-stacktrace--should-hide-p (neg-filters pos-filters flags)
+  "Decide whether a stackframe should be hidden or not.
+NEG-FILTERS dictate which frames should be hidden while POS-FILTERS can
+override this and ensure that those frames are shown.
+Argument FLAGS are the flags set on the stackframe, ie: clj dup, etc."
+  (let ((neg (seq-intersection neg-filters flags))
+        (pos (seq-intersection pos-filters flags)))
+    (cond ((and pos neg) nil)
+          (pos nil)
+          (neg t)
+          (t nil))))
+
+(defun cider-stacktrace-apply-filters (neg-filters pos-filters)
+  "Set visibility on stack frames.
 Update `cider-stacktrace-hidden-frame-count' and indicate filters applied.
 Currently collapsed stacktraces are ignored, and do not contribute to the
-hidden count."
+hidden count.  NEG-FILTERS remove frames with the flag in that list and
+POS-FILTERS ensure that frames with flag is shown."
   (with-current-buffer cider-error-buffer
     (save-excursion
       (goto-char (point-min))
@@ -294,13 +310,15 @@ hidden count."
           (when (and (cider-stacktrace-frame-p)
                      (not (cider-stacktrace-collapsed-p)))
             (let* ((flags (get-text-property (point) 'flags))
-                   (hide (if (seq-intersection filters flags) t nil)))
+                   (hide (cider-stacktrace--should-hide-p neg-filters
+                                                          pos-filters
+                                                          flags)))
               (when hide (cl-incf hidden))
               (put-text-property (point) (line-beginning-position 2)
                                  'invisible hide)))
           (forward-line 1))
         (setq cider-stacktrace-hidden-frame-count hidden)))
-    (cider-stacktrace-indicate-filters filters)))
+    (cider-stacktrace-indicate-filters neg-filters pos-filters)))
 
 
 (defun cider-stacktrace-apply-cause-visibility ()
@@ -326,8 +344,8 @@ hidden count."
                   (add-text-properties (point) detail-end
                                        (list 'invisible hide
                                              'collapsed hide))))))))
-      (cider-stacktrace-apply-filters
-       cider-stacktrace-filters))))
+      (cider-stacktrace-apply-filters cider-stacktrace-filters
+                                      cider-stacktrace-positive-filters))))
 
 ;;; Internal/Middleware error suppression
 
@@ -436,7 +454,8 @@ When it reaches 3, it wraps to 0."
   (cider-stacktrace-apply-filters
    (setq cider-stacktrace-filters
          (unless cider-stacktrace-filters      ; when current filters are nil,
-           cider-stacktrace-prior-filters))))  ;  reenable prior filter set
+           cider-stacktrace-prior-filters))    ; reenable prior filter set
+   cider-stacktrace-positive-filters))
 
 (defun cider-stacktrace-toggle (flag)
   "Update `cider-stacktrace-filters' to add or remove FLAG, and apply filters."
@@ -444,7 +463,9 @@ When it reaches 3, it wraps to 0."
    (setq cider-stacktrace-filters
          (if (memq flag cider-stacktrace-filters)
              (remq flag cider-stacktrace-filters)
-           (cons flag cider-stacktrace-filters)))))
+           (cons flag cider-stacktrace-filters)))
+   cider-stacktrace-positive-filters))
+
 
 (defun cider-stacktrace-toggle-java ()
   "Toggle display of Java stack frames."

--- a/doc/navigating_stacktraces.md
+++ b/doc/navigating_stacktraces.md
@@ -21,6 +21,7 @@ Command                                | Keyboard shortcut                   | D
 `cider-stacktrace-toggle-repl`         |<kbd>r</kbd>                         | Toggle display of REPL frames
 `cider-stacktrace-toggle-tooling`      |<kbd>t</kbd>                         | Toggle display of tooling frames (e.g. compiler, nREPL middleware)
 `cider-stacktrace-toggle-duplicates`   |<kbd>d</kbd>                         | Toggle display of duplicate frames
+`cider-stacktrace-show-only-project    |<kbd>p</kbd>                         | Toggle display only project frames
 `cider-stacktrace-toggle-all`          |<kbd>a</kbd>                         | Toggle display of all frames
 
 You can configure whether the error buffer with stacktraces should be automatically

--- a/test/cider-stacktrace-tests.el
+++ b/test/cider-stacktrace-tests.el
@@ -87,11 +87,12 @@
 (defun cider--testing-dict (names &optional stipulated)
   (let ((numeric? (lambda (sym) (member sym '(line column)))))
     (apply #'nrepl-dict
-           (append (mapcan (lambda (name) (list (symbol-name name)
+           (append (apply #'append
+                          (mapcar (lambda (name) (list (symbol-name name)
                                                 (if (funcall numeric? name)
                                                     4
                                                   (symbol-name name))))
-                           names)
+                                  names))
                    stipulated))))
 
 (defun cider--frame-of-type (flags)
@@ -114,3 +115,15 @@
                                              (cider--testing-dict '(file path column line)))
       (goto-char (point-min))
       (expect (cider-stacktrace-frame-p) :to-be nil))))
+
+(describe "cider-stacktrace--should-hide-p-tests"
+  (it "should hide when members of the neg filters"
+    (let ((hidden1 (cider-stacktrace--should-hide-p '(a b c) '() '(a)))
+          (hidden2 (cider-stacktrace--should-hide-p '(a) '(b) '(a)))
+          (both (cider-stacktrace--should-hide-p '(a) '(a) '(a)))
+          (shown1 (cider-stacktrace--should-hide-p '(a) '(b) '(b)))
+          (shown2 (cider-stacktrace--should-hide-p '() '(a) '(a))))
+      (expect (and hidden1 hidden2)
+              :to-be-truthy)
+      (expect (or both shown1 shown2)
+              :to-be nil))))


### PR DESCRIPTION
Clojure stacktraces can often be quite difficult to read. This follows a recent addition to cider-nrepl which marked stackframes as coming from the project. This allows us to filter to the project stackframes.

The old filtering system is a "negative" filtering system. This would hide lines with the tags, and therefore our project would be hidden as it was marked with clj and repl and other tags. The solution is to add a "positive filter", ie, if a tag is found, show it, regardless if it overlaps with a negative filter as well.

So now in a stacktrace buffer, hit p to narrow down to just the project stakframes and then hit p again to go back to all stack frames.

![normal-errors](https://user-images.githubusercontent.com/6377293/27989255-505094e2-63fa-11e7-8046-4a71400e394c.png)

![project-errors-only](https://user-images.githubusercontent.com/6377293/27989256-560d49de-63fa-11e7-9965-9e10dfbfde19.png)

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][2] extremely useful.*

[1]: https://github.com/clojure-emacs/cider/blob/master/.github/CONTRIBUTING.md
[2]: https://cider.readthedocs.io/en/latest/hacking_on_cider/
