### PR TITLE
[Fix #2045] *cider-scratch* is no longer an ancillary buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changes
 
+* [#2045](https://github.com/clojure-emacs/cider/issues/2045) `*cider-scratch*` buffers are no longer automatically killed on connection quit.
+
 ### Bugs Fixed
 
 * [#2004](https://github.com/clojure-emacs/cider/issues/2004), [#2039](https://github.com/clojure-emacs/cider/issues/2039), [cider-nrepl#420](https://github.com/clojure-emacs/cider-nrepl/issues/420): Fix namespace issues in instrumentation and debugging commands.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 * Fix interactive evaluation in cljc buffers with only one connection.
 * [#2058](https://github.com/clojure-emacs/cider/pull/2058): Don't cache ns-forms in buffers with no such forms.
 * [#2057](https://github.com/clojure-emacs/cider/pull/2057): Use `cider--font-lock-ensure` for compatibility with Emacs 24.5.
+* [cider-nrepl#436](https://github.com/clojure-emacs/cider-nrepl/pull/436): Ensure that `*print-right-margin*` is not ignored by cider-nrepl middleware. 
+* [cider-nrepl#435](https://github.com/clojure-emacs/cider-nrepl/pull/435): Allow debugging of forms with `#?(:cljs ... :clj ..)` conditionals.
 * [cider-nrepl#432](https://github.com/clojure-emacs/cider-nrepl/pull/432): Ensure `pprint` is after `load-file`.
 
 ## 0.15.0 (2017-07-20)

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1775,15 +1775,18 @@ START and END represent the region's boundaries."
   (when conn
     (cider--close-connection-buffer conn)))
 
+(defvar cider-scratch-buffer-name)
 (defun cider-quit (&optional quit-all)
   "Quit the currently active CIDER connection.
-
 With a prefix argument QUIT-ALL the command will kill all connections
 and all ancillary CIDER buffers."
   (interactive "P")
   (cider-ensure-connected)
   (if (and quit-all (y-or-n-p "Are you sure you want to quit all CIDER connections? "))
       (progn
+        (when-let ((scratch (get-buffer cider-scratch-buffer-name)))
+          (when (y-or-n-p (format "Kill %s? buffer" cider-scratch-buffer-name))
+            (kill-buffer cider-scratch-buffer-name)))
         (dolist (connection cider-connections)
           (cider--quit-connection connection))
         (message "All active nREPL connections were closed"))

--- a/cider-scratch.el
+++ b/cider-scratch.el
@@ -52,7 +52,6 @@
     map))
 
 (defconst cider-scratch-buffer-name "*cider-scratch*")
-(add-to-list 'cider-ancillary-buffers cider-scratch-buffer-name)
 
 ;;;###autoload
 (defun cider-scratch ()


### PR DESCRIPTION
AFAICS the only function of ancillary buffers right now is to be killed on `cider-quit`, so this simple change seems to be just what's needed.  