### PR TITLE
Add stacktrace navigator for clojure.spec/asserts

### DIFF
--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -596,11 +596,22 @@ prompt and whether to use a new window.  Similar to `cider-find-var'."
 
 ;; Rendering
 
-(defun cider-stacktrace-emit-indented (text indent &optional fill)
-  "Insert TEXT, and INDENT and optionally FILL the entire block."
-  (let ((beg (point)))
+(defun cider-stacktrace-emit-indented (text &optional indent fill fontify)
+  "Insert TEXT, and optionally FILL and FONTIFY as clojure the entire block.
+INDENT is a string to insert before each line.  When INDENT is nil, first
+line is not indented and INDENT defaults to a white-spaced string with
+length given by `current-column'."
+  (let ((text (if fontify
+                  (cider-font-lock-as-clojure text)
+                text))
+        (do-first indent)
+        (indent (or indent (make-string (current-column) ? )))
+        (beg (point)))
     (insert text)
     (goto-char beg)
+    (when do-first
+      (insert indent))
+    (forward-line)
     (while (not (eobp))
       (insert indent)
       (forward-line))

--- a/cider-util.el
+++ b/cider-util.el
@@ -192,7 +192,8 @@ Can only error if SKIP is non-nil."
   "Execute BODY and add PROPS to all the inserted text.
 More precisely, PROPS are added to the region between the point's
 positions before and after executing BODY."
-  (declare (indent 1))
+  (declare (indent 1)
+           (debug (sexp body)))
   (let ((start (make-symbol "start")))
     `(let ((,start (point)))
        (prog1 (progn ,@body)


### PR DESCRIPTION
`clojure.spec/assert`s are hard to read, especially in cider stacktrace browser. Adding specialized support for spec/asserts with the ability to toggle visibility of multi-line values.

![spec-stacktrace](https://user-images.githubusercontent.com/1363467/29740773-779d78c8-8a5e-11e7-833c-7c0683c2039a.gif)
   
The visibility toggling is not fully integrated with the default cause-visibility-cycling in the stacktrace browser, mostly because the non-idiomatic usage of invisibility properties by `cider-stacktrace.el`. Instead of modifying `buffer-invisibility-spec`, as intended by emacs design, it modifies buffer text properties directly. I might rewrite that part some day but it's low priority. For now it's unlikely that anyone will be bothered by this.

Assuming that this will go into 0.16, so no doc entry as yet. 