### PR TITLE
[Fix #390] Workaround for orphaned java process on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 * [#1895](https://github.com/clojure-emacs/cider/issues/1895): Connect to the same host:port after `cider-restart` if the connection was established with `cider-connect`.
 * [#1881](https://github.com/clojure-emacs/cider/issues/1881): Add `cider-cljs-boot-repl` and `cider-cljs-gradle-repl` defcustom and hook `boot-cljs-repl`.
 * [#1997](https://github.com/clojure-emacs/cider/pull/1997): Fix a nil error when loading a code buffer and the error buffer is visible.
+* [#390](https://github.com/clojure-emacs/cider/issues/390): Workaround for orphaned java process on windows machine after quitting the REPL.
 
 ## 0.14.0 (2016-10-13)
 

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -616,6 +616,13 @@ If NO-ERROR is non-nil, show messages instead of throwing an error."
 
 
 ;;; Client: Process Handling
+(defun nrepl--kill-process (proc)
+  "Kill PROC using the appropriate, os specific way.
+Implement a workaround to clean up an orphaned JVM process left around
+after exiting the REPL on some windows machines."
+  (if (memq system-type '(cygwin windows-nt))
+      (interrupt-process proc)
+    (kill-process proc)))
 
 (defun nrepl--maybe-kill-server-buffer (server-buf)
   "Kill SERVER-BUF and its process, subject to user confirmation.
@@ -628,7 +635,7 @@ Do nothing if there is a REPL connected to that server."
       (let ((proc (get-buffer-process server-buf)))
         (when (process-live-p proc)
           (set-process-query-on-exit-flag proc nil)
-          (kill-process proc))
+          (nrepl--kill-process proc))
         (kill-buffer server-buf)))))
 
 ;; `nrepl-start-client-process' is called from `nrepl-server-filter'. It


### PR DESCRIPTION
after quitting the REPL. Use `interrupt-process` instead of `kill-process` if OS
is windows.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

