### PR TITLE
Interactive stacktraces in REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### New Features
 
 * [#2050](https://github.com/clojure-emacs/cider/pull/2050) Use `view-mode` for `cider-grimoire` buffers
+* Make stacktraces and other location references in REPL clickable.
+* Highlight root namespace in REPL stacktraces.
 * Filter stacktrace to just frames from your project.
 * [#1918](https://github.com/clojure-emacs/cider/issues/1918): Add new commands `cider-browse-spec` and `cider-browse-spec-all` which start a spec browser.
 * [#2015](https://github.com/clojure-emacs/cider/pull/2015): Show symbols as special forms *and* macros in `cider-doc`

--- a/cider-client.el
+++ b/cider-client.el
@@ -596,6 +596,11 @@ EVAL-BUFFER is the buffer where the spinner was started."
   "Check if FORM is an ns form."
   (string-match-p "^[[:space:]]*\(ns\\([[:space:]]*$\\|[[:space:]]+\\)" form))
 
+(defun cider-ns-from-form (ns-form)
+  "Get ns substring from NS-FORM."
+  (when (string-match "^[ \t\n]*\(ns[ \t\n]+\\([^][ \t\n(){}]+\\)" ns-form)
+    (match-string-no-properties 1 ns-form)))
+
 (defvar-local cider-buffer-ns nil
   "Current Clojure namespace of some buffer.
 

--- a/cider-client.el
+++ b/cider-client.el
@@ -702,13 +702,12 @@ buffer, defaults to (cider-current-connection)."
                         ns line column additional-params)
     (cider-spinner-start connection)))
 
-(defun cider-nrepl-sync-request:eval (input &optional ns)
-  "Send the INPUT to the nREPL server synchronously.
-If NS is non-nil, include it in the request."
-  (nrepl-sync-request:eval
-   input
-   (cider-current-connection)
-   ns))
+(defun cider-nrepl-sync-request:eval (input &optional connection ns)
+  "Send the INPUT to the nREPL CONNECTION synchronously.
+If NS is non-nil, include it in the eval request."
+  (nrepl-sync-request:eval input
+                           (or connection (cider-current-connection))
+                           ns))
 
 (defcustom cider-pprint-fn 'pprint
   "Sets the function to use when pretty-printing evaluation results.

--- a/cider-client.el
+++ b/cider-client.el
@@ -1007,6 +1007,13 @@ CONTEXT represents a completion context for compliment."
     (cider-nrepl-send-sync-request)
     (nrepl-dict-get "ns-vars")))
 
+(defun cider-sync-request:ns-path (ns)
+  "Get the path to the file containing NS."
+  (thread-first `("op" "ns-path"
+                  "ns" ,ns)
+    (cider-nrepl-send-sync-request)
+    (nrepl-dict-get "path")))
+
 (defun cider-sync-request:ns-vars-with-meta (ns)
   "Get a map of the vars in NS to its metadata information."
   (thread-first `("op" "ns-vars-with-meta"

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -465,13 +465,6 @@ Invert meaning of `cider-prompt-for-symbol' if PREFIX indicates it should be."
   (if (cider--prefix-invert-prompt-p prefix)
       (not cider-prompt-for-symbol) cider-prompt-for-symbol))
 
-(defun cider-sync-request:ns-path (ns)
-  "Get the path to the file containing NS."
-  (thread-first `("op" "ns-path"
-                  "ns" ,ns)
-    cider-nrepl-send-sync-request
-    (nrepl-dict-get "path")))
-
 (defun cider--find-ns (ns &optional other-window)
   "Find the file containing NS's definition.
 Optionally open it in a different window if OTHER-WINDOW is truthy."

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1081,6 +1081,7 @@ window."
                (not (string= cur-ns-form
                              (buffer-local-value 'cider--last-ns-form connection)))
                (not (cider-ns-form-p form)))
+      (cider-repl--cache-ns-roots cur-ns-form connection)
       (when cider-auto-track-ns-form-changes
         ;; The first interactive eval on a file can load a lot of libs. This can
         ;; easily lead to more than 10 sec.
@@ -1612,6 +1613,7 @@ ClojureScript REPL exists for the project, it is evaluated in both REPLs."
        (lambda (connection)
          (with-current-buffer connection
            (setq cider--last-ns-form ns-form))
+         (cider-repl--cache-ns-roots ns-form connection)
          (cider-request:load-file (cider-file-string filename)
                                   (funcall cider-to-nrepl-filename-function
                                            (cider--server-filename filename))

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1268,21 +1268,13 @@ command `cider-debug-defun-at-point'."
   (interactive)
   (cider--pprint-eval-form (cider-defun-at-point 'bounds)))
 
-(defun cider-eval-ns-form (&optional sync)
-  "Evaluate the current buffer's namespace form.
-
-When SYNC is true the form is evaluated synchronously,
-otherwise it's evaluated interactively."
+(defun cider-eval-ns-form ()
+  "Evaluate the current buffer's namespace form."
   (interactive)
   (when (clojure-find-ns)
     (save-excursion
       (goto-char (match-beginning 0))
-      (if sync
-          ;; The first interactive eval on a file can load a lot of libs. This
-          ;; can easily lead to more than 10 sec.
-          (let ((nrepl-sync-request-timeout 30))
-            (cider-nrepl-sync-request:eval (cider-defun-at-point)))
-        (cider-eval-defun-at-point)))))
+      (cider-eval-defun-at-point))))
 
 (defun cider-read-and-eval (&optional value)
   "Read a sexp from the minibuffer and output its result to the echo area.

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1125,7 +1125,7 @@ ADDITIONAL-PARAMS is a plist to be appended to the request message.
 
 If `cider-interactive-eval-override' is a function, call it with the same
 arguments and only proceed with evaluation if it returns nil."
-  (let ((form  (or form (apply #'buffer-substring bounds)))
+  (let ((form  (or form (apply #'buffer-substring-no-properties bounds)))
         (start (car-safe bounds))
         (end   (car-safe (cdr-safe bounds))))
     (when (and start end)

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -554,7 +554,7 @@ When there is a possible unfinished ansi control sequence,
   "Regexp used to highlight root ns in REPL buffers.")
 
 (defvar-local cider-repl--root-ns-regexp nil
-  "Cache of root ns regexp in REPLs")
+  "Cache of root ns regexp in REPLs.")
 
 (defun cider-repl--apply-current-project-color (string)
   "Fontify project's root namespace to make stacktraces more readable.

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -206,8 +206,7 @@ via `cider-current-connection'.")
 (declare-function cider-refresh-dynamic-font-lock "cider-mode")
 
 (defun cider-repl--state-handler (response)
-  "Handle the server state contained in RESPONSE.
-Currently, this is only used to keep `cider-repl-type' updated."
+  "Handle server state contained in RESPONSE."
   (with-demoted-errors "Error in `cider-repl--state-handler': %s"
     (when (member "state" (nrepl-dict-get response "status"))
       (nrepl-dbind-response response (repl-type changed-namespaces)


### PR DESCRIPTION
Two new features to make REPL location references useful:

 1. Interactive locations in REPL. 
 2. Highlight vars from the current project 

Interactive locations are implemented as help-echo and have 0 overhead on printout in REPL.  Currently understood are stdout stacks, aviso stacks, printouts of exception objects and references in timbre's logging.  

Highlighting of vars currently uses project directory to infer the root namespaces. Would be happy to know a better way without recurring to parsing project files.  

![stack](https://user-images.githubusercontent.com/1363467/28240591-1d2ae05a-6985-11e7-8556-02968ae3f84c.gif)
