### PR TITLE
cider-switch-to-repl-buffer switches to CLJS repl when relevant

### DIFF
--- a/cider-mode.el
+++ b/cider-mode.el
@@ -137,10 +137,16 @@ the buffer should appear.
 With a prefix arg SET-NAMESPACE sets the namespace in the REPL buffer to that
 of the namespace in the Clojure source buffer."
   (interactive "P")
-  (let* ((connections (cider-connections))
-         (buffer (seq-find (lambda (b) (member b connections))
-                           (buffer-list))))
-    (cider--switch-to-repl-buffer buffer set-namespace)))
+    (let* ((connections (cider-connections))
+         (buffers (seq-filter (lambda (b) (member b (cider-connections))) (buffer-list)))
+         (cljs (string= "clojurescript-mode" major-mode))
+         (correct-buffer (if cljs
+                            (seq-find (lambda (b) (string-match "CLJS" (buffer-name b))) buffers)
+                           (seq-find (lambda (b) (not (string-match "CLJS" (buffer-name b)))) buffers)))
+         (default-buffer (first buffers)))
+
+    (cider--switch-to-repl-buffer (or correct-buffer default-buffer) set-namespace)))
+
 
 (declare-function cider-load-buffer "cider-interaction")
 


### PR DESCRIPTION
When the current buffer is in CLJS mode then switches to the CLJS repl
If no CLJS repl is found, switches to the first found cider connection

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][2] extremely useful.*

[1]: https://github.com/clojure-emacs/cider/blob/master/.github/CONTRIBUTING.md
[2]: https://cider.readthedocs.io/en/latest/hacking_on_cider/
