### PR TITLE
Use `cider--font-lock-ensure` for compatibility with Emacs 24.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## master (unreleased)
 
+### New Features
+
+### Changes
+
+### Bugs Fixed
+
+* [#2057](https://github.com/clojure-emacs/cider/pull/2057) Use `cider--font-lock-ensure` for compatibility with Emacs 24.5.
+
 ## 0.15.0 (2017-07-20)
 
 ### New Features

--- a/cider-browse-spec.el
+++ b/cider-browse-spec.el
@@ -256,7 +256,7 @@ a more user friendly representation of SPEC-FORM."
                 (clojure-mode)
                 (insert (cider-browse-spec--pprint spec-form))
                 (indent-region (point-min) (point-max))
-                (font-lock-ensure)
+                (cider--font-lock-ensure)
                 (buffer-string)))
       (cider--make-back-forward-xrefs)
       (current-buffer))))


### PR DESCRIPTION
Fixes #2056.