### PR TITLE
Use buttons in spec browser buffers

### DIFF
--- a/cider-browse-spec.el
+++ b/cider-browse-spec.el
@@ -34,14 +34,14 @@
 
 ;;; Code:
 
-(require 'cider-interaction)
 (require 'cider-client)
-(require 'subr-x)
 (require 'cider-compat)
+(require 'cider-interaction)
 (require 'cider-util)
+(require 'cl-lib)
 (require 'nrepl-dict)
 (require 'seq)
-(require 'cl-lib)
+(require 'subr-x)
 
 ;; The buffer names used by the spec browser
 (defconst cider-browse-spec-buffer "*cider-spec-browser*")


### PR DESCRIPTION
Fixes #2053.

Replace custom text properties with buttons. This gives us highlights, clicks, and navigation for free.