### PR TITLE
When viewing project only, hide all others

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs Fixed
 
+* Project-Only stacktrace filter: hide all other tags when viewing project-only stacktrace.
 * Fix interactive evaluation in cljc buffers with only one connection.
 * [#2058](https://github.com/clojure-emacs/cider/pull/2058) Don't cache ns-forms in buffers with no such forms.
 * [#2057](https://github.com/clojure-emacs/cider/pull/2057) Use `cider--font-lock-ensure` for compatibility with Emacs 24.5.

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -500,7 +500,7 @@ with the button."
   (if (null cider-stacktrace-positive-filters)
       (progn
         (setq-local cider-stacktrace-prior-filters cider-stacktrace-filters)
-        (setq-local cider-stacktrace-filters cider-stacktrace-filters)
+        (setq-local cider-stacktrace-filters cider-stacktrace--all-negative-filters)
         (setq-local cider-stacktrace-positive-filters '(project)))
     (progn
       (setq-local cider-stacktrace-filters cider-stacktrace-prior-filters)


### PR DESCRIPTION
when showing project only, set all filters to remove all frames and then the project frames remain. I accidentally didn't clobber all of the old ones.