### PR TITLE
fix typo in link to cider-nrepl repo

### DIFF
--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -56,7 +56,7 @@ In the REPL buffer, issue the following.
 
 This will cause CIDER to print extensive information to the REPL buffer when you
 try to debug an expression (e.g., with <kbd>C-u
-C-M-x</kbd>). [File an issue](https://github.com/clojure-emacs/cider-repl/issues/new)
+C-M-x</kbd>). [File an issue](https://github.com/clojure-emacs/cider-nrepl/issues/new)
 and copy this information.
 
 ## Debugging freezes & lock-ups


### PR DESCRIPTION
The existing link in the cider troubleshooting documentation returned a 404, I believe because it was pointing to the wrong repo within the clojure-emacs org. It has now been updated to point to `cider-nrepl` instead of `cider-repl`

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][2] extremely useful.*

[1]: https://github.com/clojure-emacs/cider/blob/master/.github/CONTRIBUTING.md
[2]: https://cider.readthedocs.io/en/latest/hacking_on_cider/
