### PR TITLE
Faster REPL - don't load extra middleware on first sync eval request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## master (unreleased)
 
+### New Features
+
+* [#2082](https://github.com/clojure-emacs/cider/pull/2082), [cider-nrepl#440](https://github.com/clojure-emacs/cider-nrepl/pull/440): Add specialized stacktraces for clojure.spec assertions.
+
+### Changes
+
+* [cider-nrepl#438](https://github.com/clojure-emacs/cider-nrepl/pull/438): Improve startup time by differing loading CIDER's middleware until the first usage.
+* [#2078](https://github.com/clojure-emacs/cider/pull/2078): Improve startup time by bundling together sync requests during startup. 
+
 ### Bugs Fixed
 
 * [#2088](https://github.com/clojure-emacs/cider/issues/2088): Fix functions defined with def being font locked as vars instead of functions.

--- a/cider.el
+++ b/cider.el
@@ -892,10 +892,15 @@ buffer."
     (cider--check-required-nrepl-version)
     (cider--check-clojure-version-supported)
     (cider--check-middleware-compatibility)
-    (cider--debug-init-connection)
     (cider--subscribe-repl-to-server-out)
     (when cider-auto-mode
       (cider-enable-on-existing-clojure-buffers))
+    ;; Middleware on cider-nrepl side is differed until first usage, but,
+    ;; loading middleware concurrently can lead to occasional "require" issues
+    ;; (likely a clojure bug). Thus, we load the heavy debug middleware towards
+    ;; the end, allowing for the faster "server-out" middleware to load
+    ;; first.
+    (cider--debug-init-connection)
     (run-hooks 'cider-connected-hook)))
 
 (defun cider--disconnected-handler ()


### PR DESCRIPTION
This saves a couple of extra seconds and brings cider repl startup time to barebones empty-project `lein repl` of 4s for me.

----

  - Send :inhibit-cider-middleware condition on first request. Relies on a feature added in clojure-emacs/cider-nrepl#438.

  - Combine `require-repl-utils` and `set-initial-ns` into one sync request for efficiency. Note that `require-repl-utils` needs to be a sync request. It could happen that the following init-debuger request would occur before it has finished, resulting in "reader/reader not found error". 

