### PR TITLE
Move test utilities in specialized files and move interaction tests out of cider-client-tests.el  

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ test-bytecomp : version $(ELS:.el=.elc-test)
 		-l test/cider-bytecomp-warnings.el $<
 
 test : version build
-	$(CASK) exec buttercup -L .
+	$(CASK) exec buttercup -L . -L ./test/utils/
 
 .PHONY: clean
 clean :

--- a/test/cider-interaction-tests.el
+++ b/test/cider-interaction-tests.el
@@ -29,6 +29,7 @@
 
 (require 'buttercup)
 (require 'cider-interaction)
+(require 'cider-connection-test-utils)
 
 (describe "cider--var-namespace"
   (it "returns the namespace of a var"
@@ -84,3 +85,20 @@
   (it "raises a user error if the op is not supported"
     (spy-on 'cider-nrepl-op-supported-p :and-return-value nil)
     (expect (lambda () (cider-load-all-project-ns)) :to-throw 'user-error)))
+
+(describe "cider-load-file"
+          (it "works as expected in empty Clojure buffers"
+              (spy-on 'cider-request:load-file :and-return-value nil)
+              (with-connection-buffer "clj" b
+                                      (with-temp-buffer
+                                        (clojure-mode)
+                                        (setq buffer-file-name (make-temp-name "tmp.clj"))
+                                        (expect (lambda () (cider-load-buffer)) :not :to-throw)))))
+
+(describe "cider-interactive-eval"
+          (it "works as expected in empty Clojure buffers"
+              (spy-on 'cider-nrepl-request:eval :and-return-value nil)
+              (with-connection-buffer "clj" b
+                                      (with-temp-buffer
+                                        (clojure-mode)
+                                        (expect (lambda () (cider-interactive-eval "(+ 1)")) :not :to-throw)))))

--- a/test/utils/cider-connection-test-utils.el
+++ b/test/utils/cider-connection-test-utils.el
@@ -1,0 +1,55 @@
+;;; cider-connection-test-utils.el
+
+;; Copyright © 2012-2017 Tim King, Bozhidar Batsov
+
+;; Author: Tim King <kingtim@gmail.com>
+;;         Bozhidar Batsov <bozhidar@batsov.com>
+;;         Artur Malabarba <bruce.connor.am@gmail.com>
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; This file is part of CIDER
+
+;;; Code:
+
+(require 'cider)
+(require 'cider-client)
+
+(defmacro with-connection-buffer (type symbol &rest body)
+  "Run BODY in a temp buffer, with the given repl TYPE.
+SYMBOL is locally let-bound to the current buffer."
+  (declare (indent 2)
+           (debug (sexp sexp &rest form)))
+  `(with-temp-buffer
+     (setq major-mode 'cider-repl-mode)
+     (setq cider-repl-type ,type)
+     ;; `with-current-buffer' doesn't bump the buffer up the list.
+     (switch-to-buffer (current-buffer))
+     (rename-buffer (format "*cider-repl %s-%s*" ,type (random 10000)) t)
+     (let ((cider-connections (cons (current-buffer) cider-connections))
+           (,symbol (current-buffer)))
+       ,@body)))
+
+(defmacro cider-test-with-buffers (buffer-names &rest body)
+  (let ((create (lambda (b) (list b `(generate-new-buffer " *temp*")))))
+    `(let (,@(mapcar create buffer-names))
+       (unwind-protect
+           ,@body
+         (mapc 'kill-buffer (list ,@buffer-names))))))
+
+(provide 'cider-connection-test-utils)


### PR DESCRIPTION
As per [previous discussion](https://github.com/clojure-emacs/cider/pull/2061#issuecomment-317636286) I am placing utility macros into specialized utilis file and moving a couple of interaction tests where they belong. The idiomatic way to add utility files in buttercup is by including them in separate directories with -L flag. See jorgenschaefer/emacs-buttercup#94. 