### PR TITLE
Adding cider-nrepl-port-search-paths defcustom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -473,7 +473,9 @@ and try to associate the created connection with this project automatically.
 ## 0.9.0 (2015-06-16)
 
 ### New features
-
+* New defcustom `cider-nrepl-port-search-paths`.
+  Used when `cider-connect` does a lookup of local ports. Mainly should be set when
+  using boot Repl server from some directory other than a specific project's.
 * [#1109](https://github.com/clojure-emacs/cider/issues/1109): New defcustom `cider-auto-mode`.
 On by default, when `nil` don't automatically enable `cider-mode` in all Clojure buffers.
 * [#1061](https://github.com/clojure-emacs/cider/issues/1061): New command `cider-find-ns`, bound to <kbd>C-c C-.</kbd>, which prompts for an ns and jumps to the corresponding source file.

--- a/cider.el
+++ b/cider.el
@@ -294,6 +294,13 @@ This variable is used by `cider-connect'."
   :type 'boolean
   :version '(cider . "0.15.0"))
 
+(defcustom cider-nrepl-port-search-paths nil
+  "When non-nil, `cider-connect' search the paths for the .nrepl-port file.
+After selecting hostname, any .nrepl-port file locaded in these paths will
+be used to display the port number to select";
+  :type '(repeat (string :tag "directory"))
+  :group 'cider)
+
 (defvar cider-ps-running-nrepls-command "ps u | grep leiningen"
   "Process snapshot command used in `cider-locate-running-nrepl-ports'.")
 
@@ -979,7 +986,8 @@ of remote SSH hosts."
   "Locate ports of running nREPL servers.
 When DIR is non-nil also look for nREPL port files in DIR.  Return a list
 of list of the form (project-dir port)."
-  (let* ((paths (cider--running-nrepl-paths))
+  (let* ((paths (append cider-nrepl-port-search-paths
+                        (cider--running-nrepl-paths)))
          (proj-ports (mapcar (lambda (d)
                                (when-let* ((port (and d (nrepl-extract-port (cider--file-path d)))))
                                  (list (file-name-nondirectory (directory-file-name d)) port)))

--- a/doc/up_and_running.md
+++ b/doc/up_and_running.md
@@ -77,6 +77,14 @@ helpful for identifying each host.
 (setq cider-known-endpoints '(("host-a" "10.10.10.1" "7888") ("host-b" "7888")))
 ```
 
+If you use boot and spawn a repl server from another directory that is not a
+boot project, you can specify directories for cider to search for the
+.nrepl-port file with the `cider-nrepl-port-search-paths`.
+
+```el
+'(cider-nrepl-port-search-paths (quote ("~" "~/.boot")))
+```
+
 ## ClojureScript usage
 
 ClojureScript support relies on the [piggieback][] nREPL middleware being


### PR DESCRIPTION
This defcustom is useful for cases when you want to connect to a local repl but
are using boot repl spawned from a location that is not a project folder.
The boot process does not display the start directory so we cannot search for
the nrepl-port file from the process. This defcustom allows you to list common
places where you would spawn your boot repl and add that to the search path when
looking for nrepl-port files to show in.

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog][3] (if adding/changing user-visible functionality)
- [x] You've updated the [user manual][4] (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][2] extremely useful.*

[1]: https://github.com/clojure-emacs/cider/blob/master/.github/CONTRIBUTING.md
[2]: https://cider.readthedocs.io/en/latest/hacking_on_cider/
[3]: https://github.com/clojure-emacs/cider/blob/master/CHANGELOG.md
[4]: https://github.com/clojure-emacs/cider/tree/master/doc
