### PR TITLE
Use `add-to-list` instead of `push` for ancillary buffers

### DIFF
--- a/cider-apropos.el
+++ b/cider-apropos.el
@@ -39,8 +39,7 @@
 (require 'button)
 
 (defconst cider-apropos-buffer "*cider-apropos*")
-
-(push cider-apropos-buffer cider-ancillary-buffers)
+(add-to-list 'cider-ancillary-buffers cider-apropos-buffer)
 
 (defcustom cider-apropos-actions '(("display-doc" . cider-doc-lookup)
                                    ("find-def" . cider--find-var)

--- a/cider-browse-ns.el
+++ b/cider-browse-ns.el
@@ -43,8 +43,7 @@
 (require 'nrepl-dict)
 
 (defconst cider-browse-ns-buffer "*cider-ns-browser*")
-
-(push cider-browse-ns-buffer cider-ancillary-buffers)
+(add-to-list 'cider-ancillary-buffers cider-browse-ns-buffer)
 
 (defvar-local cider-browse-ns-current-ns nil)
 

--- a/cider-classpath.el
+++ b/cider-classpath.el
@@ -29,8 +29,7 @@
 (require 'cider-compat)
 
 (defvar cider-classpath-buffer "*cider-classpath*")
-
-(push cider-classpath-buffer cider-ancillary-buffers)
+(add-to-list 'cider-ancillary-buffers cider-classpath-buffer)
 
 (defvar cider-classpath-mode-map
   (let ((map (make-sparse-keymap)))

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -36,8 +36,7 @@
 ;; ===================================
 
 (defconst cider-inspector-buffer "*cider-inspect*")
-
-(push cider-inspector-buffer cider-ancillary-buffers)
+(add-to-list 'cider-ancillary-buffers cider-inspector-buffer)
 
 ;;; Customization
 (defgroup cider-inspector nil

--- a/cider-macroexpansion.el
+++ b/cider-macroexpansion.el
@@ -36,8 +36,7 @@
 (require 'cider-compat)
 
 (defconst cider-macroexpansion-buffer "*cider-macroexpansion*")
-
-(push cider-macroexpansion-buffer cider-ancillary-buffers)
+(add-to-list 'cider-ancillary-buffers cider-macroexpansion-buffer)
 
 (defcustom cider-macroexpansion-display-namespaces 'tidy
   "Determines if namespaces are displayed in the macroexpansion buffer.

--- a/cider-scratch.el
+++ b/cider-scratch.el
@@ -52,8 +52,7 @@
     map))
 
 (defconst cider-scratch-buffer-name "*cider-scratch*")
-
-(push cider-scratch-buffer-name cider-ancillary-buffers)
+(add-to-list 'cider-ancillary-buffers cider-scratch-buffer-name)
 
 ;;;###autoload
 (defun cider-scratch ()


### PR DESCRIPTION
Per [discussion](https://github.com/clojure-emacs/cider/pull/2052#discussion_r127912144), use `add-to-list` instead of `push` for ancillary buffers.