### PR TITLE
Implement cider-pprint-eval-last-sexp-to-comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features
 
 * [#2082](https://github.com/clojure-emacs/cider/pull/2082), [cider-nrepl#440](https://github.com/clojure-emacs/cider-nrepl/pull/440): Add specialized stacktraces for clojure.spec assertions.
+* [#2111](https://github.com/clojure-emacs/cider/pull/2111): Add `cider-pprint-eval-last-sexp-to-comment` and `cider-pprint-eval-defun-to-comment`.
 
 ### Changes
 

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -235,8 +235,10 @@ Configure `cider-cljs-*-repl' to change the ClojureScript REPL to use for your b
     ["Eval last sexp and replace" cider-eval-last-sexp-and-replace]
     ["Eval last sexp to REPL" cider-eval-last-sexp-to-repl]
     ["Eval last sexp and pretty-print to REPL" cider-pprint-eval-last-sexp-to-repl]
+    ["Eval last sexp and pretty-print to comment" cider-pprint-eval-last-sexp-to-comment]
     ["Insert last sexp in REPL" cider-insert-last-sexp-in-repl]
     ["Eval top-level sexp to comment" cider-eval-defun-to-comment]
+    ["Eval top-level sexp and pretty-print to comment" cider-pprint-eval-defun-to-comment]
     "--"
     ["Load this buffer" cider-load-buffer]
     ["Load another file" cider-load-file]

--- a/doc/interactive_programming.md
+++ b/doc/interactive_programming.md
@@ -22,8 +22,8 @@ Here's a list of `cider-mode`'s keybindings:
 `cider-eval-last-sexp-and-replace`            |<kbd>C-c C-v w</kbd>                 | Evaluate the form preceding point and replace it with its result.
 `cider-eval-last-sexp-to-repl`                |<kbd>C-c M-e</kbd>                   | Evaluate the form preceding point and output it result to the REPL buffer.  If invoked with a prefix argument, takes you to the REPL buffer after being invoked.
 `cider-insert-last-sexp-in-repl`              |<kbd>C-c M-p</kbd>                   | Load the form preceding point in the REPL buffer.
-`cider-pprint-eval-last-sexp`                 |<kbd>C-c C-p</kbd>                   | Evaluate the form preceding point and pretty-print the result in a popup buffer.
-`cider-pprint-eval-defun-at-point`            |<kbd>C-c C-f</kbd>                   | Evaluate the top level form under point and pretty-print the result in a popup buffer.
+`cider-pprint-eval-last-sexp`                 |<kbd>C-c C-p</kbd>                   | Evaluate the form preceding point and pretty-print the result in a popup buffer. If invoked with a prefix argument, insert the result into the current buffer as a comment.
+`cider-pprint-eval-defun-at-point`            |<kbd>C-c C-f</kbd>                   | Evaluate the top level form under point and pretty-print the result in a popup buffer. If invoked with a prefix argument, insert the result into the current buffer as a comment.
 `cider-eval-defun-at-point`                   |<kbd>C-M-x</kbd> <br/> <kbd>C-c C-c</kbd>  | Evaluate the top level form under point and display the result in the echo area.
 `cider-eval-sexp-at-point`                    |<kbd>C-c C-v v</kbd>                 | Evaluate the form around point.
 `cider-eval-defun-at-point`                   |<kbd>C-u C-M-x</kbd> <br/> <kbd>C-u C-c C-c</kbd>  | Debug the top level form under point and walk through its evaluation


### PR DESCRIPTION
This function has similar functionality to the other pprint interactions;
however this variant inserts the result of the evaluation directly in the
current buffer.

The comment prefix used in the output is user-configurable, and for consistency
we also use same prefix in cider-eval-defun-to-comment.

By default the output will be commented like so
```
(for [i (range 1 10)]
  (range i))
;; => ((0)
;;     (0 1)
;;     (0 1 2)
;;     (0 1 2 3)
;;     (0 1 2 3 4)
;;     (0 1 2 3 4 5)
;;     (0 1 2 3 4 5 6)
;;     (0 1 2 3 4 5 6 7)
;;     (0 1 2 3 4 5 6 7 8))
```
but by customizing the `cider-pprint-comment-*` variables you can also get output like this

```
#_((0)
   (0 1)
   (0 1 2)
   (0 1 2 3)
   (0 1 2 3 4)
   (0 1 2 3 4 5)
   (0 1 2 3 4 5 6)
   (0 1 2 3 4 5 6 7)
   (0 1 2 3 4 5 6 7 8))
```

or even

```
(comment
  ((0)
   (0 1)
   (0 1 2)
   (0 1 2 3)
   (0 1 2 3 4)
   (0 1 2 3 4 5)
   (0 1 2 3 4 5 6)
   (0 1 2 3 4 5 6 7)
   (0 1 2 3 4 5 6 7 8))
)
```
-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][2] extremely useful.*

[1]: https://github.com/clojure-emacs/cider/blob/master/.github/CONTRIBUTING.md
[2]: https://cider.readthedocs.io/en/latest/hacking_on_cider/
