### PR TITLE
Allow loading buffers without associated files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#2083](https://github.com/clojure-emacs/cider/pull/2083): New utility function `cider-run-chained-hook`.
 * [#2083](https://github.com/clojure-emacs/cider/pull/2083): New `cider-repl-preoutput-hook` that allows custom output processing.
 * [#2083](https://github.com/clojure-emacs/cider/pull/2083): Highlight clojure.spec keywords in REPL (`cider-repl-highlight-spec-keywords` pre-output processor).
+* [#2089](https://github.com/clojure-emacs/cider/pull/2089): Allow loading buffers without associated files
 
 ### Changes
 

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1615,7 +1615,7 @@ ClojureScript REPL exists for the project, it is evaluated in both REPLs."
                                   connection))
        :both)
       (message "Loading %s..." filename)
-      (unless buffer-file-name
+      (unless (buffer-file-name buffer)
         (delete-file filename)
         (kill-buffer (file-name-nondirectory filename))))))
 

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1590,12 +1590,12 @@ ClojureScript REPL exists for the project, it is evaluated in both REPLs."
   (cider-ensure-connected)
   (setq buffer (or buffer (current-buffer)))
   (with-current-buffer buffer
-    (when buffer-file-name
-      (when (and cider-save-file-on-load
-                 (buffer-modified-p)
-                 (or (eq cider-save-file-on-load t)
-                     (y-or-n-p (format "Save file %s? " buffer-file-name))))
-        (save-buffer)))
+    (when (and buffer-file-name
+               cider-save-file-on-load
+               (buffer-modified-p)
+               (or (eq cider-save-file-on-load t)
+                   (y-or-n-p (format "Save file %s? " buffer-file-name))))
+      (save-buffer))
     (remove-overlays nil nil 'cider-temporary t)
     (cider--clear-compilation-highlights)
     (cider--quit-error-window)

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1616,7 +1616,8 @@ ClojureScript REPL exists for the project, it is evaluated in both REPLs."
        :both)
       (message "Loading %s..." filename)
       (unless buffer-file-name
-        (delete-file filename)))))
+        (delete-file filename)
+        (kill-buffer (file-name-nondirectory filename))))))
 
 (defun cider-load-file (filename)
   "Load (eval) the Clojure file FILENAME in nREPL.

--- a/test/cider-interaction-tests.el
+++ b/test/cider-interaction-tests.el
@@ -93,6 +93,12 @@
       (with-temp-buffer
         (clojure-mode)
         (setq buffer-file-name (make-temp-name "tmp.clj"))
+        (expect (cider-load-buffer) :not :to-throw))))
+  (it "works as expected in empty Clojure buffers without filenames"
+    (spy-on 'cider-request:load-file :and-return-value nil)
+    (with-connection-buffer "clj" b
+      (with-temp-buffer
+        (clojure-mode)
         (expect (cider-load-buffer) :not :to-throw)))))
 
 (describe "cider-interactive-eval"


### PR DESCRIPTION
This lets us load `*scratch*` et al into a cider repl by saving the file to the user's temp directory. Before, it would throw an error.

- [x] The commits are consistent with our [contribution guidelines][1]
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)