### PR TITLE
Remove last remnants of cljx code causing CI breakage

### DIFF
--- a/cider-cheatsheet.el
+++ b/cider-cheatsheet.el
@@ -525,13 +525,11 @@ The list can hold one or more lists inside - one per each namespace."
 
 When you make it to a Clojure var its doc buffer gets displayed."
   (interactive)
-  (let ((section nil)
-        (cheatsheet-data cider-cheatsheet-hierarchy))
+  (let ((cheatsheet-data cider-cheatsheet-hierarchy))
     (while (stringp (caar cheatsheet-data))
       (let* ((sections (mapcar #'car cheatsheet-data))
              (sel-section (completing-read "Select cheatsheet section: " sections))
              (section-data (seq-find (lambda (elem) (equal (car elem) sel-section)) cheatsheet-data)))
-        (setq section sel-section)
         (setq cheatsheet-data (cdr section-data))))
     (cider-cheatsheet--select-var cheatsheet-data)))
 

--- a/cider-client.el
+++ b/cider-client.el
@@ -188,7 +188,6 @@ the `current-buffer'."
     (cond
      ((derived-mode-p 'clojurescript-mode) "cljs")
      ((derived-mode-p 'clojurec-mode) "multi")
-     ((derived-mode-p 'clojurex-mode) "multi")
      ((derived-mode-p 'clojure-mode) "clj")
      (cider-repl-type))))
 
@@ -372,9 +371,8 @@ over.
         there is no Clojure connection (use this for commands only
         supported in Clojure).
  :cljs - Like :clj, but demands a ClojureScript connection instead.
- :both - In `clojurec-mode' or `clojurex-mode' act on both connections,
-         otherwise function like :any.  Obviously, this option might run
-         FUNCTION twice.
+ :both - In `clojurec-mode' act on both connections, otherwise function
+         like :any.  Obviously, this option might run FUNCTION twice.
 
 If ANY-MODE is non-nil, :clj and :cljs don't signal errors due to being in
 the wrong major mode (they still signal if the desired connection type

--- a/test/cider-client-tests.el
+++ b/test/cider-client-tests.el
@@ -99,9 +99,6 @@
              (expect (cider-current-connection "clj") :to-equal b))
            (with-temp-buffer
              (clojurec-mode)
-             (expect (cider-current-connection "clj") :to-equal b))
-           (with-temp-buffer
-             (clojurex-mode)
              (expect (cider-current-connection "clj") :to-equal b))))))
 
     (describe "when type argument is given"


### PR DESCRIPTION
Looks like the builds have been broken since a recent commit where cljx was removed.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] You've updated the refcard (if you made changes to the commands listed there)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][2] extremely useful.*

[1]: https://github.com/clojure-emacs/cider/blob/master/.github/CONTRIBUTING.md
[2]: https://cider.readthedocs.io/en/latest/hacking_on_cider/
