### PR TITLE
Add support for displaying various images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#2248](https://github.com/clojure-emacs/cider/pull/2248): `cider-repl` can now display recognized images in the REPL buffer.
 * [#2172](https://github.com/clojure-emacs/cider/pull/2172): Render diffs for expected / actual test results.
 * [#2167](https://github.com/clojure-emacs/cider/pull/2167): Add new defcustom `cider-jdk-src-paths`. Configure it to connect stack trace links to Java source code.
 * [#2161](https://github.com/clojure-emacs/cider/issues/2161): Add new interactive command `cider-eval-defun-to-point` which is bound to `C-c C-v (C-)z`. It evaluates the current top-level form up to the point.

--- a/cider-client.el
+++ b/cider-client.el
@@ -780,6 +780,10 @@ result, and is included in the request if non-nil."
            "pprint-fn" ,(or pprint-fn (cider--pprint-fn)))
          (and right-margin `("print-right-margin" ,right-margin))))
 
+(defun cider--nrepl-content-type-plist ()
+  "Plist to be appended to an eval request to make it use content-types."
+  '("content-type" "true"))
+
 (defun cider-tooling-eval (input callback &optional ns)
   "Send the request INPUT and register the CALLBACK as the response handler.
 NS specifies the namespace in which to evaluate the request.

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -817,33 +817,47 @@ the symbol."
 
 (defcustom cider-repl-image-margin 10
   "Number or pair of numbers encoding either a symmetric margin for REPL
-  visualized images, or the `(x . y)' offset to use in placing the image.")
+  visualized images, or the `(x . y)' offset to use in placing the image."
+  :group 'cider-repl
+  :package-version '(cider . "0.17.0"))
 
 (defun cider-repl--image (image type datap)
   (create-image (if datap (base64-decode-string image) image) type datap
                 :margin cider-repl-image-margin))
 
-(setq cider-repl-content-type-handler-alist
-      '(("image/jpeg" .
-         (lambda (buffer image &optional show-prefix bol)
-           (cider-repl--display-image buffer
-                                      (cider-repl--image image 'jpeg nil)
-                                      show-prefix bol image)))
-        ("image/jpeg;base64" .
-         (lambda (buffer image &optional show-prefix bol)
-           (cider-repl--display-image buffer
-                                      (cider-repl--image image 'jpeg t)
-                                      show-prefix bol)))
-        ("image/png".
-         (lambda (buffer image &optional show-prefix bol)
-           (cider-repl--display-image buffer
-                                      (cider-repl--image image 'png nil)
-                                      show-prefix bol image)))
-        ("image/png;base64" .
-         (lambda (buffer image &optional show-prefix bol)
-           (cider-repl--display-image buffer
-                                      (cider-repl--image image 'png t)
-                                      show-prefix bol)))))
+(defun cider-repl-handle-jpeg (buffer image &optional show-prefix bol)
+  (cider-repl--display-image buffer
+                             (cider-repl--image image 'jpeg nil)
+                             show-prefix bol image))
+
+(defun cider-repl-handle-jpeg64 (buffer image &optional show-prefix bol)
+  (cider-repl--display-image buffer
+                             (cider-repl--image image 'jpeg t)
+                             show-prefix bol))
+
+(defun cider-repl-handle-png (buffer image &optional show-prefix bol)
+  (cider-repl--display-image buffer
+                             (cider-repl--image image 'png nil)
+                             show-prefix bol image))
+
+(defun cider-repl-handle-png64 (buffer image &optional show-prefix bol)
+  (cider-repl--display-image buffer
+                             (cider-repl--image image 'png t)
+                             show-prefix bol))
+
+(defcustom cider-repl-content-type-handler-alist
+  '(("image/jpeg" . #'cider-repl-handle-jpeg)
+    ("image/jpeg;base64" .  #'cider-repl-handle-jpeg64)
+    ("image/png". #'cider-repl-handle-png)
+    ("image/png;base64" . #'cider-repl-handle-png64))
+  "Association list from content-types to handlers for inserting nREPL
+responses of that content type  into the CIDER REPL buffer.
+
+Handlers must be functions of two required and two optional arguments -
+being the REPL buffer to insert into, the value of the given content type
+as a raw string, the REPL's show prefix as any and an end-of-line flag."
+  :group 'cider-repl
+  :package-version '(cider . "0.17.0"))
 
 (defun cider-repl-handler (buffer)
   "Make an nREPL evaluation handler for the REPL BUFFER."

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -815,18 +815,18 @@ the symbol."
     (cider-repl--show-maximum-output)))
 
 (setq cider-repl-content-type-handler-alist
-  '(("image/jpeg" .
-     (lambda (u v s b)
-       (cider-repl--display-image u (create-image v 'jpeg) s b)))
-    ("image/jpeg;base64" .
-     (lambda (u v s b)
-       (cider-repl--display-image u (create-image (base64-decode-string v) 'jpeg 't) s b)))
-    ("image/png".
-     (lambda (u v s b)
-       (cider-repl--display-image u (create-image v 'png) s b)))
-    ("image/png;base64" .
-     (lambda (u v s b)
-       (cider-repl--display-image u (create-image (base64-decode-string v) 'png 't) s v)))))
+      '(("image/jpeg" .
+         (lambda (u v s b)
+           (cider-repl--display-image u (create-image v 'jpeg) s b)))
+        ("image/jpeg;base64" .
+         (lambda (u v s b)
+           (cider-repl--display-image u (create-image (base64-decode-string v) 'jpeg 't) s b)))
+        ("image/png".
+         (lambda (u v s b)
+           (cider-repl--display-image u (create-image v 'png) s b)))
+        ("image/png;base64" .
+         (lambda (u v s b)
+           (cider-repl--display-image u (create-image (base64-decode-string v) 'png 't) s v)))))
 
 (defun cider-repl-handler (buffer)
   "Make an nREPL evaluation handler for the REPL BUFFER."
@@ -836,22 +836,22 @@ the symbol."
                                  (lambda (buffer value)
                                    (cider-repl-emit-result buffer value (not after-first-result-chunk) t)
                                    (setq after-first-result-chunk t))
-                               (lambda (buffer out)
-                                 (cider-repl-emit-stdout buffer out))
-                               (lambda (buffer err)
-                                 (cider-repl-emit-stderr buffer err))
-                               (lambda (buffer)
-                                 (cider-repl-emit-prompt buffer)
-                                 (let ((win (get-buffer-window (current-buffer) t)))
-                                   (when (and win force-prompt)
-                                     (with-selected-window win
-                                       (set-window-point win cider-repl-input-start-mark))
-                                     (cider-repl--show-maximum-output))))
-                               nrepl-err-handler
-                               (lambda (buffer pprint-out)
-                                 (cider-repl-emit-result buffer pprint-out (not after-first-result-chunk))
-                                 (setq after-first-result-chunk t))
-                               (lambda (buffer value content-type)
+                                 (lambda (buffer out)
+                                   (cider-repl-emit-stdout buffer out))
+                                 (lambda (buffer err)
+                                   (cider-repl-emit-stderr buffer err))
+                                 (lambda (buffer)
+                                   (cider-repl-emit-prompt buffer)
+                                   (let ((win (get-buffer-window (current-buffer) t)))
+                                     (when (and win force-prompt)
+                                       (with-selected-window win
+                                         (set-window-point win cider-repl-input-start-mark))
+                                       (cider-repl--show-maximum-output))))
+                                 nrepl-err-handler
+                                 (lambda (buffer pprint-out)
+                                   (cider-repl-emit-result buffer pprint-out (not after-first-result-chunk))
+                                   (setq after-first-result-chunk t))
+                                 (lambda (buffer value content-type)
                                    (if-let ((handler (cdr (assoc content-type cider-repl-content-type-handler-alist))))
                                        (progn (funcall handler buffer value (not after-first-result-chunk) t)
                                               (setq force-prompt t))

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -801,6 +801,10 @@ the symbol."
           (t t))))
 
 (defun cider-repl--display-image (buffer image &optional show-prefix bol string)
+  "Insert IMAGE into BUFFER at the current point.
+
+For compatibility with the rest of CIDER's REPL machinery, supports
+SHOW-PREFIX and BOL."
   (with-current-buffer buffer
     (save-excursion
       (cider-save-marker cider-repl-output-start
@@ -816,31 +820,49 @@ the symbol."
     (cider-repl--show-maximum-output)))
 
 (defcustom cider-repl-image-margin 10
-  "Number or pair of numbers encoding either a symmetric margin for REPL
-  visualized images, or the `(x . y)' offset to use in placing the image."
+  "Specifies the margin to be applied to images displayed in the REPL.
+
+Either a single number of pixels - interpreted as a symmetric margin, or
+pair of numbers `(x . y)' encoding an arbitrary margin."
   :group 'cider-repl
   :package-version '(cider . "0.17.0"))
 
-(defun cider-repl--image (image type datap)
-  (create-image (if datap (base64-decode-string image) image) type datap
+(defun cider-repl--image (file-or-data type datap)
+  "A helper for creating images with CIDER's image options.
+
+FILE-OR-DATA is either the path to an image or its base64 coded data.  TYPE
+is a symbol indicating the image type.  DATAP indicates whether the image is
+the base64'd image data or a filename.
+
+Returns an image instance with a margin per `cider-repl-image-margin'."
+  (create-image (if datap (base64-decode-string file-or-data) file-or-data)
+                type datap
                 :margin cider-repl-image-margin))
 
 (defun cider-repl-handle-jpeg (buffer image &optional show-prefix bol)
+  "A handler for inserting a jpeg IMAGE file into a repl BUFFER.
+Part of the default `cider-repl-content-type-handler-alist'."
   (cider-repl--display-image buffer
                              (cider-repl--image image 'jpeg nil)
                              show-prefix bol image))
 
 (defun cider-repl-handle-jpeg64 (buffer image &optional show-prefix bol)
+  "A handler for inserting base64 coded jpeg IMAGE data into a repl BUFFER.
+Part of the default `cider-repl-content-type-handler-alist'."
   (cider-repl--display-image buffer
                              (cider-repl--image image 'jpeg t)
                              show-prefix bol))
 
 (defun cider-repl-handle-png (buffer image &optional show-prefix bol)
+  "A handler for inserting a png IMAGE file into a repl BUFFER.
+Part of the default `cider-repl-content-type-handler-alist'."
   (cider-repl--display-image buffer
                              (cider-repl--image image 'png nil)
                              show-prefix bol image))
 
 (defun cider-repl-handle-png64 (buffer image &optional show-prefix bol)
+  "Handler for inserting base64 png IMAGE data into a repl BUFFER.
+Part of the default `cider-repl-content-type-handler-alist'."
   (cider-repl--display-image buffer
                              (cider-repl--image image 'png t)
                              show-prefix bol))
@@ -850,12 +872,11 @@ the symbol."
     ("image/jpeg;base64" .  #'cider-repl-handle-jpeg64)
     ("image/png". #'cider-repl-handle-png)
     ("image/png;base64" . #'cider-repl-handle-png64))
-  "Association list from content-types to handlers for inserting nREPL
-responses of that content type  into the CIDER REPL buffer.
+  "Association list from content-types to handlers.
 
-Handlers must be functions of two required and two optional arguments -
-being the REPL buffer to insert into, the value of the given content type
-as a raw string, the REPL's show prefix as any and an end-of-line flag."
+Handlers must be functions of two required and two optional arguments - the
+REPL buffer to insert into, the value of the given content type as a raw
+string, the REPL's show prefix as any and an `end-of-line' flag."
   :group 'cider-repl
   :package-version '(cider . "0.17.0"))
 

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -809,7 +809,7 @@ the symbol."
             (insert-before-markers "\n"))
           (when show-prefix
             (insert-before-markers (propertize cider-repl-result-prefix 'font-lock-face 'font-lock-comment-face)))
-          (let ((image (create-image (substring string 1 -1) type)))
+          (let ((image (create-image string type)))
             (insert-image image string))
           (set-marker cider-repl-input-start-mark (point) buffer)
           (set-marker cider-repl-prompt-start-mark (point) buffer))))

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -799,7 +799,7 @@ the symbol."
                t)))
           (t t))))
 
-(defun cider-repl--display-image (type buffer string &optional show-prefix bol)
+(defun cider-repl--display-image (buffer image &optional show-prefix bol)
   (with-current-buffer buffer
     (save-excursion
       (cider-save-marker cider-repl-output-start
@@ -809,17 +809,24 @@ the symbol."
             (insert-before-markers "\n"))
           (when show-prefix
             (insert-before-markers (propertize cider-repl-result-prefix 'font-lock-face 'font-lock-comment-face)))
-          (let ((image (create-image string type)))
-            (insert-image image string))
+          (insert-image image)
           (set-marker cider-repl-input-start-mark (point) buffer)
           (set-marker cider-repl-prompt-start-mark (point) buffer))))
     (cider-repl--show-maximum-output)))
 
 (setq cider-repl-content-type-handler-alist
-  '(("image/jpeg" . (lambda (u v s b) (cider-repl--display-image 'jpeg u v s b)))
-    ("image/jpeg;base64" . (lambda (u v s b) (cider-repl--display-image 'jpeg u (base64-decode-string v) s b)))
-    ("image/png". (lambda (u v s b) (cider-repl--display-image 'png u v s b)))
-    ("image/png;base64" . (lambda (u v s b) (cider-repl--display-image 'png u (base64-decode-string v) s v)))))
+  '(("image/jpeg" .
+     (lambda (u v s b)
+       (cider-repl--display-image u (create-image v 'jpeg) s b)))
+    ("image/jpeg;base64" .
+     (lambda (u v s b)
+       (cider-repl--display-image u (create-image (base64-decode-string v) 'jpeg 't) s b)))
+    ("image/png".
+     (lambda (u v s b)
+       (cider-repl--display-image u (create-image v 'png) s b)))
+    ("image/png;base64" .
+     (lambda (u v s b)
+       (cider-repl--display-image u (create-image (base64-decode-string v) 'png 't) s v)))))
 
 (defun cider-repl-handler (buffer)
   "Make an nREPL evaluation handler for the REPL BUFFER."

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -820,7 +820,8 @@ SHOW-PREFIX and BOL."
           (when (and bol (not (bolp)))
             (insert-before-markers "\n"))
           (when show-prefix
-            (insert-before-markers (propertize cider-repl-result-prefix 'font-lock-face 'font-lock-comment-face)))
+            (insert-before-markers
+             (propertize cider-repl-result-prefix 'font-lock-face 'font-lock-comment-face)))
           (insert-image image string)
           (set-marker cider-repl-input-start-mark (point) buffer)
           (set-marker cider-repl-prompt-start-mark (point) buffer))))

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -877,6 +877,8 @@ Part of the default `cider-repl-content-type-handler-alist'."
                              show-prefix bol))
 
 (defun cider-repl-handle-external-body (type buffer _ &optional show-prefix bol)
+  "Handler for slurping external content into BUFFER.
+Handles an external-body TYPE by issuing a slurp request to fetch the body."
   (if-let* ((args        (second type))
             (access-type (nrepl-dict-get args "access-type")))
       (nrepl-send-request

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -836,49 +836,34 @@ pair of numbers `(x . y)' encoding an arbitrary margin."
   :group 'cider-repl
   :package-version '(cider . "0.17.0"))
 
-(defun cider-repl--image (file-or-data type datap)
+(defun cider-repl--image (data type datap)
   "A helper for creating images with CIDER's image options.
 
 FILE-OR-DATA is either the path to an image or its base64 coded data.  TYPE
 is a symbol indicating the image type.  DATAP indicates whether the image is
-the base64'd image data or a filename.
+the raw image data or a filename.
 
 Returns an image instance with a margin per `cider-repl-image-margin'."
-  (create-image (if datap (base64-decode-string file-or-data) file-or-data)
-                type datap
+  (create-image data type datap
                 :margin cider-repl-image-margin))
 
 (defun cider-repl-handle-jpeg (_type buffer image &optional show-prefix bol)
-  "A handler for inserting a jpeg IMAGE file into a repl BUFFER.
-Part of the default `cider-repl-content-type-handler-alist'."
-  (cider-repl--display-image buffer
-                             (cider-repl--image image 'jpeg nil)
-                             show-prefix bol image))
-
-(defun cider-repl-handle-jpeg64 (_type buffer image &optional show-prefix bol)
-  "A handler for inserting base64 coded jpeg IMAGE data into a repl BUFFER.
+  "A handler for inserting a jpeg IMAGE into a repl BUFFER.
 Part of the default `cider-repl-content-type-handler-alist'."
   (cider-repl--display-image buffer
                              (cider-repl--image image 'jpeg t)
-                             show-prefix bol))
-
-(defun cider-repl-handle-png (_type buffer image &optional show-prefix bol)
-  "A handler for inserting a png IMAGE file into a repl BUFFER.
-Part of the default `cider-repl-content-type-handler-alist'."
-  (cider-repl--display-image buffer
-                             (cider-repl--image image 'png nil)
                              show-prefix bol image))
 
-(defun cider-repl-handle-png64 (_type buffer image &optional show-prefix bol)
-  "Handler for inserting base64 png IMAGE data into a repl BUFFER.
+(defun cider-repl-handle-png (_type buffer image &optional show-prefix bol)
+  "A handler for inserting a png IMAGE into a repl BUFFER.
 Part of the default `cider-repl-content-type-handler-alist'."
   (cider-repl--display-image buffer
                              (cider-repl--image image 'png t)
-                             show-prefix bol))
+                             show-prefix bol image))
 
 (defun cider-repl-handle-external-body (type buffer _ &optional show-prefix bol)
   "Handler for slurping external content into BUFFER.
-Handles an external-body TYPE by issuing a slurp request to fetch the body."
+Handles an external-body TYPE by issuing a slurp request to fetch the content."
   (if-let* ((args        (second type))
             (access-type (nrepl-dict-get args "access-type")))
       (nrepl-send-request
@@ -890,9 +875,7 @@ Handles an external-body TYPE by issuing a slurp request to fetch the body."
 (defcustom cider-repl-content-type-handler-alist
   `(("message/external-body" . ,#'cider-repl-handle-external-body)
     ("image/jpeg" . ,#'cider-repl-handle-jpeg)
-    ("image/jpeg;base64" . ,#'cider-repl-handle-jpeg64)
-    ("image/png" . ,#'cider-repl-handle-png)
-    ("image/png;base64" . ,#'cider-repl-handle-png64))
+    ("image/png" . ,#'cider-repl-handle-png))
   "Association list from content-types to handlers.
 
 Handlers must be functions of two required and two optional arguments - the

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -9,6 +9,7 @@
 ;;         Artur Malabarba <bruce.connor.am@gmail.com>
 ;;         Hugo Duncan <hugo@hugoduncan.org>
 ;;         Steve Purcell <steve@sanityinc.com>
+;;         Reid McKenzie <me@arrdem.com>
 
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -848,31 +848,34 @@ the symbol."
   "Make an nREPL evaluation handler for the REPL BUFFER."
   (let (after-first-result-chunk
         force-prompt)
-    (nrepl-make-response-handler buffer
-                                 (lambda (buffer value)
-                                   (cider-repl-emit-result buffer value (not after-first-result-chunk) t)
-                                   (setq after-first-result-chunk t))
-                                 (lambda (buffer out)
-                                   (cider-repl-emit-stdout buffer out))
-                                 (lambda (buffer err)
-                                   (cider-repl-emit-stderr buffer err))
-                                 (lambda (buffer)
-                                   (cider-repl-emit-prompt buffer)
-                                   (let ((win (get-buffer-window (current-buffer) t)))
-                                     (when (and win force-prompt)
-                                       (with-selected-window win
-                                         (set-window-point win cider-repl-input-start-mark))
-                                       (cider-repl--show-maximum-output))))
-                                 nrepl-err-handler
-                                 (lambda (buffer pprint-out)
-                                   (cider-repl-emit-result buffer pprint-out (not after-first-result-chunk))
-                                   (setq after-first-result-chunk t))
-                                 (lambda (buffer value content-type)
-                                   (if-let ((handler (cdr (assoc content-type cider-repl-content-type-handler-alist))))
-                                       (progn (funcall handler buffer value (not after-first-result-chunk) t)
-                                              (setq force-prompt t))
-                                     (cider-repl-emit-result buffer value (not after-first-result-chunk) t))
-                                   (setq after-first-result-chunk t)))))
+    (nrepl-make-response-handler
+     buffer
+     (lambda (buffer value)
+       (cider-repl-emit-result buffer value (not after-first-result-chunk) t)
+       (setq after-first-result-chunk t))
+     (lambda (buffer out)
+       (cider-repl-emit-stdout buffer out))
+     (lambda (buffer err)
+       (cider-repl-emit-stderr buffer err))
+     (lambda (buffer)
+       (cider-repl-emit-prompt buffer)
+       (let ((win (get-buffer-window (current-buffer) t)))
+         (when (and win force-prompt)
+           (with-selected-window win
+             (set-window-point win cider-repl-input-start-mark))
+           (cider-repl--show-maximum-output))))
+     nrepl-err-handler
+     (lambda (buffer pprint-out)
+       (cider-repl-emit-result buffer pprint-out (not after-first-result-chunk))
+       (setq after-first-result-chunk t))
+     (lambda (buffer value content-type)
+       (if-let ((handler (cdr (assoc content-type
+                                     cider-repl-content-type-handler-alist))))
+           (progn (funcall handler buffer value
+                           (not after-first-result-chunk) t)
+                  (setq force-prompt t))
+         (cider-repl-emit-result buffer value (not after-first-result-chunk) t))
+       (setq after-first-result-chunk t)))))
 
 (defun cider-repl--send-input (&optional newline)
   "Go to the end of the input and send the current input.

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -870,8 +870,8 @@ the symbol."
        (cider-repl-emit-result buffer pprint-out (not after-first-result-chunk))
        (setq after-first-result-chunk t))
      (lambda (buffer value content-type)
-       (if-let ((handler (cdr (assoc content-type
-                                     cider-repl-content-type-handler-alist))))
+       (if-let* ((handler (cdr (assoc content-type
+                                      cider-repl-content-type-handler-alist))))
            (progn (funcall handler buffer value
                            (not after-first-result-chunk) t)
                   (setq force-prompt t))

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -824,6 +824,7 @@ SHOW-PREFIX and BOL."
 
 Either a single number of pixels - interpreted as a symmetric margin, or
 pair of numbers `(x . y)' encoding an arbitrary margin."
+  :type '(choice integer (vector integer integer))
   :group 'cider-repl
   :package-version '(cider . "0.17.0"))
 

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -871,7 +871,7 @@ Handles an external-body TYPE by issuing a slurp request to fetch the content."
        (list "op" "slurp" "url" (nrepl-dict-get args "URL"))
        (cider-repl-handler buffer)
        (cider-current-connection)))
- nil)
+  nil)
 
 (defcustom cider-repl-content-type-handler-alist
   `(("message/external-body" . ,#'cider-repl-handle-external-body)

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -847,28 +847,28 @@ Returns an image instance with a margin per `cider-repl-image-margin'."
                 type datap
                 :margin cider-repl-image-margin))
 
-(defun cider-repl-handle-jpeg (buffer image &optional show-prefix bol)
+(defun cider-repl-handle-jpeg (_type buffer image &optional show-prefix bol)
   "A handler for inserting a jpeg IMAGE file into a repl BUFFER.
 Part of the default `cider-repl-content-type-handler-alist'."
   (cider-repl--display-image buffer
                              (cider-repl--image image 'jpeg nil)
                              show-prefix bol image))
 
-(defun cider-repl-handle-jpeg64 (buffer image &optional show-prefix bol)
+(defun cider-repl-handle-jpeg64 (_type buffer image &optional show-prefix bol)
   "A handler for inserting base64 coded jpeg IMAGE data into a repl BUFFER.
 Part of the default `cider-repl-content-type-handler-alist'."
   (cider-repl--display-image buffer
                              (cider-repl--image image 'jpeg t)
                              show-prefix bol))
 
-(defun cider-repl-handle-png (buffer image &optional show-prefix bol)
+(defun cider-repl-handle-png (_type buffer image &optional show-prefix bol)
   "A handler for inserting a png IMAGE file into a repl BUFFER.
 Part of the default `cider-repl-content-type-handler-alist'."
   (cider-repl--display-image buffer
                              (cider-repl--image image 'png nil)
                              show-prefix bol image))
 
-(defun cider-repl-handle-png64 (buffer image &optional show-prefix bol)
+(defun cider-repl-handle-png64 (_type buffer image &optional show-prefix bol)
   "Handler for inserting base64 png IMAGE data into a repl BUFFER.
 Part of the default `cider-repl-content-type-handler-alist'."
   (cider-repl--display-image buffer
@@ -913,9 +913,11 @@ string, the REPL's show prefix as any and an `end-of-line' flag."
        (cider-repl-emit-result buffer pprint-out (not after-first-result-chunk))
        (setq after-first-result-chunk t))
      (lambda (buffer value content-type)
-       (if-let* ((handler (cdr (assoc content-type
+       (if-let* ((content-attrs (caar content-type))
+                 (content-type* (car content-type))
+                 (handler (cdr (assoc content-type*
                                       cider-repl-content-type-handler-alist))))
-           (progn (funcall handler buffer value
+           (progn (funcall handler buffer content-type value
                            (not after-first-result-chunk) t)
                   (setq force-prompt t))
          (cider-repl-emit-result buffer value (not after-first-result-chunk) t))

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -895,7 +895,13 @@ Part of the default `cider-repl-content-type-handler-alist'."
 
 Handlers must be functions of two required and two optional arguments - the
 REPL buffer to insert into, the value of the given content type as a raw
-string, the REPL's show prefix as any and an `end-of-line' flag."
+string, the REPL's show prefix as any and an `end-of-line' flag.
+
+The return value of the handler should be a flag, indicating whether or not
+the REPL is ready for a prompt to be displayed. Most handlers should return
+`t', as the content-type response is (currently) an alternative to the
+value response. However for handlers which themselves issue subsequent
+nREPL ops, it may be convenient to prevent inserting a prompt."
   :group 'cider-repl
   :package-version '(cider . "0.17.0"))
 

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -790,13 +790,13 @@ If the optional EVAL-ERROR-HANDLER is nil, the default `nrepl-err-handler'
 is used.  If any of the other supplied handlers are nil nothing happens for
 the corresponding type of response."
   (lambda (response)
-    (nrepl-dbind-response response (content-type content value ns out err status id pprint-out)
+    (nrepl-dbind-response response (content-type body value ns out err status id pprint-out)
       (when (buffer-live-p buffer)
         (with-current-buffer buffer
           (when (and ns (not (derived-mode-p 'clojure-mode)))
             (cider-set-buffer-ns ns))))
-      (cond ((and content content-type content-type-handler)
-             (funcall content-type-handler buffer content content-type))
+      (cond ((and content-type content-type-handler)
+             (funcall content-type-handler buffer body content-type))
             (value
              (when value-handler
                (funcall value-handler buffer value)))

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -790,13 +790,18 @@ If the optional EVAL-ERROR-HANDLER is nil, the default `nrepl-err-handler'
 is used.  If any of the other supplied handlers are nil nothing happens for
 the corresponding type of response."
   (lambda (response)
-    (nrepl-dbind-response response (content-type body value ns out err status id pprint-out)
+    (nrepl-dbind-response response (content-type content-transfer-encoding body
+                                    value ns out err status id pprint-out)
       (when (buffer-live-p buffer)
         (with-current-buffer buffer
           (when (and ns (not (derived-mode-p 'clojure-mode)))
             (cider-set-buffer-ns ns))))
       (cond ((and content-type content-type-handler)
-             (funcall content-type-handler buffer body content-type))
+             (funcall content-type-handler buffer
+                      (if (string= content-transfer-encoding "base64")
+                          (base64-decode-string body)
+                        body)
+                      content-type))
             (value
              (when value-handler
                (funcall value-handler buffer value)))

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -780,9 +780,11 @@ example, if 'value' key is present, the response is of type 'value', if
 Depending on the type, the handler dispatches the appropriate value to one
 of the supplied handlers: VALUE-HANDLER, STDOUT-HANDLER, STDERR-HANDLER,
 DONE-HANDLER, EVAL-ERROR-HANDLER, PPRINT-OUT-HANDLER and
-CONTENT-TYPE-HANDLER. Handlers are functions of the buffer and the value
-they handle, except for the optional CONTENT-TYPE-HANDLER which should be a
-function of the buffer, content and content-type to be handled.
+CONTENT-TYPE-HANDLER.
+
+ Handlers are functions of the buffer and the value they handle, except for
+the optional CONTENT-TYPE-HANDLER which should be a function of the buffer,
+content and content-type to be handled.
 
 If the optional EVAL-ERROR-HANDLER is nil, the default `nrepl-err-handler'
 is used.  If any of the other supplied handlers are nil nothing happens for

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -782,13 +782,13 @@ EVAL-ERROR-HANDLER is nil, the default `nrepl-err-handler' is used.  If any
 of the other supplied handlers are nil nothing happens for the
 corresponding type of response."
   (lambda (response)
-    (nrepl-dbind-response response (content-type value ns out err status id pprint-out)
+    (nrepl-dbind-response response (content-type content value ns out err status id pprint-out)
       (when (buffer-live-p buffer)
         (with-current-buffer buffer
           (when (and ns (not (derived-mode-p 'clojure-mode)))
             (cider-set-buffer-ns ns))))
-      (cond ((and value content-type content-type-handler)
-             (funcall content-type-handler buffer value content-type))
+      (cond ((and content content-type content-type-handler)
+             (funcall content-type-handler buffer content content-type))
             (value
              (when value-handler
                (funcall value-handler buffer value)))

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -782,9 +782,9 @@ of the supplied handlers: VALUE-HANDLER, STDOUT-HANDLER, STDERR-HANDLER,
 DONE-HANDLER, EVAL-ERROR-HANDLER, PPRINT-OUT-HANDLER and
 CONTENT-TYPE-HANDLER.
 
- Handlers are functions of the buffer and the value they handle, except for
+Handlers are functions of the buffer and the value they handle, except for
 the optional CONTENT-TYPE-HANDLER which should be a function of the buffer,
-content and content-type to be handled.
+content, the content-type to be handled as a list `(type attrs)'.
 
 If the optional EVAL-ERROR-HANDLER is nil, the default `nrepl-err-handler'
 is used.  If any of the other supplied handlers are nil nothing happens for

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -775,13 +775,18 @@ and 'session' keys.  Other standard response keys are 'value', 'out', 'err',
 
 The presence of a particular key determines the type of the response.  For
 example, if 'value' key is present, the response is of type 'value', if
-'out' key is present the response is 'stdout' etc.  Depending on the type,
-the handler dispatches the appropriate value to one of the supplied
-handlers: VALUE-HANDLER, STDOUT-HANDLER, STDERR-HANDLER, DONE-HANDLER,
-EVAL-ERROR-HANDLER, and PPRINT-OUT-HANDLER.  If the optional
-EVAL-ERROR-HANDLER is nil, the default `nrepl-err-handler' is used.  If any
-of the other supplied handlers are nil nothing happens for the
-corresponding type of response."
+'out' key is present the response is 'stdout' etc.
+
+Depending on the type, the handler dispatches the appropriate value to one
+of the supplied handlers: VALUE-HANDLER, STDOUT-HANDLER, STDERR-HANDLER,
+DONE-HANDLER, EVAL-ERROR-HANDLER, PPRINT-OUT-HANDLER and
+CONTENT-TYPE-HANDLER. Handlers are functions of the buffer and the value
+they handle, except for the optional CONTENT-TYPE-HANDLER which should be a
+function of the buffer, content and content-type to be handled.
+
+If the optional EVAL-ERROR-HANDLER is nil, the default `nrepl-err-handler'
+is used.  If any of the other supplied handlers are nil nothing happens for
+the corresponding type of response."
   (lambda (response)
     (nrepl-dbind-response response (content-type content value ns out err status id pprint-out)
       (when (buffer-live-p buffer)

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -791,7 +791,8 @@ is used.  If any of the other supplied handlers are nil nothing happens for
 the corresponding type of response."
   (lambda (response)
     (nrepl-dbind-response response (content-type content-transfer-encoding body
-                                    value ns out err status id pprint-out)
+                                                 value ns out err status id
+                                                 pprint-out)
       (when (buffer-live-p buffer)
         (with-current-buffer buffer
           (when (and ns (not (derived-mode-p 'clojure-mode)))

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -9,6 +9,7 @@
 ;;         Artur Malabarba <bruce.connor.am@gmail.com>
 ;;         Hugo Duncan <hugo@hugoduncan.org>
 ;;         Steve Purcell <steve@sanityinc.com>
+;;         Reid McKenzie <me@arrdem.com>
 ;;
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Fixes #1510 

This is my second-pass changeset to implement support for embedding images in the REPL. It's probably got some sharp edges - my elisp isn't that good - but it definitely functions as advertised. I'd appreocate criticism on how the handlers should be made more configurable both on the nREPL side of the changeset (clojure-emacs/cider-nrepl#517) and on the emacs side.

### Demo

![2018-03-23-220235_1188x1542_scrot](https://user-images.githubusercontent.com/704767/37860629-85c7fa22-2ee6-11e8-9094-df398c82c3c2.png)

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog][3] (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual][4] (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][2] extremely useful.*

[1]: https://github.com/clojure-emacs/cider/blob/master/.github/CONTRIBUTING.md
[2]: https://cider.readthedocs.io/en/latest/hacking_on_cider/
[3]: https://github.com/clojure-emacs/cider/blob/master/CHANGELOG.md
[4]: https://github.com/clojure-emacs/cider/tree/master/doc
