### PR TITLE
Fix refactor masking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#2029](https://github.com/clojure-emacs/cider/pull/2154): Make cider-doc use cider-browse-spec functionality to print the spec part of the doc buffer
 * [#2151](https://github.com/clojure-emacs/cider/pull/2151): Improve formatting of spec in `cider-doc` buffer.
 * Remove support for CLJX.
+* Fix `cider-eval-region` masking `clojure-refactor-map` in `cider-repl-mode`
 * [#2171](https://github.com/clojure-emacs/cider/issues/2171): Update `See Also` mappings for Clojure 1.9.
 
 ## 0.16.0 (2017-12-28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 * [#2029](https://github.com/clojure-emacs/cider/pull/2154): Make cider-doc use cider-browse-spec functionality to print the spec part of the doc buffer
 * [#2151](https://github.com/clojure-emacs/cider/pull/2151): Improve formatting of spec in `cider-doc` buffer.
 * Remove support for CLJX.
-* Fix `cider-eval-region` masking `clojure-refactor-map` in `cider-repl-mode`
+* Fix `cider-eval-region` masking `clojure-refactor-map` in `cider-repl-mode`.
 * [#2171](https://github.com/clojure-emacs/cider/issues/2171): Update `See Also` mappings for Clojure 1.9.
 
 ## 0.16.0 (2017-12-28)

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1469,7 +1469,7 @@ constructs."
 (defvar cider-repl-mode-syntax-table
   (copy-syntax-table clojure-mode-syntax-table))
 
-(declare-function cider-eval-region "cider-interaction")
+(declare-function cider-eval-commands-map "cider-interaction")
 (declare-function cider-eval-last-sexp "cider-interaction")
 (declare-function cider-refresh "cider-interaction")
 (declare-function cider-toggle-trace-ns "cider-interaction")
@@ -1522,7 +1522,8 @@ constructs."
     (define-key map (kbd "C-c M-t n") #'cider-toggle-trace-ns)
     (define-key map (kbd "C-c C-x") #'cider-refresh)
     (define-key map (kbd "C-x C-e") #'cider-eval-last-sexp)
-    (define-key map (kbd "C-c C-r") #'cider-eval-region)
+    (define-key map (kbd "C-c C-r") 'clojure-refactor-map)
+    (define-key map (kbd "C-c C-v") 'cider-eval-commands-map)
     (define-key map (string cider-repl-shortcut-dispatch-char) #'cider-repl-handle-shortcut)
     (easy-menu-define cider-repl-mode-menu map
       "Menu for CIDER's REPL mode"

--- a/cider-util.el
+++ b/cider-util.el
@@ -642,6 +642,8 @@ through a stack of help buffers.  Variables `help-back-label' and
     "Oh, what a day... what a lovely day!"
     "What a day! What cannot be accomplished on such a splendid day!"
     "Home is where your REPL is."
+    "The worst day programming is better than the best day working."
+    "The only thing worse than a rebel without a cause is a REPL without a cause."
     ,(format "%s, I've a feeling we're not in Kansas anymore."
              (cider-user-first-name))
     ,(format "%s, this could be the start of a beautiful program."

--- a/doc/cider-refcard.tex
+++ b/doc/cider-refcard.tex
@@ -80,7 +80,8 @@
   \item[C-c C-k] cider-load-buffer
   \item[C-c C-l] cider-load-file
   \item[C-c C-M-l] cider-load-all-files
-  \item[C-c C-r] cider-eval-region
+  \item[C-c C-r] clojure-refactor-map
+  \item[C-c C-v] cider-eval-commands-map
   \item[C-c C-n] cider-eval-ns-form
   \item[C-x C-e] \ns{cider-eval-last-sexp}
   \item[C-c C-w] \ns                     -and-replace

--- a/doc/cider-refcard.tex
+++ b/doc/cider-refcard.tex
@@ -80,7 +80,6 @@
   \item[C-c C-k] cider-load-buffer
   \item[C-c C-l] cider-load-file
   \item[C-c C-M-l] cider-load-all-files
-  \item[C-c C-r] clojure-refactor-map
   \item[C-c C-v] cider-eval-commands-map
   \item[C-c C-n] cider-eval-ns-form
   \item[C-x C-e] \ns{cider-eval-last-sexp}


### PR DESCRIPTION
In `cider-mode` `cider-eval-region` is grouped under `cider-eval-commands-map` as `C-c C-v C-r` and `clojure-refactor-map` is under `C-c C-r`. In `cider-repl-mode` on the other hand `clojure-refactor-map` is shadowed by `cider-eval-region` on `C-c C-r`. This PR allows both prefix maps to coexist in `cider-repl-mode` as they do in `cider-mode`. And balance was once again brought to the force.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog][3] (if adding/changing user-visible functionality)
- [x] You've updated the [user manual][4] (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][2] extremely useful.*

[1]: https://github.com/clojure-emacs/cider/blob/master/.github/CONTRIBUTING.md
[2]: https://cider.readthedocs.io/en/latest/hacking_on_cider/
[3]: https://github.com/clojure-emacs/cider/blob/master/CHANGELOG.md
[4]: https://github.com/clojure-emacs/cider/tree/master/doc
