### PR TITLE
[Fix #2155] install-gnutls.sh should exit early on error

### DIFF
--- a/travis-ci/install-gnutls.sh
+++ b/travis-ci/install-gnutls.sh
@@ -38,6 +38,8 @@ curl -O https://ftp.gnu.org/gnu/nettle/nettle-${NETTLE_VERSION}.tar.gz \
     && make -j4 install \
     && make distclean
 
+if [ "$?" -ne "0" ]; then exit 1; fi
+
 cd $WORKDIR
 curl -O https://www.gnupg.org/ftp/gcrypt/gnutls/v3.5/gnutls-${GNUTLS_VERSION}.tar.xz \
     && xz -d -k gnutls-${GNUTLS_VERSION}.tar.xz \


### PR DESCRIPTION
When setting up the job in Travis CI, it is possible for libnettle to fail to install properly, and should that actually happen, then there is little point trying to download and compile gnutls. This change detects this case and exits immediately with an error code.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines][1]
- [X] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`make test`)
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [X] You've updated the changelog (if adding/changing user-visible functionality)
- [X] You've updated the readme (if adding/changing user-visible functionality)
- [X] You've updated the refcard (if you made changes to the commands listed there)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][2] extremely useful.*

[1]: https://github.com/clojure-emacs/cider/blob/master/.github/CONTRIBUTING.md
[2]: https://cider.readthedocs.io/en/latest/hacking_on_cider/
