### PR TITLE
Render diffs for expected / actual test results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#2172](https://github.com/clojure-emacs/cider/pull/2172): Render diffs for expected / actual test results.
 * [#2167](https://github.com/clojure-emacs/cider/pull/2167): Add new defcustom `cider-jdk-src-paths`. Configure it to connect stack trace links to Java source code.
 * [#2161](https://github.com/clojure-emacs/cider/issues/2161): Add new interactive command `cider-eval-defun-to-point` which is bound to `C-c C-v (C-)z`. It evaluates the current top-level form up to the point.
 * [#2113](https://github.com/clojure-emacs/cider/issues/2113): Add new interactive commands `cider-eval-last-sexp-in-context` (bound to `C-c C-v (C-)c`) and `cider-eval-sexp-at-point-in-context` (bound to `C-c C-v (C-)b`).


### PR DESCRIPTION
Renders diffs provided by clojure-emacs/cider-nrepl#478 in test result buffer.

```clojure
(deftest my-test
  (is (= {:a 1 :b 2}
         {:a 2 :b 3}
         {:c "a" :d "b"})))
```

![image](https://user-images.githubusercontent.com/1624090/35189597-c0b3fc18-fe02-11e7-959e-5c6b6e8c4b39.png)
