### PR TITLE
add reverse destructuring form function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features
 
 * [#2082](https://github.com/clojure-emacs/cider/pull/2082), [cider-nrepl#440](https://github.com/clojure-emacs/cider-nrepl/pull/440): Add specialized stacktraces for clojure.spec assertions.
+* [#2119](https://github.com/clojure-emacs/cider/pull/2119): Add reverse destructuring form function
 
 ### Changes
 


### PR DESCRIPTION
This change adds a function that reads clojure destructuring form and gives user a clojure structure that matches that form.

Use case:
Let's say user has a function:
```clojure
(defn f [{:keys [a] {[c] :c} :b}]
  (timbre/info a c))
```
He would like to test that function using repl. He can simply select a region `{:keys [a] {[c] :c} :b}` and run command `cider-reverse-destructuring-form-region`. It will give him a buffer with resulting `{:a a, :b {:c [c]}}`. Which he can then use to write a function call like this:
```clojure
(f {:a 1, :b {:c [2]}}
```
-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][2] extremely useful.*

[1]: https://github.com/clojure-emacs/cider/blob/master/.github/CONTRIBUTING.md
[2]: https://cider.readthedocs.io/en/latest/hacking_on_cider/
