### PR TITLE
Improve formatting of spec in `cider-doc` buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#2151](https://github.com/clojure-emacs/cider/pull/2151) Improve formatting of spec in `cider-doc` buffer
+
 ## 0.16.0 (2017-12-28)
 
 ### New Features

--- a/cider-doc.el
+++ b/cider-doc.el
@@ -462,7 +462,16 @@ Tables are marked to be ignored by line wrap."
         (insert "\n")
         (when spec
           (emit "Spec: " 'font-lock-function-name-face)
-          (mapc (lambda (s) (insert s "\n")) spec)
+          (dolist (part spec)
+            (let ((role (car part))
+                  (desc (cadr part)))
+              (insert (format "%-4s: " role))
+              (thread-first desc
+                cider-sync-request:format-code
+                cider-font-lock-as-clojure
+                (split-string "\n")
+                insert-rectangle))
+            (insert "\n"))
           (insert "\n"))
         (if cider-docview-file
             (progn


### PR DESCRIPTION
Fix #2150

Depends on clojure-emacs/cider-nrepl#465

Font-lock and align spec in `cider-doc` buffer properly.