### PR TITLE
[#2120] fix TLS related errors in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,54 @@
 sudo: false
 language: emacs-lisp
+
+addons:
+  apt:
+    packages:
+    - autogen
+    - ca-certificates
+    - curl
+    - gcc
+    - libgmp-dev
+    - m4
+    - make
+    - pkg-config
+    - xz-utils
+
+cache:
+  directories:
+  - $HOME/local
+
 env:
-  - EMACS_BINARY=emacs-24.4-travis MAKE_TEST=test
-  - EMACS_BINARY=emacs-24.4-travis MAKE_TEST=test-bytecomp
-  - EMACS_BINARY=emacs-24.5-travis MAKE_TEST=test
-  - EMACS_BINARY=emacs-24.5-travis MAKE_TEST=test-bytecomp
-  - EMACS_BINARY=emacs-25.1-travis MAKE_TEST=test
-  - EMACS_BINARY=emacs-25.1-travis MAKE_TEST=test-bytecomp
-  - EMACS_BINARY=emacs-25.2-travis MAKE_TEST=test
-  - EMACS_BINARY=emacs-25.2-travis MAKE_TEST=test-bytecomp
-  - EMACS_BINARY=emacs-25.2-travis MAKE_TEST=test-checks
-  - EMACS_BINARY=emacs-git-snapshot-travis MAKE_TEST=test
-  - EMACS_BINARY=emacs-git-snapshot-travis MAKE_TEST=test-bytecomp
-  - EMACS_BINARY=emacs-git-snapshot-travis MAKE_TEST=test-checks
+  global:
+    - PATH=$HOME/local/bin:$PATH
+  matrix:
+    - EMACS_BINARY=emacs-24.4-travis MAKE_TEST=test
+    - EMACS_BINARY=emacs-24.4-travis MAKE_TEST=test-bytecomp
+    - EMACS_BINARY=emacs-24.5-travis MAKE_TEST=test
+    - EMACS_BINARY=emacs-24.5-travis MAKE_TEST=test-bytecomp
+    - EMACS_BINARY=emacs-25.1-travis MAKE_TEST=test
+    - EMACS_BINARY=emacs-25.1-travis MAKE_TEST=test-bytecomp
+    - EMACS_BINARY=emacs-25.2-travis MAKE_TEST=test
+    - EMACS_BINARY=emacs-25.2-travis MAKE_TEST=test-bytecomp
+    - EMACS_BINARY=emacs-25.3-travis MAKE_TEST=test
+    - EMACS_BINARY=emacs-25.3-travis MAKE_TEST=test-bytecomp
+    - EMACS_BINARY=emacs-25.3-travis MAKE_TEST=test-checks
+    - EMACS_BINARY=emacs-26-pretest-travis MAKE_TEST=test
+    - EMACS_BINARY=emacs-26-pretest-travis MAKE_TEST=test-bytecomp
+    - EMACS_BINARY=emacs-26-pretest-travis MAKE_TEST=test-checks
+    - EMACS_BINARY=emacs-git-snapshot-travis MAKE_TEST=test
+    - EMACS_BINARY=emacs-git-snapshot-travis MAKE_TEST=test-bytecomp
+    - EMACS_BINARY=emacs-git-snapshot-travis MAKE_TEST=test-checks
 
 before_script:
+  - sudo sh travis-ci/travis-gnutls.sh
+  - gnutls-cli -v
   - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
   - evm install $EMACS_BINARY --use --skip
   - make elpa
 script:
   - emacs --version
   - make $MAKE_TEST
-matrix:
-  - env: EMACS_BINARY=emacs-git-snapshot-travis
 
 notifications:
   webhooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 * [#2088](https://github.com/clojure-emacs/cider/issues/2088): Fix functions defined with `def` being font-locked as vars instead of functions.
 * [#1651](https://github.com/clojure-emacs/cider/issues/1651), [cider-nrepl#445](https://github.com/clojure-emacs/cider-nrepl/pull/455): Fix `cider-expected-ns` returns `nil` on boot projects.
+* [#2120](https://github.com/clojure-emacs/cider/issues/2120): Fix Travis CI build errors for emacs versions >25.2.
 
 ## 0.15.1 (2017-09-13)
 

--- a/travis-ci/travis-gnutls.sh
+++ b/travis-ci/travis-gnutls.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Setup a newer gnutls-cli on Travis CI
+# We need this as long as the Travis workers are Ubuntu 14.04
+# and the TLS cert chain on elpa.gnu.org is out-of-order
+
+set -x
+
+# adjust these versions as needed
+export NETTLE_VERSION=3.4
+export GNUTLS_VERSION=3.5.16
+
+export WORKDIR=${HOME}/local/
+export LD_LIBRARY_PATH=${WORKDIR}/lib/
+export PKG_CONFIG_PATH=${WORKDIR}/lib/pkgconfig/
+
+# exit if the cache is valid and up-to-date
+if [ -f ${WORKDIR}/bin/gnutls-cli ] && \
+   [ -f ${WORKDIR}/nettle-${NETTLE_VERSION}.tar.gz ] && \
+   [ -f ${WORKDIR}/gnutls-${GNUTLS_VERSION}.tar.xz ]
+then
+    exit 0
+fi
+
+# delete cache and rebuild
+rm -rf $WORKDIR
+mkdir $WORKDIR
+cd $WORKDIR
+curl -O https://ftp.gnu.org/gnu/nettle/nettle-${NETTLE_VERSION}.tar.gz \
+    && tar xfz nettle-${NETTLE_VERSION}.tar.gz \
+    && cd nettle-${NETTLE_VERSION} \
+    && ./configure --prefix=${WORKDIR} \
+    && make -j4 install \
+    && make distclean
+
+cd $WORKDIR
+curl -O https://www.gnupg.org/ftp/gcrypt/gnutls/v3.5/gnutls-${GNUTLS_VERSION}.tar.xz \
+    && xz -d -k gnutls-${GNUTLS_VERSION}.tar.xz \
+    && tar xf gnutls-${GNUTLS_VERSION}.tar \
+    && cd gnutls-${GNUTLS_VERSION} \
+    && ./configure --prefix=${WORKDIR} \
+                   --with-included-libtasn1 \
+                   --with-included-unistring \
+                   --without-p11-kit \
+    && make -j4 install \
+    && make distclean


### PR DESCRIPTION
Fixes the Travis CI build errors reported in #2120.

Diffs to .travis.yml are as follows:

(1) I've added some explicit package dependencies into `addons.apt.packages`. This is basically the compiler toolchain needed to build gnutls from source

(2) Configured $HOME/local to be cached by Travis between subsequent builds. This is done with the setting `cache.directories`.

See Travis documentation for further information about the caching of data.  Basically, the contents of that folder are rolled up into a tar ball and saved to an S3 bucket whenever the contents change. The tarball is retrieved and installed prior to the start of your CI job.

(3) Added a utility script named `travis-ci/travis-gnutls.sh` which handles the downloading and compiling of the sources.

The script is organized so that the version of gnutls can be easily updated whenever needed. Just edit the version numbers in that script and push the change. The script is able to detect when it doesn't have the specific version requested, and when that happens it deletes the cache and rebuilds gnutls.

(4) While I was at it, I added emacs 25.3-travis and 26-pretest-travis to the build matrix. Note that git-snapshot-travis now reports itself as being version 27. (Also note, emacs 26 and 27 are still broken builds, but at least now it's not because of the build script itself.)