### PR TITLE
[#2144] create a docker image to mimic the travis environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#2111](https://github.com/clojure-emacs/cider/pull/2111): Add `cider-pprint-eval-last-sexp-to-comment` and `cider-pprint-eval-defun-to-comment`.
 * Add a REPL shortcut for `cider-repl-require-repl-utils` (this makes it easy to require common functions like `doc`, `source`, etc. in REPL buffers).
 * [#2112](https://github.com/clojure-emacs/cider/issues/2112): Add a new interactive command `cider-find-keyword` (bound to `C-c C-:`).
+* [#2144](https://github.com/clojure-emacs/cider/issues/2144): Create a Docker image to mimic the Travis environment
 
 ### Changes
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM travisci/ci-garnet:packer-1490989530
+
+RUN apt-get update -y \
+ && apt-get install -y \
+      autogen \
+      ca-certificates \
+      curl \
+      gcc \
+      git \
+      libgmp-dev \
+      m4 \
+      make \
+      pkg-config \
+      python \
+      ruby \
+      xz-utils
+
+USER travis
+ENV HOME=/home/travis
+ENV PATH="${HOME}/local/evm/bin:${HOME}/local/cask/bin:${HOME}/local/bin:${PATH}"
+
+ADD travis-ci/ ${HOME}/cider-setup/travis-ci/
+RUN echo ". ${HOME}/cider-setup/travis-ci/prompt.sh" >> ${HOME}/.bashrc
+
+RUN ${HOME}/cider-setup/travis-ci/install-gnutls.sh
+RUN ${HOME}/cider-setup/travis-ci/install-evm.sh
+RUN ${HOME}/cider-setup/travis-ci/install-cask.sh
+
+RUN evm install emacs-25.3-travis --use
+RUN evm install emacs-26-pretest-travis
+RUN evm install emacs-git-snapshot-travis
+
+WORKDIR /home/travis/cider
+CMD /bin/bash

--- a/doc/hacking_on_cider.md
+++ b/doc/hacking_on_cider.md
@@ -77,6 +77,72 @@ You can also check for the presence of byte-compilation warnings in batch mode:
 $ make test-bytecomp
 ```
 
+#### Running the tests in Travis CI
+
+If you prefer to see the full Travis test suite run successfully, the easiest
+way to achieve that is to create your own personal account on
+https://travis-ci.org. View your profile details on the Travis site, and toggle
+the switch to enable builds on your fork of the cider project.
+
+Subsequent pushes to your fork will generate a Travis build you can monitor for
+success or failure.
+
+#### Simulating the Travis tests locally in Docker
+
+If you prefer not to wait for Travis all the time, or if you need to debug
+something that fails in Travis but does not fail for you on your own machine,
+then you can also run the Travis tests manually in Docker.
+
+You will need to run some scripts to build and launch the Docker image.
+
+To build:
+```
+$ docker/build.sh
+```
+
+The build script uses a base image provided by the engineers at Travis. Note: the
+Travis docker image is currently more than 8GB, so be prepared with a good
+internet connection and time to spare.
+
+The resulting docker image is tagged simply `cider-travis`. You can run this
+image by hand, but there is a convenience script available:
+```
+$ docker/run.sh
+```
+
+This script launches a docker container and bind-mounts your cider project
+directory as `/home/travis/cider` such that you can instantly see any code
+changes reflected inside the docker environment.
+
+For instance, you can run tests on emacs 25.3
+```
+(emacs-25.3-travis) ~/cider$ make test
+```
+
+and then switch to emacs 26 and test again
+
+```
+(emacs-25.3-travis) ~/cider$ evm use emacs-26-pretest-travis
+(emacs-26-pretest-travis) ~/cider$ cask install
+(emacs-26-pretest-travis) ~/cider$ make test
+```
+
+You can test byte compilation too
+```
+(emacs-26-pretest-travis) ~/cider$ make test-bytecomp
+```
+
+When you are done working in docker, just `exit` the bash prompt, and the docker
+container will also exit. Note that `docker/run.sh` runs the container with
+`--rm`, meaning any changes to the docker container are discarded when the
+container exits.
+
+So for example, by default, the docker image pre-installs only the most recent
+releases of emacs 25, emacs 26, and a recent snapshot of the emacs git
+repository. The `evm` tool is available should you need to install some other
+specific build. However additional versions of emacs will be discarded when
+you exit the docker container.
+
 ## Hacking on cider-nrepl
 
 ### Obtaining the code

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker build -t cider-travis .
+

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker run -it --rm -v `pwd`:/home/travis/cider cider-travis bash
+

--- a/travis-ci/install-cask.sh
+++ b/travis-ci/install-cask.sh
@@ -1,14 +1,13 @@
-#!/bin/bash
+#!/bin/bash -x
 
 # Install cask for Travis CI
 # or if already installed, then check for updates
 
-set -x
-
 WORKDIR=${HOME}/local
 CASKDIR=$WORKDIR/cask
+SCRIPTDIR=`dirname $(readlink -f $0)`
 
-. travis-ci/retry.sh
+. $SCRIPTDIR/retry.sh
 
 cask_upgrade_cask_or_reset() {
     cask upgrade-cask || { rm -rf $HOME/.emacs.d/.cask && false; }
@@ -30,4 +29,7 @@ fi
 # Install dependencies for cider as descriped in ./Cask
 # Effect is identical to "make elpa", but here we can retry
 # in the event of network failures.
-travis_retry cask_install_or_reset && touch elpa-emacs
+if [ -f Cask ]
+then
+    travis_retry cask_install_or_reset && touch elpa-emacs
+fi

--- a/travis-ci/install-evm.sh
+++ b/travis-ci/install-evm.sh
@@ -1,14 +1,13 @@
-#!/bin/bash
+#!/bin/bash -x
 
 # Install evm for Travis CI
 # or if already installed, then check for updates
 
-set -x
-
 WORKDIR=${HOME}/local
 EVMDIR=$WORKDIR/evm
+SCRIPTDIR=`dirname $(readlink -f $0)`
 
-. travis-ci/retry.sh
+. $SCRIPTDIR/retry.sh
 
 if [ -d $EVMDIR ]
 then

--- a/travis-ci/install-gnutls.sh
+++ b/travis-ci/install-gnutls.sh
@@ -1,10 +1,8 @@
-#!/bin/bash
+#!/bin/bash -x
 
 # Setup a newer gnutls-cli on Travis CI
 # We need this as long as the Travis workers are Ubuntu 14.04
 # and the TLS cert chain on elpa.gnu.org is out-of-order
-
-set -x
 
 # adjust these versions as needed
 export NETTLE_VERSION=3.4
@@ -13,6 +11,12 @@ export GNUTLS_VERSION=3.5.16
 export WORKDIR=${HOME}/local/
 export LD_LIBRARY_PATH=${WORKDIR}/lib/
 export PKG_CONFIG_PATH=${WORKDIR}/lib/pkgconfig/
+
+# make sure workdir exists
+if [ ! -d ${WORKDIR} ]
+then
+    mkdir $WORKDIR
+fi
 
 # exit if the cache is valid and up-to-date
 if [ -f ${WORKDIR}/bin/gnutls-cli ] && \

--- a/travis-ci/prompt.sh
+++ b/travis-ci/prompt.sh
@@ -1,0 +1,1 @@
+export PS1="(\$(sed -ne 's/^.*\(emacs-.*-travis\).*$/\1/p' ~/local/evm/.config)) \w$ "


### PR DESCRIPTION
This pull request addresses #2144. It adds a Dockerfile and some convenience scripts that facilitate building and using a docker container that emulates the build environment in Travis.  This provides developers a more convenient way to run tests locally without having to manage multiple emacs versions on their actual laptop.

The Docker container can be launched with your source tree mounted, such that you can edit interactively as you like from your host computer, and at any point you can use the docker container to confirm tests on your code.

See documentation (hacking_on_cider.md) for more information.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines][1]
- [X] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`make test`)
- [ ] n/a The new code is not generating bytecode or `M-x checkdoc` warnings
- [X] You've updated the changelog (if adding/changing user-visible functionality)
- [X] You've updated the readme (if adding/changing user-visible functionality)
- [ ] n/a You've updated the refcard (if you made changes to the commands listed there)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][2] extremely useful.*

[1]: https://github.com/clojure-emacs/cider/blob/master/.github/CONTRIBUTING.md
[2]: https://cider.readthedocs.io/en/latest/hacking_on_cider/
