### PR TITLE
[Fix #2023] Make popup-buffer sexp indentation optional

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -806,15 +806,18 @@ COMMENT-PREFIX is the comment prefix to use."
   "Make a handler for evaluating and printing stdout/stderr in popup BUFFER.
 
 This is used by pretty-printing commands and intentionally discards their results."
-  (nrepl-make-response-handler (or buffer (current-buffer))
-                               '()
-                               ;; stdout handler
-                               (lambda (buffer str)
-                                 (cider-emit-into-popup-buffer buffer (ansi-color-apply str)))
-                               ;; stderr handler
-                               (lambda (buffer str)
-                                 (cider-emit-into-popup-buffer buffer (ansi-color-apply str)))
-                               '()))
+  (cl-flet ((popup-handler (buffer str)
+                           (cider-emit-into-popup-buffer buffer
+                                                         (ansi-color-apply str)
+                                                         nil
+                                                         t)))
+   (nrepl-make-response-handler (or buffer (current-buffer))
+                                '()
+                                ;; stdout handler
+                                #'popup-handler
+                                ;; stderr handler
+                                #'popup-handler
+                                '())))
 
 (defun cider-visit-error-buffer ()
   "Visit the `cider-error-buffer' (usually *cider-error*) if it exists."
@@ -1483,7 +1486,7 @@ Defaults to the current ns.  With prefix arg QUERY, prompts for a ns."
   "Refresh LOG-BUFFER with RESPONSE."
   (nrepl-dbind-response response (out err reloading status error error-ns after before)
     (cl-flet* ((log (message &optional face)
-                    (cider-emit-into-popup-buffer log-buffer message face))
+                    (cider-emit-into-popup-buffer log-buffer message face t))
 
                (log-echo (message &optional face)
                          (log message face)
@@ -1577,7 +1580,10 @@ refresh functions (defined in `cider-refresh-before-fn' and
          (when cider-refresh-show-log-buffer
            (cider-popup-buffer-display log-buffer))
          (when inhibit-refresh-fns
-           (cider-emit-into-popup-buffer log-buffer "inhibiting refresh functions\n"))
+           (cider-emit-into-popup-buffer log-buffer
+                                         "inhibiting refresh functions\n"
+                                         nil
+                                         t))
          (when clear?
            (cider-nrepl-send-sync-request '("op" "refresh-clear") conn))
          (cider-nrepl-send-request

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -806,18 +806,18 @@ COMMENT-PREFIX is the comment prefix to use."
   "Make a handler for evaluating and printing stdout/stderr in popup BUFFER.
 
 This is used by pretty-printing commands and intentionally discards their results."
-  (cl-flet ((popup-handler (buffer str)
-                           (cider-emit-into-popup-buffer buffer
-                                                         (ansi-color-apply str)
-                                                         nil
-                                                         t)))
-   (nrepl-make-response-handler (or buffer (current-buffer))
-                                '()
-                                ;; stdout handler
-                                #'popup-handler
-                                ;; stderr handler
-                                #'popup-handler
-                                '())))
+  (cl-flet ((popup-output-handler (buffer str)
+                                  (cider-emit-into-popup-buffer buffer
+                                                                (ansi-color-apply str)
+                                                                nil
+                                                                t)))
+    (nrepl-make-response-handler (or buffer (current-buffer))
+                                 '()
+                                 ;; stdout handler
+                                 #'popup-output-handler
+                                 ;; stderr handler
+                                 #'popup-output-handler
+                                 '())))
 
 (defun cider-visit-error-buffer ()
   "Visit the `cider-error-buffer' (usually *cider-error*) if it exists."

--- a/cider-popup.el
+++ b/cider-popup.el
@@ -103,8 +103,9 @@ and automatically removed when killed."
                 nil 'local))
     (current-buffer)))
 
-(defun cider-emit-into-popup-buffer (buffer value &optional face)
-  "Emit into BUFFER the provided VALUE optionally using FACE."
+(defun cider-emit-into-popup-buffer (buffer value &optional face inhibit-indent)
+  "Emit into BUFFER the provided VALUE optionally using FACE. Indents
+emitted sexp value unless INHIBIT-INDENT is specified and non-nil."
   ;; Long string output renders Emacs unresponsive and users might intentionally
   ;; kill the frozen popup buffer. Therefore, we don't re-create the buffer and
   ;; silently ignore the output.
@@ -121,7 +122,8 @@ and automatically removed when killed."
                   (add-face-text-property 0 (length value-str) face nil value-str)
                 (add-text-properties 0 (length value-str) (list 'face face) value-str)))
             (insert value-str))
-          (indent-sexp)
+          (unless inhibit-indent
+            (indent-sexp))
           (set-marker cider-popup-output-marker (point)))
         (when moving (goto-char cider-popup-output-marker))))))
 

--- a/cider-popup.el
+++ b/cider-popup.el
@@ -104,8 +104,8 @@ and automatically removed when killed."
     (current-buffer)))
 
 (defun cider-emit-into-popup-buffer (buffer value &optional face inhibit-indent)
-  "Emit into BUFFER the provided VALUE optionally using FACE. Indents
-emitted sexp value unless INHIBIT-INDENT is specified and non-nil."
+  "Emit into BUFFER the provided VALUE optionally using FACE.
+Indents emitted sexp value unless INHIBIT-INDENT is specified and non-nil."
   ;; Long string output renders Emacs unresponsive and users might intentionally
   ;; kill the frozen popup buffer. Therefore, we don't re-create the buffer and
   ;; silently ignore the output.


### PR DESCRIPTION
- Add optional inhibit-indent argument to cider-emit-into-popup-buffer.

- Inhibit indentation where output is already indented (pprint) or not sexps.

-----------------

- [X] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)
