### PR TITLE
Provide a way to specify known locations for .nrepl-port lookup

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -267,6 +267,13 @@ This variable is used by `cider-connect'."
   :type 'boolean
   :version '(cider . "0.15.0"))
 
+(defcustom cider-nrepl-port-additional-search-paths nil
+  "When non-nil, `cider-connect' search the paths for the .nrepl-port file.
+After selecting hostname, any .nrepl-port file locaded in these paths will
+be used to display the port number to select";
+  :type '(repeat (string :tag "directory"))
+  :group 'cider)
+
 (defvar cider-ps-running-nrepls-command "ps u | grep leiningen"
   "Process snapshot command used in `cider-locate-running-nrepl-ports'.")
 
@@ -872,7 +879,8 @@ of remote SSH hosts."
   "Locate ports of running nREPL servers.
 When DIR is non-nil also look for nREPL port files in DIR.  Return a list
 of list of the form (project-dir port)."
-  (let* ((paths (cider--running-nrepl-paths))
+  (let* ((paths (append cider-nrepl-port-additional-search-paths
+                       (cider--running-nrepl-paths)))
          (proj-ports (mapcar (lambda (d)
                                (when-let* ((port (and d (nrepl-extract-port (cider--file-path d)))))
                                  (list (file-name-nondirectory (directory-file-name d)) port)))

--- a/doc/up_and_running.md
+++ b/doc/up_and_running.md
@@ -77,6 +77,14 @@ helpful for identifying each host.
 (setq cider-known-endpoints '(("host-a" "10.10.10.1" "7888") ("host-b" "7888")))
 ```
 
+If you use boot and spawn a repl server from another directory that is not a
+boot project, you can specify directories for cider to search for the
+.nrepl-port file with the `cider-nrepl-port-additional-search-paths`.
+
+```el
+'(cider-nrepl-port-additonal-search-paths (quote ("~" "~/.boot")))
+```
+
 ## ClojureScript usage
 
 ClojureScript support relies on the [piggieback][] nREPL middleware being


### PR DESCRIPTION
If a boot process is spawned from a directory that doesn't house a boot project
the proccess will not indicate where it was spawned from.  This change adds an
additional list custom var `cider-nrepl-port-additional-search-paths` that the
user can configure in the cases they commonly spawn a repl server from a
particular directory and want to easily connect to the running repl server.  It
simply appends that path to the list of paths to paths it retrieves in
`cider-locate-running-nrepl-ports`.

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog][3] (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual][4] (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][2] extremely useful.*

[1]: https://github.com/clojure-emacs/cider/blob/master/.github/CONTRIBUTING.md
[2]: https://cider.readthedocs.io/en/latest/hacking_on_cider/
[3]: https://github.com/clojure-emacs/cider/blob/master/CHANGELOG.md
[4]: https://github.com/clojure-emacs/cider/tree/master/doc
