### PR TITLE
Bump the development version to 16-SNAPSHOT

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -90,7 +90,7 @@ project inference will take place."
 
 (require 'seq)
 
-(defconst cider-version "0.15.0"
+(defconst cider-version "0.16.0-SNAPSHOT"
   "Fallback version used when it cannot be extracted automatically.
 Normally it won't be used, unless `pkg-info' fails to extract the
 version from the CIDER package or library.")


### PR DESCRIPTION
this usually happens right after a release, was working on an issue in cider-nrepl and was surprised it kept fetching the 0.15 version and not snapshot.