### PR TITLE
Correct variable name refactor `cider-cljs-repl-types`

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -571,7 +571,7 @@ should be the regular Clojure REPL started by the server process filter."
       ;; up the list, so it takes priority on Clojure requests.
       (cider-make-connection-default client-buffer)
       (setq cider-repl-type "cljs")
-      (pcase (assoc cljs-repl-form cider--cljs-repl-types)
+      (pcase (assoc cljs-repl-form cider-cljs-repl-types)
         (`(,_ ,name ,info)
          (message "Starting a %s REPL%s" name (or info "")))
         (_ (message "Starting a custom ClojureScript REPL")))


### PR DESCRIPTION
missed a variable name in the last commit. `cider--cljs-repl-types` => `cider-cljs-repl-types`