### PR TITLE
Created cider-eval-last-sexp-to-comment

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1158,7 +1158,7 @@ If invoked with a PREFIX argument, print the result in the current buffer."
     (goto-char (cadr (cider-sexp-at-point 'bounds)))
     (cider-eval-last-sexp prefix)))
 
-(defun cider-eval-last-sexp-to-comment (loc &optional prefix)
+(defun cider-eval-last-sexp-to-comment (loc)
   "Evaluate the expression preceding point and insert result as comment at LOC.
 
 With a prefix arg, LOC, insert before the form, otherwise afterwards."

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1158,6 +1158,18 @@ If invoked with a PREFIX argument, print the result in the current buffer."
     (goto-char (cadr (cider-sexp-at-point 'bounds)))
     (cider-eval-last-sexp prefix)))
 
+(defun cider-eval-last-sexp-to-comment (loc &optional prefix)
+  "Evaluate the expression preceding point and insert result as comment at LOC.
+
+With a prefix arg, LOC, insert before the form, otherwise afterwards."
+  (interactive "P")
+  (let* ((bounds (cider-defun-at-point 'bounds))
+         (insertion-point (nth (if loc 0 1) bounds)))
+    (cider-interactive-eval nil
+                            (cider-eval-print-with-comment-handler
+                             (current-buffer) insertion-point ";; => ")
+                            (cider-last-sexp 'bounds))))
+
 (defun cider-eval-defun-to-comment (loc)
   "Evaluate the \"top-level\" form and insert result as comment at LOC.
 

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -304,7 +304,7 @@ Configure `cider-cljs-*-repl' to change the ClojureScript REPL to use for your b
     (define-key map (kbd "C-x C-e") #'cider-eval-last-sexp)
     (define-key map (kbd "C-c C-e") #'cider-eval-last-sexp)
     (define-key map (kbd "C-c C-v") 'cider-eval-commands-map)
-    (define-key map (kbd "C-c M-;") #'cider-eval-defun-to-comment)
+    (define-key map (kbd "C-c M-;") #'cider-eval-last-sexp-to-comment)
     (define-key map (kbd "C-c M-e") #'cider-eval-last-sexp-to-repl)
     (define-key map (kbd "C-c M-p") #'cider-insert-last-sexp-in-repl)
     (define-key map (kbd "C-c C-p") #'cider-pprint-eval-last-sexp)


### PR DESCRIPTION
Created cider-eval-last-sexp-to-comment which is more flexible and useful than cider-eval-defun-to-comment. You're able to eval to comment any sexp and not only functions. Also rebinded the shortcut C-c M-; to this new func.