### PR TITLE
[Fix #1913] Allow toggling of current buffer connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs Fixed
+
+* [#1913](https://github.com/clojure-emacs/cider/issues/1913): Fix `cider-toggle-buffer-connection` to allow cycling of connection and restoring all connections in cljc buffers
+
 ## 0.16.0 (2017-12-28)
 
 ### New Features

--- a/doc/up_and_running.md
+++ b/doc/up_and_running.md
@@ -215,3 +215,17 @@ You should also check out
 [leiningen]: http://leiningen.org/
 [boot]: http://boot-clj.com/
 [piggieback]: https://github.com/cemerick/piggieback
+
+## Working with cljc files
+
+Ordinarily, CIDER dispatches code from `clj` files to Clojure repls and `cljs`
+files to ClojureScript repls. However, `cljc` files have two possible connection
+targets. By default, CIDER tries to evaluate `cljc` files in all connection
+buffers, both `clj` and `cljs`. This can be modified with
+`M-x cider-toggle-connection-buffer`. Toggling this once will choose one of the
+connections as the primary, and successive calls to `M-x
+cider-toggle-connection-buffer` will alternate which connection to use. To
+restore evaluation to both connections, invoke `M-x
+cider-toggle-connection-buffer` with a prefix argument. If there is only a
+Clojure connection, no toggling will happen and a message will inform you that
+there are no other connections to switch to.

--- a/test/cider-client-tests.el
+++ b/test/cider-client-tests.el
@@ -235,6 +235,46 @@
             :to-equal "stub")
     (expect (cider-var-info "") :to-equal nil)))
 
+(describe "cider-toggle-buffer-connection"
+  (spy-on 'message :and-return-value nil)
+
+  (describe "when there are multiple connections"
+    (it "toggles between multiple buffers"
+      (with-connection-buffer "clj" clj-buffer
+        (with-connection-buffer "cljs" cljs-buffer
+          (with-temp-buffer
+            (setq major-mode 'clojurec-mode)
+            (expect (cider-connections)
+                    :to-equal (list cljs-buffer clj-buffer))
+
+            (cider-toggle-buffer-connection)
+            (expect (cider-connections)
+                    :to-equal (list clj-buffer))
+
+            (cider-toggle-buffer-connection)
+            (expect (cider-connections)
+                    :to-equal (list cljs-buffer))
+
+            (cider-toggle-buffer-connection t)
+            (expect (cider-connections)
+                    :to-equal (list cljs-buffer clj-buffer)))))))
+
+  (describe "when there is a single connection"
+    (it "reports a user error"
+      (with-connection-buffer "clj" clj-buffer
+        (with-temp-buffer
+          (setq major-mode 'clojurec-mode)
+          (expect (cider-connections)
+                  :to-equal (list clj-buffer))
+
+          (expect (cider-toggle-buffer-connection) :to-throw 'user-error)
+
+          (expect (cider-connections)
+                  :to-equal (list clj-buffer))
+
+          (expect (local-variable-p 'cider-connections)
+                  :to-be nil))))))
+
 (describe "cider-make-connection-default"
   :var (connections)
 


### PR DESCRIPTION
Cljc buffers send their evals to both clj and cljs repls if available due to
`cider-map-connections`. Toggling a current buffer's connection involves hiding
the other connection.

Previously, when toggling _again_, the original list was not consulted and only
the truncated list, preventing the other connection from being found. This
allows for the full list to be searched for the other buffer.

In addition, a prefix dictates that the local connection list is discarded in
favor of the full list, restoring the evaluation in both clj and cljs
buffers (if both are present).

- [x] The commits are consistent with our [contribution guidelines][1]
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

See https://github.com/clojure-emacs/cider/issues/1913
