### PR TITLE
Java files are now linked in stack traces if paths are configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#2167](https://github.com/clojure-emacs/cider/pull/2167): Add new defcustom `cider-jdk-src-paths`. Configure it to connect stack trace links to Java source code.
 * [#2161](https://github.com/clojure-emacs/cider/issues/2161): Add new interactive command `cider-eval-defun-to-point` which is bound to `C-c C-v (C-)z`. It evaluates the current top-level form up to the point.
 * [#2113](https://github.com/clojure-emacs/cider/issues/2113): Add new interactive commands `cider-eval-last-sexp-in-context` (bound to `C-c C-v (C-)c`) and `cider-eval-sexp-at-point-in-context` (bound to `C-c C-v (C-)b`).
 * Add new interactive command `cider-repl-set-type`.

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -576,10 +576,12 @@ Clojure sources here: https://repo1.maven.org/maven2/org/clojure/clojure/1.8.0/.
        'file-exists-p
        (mapcar
         (lambda (d)
-          (if (file-directory-p d)
-              (expand-file-name file-name d)
-            (when (file-exists-p d)
-              (format "zip:file:%s!/%s" d file-name))))
+          (cond ((file-directory-p d)
+                 (expand-file-name file-name d))
+                ((and (file-exists-p d)
+                      (member (file-name-extension d) '("jar" "zip")))
+                 (format "zip:file:%s!/%s" d file-name))
+                (t (error "Unexpected archive: %s" d))))
         cider-jdk-src-paths)))))
 
 (defun cider-stacktrace-navigate (button)

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -561,6 +561,25 @@ Achieved by destructively manipulating the `cider-stacktrace-suppressed-errors' 
         (button-put button 'help-echo "Click to promote these stacktraces."))
       (button-put button 'suppressed (not suppressed)))))
 
+(defvar cider-jdk-src-paths '("/usr/lib/jvm/openjdk-8/src.zip")
+  "Used by `cider-stacktrace-navigate'.
+Zip files work, but it's better to extract them and put the directory paths here.
+Clojure sources here: https://repo1.maven.org/maven2/org/clojure/clojure/1.8.0/.")
+
+(defun cider-resolve-java-class (class)
+  "Return a zip path to a file that corresponds to CLASS."
+  (when class
+    (let ((file-name (concat (replace-regexp-in-string "\\." "/" class) ".java")))
+      (cl-find-if
+       'file-exists-p
+       (mapcar
+        (lambda (d)
+          (if (file-directory-p d)
+              (expand-file-name file-name d)
+            (when (file-exists-p d)
+              (format "zip:file:%s!/%s" d file-name))))
+        cider-jdk-src-paths)))))
+
 (defun cider-stacktrace-navigate (button)
   "Navigate to the stack frame source represented by the BUTTON."
   (let* ((var (button-get button 'var))
@@ -574,9 +593,12 @@ Achieved by destructively manipulating the `cider-stacktrace-suppressed-errors' 
          ;; Set `line-shift' to the number of lines from the beginning of defn.
          (line-shift (- (or (button-get button 'line) 0)
                         (or (nrepl-dict-get info "line") 1)))
+         (file (or
+                (and (null var) (cider-resolve-java-class class))
+                (nrepl-dict-get info "file")
+                (button-get button 'file)))
          ;; give priority to `info` files as `info` returns full paths.
-         (info (nrepl-dict-put info "file" (or (nrepl-dict-get info "file")
-                                               (button-get button 'file)))))
+         (info (nrepl-dict-put info "file" file)))
     (cider--jump-to-loc-from-info info t)
     (forward-line line-shift)
     (back-to-indentation)))

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -565,6 +565,7 @@ Achieved by destructively manipulating the `cider-stacktrace-suppressed-errors' 
   "Used by `cider-stacktrace-navigate'.
 Zip files work, but it's better to extract them and put the directory paths here.
 Clojure sources here: https://repo1.maven.org/maven2/org/clojure/clojure/1.8.0/."
+  :package-version '(cider . "0.17.0")
   :type '(list string))
 
 (defun cider-resolve-java-class (class)

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -561,10 +561,11 @@ Achieved by destructively manipulating the `cider-stacktrace-suppressed-errors' 
         (button-put button 'help-echo "Click to promote these stacktraces."))
       (button-put button 'suppressed (not suppressed)))))
 
-(defvar cider-jdk-src-paths '("/usr/lib/jvm/openjdk-8/src.zip")
+(defcustom cider-jdk-src-paths '("/usr/lib/jvm/openjdk-8/src.zip")
   "Used by `cider-stacktrace-navigate'.
 Zip files work, but it's better to extract them and put the directory paths here.
-Clojure sources here: https://repo1.maven.org/maven2/org/clojure/clojure/1.8.0/.")
+Clojure sources here: https://repo1.maven.org/maven2/org/clojure/clojure/1.8.0/."
+  :type '(list string))
 
 (defun cider-resolve-java-class (class)
   "Return a zip path to a file that corresponds to CLASS."

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -117,6 +117,31 @@ path being `/usr/share/doc/java/api/`, put the following line in
 
 More details can be found [here](https://github.com/clojure-emacs/cider/issues/930).
 
+### Use a local copy of the Java source code
+
+When an exception is thrown, e.g. when eval-ing `(. clojure.lang.RT foo)`, a
+stack trace pops up. Some places of the stack trace link to Clojure files,
+others to Java files. By default, you can click the Clojure file links to
+navigate there. If you configure `cider-jdk-src-paths`, you can also click the
+Java file links to navigate there.
+
+Here's how do get the JDK source on Ubuntu:
+
+    sudo apt install openjdk-8-source
+
+The zip is installed to `/usr/lib/jvm/openjdk-8/src.zip`.
+
+You can download Clojure Java source code from
+[here](https://repo1.maven.org/maven2/org/clojure/clojure/1.8.0/clojure-1.8.0-sources.jar).
+
+Extract both and configure e.g. like so:
+
+    (setq cider-jdk-src-paths '("~/java/clojure-1.8.0-sources"
+                                "~/java/openjvm-8-src"))
+
+It's possible to use `jar` or `zip` files `cider-jdk-src-paths`, but extracting
+them is better since you get features like `ag` or `dired-jump`.
+
 ### Filter out namespaces in certain namespace-related commands
 
 You can hide all nREPL middleware details from `cider-browse-ns*` and `cider-apropos*`


### PR DESCRIPTION
cider-stacktrace.el (cider-jdk-src-paths): New defvar.

* cider-stacktrace.el (cider-resolve-java-class): New defun.
(cider-stacktrace-navigate): Update.

On Ubuntu:

    sudo apt install openjdk-8-source

The zip is installed to /usr/lib/jvm/openjdk-8/src.zip.

Download also this one:
https://repo1.maven.org/maven2/org/clojure/clojure/1.8.0/clojure-1.8.0-sources.jar

Extract both and configure e.g. like so:

    (setq cider-jdk-src-paths '("~/git/java/clojure-1.8.0-sources"
                                "~/git/java/openjvm-8-src"))
