### PR TITLE
[#2129] make evm and cask setup more reliable in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ cache:
 
 env:
   global:
-    - PATH=$HOME/local/bin:$PATH
+    - PATH=$HOME/local/bin:$HOME/local/evm/bin:$HOME/local/cask/bin:$PATH
   matrix:
     - EMACS_BINARY=emacs-24.4-travis MAKE_TEST=test
     - EMACS_BINARY=emacs-24.4-travis MAKE_TEST=test-bytecomp
@@ -41,11 +41,11 @@ env:
     - EMACS_BINARY=emacs-git-snapshot-travis MAKE_TEST=test-checks
 
 before_script:
-  - sudo sh travis-ci/travis-gnutls.sh
+  - sh travis-ci/install-gnutls.sh
   - gnutls-cli -v
-  - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
+  - sh travis-ci/install-evm.sh
   - evm install $EMACS_BINARY --use --skip
-  - make elpa
+  - sh travis-ci/install-cask.sh
 script:
   - emacs --version
   - make $MAKE_TEST

--- a/travis-ci/install-cask.sh
+++ b/travis-ci/install-cask.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Install cask for Travis CI
+# or if already installed, then check for updates
+
+set -x
+
+WORKDIR=${HOME}/local
+CASKDIR=$WORKDIR/cask
+
+. travis-ci/retry.sh
+
+cask_upgrade_cask_or_reset() {
+    cask upgrade-cask || { rm -rf $HOME/.emacs.d/.cask && false; }
+}
+
+cask_install_or_reset() {
+    cask install || { rm -rf .cask && false; }
+}
+
+# Bootstrap the cask tool and its dependencies
+if [ -d $CASKDIR ]
+then
+    travis_retry cask_upgrade_cask_or_reset
+else
+    git clone https://github.com/cask/cask.git $CASKDIR
+    travis_retry cask_upgrade_cask_or_reset
+fi
+
+# Install dependencies for cider as descriped in ./Cask
+# Effect is identical to "make elpa", but here we can retry
+# in the event of network failures.
+travis_retry cask_install_or_reset && touch elpa-emacs

--- a/travis-ci/install-evm.sh
+++ b/travis-ci/install-evm.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Install evm for Travis CI
+# or if already installed, then check for updates
+
+set -x
+
+WORKDIR=${HOME}/local
+EVMDIR=$WORKDIR/evm
+
+. travis-ci/retry.sh
+
+if [ -d $EVMDIR ]
+then
+    cd $EVMDIR
+    git pull origin master
+else
+    git clone https://github.com/rejeep/evm.git $EVMDIR
+    evm config path /tmp
+    travis_retry evm install emacs-24.3-travis --use --skip
+fi

--- a/travis-ci/install-gnutls.sh
+++ b/travis-ci/install-gnutls.sh
@@ -23,8 +23,9 @@ then
 fi
 
 # delete cache and rebuild
-rm -rf $WORKDIR
-mkdir $WORKDIR
+rm -rf $WORKDIR/bin $WORKDIR/lib $WORKDIR/share $WORKDIR/include
+rm -rf $WORKDIR/nettle* $WORKDIR/gnutls*
+
 cd $WORKDIR
 curl -O https://ftp.gnu.org/gnu/nettle/nettle-${NETTLE_VERSION}.tar.gz \
     && tar xfz nettle-${NETTLE_VERSION}.tar.gz \

--- a/travis-ci/retry.sh
+++ b/travis-ci/retry.sh
@@ -1,0 +1,27 @@
+# Copied retry logic from Travis CI [http://bit.ly/2jPDCtV]
+
+ANSI_RED="\033[31;1m"
+ANSI_GREEN="\033[32;1m"
+ANSI_RESET="\033[0m"
+ANSI_CLEAR="\033[0K"
+
+travis_retry() {
+  local result=0
+  local count=1
+  while [ $count -le 3 ]; do
+    [ $result -ne 0 ] && {
+      echo -e "\n${ANSI_RED}The command \"$@\" failed. Retrying, $count of 3.${ANSI_RESET}\n" >&2
+    }
+    "$@"
+    result=$?
+    [ $result -eq 0 ] && break
+    count=$(($count + 1))
+    sleep 1
+  done
+
+  [ $count -gt 3 ] && {
+    echo -e "\n${ANSI_RED}The command \"$@\" failed 3 times.${ANSI_RESET}\n" >&2
+  }
+
+  return $result
+}


### PR DESCRIPTION
Resolves [#2129] with new scripts to setup evm and cask in Travis builds.

These scripts improve on the prior process by adding error detection with
retries, such that network errors during this setup stage are less likely to
abort the build with mysterious errors.

In addition to the retry logic, we also cache the installations of evm and cask
such that the contents of those directories are restored across successful
builds. This eliminates the requirement to install evm and cask from scratch. It
is possible to force-delete these caches if needed.

The net result of all this is, most incremental builds need only attempt to
update evm and cask (essentially a git pull) and update any needed elisp
packages via cask update.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [ ] [n/a] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [ ] [n/a] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] [n/a] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] [n/a] You've updated the readme (if adding/changing user-visible functionality)
- [ ] [n/a] You've updated the refcard (if you made changes to the commands listed there)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][2] extremely useful.*

[1]: https://github.com/clojure-emacs/cider/blob/master/.github/CONTRIBUTING.md
[2]: https://cider.readthedocs.io/en/latest/hacking_on_cider/
