### PR TITLE
cider-doc now renders spec using `cider-browse-spec--pprint-indented`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changes
 
+* [#2029](https://github.com/clojure-emacs/cider/pull/2154) Make cider-doc use cider-browse-spec functionality to print the spec part of the doc buffer
 * [#2151](https://github.com/clojure-emacs/cider/pull/2151) Improve formatting of spec in `cider-doc` buffer.
 
 ## 0.16.0 (2017-12-28)

--- a/cider-doc.el
+++ b/cider-doc.el
@@ -36,6 +36,7 @@
 (require 'org-table)
 (require 'button)
 (require 'easymenu)
+(require 'cider-browse-spec)
 
 
 ;;; Variables
@@ -461,18 +462,14 @@ Tables are marked to be ignored by line wrap."
           (insert ".\n"))
         (insert "\n")
         (when spec
-          (emit "Spec: " 'font-lock-function-name-face)
-          (dolist (part spec)
-            (let ((role (car part))
-                  (desc (cadr part)))
-              (insert (format "%-4s: " role))
-              (thread-first desc
-                cider-sync-request:format-code
-                cider-font-lock-as-clojure
-                (split-string "\n")
-                insert-rectangle))
-            (insert "\n"))
-          (insert "\n"))
+          (emit "Spec:" 'font-lock-function-name-face)
+          (insert (cider-browse-spec--pprint-indented spec))
+          (insert "\n\n")
+          (insert-text-button "Browse spec"
+                              'follow-link t
+                              'action (lambda (_)
+                                        (cider-browse-spec (format "%s/%s" ns name))))
+          (insert "\n\n"))
         (if cider-docview-file
             (progn
               (insert (propertize (if class java-name clj-name)


### PR DESCRIPTION
There is also a button to jump to the browser

**This needs to be merged together with!** https://github.com/clojure-emacs/cider-nrepl/pull/472

-----------------

- [X] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)
