### PR TITLE
[docs] Remove a note about company-mode 0.9, it's stable now

### DIFF
--- a/doc/code_completion.md
+++ b/doc/code_completion.md
@@ -52,9 +52,6 @@ you can add this to your config:
 (global-set-key (kbd "TAB") #'company-indent-or-complete-common)
 ```
 
-`company-indent-or-complete-common` is available only in `company-mode` 0.9+ (at
-the time of this writing it's still in development).
-
 ### Fuzzy candidate matching
 
 By default `company-mode` will provide completion candidates with the assumption


### PR DESCRIPTION
I think it is reasonable to assume that new users will install the latest version of company.