### PR TITLE
Wait for shadow-cljs client to connect after watch

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -662,9 +662,9 @@ Generally you should not disable this unless you run into some faulty check."
 
 We have to prompt the user to select a build, that's why
 this is a command, not just a string."
-  (let ((form "(do (require '[shadow.cljs.devtools.api :as shadow]) (shadow/watch :%s) (shadow/nrepl-select :%s))")
+  (let ((form "(do (require '[shadow.cljs.devtools.api :as shadow]) (shadow/watch :%s) (while (not (shadow/repl-client-connected? (shadow/get-worker :%s))) (Thread/sleep 1000)) (shadow/nrepl-select :%s))")
         (build (string-remove-prefix ":" (read-from-minibuffer "Select shadow-cljs build: "))))
-    (format form build build)))
+    (format form build build build)))
 
 (defun cider-custom-cljs-repl-init-form ()
   "Prompt for a form that would start a ClojureScript REPL.


### PR DESCRIPTION
When jacking in to a ClojureScript REPL using Shadow CLJS, it is currently impossible to make it all the way to the CLJS REPL. The REPL init code looks like this:

```clojure
(do (require '[shadow.cljs.devtools.api :as shadow]) (shadow/watch :%s) (shadow/nrepl-select :%s))
```

`shadow/nrepl-select` currently always returns `[:no-client :app "Make sure your JS environment has loaded your compiled ClojureScript code."]` because there's no time to connect a client.

This pull request adds code that blocks until a client connects.

```
Arch Linux (Linux version: 4.16.3-1)
GNU Emacs 25.3.1
CIDER 0.17.0snapshot (package: 20180426.440), nREPL 0.2.13
Clojure 1.9.0, Java 1.8.0_172
```

-----------------

- [x] The commits are consistent with our [contribution guidelines][1]
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog][3] (if adding/changing user-visible functionality)
- [x] You've updated the [user manual][4] (if adding/changing user-visible functionality)
