### PR TITLE
New connection API and user level connection commands

### DIFF
--- a/cider-debug.el
+++ b/cider-debug.el
@@ -344,7 +344,7 @@ In order to work properly, this mode must be activated by
     ;; cider-nrepl has a chance to send the next message, and so that the user
     ;; doesn't accidentally hit `n' between two messages (thus editing the code).
     (when-let ((proc (unless nrepl-ongoing-sync-request
-                       (get-buffer-process (cider-current-connection)))))
+                       (get-buffer-process (cider-current-connection-repl)))))
       (accept-process-output proc 1))
     (unless cider--debug-mode
       (setq buffer-read-only nil)

--- a/cider-resolve.el
+++ b/cider-resolve.el
@@ -72,8 +72,8 @@
 
 (defun cider-resolve--get-in (&rest keys)
   "Return (nrepl-dict-get-in cider-repl-ns-cache KEYS)."
-  (when cider-connections
-    (with-current-buffer (cider-current-connection)
+  (when-let ((buff (cider-current-connection-repl)))
+    (with-current-buffer buff
       (nrepl-dict-get-in cider-repl-ns-cache keys))))
 
 (defun cider-resolve-alias (ns alias)
@@ -105,7 +105,7 @@ Return nil only if VAR cannot be resolved."
   "Return a dict of the core namespace for current connection.
 This will be clojure.core or cljs.core depending on `cider-repl-type'."
   (when (cider-connected-p)
-    (with-current-buffer (cider-current-connection)
+    (with-current-buffer (cider-current-connection-repl)
       (cider-resolve--get-in (if (equal cider-repl-type "cljs")
                                  "cljs.core"
                                "clojure.core")))))

--- a/cider-scratch.el
+++ b/cider-scratch.el
@@ -46,9 +46,7 @@
          "--"
          ["Reset" #'cider-scratch-reset]
          "--"
-         ["Set buffer connection" #'cider-assoc-buffer-with-connection]
-         ["Toggle buffer connection" #'cider-toggle-buffer-connection]
-         ["Reset buffer connection" #'cider-clear-buffer-local-connection])))
+         ["Set buffer connection" #'cider-assoc-buffer-with-connection])))
     map))
 
 (defconst cider-scratch-buffer-name "*cider-scratch*")

--- a/cider-selector.el
+++ b/cider-selector.el
@@ -138,7 +138,7 @@ is chosen.  The returned buffer is selected with
 
 (def-cider-selector-method ?r
   "Current REPL buffer."
-  (cider-current-repl-buffer))
+  (cider-current-connection-repl))
 
 (def-cider-selector-method ?n
   "Connections browser buffer."

--- a/cider-test.el
+++ b/cider-test.el
@@ -584,51 +584,49 @@ report is optionally displayed.  When test failures/errors occur, their sources
 are highlighted.
 If SILENT is non-nil, suppress all messages other then test results."
   (cider-test-clear-highlights)
-  (cider-map-connections
-   (lambda (conn)
-     (unless silent
-       (if (and tests (= (length tests) 1))
-           ;; we generate a different message when running individual tests
-           (cider-test-echo-running ns (car tests))
-         (cider-test-echo-running ns)))
-     (cider-nrepl-send-request
-      `("op"     ,(cond ((stringp ns)         "test")
-                        ((eq :project ns)     "test-all")
-                        ((eq :loaded ns)      "test-all")
-                        ((eq :non-passing ns) "retest"))
-        "ns"     ,(when (stringp ns) ns)
-        "tests"  ,(when (stringp ns) tests)
-        "load?"  ,(when (or (stringp ns)
-                            (eq :project ns))
-                    "true"))
-      (lambda (response)
-        (nrepl-dbind-response response (summary results status out err)
-          (cond ((member "namespace-not-found" status)
-                 (unless silent
-                   (message "No test namespace: %s" (cider-propertize ns 'ns))))
-                (out (cider-emit-interactive-eval-output out))
-                (err (cider-emit-interactive-eval-err-output err))
-                (results
-                 (nrepl-dbind-response summary (error fail)
-                   (setq cider-test-last-summary summary)
-                   (setq cider-test-last-results results)
-                   (cider-test-highlight-problems results)
-                   (cider-test-echo-summary summary results)
-                   (if (or (not (zerop (+ error fail)))
-                           cider-test-show-report-on-success)
-                       (cider-test-render-report
-                        (cider-popup-buffer cider-test-report-buffer
-                                            cider-auto-select-test-report-buffer)
-                        summary results)
-                     (when (get-buffer cider-test-report-buffer)
-                       (with-current-buffer cider-test-report-buffer
-                         (let ((inhibit-read-only t))
-                           (erase-buffer)))
-                       (cider-test-render-report
-                        cider-test-report-buffer
-                        summary results))))))))
-      conn))
-   :clj))
+  (dolist (repl (cider-current-connection-repls "clj"))
+    (unless silent
+      (if (and tests (= (length tests) 1))
+          ;; we generate a different message when running individual tests
+          (cider-test-echo-running ns (car tests))
+        (cider-test-echo-running ns)))
+    (cider-nrepl-send-request
+     `("op"     ,(cond ((stringp ns)         "test")
+                       ((eq :project ns)     "test-all")
+                       ((eq :loaded ns)      "test-all")
+                       ((eq :non-passing ns) "retest"))
+       "ns"     ,(when (stringp ns) ns)
+       "tests"  ,(when (stringp ns) tests)
+       "load?"  ,(when (or (stringp ns)
+                           (eq :project ns))
+                   "true"))
+     (lambda (response)
+       (nrepl-dbind-response response (summary results status out err)
+         (cond ((member "namespace-not-found" status)
+                (unless silent
+                  (message "No test namespace: %s" (cider-propertize ns 'ns))))
+               (out (cider-emit-interactive-eval-output out))
+               (err (cider-emit-interactive-eval-err-output err))
+               (results
+                (nrepl-dbind-response summary (error fail)
+                  (setq cider-test-last-summary summary)
+                  (setq cider-test-last-results results)
+                  (cider-test-highlight-problems results)
+                  (cider-test-echo-summary summary results)
+                  (if (or (not (zerop (+ error fail)))
+                          cider-test-show-report-on-success)
+                      (cider-test-render-report
+                       (cider-popup-buffer cider-test-report-buffer
+                                           cider-auto-select-test-report-buffer)
+                       summary results)
+                    (when (get-buffer cider-test-report-buffer)
+                      (with-current-buffer cider-test-report-buffer
+                        (let ((inhibit-read-only t))
+                          (erase-buffer)))
+                      (cider-test-render-report
+                       cider-test-report-buffer
+                       summary results))))))))
+     repl)))
 
 (defun cider-test-rerun-failed-tests ()
   "Rerun failed and erring tests from the last test run."

--- a/doc/cider-refcard.tex
+++ b/doc/cider-refcard.tex
@@ -126,7 +126,6 @@
   \item[C-c C-z] cider-switch-to-repl-buffer
   \item[C-c M-o] cider-find-and-clear-repl-buffer
   \item[C-c M-d] cider-display-connection-info
-  \item[C-c M-r] cider-rotate-default-connection
   \item[C-c M-n] cider-repl-set-ns
   \item[C-c C-b] cider-interrupt
   \item[C-c C-x] cider-refresh

--- a/doc/interactive_programming.md
+++ b/doc/interactive_programming.md
@@ -36,8 +36,7 @@ Here's a list of `cider-mode`'s keybindings:
 `cider-switch-to-repl-buffer`                 |<kbd>C-c C-z</kbd>                   | Switch to the relevant REPL buffer. Use a prefix argument to change the namespace of the REPL buffer to match the currently visited source file.
 `cider-switch-to-repl-buffer`                 |<kbd>C-u C-u C-c C-z</kbd>           | Switch to the REPL buffer based on a user prompt for a directory.
 `cider-load-buffer-and-switch-to-repl-buffer` |<kbd>C-c M-z</kbd>                   | Load (eval) the current buffer and switch to the relevant REPL buffer. Use a prefix argument to change the namespace of the REPL buffer to match the currently visited source file.
-`cider-display-connection-info`               |<kbd>C-c M-d</kbd>                   | Display default REPL connection details, including project directory name, buffer namespace, host and port.
-`cider-rotate-default-connection`             |<kbd>C-c M-r</kbd>                   | Rotate and display the default nREPL connection.
+`cider-display-connection-info`               |<kbd>C-c M-d</kbd>                   | Display REPL connection details, including project directory name, buffer namespace, host and port.
 `cider-find-and-clear-repl-output`            |<kbd>C-c C-o</kbd>                   | Clear the last output in the REPL buffer. With a prefix argument it will clear the entire REPL buffer, leaving only a prompt. Useful if you're running the REPL buffer in a side by side buffer.
 `cider-load-buffer`                           |<kbd>C-c C-k</kbd>                   | Load (eval) the current buffer.
 `cider-load-file`                             |<kbd>C-c C-l</kbd>                   | Load (eval) a Clojure file.

--- a/doc/managing_connections.md
+++ b/doc/managing_connections.md
@@ -8,22 +8,9 @@ You can connect to multiple nREPL servers using <kbd>M-x</kbd> `cider-jack-in`
 CIDER maintains a list of nREPL connections and a single 'default'
 connection. When you execute CIDER commands in a Clojure editing buffer such as
 to compile a namespace, these commands are executed against a specific
-connection. This is controlled by the variable `cider-request-dispatch` - when
-it's set to `'dynamic` (the default), CIDER will try to infer which connection
-to use from the current project and currently visited file; when `'static`
-dispatch is used all requests will always be routed to the default connection
-(this was the default behavior in CIDER before 0.10).
+connection.
 
-There's a handy command called `cider-toggle-request-dispatch`. You can use it
-to quickly switch between dynamic and static request dispatch. A common use-case
-for it would be to force temporary all evaluation commands to be using a
-particular (the default) connection.
-
-You can display the current nREPL connection using <kbd>C-c M-d</kbd>
-and rotate the default connection using <kbd>C-c M-r</kbd>. Another
-option for setting the default connection is to execute the command
-<kbd>M-x</kbd> `cider-make-connection-default` in the appropriate
-REPL buffer.
+You can display info on current nREPL connection using <kbd>C-c M-d</kbd>.
 
 ## Connection browser
 
@@ -32,7 +19,6 @@ You can obtain a list of all active connections using <kbd>M-x</kbd>
 
 Command                              |Keyboard shortcut               | Description
 -------------------------------------|--------------------------------|-------------------------------
-`cider-connections-make-default`     |<kbd>d</kbd>                    | Make connection at point default.
 `cider-connections-close-connection` |<kbd>k</kbd>                    | Close connection at point.
 `cider-connection-browser`           |<kbd>g</kbd>                    | Refresh connection browser.
 `cider-connections-goto-connection`  |<kbd>RET</kbd>                  | Visit connection buffer.

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -71,6 +71,7 @@
 (require 'seq)
 (require 'subr-x)
 (require 'cider-compat)
+(require 'cider-popup)
 (require 'cl-lib)
 (require 'nrepl-dict)
 (require 'queue)
@@ -141,10 +142,6 @@ When true some special buffers like the server buffer will be hidden."
   "Name of a function that returns a client process buffer.
 It is called with one argument, a plist containing :host, :port and :proc
 as returned by `nrepl-connect'.")
-
-(defvar nrepl-use-this-as-repl-buffer 'new
-  "Name of the buffer to use as REPL buffer.
-In case of a special value 'new, a new buffer is created.")
 
 
 ;;; Buffer Local Declarations
@@ -1022,9 +1019,7 @@ client process is started, the function is called with the client buffer."
       ;; as long as `serv-buf' is not the buffer where the let-binding was
       ;; started. http://www.gnu.org/software/emacs/manual/html_node/elisp/Creating-Buffer_002dLocal.html
       (setq-local nrepl-create-client-buffer-function
-                  nrepl-create-client-buffer-function)
-      (setq-local nrepl-use-this-as-repl-buffer
-                  nrepl-use-this-as-repl-buffer))
+                  nrepl-create-client-buffer-function))
     (message "Starting nREPL server via %s..."
              (propertize cmd 'face 'font-lock-keyword-face))
     serv-proc))

--- a/test/cider-bytecomp-warnings.el
+++ b/test/cider-bytecomp-warnings.el
@@ -30,6 +30,7 @@
 
 (setq load-prefer-newer t)
 (add-to-list 'load-path (expand-file-name "./"))
+(add-to-list 'load-path (expand-file-name "./utils/"))
 (require 'package)
 (package-generate-autoloads 'cider default-directory)
 (package-initialize)

--- a/test/cider-client-tests.el
+++ b/test/cider-client-tests.el
@@ -35,183 +35,226 @@
 
 ;;; cider-client tests
 
-(describe "cider-current-connection"
+(describe "cider-current-connection-repl"
+
+  :var (project-dir)
+
+  (before-all
+    (setq project-dir "~/dummy/project/")
+    (spy-on 'clojure-project-dir :and-return-value project-dir))
 
   (describe "when there are no active connections"
-    :var (cider-connections)
+    :var (cider-connection-alist)
     (it "returns nil"
-      (setq cider-connections nil)
-      (expect (cider-current-connection) :not :to-be-truthy)
-      (expect (cider-current-connection "clj") :not :to-be-truthy)
-      (expect (cider-current-connection "cljs") :not :to-be-truthy)))
+      (setq cider-connection-alist nil)
+      (expect (cider-current-connection-repl) :not :to-be-truthy)
+      (expect (cider-current-connection-repl "clj") :not :to-be-truthy)
+      (expect (cider-current-connection-repl "cljs") :not :to-be-truthy)))
 
   (describe "when active connections are available"
 
     (it "always returns the latest connection"
-      (with-connection-buffer "clj" bb1
-        (with-connection-buffer "cljs" bb2
-          (with-connection-buffer "clj" b1
-            (with-connection-buffer "cljs" b2
-              (expect (cider-current-connection) :to-equal b2)
+      (with-connection-buffer "bb" project-dir "clj" bb1
+        (with-connection-buffer "bb" project-dir "cljs" bb2
+          (with-connection-buffer "b" project-dir "clj" b1
+            (with-connection-buffer "b" project-dir "cljs" b2
+              (expect (cider-current-connection-repl) :to-equal b2)
 
               ;; follows type arguments
-              (expect (cider-current-connection "clj") :to-equal b1)
-              (expect (cider-current-connection "cljs") :to-equal b2)
+              (expect (cider-current-connection-repl "clj") :to-equal b1)
+              (expect (cider-current-connection-repl "cljs") :to-equal b2)
 
               ;; follows file type
               (with-temp-buffer
                 (setq major-mode 'clojure-mode)
-                (expect (cider-current-connection) :to-equal b1))
+                (expect (cider-current-connection-repl) :to-equal b1))
 
               (with-temp-buffer
                 (setq major-mode 'clojurescript-mode)
-                (expect (cider-current-connection) :to-equal b2)))))))
+                (expect (cider-current-connection-repl) :to-equal b2)))))))
 
     (it "always returns the most recently used connection"
-      (with-connection-buffer "clj" bb1
-        (with-connection-buffer "cljs" bb2
-          (with-connection-buffer "clj" b1
-            (with-connection-buffer "cljs" b2
+      (with-connection-buffer "bb" project-dir "clj" bb1
+        (with-connection-buffer "bb" project-dir "cljs" bb2
+          (with-connection-buffer "b" project-dir "clj" b1
+            (with-connection-buffer "b" project-dir "cljs" b2
 
               (switch-to-buffer bb2)
               (switch-to-buffer bb1)
-              (expect (cider-current-connection) :to-equal bb1)
+              (expect (cider-current-connection-repl) :to-equal bb1)
 
               ;; follows type arguments
-              (expect (cider-current-connection "clj") :to-equal bb1)
-              (expect (cider-current-connection "cljs") :to-equal bb2)
+              (expect (cider-current-connection-repl "clj") :to-equal bb1)
+              (expect (cider-current-connection-repl "cljs") :to-equal bb2)
 
               ;; follows file type
               (with-temp-buffer
                 (setq major-mode 'clojure-mode)
-                (expect (cider-current-connection) :to-equal bb1))
+                (expect (cider-current-connection-repl) :to-equal bb1))
 
               (with-temp-buffer
                 (setq major-mode 'clojurescript-mode)
-                (expect (cider-current-connection) :to-equal bb2)))))))
+                (expect (cider-current-connection-repl) :to-equal bb2)))))))
 
     (describe "when current buffer is a 'multi' buffer"
       (describe "when there is only one connection available"
-       (it "returns the only connection"
-         (with-connection-buffer "clj" b
-           (with-temp-buffer
-             (clojure-mode)
-             (expect (cider-current-connection "clj") :to-equal b))
-           (with-temp-buffer
-             (clojurec-mode)
-             (expect (cider-current-connection "clj") :to-equal b))
-           (with-temp-buffer
-             (clojurex-mode)
-             (expect (cider-current-connection "clj") :to-equal b))))))
+        (it "returns the only connection"
+          (with-connection-buffer "tmp" project-dir "clj" b
+            (with-temp-buffer
+              (clojure-mode)
+              (expect (cider-current-connection-repl "clj") :to-equal b))
+            (with-temp-buffer
+              (clojurec-mode)
+              (expect (cider-current-connection-repl "clj") :to-equal b))
+            (with-temp-buffer
+              (clojurex-mode)
+              (expect (cider-current-connection-repl "clj") :to-equal b))))))
 
     (describe "when type argument is given"
       (describe "when connection of that type exists"
         (it "returns that connection buffer"
           ;; for clj
-          (with-connection-buffer "clj" b1
-            (with-connection-buffer "cljs" b2
-              (expect (cider-current-connection "clj") :to-equal b1)))
+          (with-connection-buffer "tmp" project-dir "clj" b1
+            (with-connection-buffer "tmp" project-dir "cljs" b2
+              (expect (cider-current-connection-repl "clj") :to-equal b1)))
           ;; for cljs
-          (with-connection-buffer "cljs" b1
-            (with-connection-buffer "clj" b2
-              (expect (cider-current-connection "cljs") :to-equal b1)))))
+          (with-connection-buffer "tmp" project-dir "cljs" b1
+            (with-connection-buffer "tmp" project-dir "clj" b2
+              (expect (cider-current-connection-repl "cljs") :to-equal b1)))))
 
       (describe "when connection of that type doesn't exists"
         (it "returns nil"
           ;; for clj
-          (with-connection-buffer "cljs" b1
-            (expect (cider-current-connection "clj") :to-equal nil))
+          (with-connection-buffer "tmp" project-dir "cljs" b1
+            (expect (cider-current-connection-repl "clj") :to-equal nil))
 
           ;; for cljs
-          (with-connection-buffer "clj" b2
-            (expect (cider-current-connection "cljs") :to-equal nil)))))
+          (with-connection-buffer "tmp" project-dir "clj" b2
+            (expect (cider-current-connection-repl "cljs") :to-equal nil)))))
 
     (describe "when type argument is not given"
       (describe "when a connection matching current file extension exists"
         (it "returns that connection buffer"
           ;; for clj
-          (with-connection-buffer "clj" b1
-            (with-connection-buffer "cljs" b2
+          (with-connection-buffer "tmp" project-dir "clj" b1
+            (with-connection-buffer "tmp" project-dir "cljs" b2
               (with-temp-buffer
                 (setq major-mode 'clojure-mode)
-                (expect (cider-current-connection) :to-equal b1))))
+                (expect (cider-current-connection-repl) :to-equal b1))))
 
           ;; for cljs
-          (with-connection-buffer "cljs" b1
-            (with-connection-buffer "clj" b2
+          (with-connection-buffer "tmp" project-dir "cljs" b1
+            (with-connection-buffer "tmp" project-dir "clj" b2
               (with-temp-buffer
                 (setq major-mode 'clojurescript-mode)
-                (expect (cider-current-connection) :to-equal b1))))))
+                (expect (cider-current-connection-repl) :to-equal b1))))))
 
       (describe "when a connection matching current file extension doesn't exist"
-        (it "returns the latest connection buffer"
+        (it "returns nil"
           ;; for clj
-          (with-connection-buffer "clj" b1
+          (with-connection-buffer "tmp" project-dir "clj" b1
             (with-temp-buffer
               (setq major-mode 'clojurescript-mode)
-              (expect (cider-current-connection) :to-equal b1)))
+              (expect (cider-current-connection-repl) :to-equal nil)))
 
           ;; for cljs
-          (with-connection-buffer "cljs" b2
+          (with-connection-buffer "tmp" project-dir "cljs" b2
             (with-temp-buffer
               (setq major-mode 'clojure-mode)
-              (expect (cider-current-connection) :to-equal b2))))))))
+              (expect (cider-current-connection-repl) :to-equal nil))))))))
 
-(describe "cider-other-connection"
-  (describe "when there are no active connections"
-    :var (cider-connections)
+(describe "cider-other-repl"
+
+  :var (project-dir)
+
+  (before-all
+    (setq project-dir "~/dummy/project/")
+    (spy-on 'clojure-project-dir :and-return-value project-dir))
+
+  (describe "when within different connections"
     (it "returns nil"
-      (setq cider-connections nil)
-      (expect (cider-other-connection) :to-equal nil)))
+      ;; for clj
+      (with-connection-buffer "tmp1" project-dir "clj" b1
+        (with-connection-buffer "tmp2" project-dir "cljs" b2
+          (expect (cider-other-repl) :to-equal nil)
+          (expect (cider-other-repl b1) :to-equal nil)
+          (expect (cider-other-repl b2) :to-equal nil)))
+      ;; for cljs
+      (with-connection-buffer "tmp1" project-dir "cljs" b1
+        (with-connection-buffer "tmp2" project-dir "cljc" b2
+          (expect (cider-other-repl) :to-equal nil)
+          (expect (cider-other-repl b1) :to-equal nil)
+          (expect (cider-other-repl b2) :to-equal nil)))))
+
+  (describe "when there are no active connections"
+    :var (cider-connection-alist)
+    (it "returns nil"
+      (setq cider-connection-alist nil)
+      (expect (cider-other-repl) :to-equal nil)))
 
   (describe "when there is only 1 active connection"
     (it "returns nil"
       ;; for clj
-      (with-connection-buffer "clj" b1
-        (expect (cider-other-connection) :to-equal nil)
-        (expect (cider-other-connection b1) :to-equal nil))
+      (with-connection-buffer "tmp" project-dir "clj" b1
+        (expect (cider-other-repl) :to-equal nil)
+        (expect (cider-other-repl b1) :to-equal nil))
       ;; for cljs
-      (with-connection-buffer "cljs" b1
-        (expect (cider-other-connection) :to-equal nil)
-        (expect (cider-other-connection b1) :to-equal nil))))
+      (with-connection-buffer "tmp" project-dir "cljs" b1
+        (expect (cider-other-repl) :to-equal nil)
+        (expect (cider-other-repl b1) :to-equal nil))))
 
   (describe "when active connections are available"
     (describe "when a connection of other type doesn't exist"
-      (it "returns nil"
-        ;; for clj
-        (with-connection-buffer "clj" b1
-          (with-connection-buffer "clj" b2
-            (expect (cider-other-connection) :to-equal nil)
-            (expect (cider-other-connection b1) :to-equal nil)
-            (expect (cider-other-connection b2) :to-equal nil)))
-        ;; for cljs
-        (with-connection-buffer "cljs" b1
-          (with-connection-buffer "cljs" b2
-            (expect (cider-other-connection) :to-equal nil)
-            (expect (cider-other-connection b1) :to-equal nil)
-            (expect (cider-other-connection b2) :to-equal nil)))))
+      (describe "and within same connection"
+        (it "returns nil"
+          ;; for clj
+          (with-connection-buffer "tmp" project-dir "clj" b1
+            (with-connection-buffer "tmp" project-dir "clj" b2
+              (expect (cider-other-repl) :to-equal nil)
+              (expect (cider-other-repl b1) :to-equal nil)
+              (expect (cider-other-repl b2) :to-equal nil)))
+          ;; for cljs
+          (with-connection-buffer "tmp" project-dir "cljs" b1
+            (with-connection-buffer "tmp" project-dir "cljs" b2
+              (expect (cider-other-repl) :to-equal nil)
+              (expect (cider-other-repl b1) :to-equal nil)
+              (expect (cider-other-repl b2) :to-equal nil)))))
+
+      (describe "when within different connections"
+        (it "returns nil"
+          ;; for clj
+          (with-connection-buffer "tmp1" project-dir "clj" b1
+            (with-connection-buffer "tmp2" project-dir "cljs" b2
+              (expect (cider-other-repl) :to-equal nil)
+              (expect (cider-other-repl b1) :to-equal nil)
+              (expect (cider-other-repl b2) :to-equal nil)))
+          ;; for cljs
+          (with-connection-buffer "tmp1" project-dir "cljs" b1
+            (with-connection-buffer "tmp2" project-dir "cljc" b2
+              (expect (cider-other-repl) :to-equal nil)
+              (expect (cider-other-repl b1) :to-equal nil)
+              (expect (cider-other-repl b2) :to-equal nil))))))
 
     (describe "when a connection of other type exists"
       (it "returns that connection"
-        (with-connection-buffer "clj" b1
-          (with-connection-buffer "cljs" b2
-            (expect (cider-other-connection) :to-equal b1)
-            (expect (cider-other-connection b1) :to-equal b2)
-            (expect (cider-other-connection b2) :to-equal b1)))))
+        (with-connection-buffer "tmp" project-dir "clj" b1
+          (with-connection-buffer "tmp" project-dir "cljs" b2
+            (expect (cider-other-repl) :to-equal b1)
+            (expect (cider-other-repl b1) :to-equal b2)
+            (expect (cider-other-repl b2) :to-equal b1)))))
 
     (describe "when there are multiple active connections"
       (it "always returns the latest connection"
-
-        (with-connection-buffer "clj" bb1
-          (with-connection-buffer "cljs" bb2
-            (with-connection-buffer "clj" b1
-              (with-connection-buffer "cljs" b2
-                (expect (cider-other-connection) :to-equal b1)
-                (expect (cider-other-connection b1) :to-equal b2)
-                (expect (cider-other-connection b2) :to-equal b1)
+        (with-connection-buffer "bb" project-dir "clj" bb1
+          (with-connection-buffer "bb" project-dir "cljs" bb2
+            (with-connection-buffer "b" project-dir "clj" b1
+              (with-connection-buffer "b" project-dir "cljs" b2
+                (expect (cider-other-repl) :to-equal b1)
+                (expect (cider-other-repl b1) :to-equal b2)
+                (expect (cider-other-repl b2) :to-equal b1)
                 ;; older connections still work
-                (expect (cider-other-connection bb1) :to-equal b2)
-                (expect (cider-other-connection bb2) :to-equal b1)))))))))
+                (expect (cider-other-repl bb1) :to-equal bb2)
+                (expect (cider-other-repl bb2) :to-equal bb1)))))))))
 
 (describe "cider-var-info"
   (it "returns vars info as an alist"
@@ -235,64 +278,15 @@
             :to-equal "stub")
     (expect (cider-var-info "") :to-equal nil)))
 
-(describe "cider-make-connection-default"
-  :var (connections)
-
-  (it "makes the nrepl connection buffer, the default connection"
-    (cider-test-with-buffers
-     (a b)
-     ;; Add one connection
-     (cider-make-connection-default a)
-     (expect (cider-default-connection) :to-equal a)
-     ;; Add second connection
-     (cider-make-connection-default b)
-     (expect (cider-default-connection) :to-equal b)
-     ;; Re-add first connection
-     (cider-make-connection-default a)
-     (expect (cider-default-connection) :to-equal a)))
-
-  (it "moves the connection buffer to the front of `cider-connections'"
-    (setq connections (cider-connections))
-    (cider-test-with-buffers
-     (a b)
-     ;; Add one connection
-     (cider-make-connection-default a)
-     (expect (cider-connections) :to-equal (append (list a) connections))
-     ;; Add second connection
-     (cider-make-connection-default b)
-     (expect (cider-connections) :to-equal (append (list b a) connections))
-     ;; Re-add first connection
-     (cider-make-connection-default a)
-     (expect (cider-connections) :to-equal (append (list a b) connections)))))
-
-(describe "cider-connections"
-  :var (connections)
-  (it "removes a connection buffer from connections list, when it is killed"
-    (setq connections (cider-connections))
-    (cider-test-with-buffers
-     (a b)
-     (cider-make-connection-default a)
-     (cider-make-connection-default b)
-     (kill-buffer a)
-     (expect (cider-default-connection) :to-equal b)
-     (expect (cider-connections) :to-equal (append (list b) connections)))))
-
-(describe "cider-rotate-default-connection"
-  (it "rotates the default nREPL connections in `cider-connections'"
-    ;; to mute the output on stdout
-    (spy-on 'message :and-return-value nil)
-    (cider-test-with-buffers
-     (a b c)
-     (cider-make-connection-default c)
-     (cider-make-connection-default b)
-     (cider-make-connection-default a)
-     (expect (cider-default-connection) :to-equal a)
-     (cider-rotate-default-connection)
-     (expect (cider-default-connection) :to-equal b)
-     (cider-rotate-default-connection)
-     (expect (cider-default-connection) :to-equal c)
-     (cider-rotate-default-connection)
-     (expect (cider-default-connection) :to-equal a))))
+;; (describe "cider-connections"
+;;   :var (connections)
+;;   (it "removes a connection buffer from connections list, when it is killed"
+;;     (setq connections (cider-connections))
+;;     (cider-test-with-buffers
+;;      (a b)
+;;      (kill-buffer a)
+;;      (expect (cider-current-connection-repl) :to-equal b)
+;;      (expect (cider-connections) :to-equal (append (list b) connections)))))
 
 (describe "cider--connection-info"
   (spy-on 'cider--java-version :and-return-value "1.7")
@@ -318,17 +312,19 @@
 
 (describe "cider--close-connection-buffer"
   :var (connections)
-  (it "removes the connection from `cider-connections'"
+  (it "removes the connection from `cider-connection-alist'"
     (setq connections (cider-connections))
-    (cider-test-with-buffers
-     (a b)
-     (cider-make-connection-default a)
-     (cider-make-connection-default b)
-     ;; closing a buffer should see it removed from the connection list
-     (cider--close-connection-buffer a)
-     (expect (buffer-live-p a) :not :to-be-truthy)
-     (expect (cider-connections) :to-equal (cons b connections))
-     (expect (cider-default-connection) :to-equal b))))
+    (cider-test-with-buffers (a b)
+      (let ((conn-name (make-temp-name "conn")))
+        (cider-add-connection-repl conn-name a)
+        (cider-add-connection-repl conn-name b)
+        ;; closing a buffer should see it removed from the connection list
+        (cider--close-connection-buffer a)
+        (expect (buffer-live-p a) :not :to-be-truthy)
+        (expect (cider-connections) :to-equal (cons (list conn-name b) connections))
+        (cider--close-connection-buffer b)
+        (expect (buffer-live-p b) :not :to-be-truthy)
+        (expect (cider-connections) :to-equal connections)))))
 
 (describe "cider-connection-type-for-buffer"
   :var (cider-repl-type)
@@ -355,19 +351,15 @@
     (setq cider-repl-type nil)
     (expect (cider-connection-type-for-buffer) :to-equal nil)))
 
-
 (describe "cider-nrepl-send-unhandled-request"
   (it "returns the id of the request sent to nREPL server and ignores the response"
     (spy-on 'process-send-string :and-return-value nil)
-    (with-temp-buffer
+    (with-connection-buffer "dummy" "/dummy/project/" "clj" repl
       (setq-local nrepl-pending-requests (make-hash-table :test 'equal))
       (setq-local nrepl-completed-requests (make-hash-table :test 'equal))
-      (let* ((cider-connections (list (current-buffer)))
-             (id (cider-nrepl-send-unhandled-request '("op" "t" "extra" "me"))))
-
+      (let ((id (cider-nrepl-send-unhandled-request '("op" "t" "extra" "me"))))
         ;; the request should never be marked as pending
         (expect (gethash id nrepl-pending-requests) :not :to-be-truthy)
-
         ;; the request should be marked completed immediately
         (expect (gethash id nrepl-completed-requests) :to-be-truthy)
         (expect (gethash id nrepl-completed-requests) :to-equal #'ignore)))
@@ -378,51 +370,51 @@
   (it "changes designation in all cider buffer names"
     (with-temp-buffer
       (let ((server-buffer (current-buffer)))
-        (with-temp-buffer
-          (let* ((connection-buffer (current-buffer))
-                 (cider-connections (list connection-buffer)))
+        (with-connection-buffer "dummy" "/dummy/" "clj" repl
+          (let* ((connection-buffer (current-buffer)))
             (setq-local nrepl-server-buffer server-buffer)
+            (setq-local cider-connection-name "dummy")
             (cider-change-buffers-designation "bob")
             (expect (buffer-name connection-buffer) :to-equal "*cider-repl bob*")
             (expect (buffer-name server-buffer) :to-equal "*nrepl-server bob*")
             (with-current-buffer connection-buffer
               (expect (buffer-name) :to-equal "*cider-repl bob*"))))))))
 
-
 (describe "cider-extract-designation-from-current-repl-buffer"
+
+  :var (cider-connection-alist)
+  (before-all
+    (spy-on 'clojure-project-dir :and-return-value "/dummy/")
+    (setq cider-connection-alist nil))
 
   (describe "when the buffers have a designation"
     (it "returns that designation string"
-      (with-temp-buffer
-        (let ((cider-connections (list (current-buffer)))
-              (nrepl-repl-buffer-name-template "*cider-repl%s*"))
+      (with-connection-buffer "dummy" "/dummy/" "clj" repl
+        (let ((nrepl-repl-buffer-name-template "*cider-repl%s*"))
           (rename-buffer "*cider-repl bob*")
           (switch-to-buffer (current-buffer))
           (with-temp-buffer
             (switch-to-buffer (current-buffer))
             (expect (cider-extract-designation-from-current-repl-buffer)
                     :to-equal "bob")
-            (rename-buffer "*cider-repl apa*")
-            (push (current-buffer) cider-connections)
-            (expect (cider-extract-designation-from-current-repl-buffer)
-                    :to-equal "apa")
-            (setq-local cider-connections (list (current-buffer)))
-            (expect (cider-extract-designation-from-current-repl-buffer)
-                    :to-equal "apa"))))))
+            (with-connection-buffer "dummy2" "/dummy/" "clj" repl2
+              (rename-buffer "*cider-repl apa*")
+              (expect (cider-extract-designation-from-current-repl-buffer)
+                      :to-equal "apa")))))))
 
-  (describe "when the buffers don't have a designation"
-    (it "returns <no designation>"
-      (with-temp-buffer
-        (let* ((connection-buffer (current-buffer))
-               (cider-connections (list connection-buffer)))
-          (with-temp-buffer
-            (let ((repl-buffer (current-buffer)))
-              (rename-buffer "*cider-repl*")
-              (with-temp-buffer
-                (with-current-buffer connection-buffer
-                  (setq-local nrepl-repl-buffer repl-buffer))
-                (expect (cider-extract-designation-from-current-repl-buffer)
-                        :to-equal "<no designation>")))))))))
+  ;; (describe "when the buffers don't have a designation"
+  ;;   (it "returns <no designation>"
+  ;;     (with-connection-buffer "dummy" "/dummy/" "clj" repl
+  ;;       (let* ((connection-buffer (current-buffer)))
+  ;;         (with-temp-buffer
+  ;;           (let ((repl-buffer (current-buffer)))
+  ;;             (rename-buffer "*cider-repl*")
+  ;;             (with-temp-buffer
+  ;;               (with-current-buffer connection-buffer
+  ;;                 (setq-local nrepl-repl-buffer repl-buffer))
+  ;;               (expect (cider-extract-designation-from-current-repl-buffer)
+  ;;                       :to-equal "<no designation>"))))))))
+  )
 
 
 (describe "cider-project-name"
@@ -431,14 +423,6 @@
     (expect (cider-project-name "") :to-equal "-")
     (expect (cider-project-name "path/to/project") :to-equal "project")
     (expect (cider-project-name "path/to/project/") :to-equal "project")))
-
-(describe "cider-ensure-connected"
-  (it "returns nil when a cider connection is available"
-    (spy-on 'cider-connected-p :and-return-value t)
-    (expect (cider-ensure-connected) :to-equal nil))
-  (it "raises a user-error in the absence of a connection"
-    (spy-on 'cider-connected-p :and-return-value nil)
-    (expect (lambda () (cider-ensure-connected)) :to-throw 'user-error)))
 
 (describe "cider-ensure-op-supported"
   (it "returns nil when the op is supported"

--- a/test/cider-interaction-tests.el
+++ b/test/cider-interaction-tests.el
@@ -87,18 +87,18 @@
     (expect (lambda () (cider-load-all-project-ns)) :to-throw 'user-error)))
 
 (describe "cider-load-file"
-          (it "works as expected in empty Clojure buffers"
-              (spy-on 'cider-request:load-file :and-return-value nil)
-              (with-connection-buffer "clj" b
-                                      (with-temp-buffer
-                                        (clojure-mode)
-                                        (setq buffer-file-name (make-temp-name "tmp.clj"))
-                                        (expect (lambda () (cider-load-buffer)) :not :to-throw)))))
+  (it "works as expected in empty Clojure buffers"
+    (spy-on 'cider-request:load-file :and-return-value nil)
+    (with-connection-buffer "dummy" "/dummy/" "clj" b
+      (with-temp-buffer
+        (clojure-mode)
+        (setq buffer-file-name (make-temp-name "tmp.clj"))
+        (expect (lambda () (cider-load-buffer)) :not :to-throw)))))
 
 (describe "cider-interactive-eval"
-          (it "works as expected in empty Clojure buffers"
-              (spy-on 'cider-nrepl-request:eval :and-return-value nil)
-              (with-connection-buffer "clj" b
-                                      (with-temp-buffer
-                                        (clojure-mode)
-                                        (expect (lambda () (cider-interactive-eval "(+ 1)")) :not :to-throw)))))
+  (it "works as expected in empty Clojure buffers"
+    (spy-on 'cider-nrepl-request:eval :and-return-value nil)
+    (with-connection-buffer "dummy" "/dummy/" "clj" b
+      (with-temp-buffer
+        (clojure-mode)
+        (expect (lambda () (cider-interactive-eval "(+ 1)")) :not :to-throw)))))

--- a/test/cider-selector-tests.el
+++ b/test/cider-selector-tests.el
@@ -47,11 +47,11 @@
         (expect (current-buffer) :to-equal expected-buffer)))))
 
 (describe "cider-selector-n"
-  :var (cider-endpoint cider-connections)
+  :var (cider-endpoint cider-connection-alist)
   (it "switches to the connection browser buffer"
     (with-temp-buffer
       (setq cider-endpoint '("123.123.123.123" 4006)
-            cider-connections (list (current-buffer)))
+            cider-connection-alist (list (current-buffer)))
       (with-temp-buffer
         ;; switch to another buffer
         (cider-invoke-selector-method-by-key ?n)
@@ -68,9 +68,9 @@
     (cider--test-selector-method ?e 'emacs-lisp-mode "*testfile*.el")))
 
 (describe "cider-seletor-method-r"
-  :var (cider-current-repl-buffer)
+  :var (cider-current-connection-repl)
   (it "switches to current REPL buffer"
-    (spy-on 'cider-current-repl-buffer :and-return-value "*cider-repl xyz*")
+    (spy-on 'cider-current-connection-repl :and-return-value "*cider-repl xyz*")
     (cider--test-selector-method ?r 'cider-repl-mode "*cider-repl xyz*")))
 
 (describe "cider-selector-method-m"

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -36,44 +36,40 @@
 
 ;;; connection browser
 
-(describe "cider-connections-buffer"
-  (it "lists all the active connections"
-    (with-temp-buffer
-      (rename-buffer "*cider-repl test1*")
-      (let ((b1 (current-buffer)))
-        (setq-local nrepl-endpoint '("localhost" 4005))
-        (setq-local nrepl-project-dir "proj")
-        (setq-local cider-repl-type "clj")
-        (with-temp-buffer
-          (rename-buffer "*cider-repl test2*")
-          (let ((b2 (current-buffer)))
-            (setq-local nrepl-endpoint '("123.123.123.123" 4006))
-            (setq-local cider-repl-type "clj")
-            (let ((cider-connections (list b1 b2)))
-              (cider-connection-browser)
-              (with-current-buffer "*cider-connections*"
-                (expect (buffer-string) :to-equal "  REPL                           Host             Port    Project          Type
+;; (describe "cider-connections-buffer"
+;;   (it "lists all the active connections"
+;;     (with-temp-buffer
+;;       (rename-buffer "*cider-repl test1*")
+;;       (let ((b1 (current-buffer)))
+;;         (setq-local nrepl-endpoint '("localhost" 4005))
+;;         (setq-local nrepl-project-dir "proj")
+;;         (setq-local cider-repl-type "clj")
+;;         (with-temp-buffer
+;;           (rename-buffer "*cider-repl test2*")
+;;           (let ((b2 (current-buffer)))
+;;             (setq-local nrepl-endpoint '("123.123.123.123" 4006))
+;;             (setq-local cider-repl-type "clj")
+;;             (let ((cider-connection-alist (list b1 b2)))
+;;               (cider-connection-browser)
+;;               (with-current-buffer "*cider-connections*"
+;;                 (expect (buffer-string) :to-equal "  REPL                           Host             Port    Project          Type
 
-* *cider-repl test1*             localhost         4005   proj             Clojure
-  *cider-repl test2*             123.123.123.123   4006   -                Clojure\n\n")
+;;  *cider-repl test1*             localhost         4005   proj             Clojure
+;;  *cider-repl test2*             123.123.123.123   4006   -                Clojure\n\n")
 
-                (goto-line 4)         ; somewhere in the second connection listed
-                (cider-connections-make-default)
-                (expect (car cider-connections) :to-equal b2)
-                (message "%s" (cider-connections))
-                (expect (buffer-string) :to-equal "  REPL                           Host             Port    Project          Type
+;;                 (goto-line 4)         ; somewhere in the second connection listed
+;;                 (expect (buffer-string) :to-equal "  REPL                           Host             Port    Project          Type
 
-  *cider-repl test1*             localhost         4005   proj             Clojure
-* *cider-repl test2*             123.123.123.123   4006   -                Clojure\n\n")
-                (goto-line 4)         ; somewhere in the second connection listed
-                (cider-connections-close-connection)
-                (expect cider-connections :to-equal (list b1))
-                (expect (buffer-string) :to-equal "  REPL                           Host             Port    Project          Type
+;;  *cider-repl test1*             localhost         4005   proj             Clojure
+;;  *cider-repl test2*             123.123.123.123   4006   -                Clojure\n\n")
+;;                 (goto-line 4)         ; somewhere in the second connection listed
+;;                 (cider-connections-close-connection)
+;;                 (expect (buffer-string) :to-equal "  REPL                           Host             Port    Project          Type
 
-* *cider-repl test1*             localhost         4005   proj             Clojure\n\n")
-                (cider-connections-goto-connection)
-                (expect (current-buffer) :to-equal b1)
-                (kill-buffer "*cider-connections*")))))))))
+;;  *cider-repl test1*             localhost         4005   proj             Clojure\n\n")
+;;                 (cider-connections-goto-connection)
+;;                 (expect (current-buffer) :to-equal b1)
+;;                 (kill-buffer "*cider-connections*")))))))))
 
 (describe "cider-inject-jack-in-dependencies"
   :var (cider-jack-in-dependencies cider-jack-in-nrepl-middlewares cider-jack-in-lein-plugins cider-jack-in-dependencies-exclusions)


### PR DESCRIPTION
 Attempting to bootstrap the connection API . I guess we could all agree by now that the current status is rather unsatisfactory, so I am skipping the introduction.

It's probably best to review the new code directly rather than from the diff. The key points are:

  -  Most of the issues with connections are due to the lack of an intermediate "connection unit" in between nREPL sessions (or REPL buffer) and project directory.  To fix that, one could either introduce a new unit directly or re-brand the old name into a new concept. I have opted for the second as the change should then be transparent to the user. 

     So, there is now a new "connection" unit defined as a collection of nREPL transport processes. As nREPL process in Cider is confounded with the corresponding REPL buffer the new "connection" is a structure with a name and a bunch of REPL buffers. This is the user visible connection unit. Most user interactions should operate on this unit (assoc connections and interactive eval being the most important).

  - The [connection API](https://github.com/vspinu/cider/blob/refactor-connections/cider-client.el#L207) consists of a few functions to add/delete and retrieve relevant REPLs from `cider-connection-alist`.  Most notably [`cider-current-connection`](https://github.com/vspinu/cider/blob/refactor-connections/cider-client.el#L263-L288) has now a  clear semantics which allows for buffer local association, directory association and project level associations. There is now very little room for sending code to wrong connections.  

  - The user level [association API](https://github.com/vspinu//cider/blob/refactor-connections/cider-client.el#L331) consists of three commands for buffer, dir and project associations and one DWIM command for most common case. There is a need for a one or two `dissoc` commands which I left for a later date. I still need to add a proper md doc entry for this part, but hopefully the code is sufficiently clear.

  - I have removed the old `static` connection API altogether. Life is too short to maintain two parallel APIs, let alone that that system was a pretty awful UI to begin with. 

I have also added a bunch of FIXMEs in the code. Those are not regressions but probable bugs in current implementation mostly concerning `cljc` interaction. Basically, every occurrence of `cider-current-connection` in the old code ( `cider-current-connection-repl` in the new version) is likely to be doing something wrong for `cljc` setup.  Those should be tackled on case by case, but are relatively straightforward to fix within the new framework. 

------
  New variables:

      cider-connection-alist, cider-connection-name, cider-connected-directories

  New connection API functions:

      cider-delete-connection-repl, cider-add-connection-repl,
      cider-get-connection, cider-project-connections-repls,
      cider-current-connection-repls, cider-current-connection-repl

  New commands for connection association:

      cider-assoc-buffer-with-connection
      cider-assoc-directory-with-connection
      cider-assoc-project-with-connection
      cider-assoc-with-connection

  New semantics:

      cider-assoc-project-with-connection, cider-connections,
      cider-current-connection, cider-project-connections

  Removed:

      cider-request-dispatch, cider-connections,
      cider-find-connection-buffer-for-project-directory,
      cider-toggle-buffer-connection, cider-clear-buffer-local-connection,
      cider-toggle-request-dispatch, cider-current-connection,
      cider--in-connection-buffer-p, cider-default-connection,
      cider-rotate-default-connection cider--guess-cljs-connection,
      cider--has-warned-about-bad-repl-type, cider-map-connections,
      cider-connections-make-default, cider--connections-make-default,
      nrepl-use-this-as-repl-buffer

  Work, but need to be re-factored/adjusted:

      cider-change-buffers-designation
      cider-connection-browser
