### PR TITLE
cider-repl-result-prefix only inserted before the first result

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -649,8 +649,10 @@ in the buffer."
 (defun cider-stdin-handler (&optional buffer)
   "Make a stdin response handler for BUFFER."
   (nrepl-make-response-handler (or buffer (current-buffer))
-                               (lambda (buffer value)
-                                 (cider-repl-emit-result buffer value t))
+                               (let (after-first-call)
+                                 (lambda (buffer value)
+                                   (cider-repl-emit-result buffer value t (not after-first-call))
+                                   (setq after-first-call t)))
                                (lambda (buffer out)
                                  (cider-repl-emit-stdout buffer out))
                                (lambda (buffer err)


### PR DESCRIPTION
- subsequent chunks of result should not have this re-inserted.

See also https://github.com/clojure-emacs/cider/issues/315

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][2] extremely useful.*

[1]: https://github.com/clojure-emacs/cider/blob/master/.github/CONTRIBUTING.md
[2]: https://cider.readthedocs.io/en/latest/hacking_on_cider/
