### PR TITLE
[Fix #2148] 'jump to definition' when remote cider -jack-in and -connect (#2148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs Fixed
 
 * [#1913](https://github.com/clojure-emacs/cider/issues/1913): Fix `cider-toggle-buffer-connection` to allow cycling of connection and restoring all connections in cljc buffers.
+* [#2148](https://github.com/clojure-emacs/cider/issues/2148): Fix `jump to definition` working properly when remote `cider-jack-in` and `cider-connect`. 
 
 ### Changes
 

--- a/cider-common.el
+++ b/cider-common.el
@@ -125,13 +125,13 @@ create a valid path."
 
 (defun cider-make-tramp-prefix (method user host)
   "Constructs a Tramp file prefix from METHOD, USER, HOST.
-It originated from Tramp's `tramp-make-tramp-file-name'.  The original be forced
-to make full file name with `with-parsed-tramp-file-name', not providing
-prefix only option.  This function does not support to Emacs 26 or later."
+It originated from Tramp's `tramp-make-tramp-file-name'.  The original be
+forced to make full file name with `with-parsed-tramp-file-name', not providing
+prefix only option."
   (concat tramp-prefix-format
-          (when (not (zerop (length method)))
+          (unless (zerop (length method))
             (concat method tramp-postfix-method-format))
-          (when (not (zerop (length user)))
+          (unless (zerop (length user))
             (concat user tramp-postfix-user-format))
           (when host
             (if (string-match tramp-ipv6-regexp host)
@@ -141,21 +141,16 @@ prefix only option.  This function does not support to Emacs 26 or later."
 
 (defun cider-tramp-prefix (&optional buffer)
   "Use the filename for BUFFER to determine a tramp prefix.
-Defaults to the current buffer.
-Return the tramp prefix, or nil if BUFFER is local."
+Defaults to the current buffer. Return the tramp prefix, or nil
+if BUFFER is local."
   (let* ((buffer (or buffer (current-buffer)))
          (name (or (buffer-file-name buffer)
                    (with-current-buffer buffer
                      default-directory))))
     (when (tramp-tramp-file-p name)
       (with-parsed-tramp-file-name name v
-        ;; `tramp-make-tramp-file-name' was changed to take 6 mandatory
-        ;; parameters in Emacs 26 instead of 4
-        (if (version< emacs-version "26")
-            (with-no-warnings
-              (cider-make-tramp-prefix v-method v-user v-host))
-          (with-no-warnings
-            (tramp-make-tramp-file-name v-method v-user v-domain v-host v-port v-localname)))))))
+        (with-no-warnings
+          (cider-make-tramp-prefix v-method v-user v-host))))))
 
 (defun cider--client-tramp-filename (name &optional buffer)
   "Return the tramp filename for path NAME relative to BUFFER.
@@ -219,12 +214,19 @@ existing file ending with URL has been found."
          (when-let* ((entry (match-string 3 url))
                      (file  (cider--url-to-file (match-string 2 url)))
                      (path  (cider--file-path file))
+                     ;; It is used for targeting useless intermediate buffer.
+                     ;; That buffer is made by (find-file path) below.
+                     ;; It has the name which is the last part of the path.
                      (trash (replace-regexp-in-string "^/.+/" "" path))
                      (name  (format "%s:%s" path entry)))
            (or (find-buffer-visiting name)
                (if (tramp-tramp-file-p path)
                    (progn
-                     ;; Use emacs built in archiving
+                     ;; Use emacs built in archiving.
+                     ;; This makes a list of files in archived Zip or Jar.
+                     ;; That list buffer is useless after jumping to the
+                     ;; buffer which has the real definition.
+                     ;; It'll be removed by (kill-buffer trash) below.
                      (find-file path)
                      (goto-char (point-min))
                      ;; Make sure the file path is followed by a newline to
@@ -233,6 +235,7 @@ existing file ending with URL has been found."
                      ;; moves up to matching line
                      (forward-line -1)
                      (archive-extract)
+                     ;; Remove useless buffer made by (find-file path) above.
                      (kill-buffer trash)
                      (current-buffer))
                  ;; Use external zip program to just extract the single file

--- a/cider-common.el
+++ b/cider-common.el
@@ -127,7 +127,7 @@ create a valid path."
   "Constructs a Tramp file prefix from METHOD, USER, HOST.
 It originated from Tramp's `tramp-make-tramp-file-name'.  The original be forced
 to make full file name with `with-parsed-tramp-file-name', not providing
-prefix only option.  This function does not support to emacs 26 or later."
+prefix only option.  This function does not support to Emacs 26 or later."
   (concat tramp-prefix-format
           (when (not (zerop (length method)))
             (concat method tramp-postfix-method-format))

--- a/cider-common.el
+++ b/cider-common.el
@@ -219,6 +219,7 @@ existing file ending with URL has been found."
          (when-let* ((entry (match-string 3 url))
                      (file  (cider--url-to-file (match-string 2 url)))
                      (path  (cider--file-path file))
+                     (trash (replace-regexp-in-string "^/.+/" "" path))
                      (name  (format "%s:%s" path entry)))
            (or (find-buffer-visiting name)
                (if (tramp-tramp-file-p path)
@@ -232,7 +233,7 @@ existing file ending with URL has been found."
                      ;; moves up to matching line
                      (forward-line -1)
                      (archive-extract)
-                     (kill-buffer (previous-buffer))
+                     (kill-buffer trash)
                      (current-buffer))
                  ;; Use external zip program to just extract the single file
                  (with-current-buffer (generate-new-buffer

--- a/cider-common.el
+++ b/cider-common.el
@@ -127,7 +127,7 @@ create a valid path."
   "Constructs a Tramp file prefix from METHOD, USER, HOST.
 It originated from Tramp's `tramp-make-tramp-file-name'.  The original be forced
 to make full file name with `with-parsed-tramp-file-name', not providing
-prefix only option.  This function does not support to `emacs-version' 26"
+prefix only option.  This function does not support to emacs 26 or later."
   (concat tramp-prefix-format
           (when (not (zerop (length method)))
             (concat method tramp-postfix-method-format))

--- a/cider-common.el
+++ b/cider-common.el
@@ -124,10 +124,10 @@ create a valid path."
       filename)))
 
 (defun cider-make-tramp-prefix (method user host)
-  "Constructs a Tramp file prefix from METHOD, USER, HOST. It originated from 
-Tramp's `tramp-make-tramp-file-name'. The original be forced to make full file
- name with `with-parsed-tramp-file-name', not providing prefix only option.
-This function does not support to emacs-version 26"
+  "Constructs a Tramp file prefix from METHOD, USER, HOST.
+It originated from Tramp's `tramp-make-tramp-file-name'.  The original be forced
+to make full file name with `with-parsed-tramp-file-name', not providing
+prefix only option.  This function does not support to `emacs-version' 26"
   (concat tramp-prefix-format
           (when (not (zerop (length method)))
             (concat method tramp-postfix-method-format))

--- a/cider-common.el
+++ b/cider-common.el
@@ -141,7 +141,7 @@ prefix only option."
 
 (defun cider-tramp-prefix (&optional buffer)
   "Use the filename for BUFFER to determine a tramp prefix.
-Defaults to the current buffer. Return the tramp prefix, or nil
+Defaults to the current buffer.  Return the tramp prefix, or nil
 if BUFFER is local."
   (let* ((buffer (or buffer (current-buffer)))
          (name (or (buffer-file-name buffer)

--- a/doc/up_and_running.md
+++ b/doc/up_and_running.md
@@ -216,16 +216,25 @@ You should also check out
 [boot]: http://boot-clj.com/
 [piggieback]: https://github.com/cemerick/piggieback
 
-## Working with cljc files
+## Working with `.cljc` files
 
-Ordinarily, CIDER dispatches code from `clj` files to Clojure repls and `cljs`
-files to ClojureScript repls. However, `cljc` files have two possible connection
-targets. By default, CIDER tries to evaluate `cljc` files in all connection
-buffers, both `clj` and `cljs`. This can be modified with
-`M-x cider-toggle-connection-buffer`. Toggling this once will choose one of the
-connections as the primary, and successive calls to `M-x
-cider-toggle-connection-buffer` will alternate which connection to use. To
-restore evaluation to both connections, invoke `M-x
-cider-toggle-connection-buffer` with a prefix argument. If there is only a
-Clojure connection, no toggling will happen and a message will inform you that
-there are no other connections to switch to.
+Ordinarily, CIDER dispatches code from `clj` files to Clojure REPLs and `cljs`
+files to ClojureScript REPLs. However, `cljc` files have two possible connection
+targets. By default, CIDER tries to evaluate `cljc` files in all matching
+connection buffers, both `clj` and `cljs` (if present).
+
+Simply put - if you're evaluating the code `(+ 2 2)` in a `cljc` file and you
+have an active Clojure and and active ClojureScript REPL, then the code is going
+to be evaluated 2 times - once for each of them. This behavior might be a bit
+confusing, but that's what we came up with, when ruminating what was the most
+logical thing to do out-of-the-box.
+
+This can be modified with <kbd>M-x</kbd> `cider-toggle-connection-buffer`
+<kbd>RET</kbd>. Toggling this once will choose one of the connections as the
+primary, and successive calls to <kbd>M-x</kbd> `cider-toggle-connection-buffer`
+<kbd>RET</kbd> will alternate which connection to use. To restore evaluation to
+both connections, invoke `cider-toggle-connection-buffer` with a prefix argument
+(<kbd>C-u M-x</kbd> `cider-toggle-connection-buffer` <kbd>RET</kbd>).
+
+If there is only a Clojure connection, no toggling will happen and a message
+will inform you that there are no other connections to switch to.

--- a/test/cider-common-tests.el
+++ b/test/cider-common-tests.el
@@ -64,3 +64,14 @@
     (expect (cider--kw-to-symbol ":clj.core/str") :to-equal "clj.core/str")
     (expect (cider--kw-to-symbol "::keyword") :to-equal "keyword")
     (expect (cider--kw-to-symbol nil) :to-equal nil)))
+
+(describe "cider-make-tramp-prefix"
+  (it "returns tramp-prefix only"
+      ;;; The third parameter is a host. It must contains a port number.
+      (expect (cider-make-tramp-prefix "ssh" "cider-devs" "192.168.50.9#22")
+              :to-equal "/ssh:cider-devs@192.168.50.9#22:")
+      ;;; These two cases are for using ssh config alias.
+      (expect (cider-make-tramp-prefix "ssh" nil "test.cider.com")
+              :to-equal "/ssh:test.cider.com:")
+      (expect (cider-make-tramp-prefix "ssh" nil "test.local")
+              :to-equal "/ssh:test.local:")))

--- a/test/cider-common-tests.el
+++ b/test/cider-common-tests.el
@@ -5,6 +5,7 @@
 ;; Author: Tim King <kingtim@gmail.com>
 ;;         Bozhidar Batsov <bozhidar@batsov.com>
 ;;         Artur Malabarba <bruce.connor.am@gmail.com>
+;;         HyungSuk Ryu <soulawaker@gmail.com>
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/test/cider-common-tests.el
+++ b/test/cider-common-tests.el
@@ -5,7 +5,6 @@
 ;; Author: Tim King <kingtim@gmail.com>
 ;;         Bozhidar Batsov <bozhidar@batsov.com>
 ;;         Artur Malabarba <bruce.connor.am@gmail.com>
-;;         HyungSuk Ryu <soulawaker@gmail.com>
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
1. The `cider-tramp-prefix` does not return only tramp prefix.
     It used the `tramp-make-tramp-file` in the `with-parsed-tramp-file-name` which force it to make a full tramp file path, not only prefix. I placed the `cider-make-tramp-prefix` for making prefix only. It is modified a little bit from `tramp-make-tramp-file`.

2. The `cider--client-tramp-filename` does not remove `file:` scheme for tramp filename.
    It should return the string with tramp prefix and remote source path. But previous version leaves `file:` scheme in a remote source path. I just added a line to remove this scheme in this function.

3. The `cider-find-file` leaves a useless list buffer per opening remote archived source like zip, jar.  
   When continuous tracking, it'll be big trash make us tired to remove. Now it'll be removed automatically.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][2] extremely useful.*

[1]: https://github.com/clojure-emacs/cider/blob/master/.github/CONTRIBUTING.md
[2]: https://cider.readthedocs.io/en/latest/hacking_on_cider/

  