### PR TITLE
Allow predicates in plugin and middleware lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#2241](https://github.com/clojure-emacs/cider/pull/2241): Make `cider-test-ediff` diff eval'ed values.
 * Add support for shadow-cljs to `cider-jack-in`.
 * [#2244](https://github.com/clojure-emacs/cider/issues/2244): Display the REPL type in the modeline.
+* [#2238](https://github.com/clojure-emacs/cider/pull/2238): Allow specifying predicates for entries in `cider-jack-in-lein-plugins` and `cider-jack-in-nrepl-middlewares`.
 
 ### Bugs Fixed
 

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -134,7 +134,62 @@
                 :to-equal "-C -o -i \"(require 'cider.tasks)\" -d org.clojure/tools.nrepl\\:0.2.12 -d cider/cider-nrepl\\:0.11.0 cider.tasks/add-middleware -m cider.nrepl/cider-middleware repl -s wait"))
     (it "can concat in a gradle project"
         (expect (cider-inject-jack-in-dependencies "-m" "--no-daemon clojureRepl" "gradle")
-                :to-equal "-m --no-daemon clojureRepl"))))
+                :to-equal "-m --no-daemon clojureRepl")))
+
+  (describe "when there are predicates"
+    :var (plugins-predicate middlewares-predicate)
+
+    (before-each
+      (fset 'plugins-predicate (lambda (&rest _) t))
+      (fset 'middlewares-predicate (lambda (&rest _) t))
+      (setq-local cider-jack-in-lein-plugins '(("refactor-nrepl" "2.0.0" :predicate plugins-predicate) ("cider/cider-nrepl" "0.11.0")))
+      (setq-local cider-jack-in-nrepl-middlewares '(("refactor-nrepl.middleware/wrap-refactor" :predicate middlewares-predicate) "cider.nrepl/cider-middleware" ("another/middleware"))))
+    (it "includes plugins whose predicates return true"
+      (expect (cider-jack-in-normalized-lein-plugins)
+              :to-equal '(("refactor-nrepl" "2.0.0") ("cider/cider-nrepl" "0.11.0"))))
+    (it "includes middlewares whose predicates return true"
+      (expect (cider-jack-in-normalized-nrepl-middlewares)
+              :to-equal '("refactor-nrepl.middleware/wrap-refactor" "cider.nrepl/cider-middleware" "another/middleware")))
+    (it "ignores plugins whose predicates return false"
+      (spy-on 'plugins-predicate :and-return-value nil)
+      (expect (cider-jack-in-normalized-lein-plugins)
+              :to-equal '(("cider/cider-nrepl" "0.11.0"))))
+    (it "ignores plugins whose predicates return false"
+      (spy-on 'middlewares-predicate :and-return-value nil)
+      (expect (cider-jack-in-normalized-nrepl-middlewares)
+              :to-equal '("cider.nrepl/cider-middleware" "another/middleware")))
+    (it "calls plugin predicates with the whole list entry"
+      (spy-on 'plugins-predicate)
+      (cider-jack-in-normalized-lein-plugins)
+      (expect 'plugins-predicate
+              :to-have-been-called-with '("refactor-nrepl" "2.0.0" :predicate plugins-predicate)))
+    (it "calls middleware predicates with the whole list entry"
+      (spy-on 'middlewares-predicate)
+      (cider-jack-in-normalized-nrepl-middlewares)
+      (expect 'middlewares-predicate
+              :to-have-been-called-with '("refactor-nrepl.middleware/wrap-refactor" :predicate middlewares-predicate)))
+    (it "only calls plugin predicates for their own entries"
+      (spy-on 'plugins-predicate)
+      (cider-jack-in-normalized-lein-plugins)
+      (expect 'plugins-predicate :to-have-been-called-times 1))
+    (it "only calls middleware predicates for their own entries"
+      (spy-on 'middlewares-predicate)
+      (cider-jack-in-normalized-nrepl-middlewares)
+      (expect 'middlewares-predicate :to-have-been-called-times 1)))
+
+  (describe "when the middleware and plugin lists have been normalized"
+    (before-each
+      (spy-on 'cider-jack-in-normalized-nrepl-middlewares
+              :and-return-value '("refactor-nrepl.middleware/wrap-refactor" "cider.nrepl/cider-middleware"))
+      (spy-on 'cider-jack-in-normalized-lein-plugins
+              :and-return-value '(("refactor-nrepl" "2.0.0") ("cider/cider-nrepl" "0.11.0")))
+      (setq-local cider-jack-in-dependencies-exclusions '()))
+    (it "uses them in a lein project"
+      (expect (cider-inject-jack-in-dependencies "" "repl :headless" "lein")
+              :to-equal "update-in :dependencies conj \\[org.clojure/tools.nrepl\\ \\\"0.2.12\\\"\\] -- update-in :plugins conj \\[refactor-nrepl\\ \\\"2.0.0\\\"\\] -- update-in :plugins conj \\[cider/cider-nrepl\\ \\\"0.11.0\\\"\\] -- repl :headless"))
+    (it "uses them in a boot project"
+      (expect (cider-inject-jack-in-dependencies "" "repl -s wait" "boot")
+              :to-equal "-i \"(require 'cider.tasks)\" -d org.clojure/tools.nrepl\\:0.2.12 -d refactor-nrepl\\:2.0.0 -d cider/cider-nrepl\\:0.11.0 cider.tasks/add-middleware -m refactor-nrepl.middleware/wrap-refactor -m cider.nrepl/cider-middleware repl -s wait"))))
 
 (describe "cider-jack-in-auto-inject-clojure"
   (it "injects `cider-minimum-clojure-version' when `cider-jack-in-auto-inject-clojure' is set to minimal"


### PR DESCRIPTION
This pull request is a follow-up to [discussion on the `clj-refactor.el` issue tracker](https://github.com/clojure-emacs/clj-refactor.el/pull/392#issuecomment-352399191). Basically, the problem is that `clj-refactor.el` wants to inject Leiningen plugins and nREPL middleware, but only for REPLs within a project context. (If the middleware is injected outside a project context, then errors result.) Unfortunately, CIDER provides no way to change `cider-jack-in-lein-plugins` or `cider-jack-in-nrepl-middlewares` without using advice. This pull request adds support for including arbitrary attributes in those variables using keyword arguments. In particular, the `:predicate` keyword allows for conditionally adding to those variables. I designed the interface with the idea of not breaking backwards compatibility and not making it hard to reverse the change later, if desired.

I haven't gone through the checklist yet, since I'd first like feedback on whether this is a reasonable approach to the problem.

- [x] The commits are consistent with our [contribution guidelines][1]
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog][3] (if adding/changing user-visible functionality)
- [x] You've updated the [user manual][4] (if adding/changing user-visible functionality)

[1]: https://github.com/clojure-emacs/cider/blob/master/.github/CONTRIBUTING.md
[2]: https://cider.readthedocs.io/en/latest/hacking_on_cider/
[3]: https://github.com/clojure-emacs/cider/blob/master/CHANGELOG.md
[4]: https://github.com/clojure-emacs/cider/tree/master/doc
