### PR TITLE
Use `color-lighten-name` instead of custom color scaling function

### DIFF
--- a/cider-util.el
+++ b/cider-util.el
@@ -31,13 +31,16 @@
 
 ;;; Code:
 
-(require 'seq)
-(require 'clojure-mode)
-(require 'subr-x)
-(require 'cider-compat)
-(require 'nrepl-dict)
+;; Built-ins
 (require 'ansi-color)
 (require 'color)
+(require 'seq)
+(require 'subr-x)
+
+;; clojure-mode and CIDER
+(require 'cider-compat)
+(require 'clojure-mode)
+(require 'nrepl-dict)
 
 (defalias 'cider-pop-back 'pop-tag-mark)
 

--- a/cider-util.el
+++ b/cider-util.el
@@ -37,6 +37,7 @@
 (require 'cider-compat)
 (require 'nrepl-dict)
 (require 'ansi-color)
+(require 'color)
 
 (defalias 'cider-pop-back 'pop-tag-mark)
 
@@ -336,19 +337,12 @@ propertized (defaults to current buffer)."
 
 ;;; Colors
 
-(defun cider-scale-color (color scale)
-  "For a COLOR hex string or name, adjust intensity of RGB components by SCALE."
-  (let* ((rgb (color-values color))
-         (scaled-rgb (mapcar (lambda (n)
-                               (format "%04x" (round (+ n (* scale 65535)))))
-                             rgb)))
-    (apply #'concat "#" scaled-rgb)))
-
 (defun cider-scale-background-color ()
   "Scale the current background color to get a slighted muted version."
   (let ((color (frame-parameter nil 'background-color))
-        (dark (eq (frame-parameter nil 'background-mode) 'dark)))
-    (cider-scale-color color (if dark 0.05 -0.05))))
+        (darkp (eq (frame-parameter nil 'background-mode) 'dark)))
+    (unless (equal "unspecified-bg" color)
+      (color-lighten-name color (if darkp 5 -5)))))
 
 (autoload 'pkg-info-version-info "pkg-info.el")
 


### PR DESCRIPTION
No need to implement our own `cider-scale-color` when there's a built-in `color-lighten-name`.

Note that this does not given the _exact_ same result. `(cider-scale-color "#3F3F3F" 0.05)` gives `#4bcd4bcd4bcd`, shortened to `#4b4b4b`, while `(color-lighten-name "#3F3F3F" 5)` gives `"#4c0b4c0b4c0b"`, shortened to `#4c4c4c`. Close enough, I'd say.

See #2157.
  