### PR TITLE
cider-doc: make links in "Also see" section to be text buttons

### DIFF
--- a/cider-doc.el
+++ b/cider-doc.el
@@ -484,9 +484,9 @@ Tables are marked to be ignored by line wrap."
                          ;; if the var belongs to the same namespace,
                          ;; we omit the namespace to save some screen space
                          (symbol (if (equal ns see-also-ns) see-also-sym ns-sym)))
-                    (insert-button symbol
-                                   'type 'help-xref
-                                   'help-function (apply-partially #'cider-doc-lookup symbol)))
+                    (insert-text-button symbol
+                                        'type 'help-xref
+                                        'help-function (apply-partially #'cider-doc-lookup symbol)))
                   (insert " "))
                 see-also))
         (cider--doc-make-xrefs)


### PR DESCRIPTION
This minor change is for compatibility with [ace-link](https://github.com/abo-abo/ace-link)
package, which cannot detect links created with `insert-button`.