### PR TITLE
Two fixes for cljc files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Make it possible to disable auto-evaluation of changed ns forms via the defcustom `cider-auto-track-ns-form-changes`.
 * [#1991](https://github.com/clojure-emacs/cider/issues/1832): Make it possible to disable the prompt to open a ClojureScript in a browser on connect via `cider-offer-to-open-cljs-app-in-browser`.
 * [#1995](https://github.com/clojure-emacs/cider/pull/1995): Add new customization variable `cider-doc-auto-select-buffer` to control cider-doc popup buffer auto selection.
+* Ensure that `cider-switch-to-repl-buffer` picks the most recent repl buffer if multiple connections are available.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@
 * [#1588](https://github.com/clojure-emacs/cider/issues/1588): Redirect `*err*`, `java.lang.System/out`, and `java.lang.System/err` to REPL buffer on all attached sessions.
 * [#1707](https://github.com/clojure-emacs/cider/issues/1707): Allow to customize line truncating in CIDER's special buffers.
 * [#1876](https://github.com/clojure-emacs/cider/issues/1876): Set pretty-printing width with `cider-repl-pretty-print-width`. If this variable is not set, fall back to `fill-column`.
-* [#1875](https://github.com/clojure-emacs/cider/issues/1875): Ensure cljc buffers can load buffer into both clj and cljs repls.
+* [#1875](https://github.com/clojure-emacs/cider/issues/1875): Ensure that loading and evaluation in cljc buffers is performed in both clj and cljs repls.
 * [#1897](https://github.com/clojure-emacs/cider/issues/1897): Bind TAB in stacktrace buffers in the terminal.
 * [#1895](https://github.com/clojure-emacs/cider/issues/1895): Connect to the same host:port after `cider-restart` if the connection was established with `cider-connect`.
 * [#1881](https://github.com/clojure-emacs/cider/issues/1881): Add `cider-cljs-boot-repl` and `cider-cljs-gradle-repl` defcustom and hook `boot-cljs-repl`.

--- a/cider-client.el
+++ b/cider-client.el
@@ -669,12 +669,13 @@ Return the id of the sent message."
       (nrepl--mark-id-completed id))
     id))
 
-(defun cider-nrepl-request:eval (input callback &optional ns line column additional-params)
+(defun cider-nrepl-request:eval (input callback &optional ns line column additional-params connection)
   "Send the request INPUT and register the CALLBACK as the response handler.
 If NS is non-nil, include it in the request.  LINE and COLUMN, if non-nil,
 define the position of INPUT in its buffer.  ADDITIONAL-PARAMS is a plist
-to be appended to the request message."
-  (let ((connection (cider-current-connection)))
+to be appended to the request message.  CONNECTION is the connection
+buffer, defaults to (cider-current-connection)."
+  (let ((connection (or connection (cider-current-connection))))
     (nrepl-request:eval input
                         (if cider-show-eval-spinner
                             (cider-eval-spinner-handler connection callback)

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1135,15 +1135,19 @@ arguments and only proceed with evaluation if it returns nil."
                  (funcall cider-interactive-eval-override form callback bounds))
       (cider-map-connections #'ignore :any)
       (cider--prep-interactive-eval form)
-      (cider-nrepl-request:eval
-       form
-       (or callback (cider-interactive-eval-handler nil bounds))
-       ;; always eval ns forms in the user namespace
-       ;; otherwise trying to eval ns form for the first time will produce an error
-       (if (cider-ns-form-p form) "user" (cider-current-ns))
-       (when start (line-number-at-pos start))
-       (when start (cider-column-number-at-pos start))
-       additional-params))))
+      (cider-map-connections
+       (lambda (connection)
+         (cider-nrepl-request:eval
+          form
+          (or callback (cider-interactive-eval-handler nil bounds))
+          ;; always eval ns forms in the user namespace
+          ;; otherwise trying to eval ns form for the first time will produce an error
+          (if (cider-ns-form-p form) "user" (cider-current-ns))
+          (when start (line-number-at-pos start))
+          (when start (cider-column-number-at-pos start))
+          additional-params
+          connection))
+       :both))))
 
 (defun cider-eval-region (start end)
   "Evaluate the region between START and END."

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -122,7 +122,9 @@ that of the namespace in the Clojure source buffer."
 
 (defun cider-switch-to-repl-buffer (&optional set-namespace)
   "Select the REPL buffer, when possible in an existing window.
-The buffer chosen is based on the file open in the current buffer.
+The buffer chosen is based on the file open in the current buffer. If
+multiple REPL buffers are associated with current connection the most
+recent is used.
 
 If the REPL buffer cannot be unambiguously determined, the REPL
 buffer is chosen based on the current connection buffer and a
@@ -135,7 +137,10 @@ the buffer should appear.
 With a prefix arg SET-NAMESPACE sets the namespace in the REPL buffer to that
 of the namespace in the Clojure source buffer."
   (interactive "P")
-  (cider--switch-to-repl-buffer (cider-current-repl-buffer) set-namespace))
+  (let* ((connections (cider-connections))
+         (buffer (cl-some (lambda (b) (and (member b connections) b))
+                          (buffer-list))))
+    (cider--switch-to-repl-buffer buffer set-namespace)))
 
 (declare-function cider-load-buffer "cider-interaction")
 


### PR DESCRIPTION
First commit finishes #1875 by fixing the interactive eval which suffered from the same issues as described there.

Second makes `cider-switch-to-repl-buffer` to switch to the most recently used repl. Current behavior is to always switch to clj repl.  To replicate, go to cljs repl, pres C-c C-z to get into cljc buffer, then C-c C-z and you will land in clj repl which covers your cljs repl.