### PR TITLE
Remove an unbalanced paren in initial ns command

### DIFF
--- a/cider-repl.el
+++ b/cider-repl.el
@@ -280,7 +280,7 @@ efficiency."
   (let ((nrepl-sync-request-timeout nil))
     (with-current-buffer buffer
       (let* ((response (nrepl-send-sync-request
-                        (lax-plist-put (nrepl--eval-request "(str *ns*))")
+                        (lax-plist-put (nrepl--eval-request "(str *ns*)")
                                        "inhibit-cider-middleware" "true")
                         (cider-current-connection)))
              (initial-ns (or (read (nrepl-dict-get response "value"))


### PR DESCRIPTION
Currently we are getting the following messages in the nrepl traffic:

```
(-->
  id                       "4"
  op                       "eval"
  session                  "08f2280f-df16-41a1-a8b1-319c58428719"
  time-stamp               "2018-03-05 09:24:34.139705200"
  code                     "(str *ns*))"
  inhibit-cider-middleware "true"
)

(<--
  id         "4"
  session    "08f2280f-df16-41a1-a8b1-319c58428719"
  time-stamp "2018-03-05 09:24:34.190585403"
  ex         "class clojure.lang.LispReader$ReaderException"
  root-ex    "class java.lang.RuntimeException"
  status     ("eval-error")
)

(<--
  id         "4"
  session    "08f2280f-df16-41a1-a8b1-319c58428719"
  time-stamp "2018-03-05 09:24:34.190934224"
  err        "RuntimeException Unmatched delimiter: )  clojure.lang.Util.r..."
)
```