### PR TITLE
Fix `cider-repl-handle-shortcut` not handling plain lambdas

### DIFF
--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1417,7 +1417,7 @@ constructs."
 (cider-repl-add-shortcut "clear-help-banner" #'cider-repl-clear-help-banner)
 (cider-repl-add-shortcut "ns" #'cider-repl-set-ns)
 (cider-repl-add-shortcut "toggle-pretty" #'cider-repl-toggle-pretty-printing)
-(cider-repl-add-shortcut "browse-ns" (lambda () (cider-browse-ns (cider-current-ns))))
+(cider-repl-add-shortcut "browse-ns" (lambda () (interactive) (cider-browse-ns (cider-current-ns))))
 (cider-repl-add-shortcut "classpath" #'cider-classpath)
 (cider-repl-add-shortcut "history" #'cider-repl-history)
 (cider-repl-add-shortcut "trace-ns" #'cider-toggle-trace-ns)
@@ -1428,8 +1428,8 @@ constructs."
 (cider-repl-add-shortcut "test-all" #'cider-test-run-loaded-tests)
 (cider-repl-add-shortcut "test-project" #'cider-test-run-project-tests)
 (cider-repl-add-shortcut "test-ns-with-selector" #'cider-test-run-ns-tests-with-selector)
-(cider-repl-add-shortcut "test-all-with-selector" (lambda () (cider-test-run-loaded-tests 'prompt-for-selector)))
-(cider-repl-add-shortcut "test-project-with-selector" (lambda () (cider-test-run-project-tests 'prompt-for-selector)))
+(cider-repl-add-shortcut "test-all-with-selector" (lambda () (interactive) (cider-test-run-loaded-tests 'prompt-for-selector)))
+(cider-repl-add-shortcut "test-project-with-selector" (lambda () (interactive) (cider-test-run-project-tests 'prompt-for-selector)))
 (cider-repl-add-shortcut "test-report" #'cider-test-show-report)
 (cider-repl-add-shortcut "run" #'cider-run)
 (cider-repl-add-shortcut "conn-info" #'cider-display-connection-info)
@@ -1471,7 +1471,7 @@ constructs."
       (if (not (equal command ""))
           (let ((command-func (gethash command cider-repl-shortcuts)))
             (if command-func
-                (call-interactively (gethash command cider-repl-shortcuts))
+                (call-interactively command-func)
               (error "Unknown command %S.  Available commands: %s"
                      command-func
                      (mapconcat 'identity (cider-repl--available-shortcuts) ", "))))


### PR DESCRIPTION
The function expects values in `cider-repl-shortcuts` to be commands
(interactively callable functions). For some cases (currently
`browse-ns`, `test-all-with-selector` and
`test-project-with-selector`) this is not true that causes the `,`
command to fail. For these cases plain lambdas are
used to call certain otherwise interactive functions with predefined parameters.




- [x] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog][3] (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual][4] (if adding/changing user-visible functionality)


