### PR TITLE
Improvements for REPL output pre-processing and locref navigation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,17 @@
 
 ### New Features
 
+* [#2083](https://github.com/clojure-emacs/cider/pull/2083): New utility function `cider-add-face`.
+* [#2083](https://github.com/clojure-emacs/cider/pull/2083): New utility function `cider-run-chained-hook`.
+* [#2083](https://github.com/clojure-emacs/cider/pull/2083): New `cider-repl-preoutput-hook` that allows custom output processing. 
+* [#2083](https://github.com/clojure-emacs/cider/pull/2083): Highlight clojure.spec keywords in REPL (`cider-repl-highlight-spec-keywords` pre-output processor).
+
 ### Changes
 
 * [#2045](https://github.com/clojure-emacs/cider/issues/2045) `*cider-scratch*` buffers are no longer automatically killed on connection quit.
+* [#2083](https://github.com/clojure-emacs/cider/pull/2083): Jump to other window when clicking on location references in REPL.
+* [#2083](https://github.com/clojure-emacs/cider/pull/2083): Improve project namespace highlighting in REPLs.
+* [#2083](https://github.com/clojure-emacs/cider/pull/2083): Find locations in more cases when clicking on references in REPL.
 
 ### Bugs Fixed
 

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1785,7 +1785,7 @@ and all ancillary CIDER buffers."
   (if (and quit-all (y-or-n-p "Are you sure you want to quit all CIDER connections? "))
       (progn
         (when-let ((scratch (get-buffer cider-scratch-buffer-name)))
-          (when (y-or-n-p (format "Kill %s? buffer" cider-scratch-buffer-name))
+          (when (y-or-n-p (format "Kill %s buffer? " cider-scratch-buffer-name))
             (kill-buffer cider-scratch-buffer-name)))
         (dolist (connection cider-connections)
           (cider--quit-connection connection))

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -561,7 +561,7 @@ When there is a possible unfinished ansi control sequence,
                    (buffer-local-value 'cider-repl--ns-forms-plist connection)
                    ns)))))
 
-(defvar cider-repl--root-ns-highlight-template "\\<\\(%s\\)[^$/: \t\n]+"
+(defvar cider-repl--root-ns-highlight-template "\\_<\\(%s\\)[^$/: \t\n()]+"
   "Regexp used to highlight root ns in REPL buffers.")
 
 (defvar-local cider-repl--root-ns-regexp nil

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1046,10 +1046,13 @@ regexes from `cider-locref-regexp-alist' to infer locations at point."
   (if-let ((loc (cider-locref-at-point pos)))
       (let* ((var (plist-get loc :var))
              (line (plist-get loc :line))
-             (file (if var
-                       (or (cider-sync-request:ns-path var)
-                           (nrepl-dict-get (cider-sync-request:info var) "file"))
-                     (plist-get loc :file))))
+             (file (or
+                    ;; retrieve from info middleware
+                    (when var
+                      (or (cider-sync-request:ns-path var)
+                          (nrepl-dict-get (cider-sync-request:info var) "file")))
+                    ;; when not found, return the file detected by regexp
+                    (plist-get loc :file))))
         (if file
             (cider--jump-to-loc-from-info (nrepl-dict "file" file "line" line))
           (error "No source location for %s" var)))

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1054,7 +1054,7 @@ regexes from `cider-locref-regexp-alist' to infer locations at point."
                     ;; when not found, return the file detected by regexp
                     (plist-get loc :file))))
         (if file
-            (cider--jump-to-loc-from-info (nrepl-dict "file" file "line" line))
+            (cider--jump-to-loc-from-info (nrepl-dict "file" file "line" line) t)
           (error "No source location for %s" var)))
     (user-error "No location reference at point")))
 

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -589,6 +589,25 @@ When there is a possible unfinished ansi control sequence,
               (setq cider-repl--root-ns-regexp
                     (format cider-repl--root-ns-highlight-template roots)))))))))
 
+(defvar cider-repl-spec-keywords-regexp
+  (concat
+   (regexp-opt '("In:" " val:"
+                 " at:" "fails at:"
+                 " spec:" "fails spec:"
+                 " predicate:" "fails predicate:"))
+   "\\|^"
+   (regexp-opt '(":clojure.spec.alpha/spec"
+                 ":clojure.spec.alpha/value")
+               "\\("))
+  "Regexp matching clojure.spec `explain` keywords.")
+
+(defun cider-repl-highlight-spec-keywords (string)
+  "Highlight clojure.spec `explain` keywords in STRING.
+Foreground of `clojure-keyword-face' is used for highlight."
+  (cider-add-face cider-repl-spec-keywords-regexp
+                  'clojure-keyword-face t nil string)
+  string)
+
 (defun cider-repl-highlight-current-project (string)
   "Fontify project's root namespace to make stacktraces more readable.
 Foreground of `cider-stacktrace-ns-face' is used to propertize matched
@@ -604,6 +623,7 @@ namespaces.  STRING is REPL's output."
 
 (defvar cider-repl-preoutput-hook '(ansi-color-apply
                                     cider-repl-highlight-current-project
+                                    cider-repl-highlight-spec-keywords
                                     cider-repl-add-locref-help-echo)
   "Hook run on output string before it is inserted into the REPL buffer.
 Each functions takes a string and must return a modified string.  Also see

--- a/cider-util.el
+++ b/cider-util.el
@@ -309,6 +309,30 @@ Unless you specify a BUFFER it will default to the current one."
 (define-button-type 'cider-plain-button
   'face nil)
 
+(defun cider-add-face (regexp face &optional foreground-only sub-expr object)
+  "Propertize all occurrences of REGEXP with FACE.
+If FOREGROUND-ONLY is non-nil, change only the foreground of matched
+regions.  SUB-EXPR is a sub-expression of REGEXP to be
+propertized (defaults to 0).  OBJECT is an object to be
+propertized (defaults to current buffer)."
+  (setq sub-expr (or sub-expr 0))
+  (when (and regexp face)
+    (let ((beg 0)
+          (end 0))
+      (with-current-buffer (or (and (bufferp object) object)
+                               (current-buffer))
+        (while (if (stringp object)
+                   (string-match regexp object end)
+                 (re-search-forward regexp nil t))
+          (setq beg (match-beginning sub-expr)
+                end (match-end sub-expr))
+          (if foreground-only
+              (let ((face-spec (list (cons 'foreground-color
+                                           (face-attribute face :foreground nil t)))))
+                (font-lock-prepend-text-property beg end 'face face-spec object))
+            (put-text-property beg end 'face face object)))))))
+
+
 ;;; Colors
 
 (defun cider-scale-color (color scale)

--- a/cider-util.el
+++ b/cider-util.el
@@ -213,6 +213,28 @@ PROP is the name of a text property."
   (when break (insert "\n")))
 
 
+;;; Hooks
+
+(defun cider-run-chained-hook (hook arg)
+  "Like `run-hook-with-args' but pass intermediate return values through.
+HOOK is a name of a hook (a symbol).  You can use `add-hook' or
+`remove-hook' to add functions to this variable.  ARG is passed to first
+function.  Its return value is passed to the second function and so forth
+till all functions are called or one of them returns nil.  Return the value
+return by the last called function."
+  (let ((functions (copy-sequence (symbol-value hook))))
+    (while (and functions arg)
+      (if (eq (car functions) t)
+          ;; global value of the hook
+          (let ((functions (default-value hook)))
+            (while (and functions arg)
+              (setq arg (funcall (car functions) arg))
+              (setq functions (cdr functions))))
+        (setq arg (funcall (car functions) arg)))
+      (setq functions (cdr functions)))
+    arg))
+
+
 ;;; Font lock
 
 (defalias 'cider--font-lock-ensure

--- a/test/cider-apropos-tests.el
+++ b/test/cider-apropos-tests.el
@@ -34,17 +34,17 @@
 (describe "cider-apropos"
   (it "raises user-error when cider is not connected."
     (spy-on 'cider-connected-p :and-return-value nil)
-    (expect (lambda () (cider-apropos "test")) :to-throw 'user-error))
+    (expect (cider-apropos "test") :to-throw 'user-error))
 
   (it "raises user-error when the `apropos' op is not supported."
     (spy-on 'cider-ensure-op-supported :and-return-value nil)
-    (expect (lambda () (cider-apropos "test")) :to-throw 'user-error)))
+    (expect (cider-apropos "test") :to-throw 'user-error)))
 
 (describe "cider-apropos-documentation"
   (it "raises user-error when cider is not connected."
     (spy-on 'cider-connected-p :and-return-value nil)
-    (expect (lambda () (cider-apropos-documentation)) :to-throw 'user-error))
+    (expect (cider-apropos-documentation) :to-throw 'user-error))
 
   (it "raises user-error when the `apropos' op is not supported."
     (spy-on 'cider-ensure-op-supported :and-return-value nil)
-    (expect (lambda () (cider-apropos-documentation)) :to-throw 'user-error)))
+    (expect (cider-apropos-documentation) :to-throw 'user-error)))

--- a/test/cider-classpath-tests.el
+++ b/test/cider-classpath-tests.el
@@ -34,17 +34,17 @@
 (describe "cider-classpath"
   (it "raises user-error when cider is not connected."
     (spy-on 'cider-connected-p :and-return-value nil)
-    (expect (lambda () (cider-classpath)) :to-throw 'user-error))
+    (expect (cider-classpath) :to-throw 'user-error))
 
   (it "raises user-error when the `classpath' op is not supported."
     (spy-on 'cider-ensure-op-supported :and-return-value nil)
-    (expect (lambda () (cider-classpath)) :to-throw 'user-error)))
+    (expect (cider-classpath) :to-throw 'user-error)))
 
 (describe "cider-open-classpath-entry"
   (it "raises user-error when cider is not connected."
     (spy-on 'cider-connected-p :and-return-value nil)
-    (expect (lambda () (cider-open-classpath-entry)) :to-throw 'user-error))
+    (expect (cider-open-classpath-entry) :to-throw 'user-error))
 
   (it "raises user-error when the `classpath' op is not supported."
     (spy-on 'cider-ensure-op-supported :and-return-value nil)
-    (expect (lambda () (cider-open-classpath-entry)) :to-throw 'user-error)))
+    (expect (cider-open-classpath-entry) :to-throw 'user-error)))

--- a/test/cider-client-tests.el
+++ b/test/cider-client-tests.el
@@ -438,7 +438,7 @@
     (expect (cider-ensure-connected) :to-equal nil))
   (it "raises a user-error in the absence of a connection"
     (spy-on 'cider-connected-p :and-return-value nil)
-    (expect (lambda () (cider-ensure-connected)) :to-throw 'user-error)))
+    (expect (cider-ensure-connected) :to-throw 'user-error)))
 
 (describe "cider-ensure-op-supported"
   (it "returns nil when the op is supported"
@@ -446,7 +446,7 @@
     (expect (cider-ensure-op-supported "foo") :to-equal nil))
   (it "raises a user-error if the op is not supported"
     (spy-on 'cider-nrepl-op-supported-p :and-return-value nil)
-    (expect (lambda () (cider-ensure-op-supported "foo"))
+    (expect (cider-ensure-op-supported "foo")
             :to-throw 'user-error)))
 
 (describe "cider-expected-ns"

--- a/test/cider-interaction-tests.el
+++ b/test/cider-interaction-tests.el
@@ -58,47 +58,47 @@
 (describe "cider-refresh"
   (it "raises a user error if cider is not connected"
     (spy-on 'cider-connected-p :and-return-value nil)
-    (expect (lambda () (cider-refresh)) :to-throw 'user-error)))
+    (expect (cider-refresh) :to-throw 'user-error)))
 
 (describe "cider-quit"
   (it "raises a user error if cider is not connected"
     (spy-on 'cider-connected-p :and-return-value nil)
-    (expect (lambda () (cider-quit)) :to-throw 'user-error)))
+    (expect (cider-quit) :to-throw 'user-error)))
 
 (describe "cider-restart"
   (it "raises a user error if cider is not connected"
     (spy-on 'cider-connected-p :and-return-value nil)
-    (expect (lambda () (cider-restart)) :to-throw 'user-error)))
+    (expect (cider-restart) :to-throw 'user-error)))
 
 (describe "cider-find-ns"
   (it "raises a user error if cider is not connected"
     (spy-on 'cider-connected-p :and-return-value nil)
-    (expect (lambda () (cider-find-ns)) :to-throw 'user-error))
+    (expect (cider-find-ns) :to-throw 'user-error))
   (it "raises a user error if the op is not supported"
     (spy-on 'cider-nrepl-op-supported-p :and-return-value nil)
-    (expect (lambda () (cider-find-ns)) :to-throw 'user-error)))
+    (expect (cider-find-ns) :to-throw 'user-error)))
 
 (describe "cider-load-all-project-ns"
   (it "raises a user error if cider is not connected"
     (spy-on 'cider-connected-p :and-return-value nil)
-    (expect (lambda () (cider-load-all-project-ns)) :to-throw 'user-error))
+    (expect (cider-load-all-project-ns) :to-throw 'user-error))
   (it "raises a user error if the op is not supported"
     (spy-on 'cider-nrepl-op-supported-p :and-return-value nil)
-    (expect (lambda () (cider-load-all-project-ns)) :to-throw 'user-error)))
+    (expect (cider-load-all-project-ns) :to-throw 'user-error)))
 
 (describe "cider-load-file"
-          (it "works as expected in empty Clojure buffers"
-              (spy-on 'cider-request:load-file :and-return-value nil)
-              (with-connection-buffer "clj" b
-                                      (with-temp-buffer
-                                        (clojure-mode)
-                                        (setq buffer-file-name (make-temp-name "tmp.clj"))
-                                        (expect (lambda () (cider-load-buffer)) :not :to-throw)))))
+  (it "works as expected in empty Clojure buffers"
+    (spy-on 'cider-request:load-file :and-return-value nil)
+    (with-connection-buffer "clj" b
+      (with-temp-buffer
+        (clojure-mode)
+        (setq buffer-file-name (make-temp-name "tmp.clj"))
+        (expect (cider-load-buffer) :not :to-throw)))))
 
 (describe "cider-interactive-eval"
-          (it "works as expected in empty Clojure buffers"
-              (spy-on 'cider-nrepl-request:eval :and-return-value nil)
-              (with-connection-buffer "clj" b
-                                      (with-temp-buffer
-                                        (clojure-mode)
-                                        (expect (lambda () (cider-interactive-eval "(+ 1)")) :not :to-throw)))))
+  (it "works as expected in empty Clojure buffers"
+    (spy-on 'cider-nrepl-request:eval :and-return-value nil)
+    (with-connection-buffer "clj" b
+      (with-temp-buffer
+        (clojure-mode)
+        (expect (cider-interactive-eval "(+ 1)") :not :to-throw)))))

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -54,6 +54,22 @@
           cider-codename "Victory")
     (expect (cider--version) :to-equal "0.11.0snapshot (package: 20160301.2217)")))
 
+(defvar some-cider-hook)
+
+(describe "cider-run-chained-hook"
+  :var (some-cider-hook)
+
+  (it "chains correctly"
+    (setq some-cider-hook (list #'upcase (lambda (x) (substring x 2 5))))
+    (expect (cider-run-chained-hook 'some-cider-hook "abcdefg")
+            :to-equal "CDE"))
+
+  (it "exits on first nil"
+    (let (here)
+      (setq some-cider-hook (list #'upcase (lambda (x) nil) (lambda (x) (setq here t))))
+      (cider-run-chained-hook 'some-cider-hook "A")
+      (expect here :to-be nil))))
+
 (describe "cider-symbol-at-point"
   (it "doesn't move the cursor"
     (with-temp-buffer

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -218,3 +218,37 @@
             :not :to-be-truthy)
     (expect (cider-ansi-color-string-p "'an-ansi-str")
             :not :to-be-truthy)))
+
+(describe "cider-add-face"
+  :var (str)
+
+  (before-each
+    (setq str "aaa bbb\n cccc\n dddd"))
+
+  (describe "works in strings"
+    (it "fontifies with correct face"
+      (cider-add-face "c+" 'font-lock-comment-face nil nil str)
+      (expect (get-pos-property 1 'face str)
+              :to-be nil)
+      (expect (get-pos-property 10 'face str)
+              :to-be 'font-lock-comment-face))
+    (it "fontifies foreground with correct face"
+      (cider-add-face "b+" 'font-lock-comment-face t nil str)
+      (expect (get-pos-property 5 'face str)
+              :to-equal `((foreground-color . ,(face-attribute 'font-lock-comment-face
+                                                               :foreground nil t)))))
+    (it "fontifies sub-expression correctly"
+      (cider-add-face "\\(a\\)aa" 'font-lock-comment-face nil 1 str)
+      (expect (get-pos-property 0 'face str)
+              :to-be 'font-lock-comment-face)
+      (expect (get-pos-property 1 'face str)
+              :to-be nil)))
+
+  (describe "works in buffers"
+    (it "fontifies with correct face"
+      (with-temp-buffer
+        (insert "aaa bbb\n cccc\n ddddd")
+        (goto-char 1)
+        (cider-add-face "c+" 'font-lock-comment-face)
+        (expect (get-pos-property 11 'face)
+                :to-be 'font-lock-comment-face)))))


### PR DESCRIPTION
Improving on #2043 a bit for navigation. Pass through file metatdata when available from location references and no info from var names could be retrieved. `cider-find-file`  does a good job  in those cases.