### PR TITLE
Add more refloc regexps and improve relative file detection

### DIFF
--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1258,7 +1258,12 @@ regexes from `cider-locref-regexp-alist' to infer locations at point."
                       (or (cider-sync-request:ns-path var)
                           (nrepl-dict-get (cider-sync-request:info var) "file")))
                     ;; when not found, return the file detected by regexp
-                    (plist-get loc :file))))
+                    (when-let* ((file (plist-get loc :file)))
+                      (if (file-name-absolute-p file)
+                          file
+                        ;; when not absolute, expand within the current project
+                        (when-let* ((proj (clojure-project-dir)))
+                          (expand-file-name file proj)))))))
         (if file
             (cider--jump-to-loc-from-info (nrepl-dict "file" file "line" line) t)
           (error "No source location for %s" var)))

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1198,7 +1198,9 @@ namespace to switch to."
   '((stdout-stacktrace "[ \t]\\(at \\([^$(]+\\).*(\\([^:()]+\\):\\([0-9]+\\))\\)" 1 2 3 4)
     (aviso-stacktrace  "^[ \t]*\\(\\([^$/ \t]+\\).*? +\\([^:]+\\): +\\([0-9]+\\)\\)" 1 2 3 4)
     (print-stacktrace  "\\[\\([^][$ \t]+\\).* +\\([^ \t]+\\) +\\([0-9]+\\)\\]" 0 1 2 3)
-    (timbre-log        "\\(TRACE\\|INFO\\|DEBUG\\|WARN\\|ERROR\\) +\\(\\[\\([^:]+\\):\\([0-9]+\\)\\]\\)" 2 3 nil 4))
+    (timbre-log        "\\(TRACE\\|INFO\\|DEBUG\\|WARN\\|ERROR\\) +\\(\\[\\([^:]+\\):\\([0-9]+\\)\\]\\)" 2 3 nil 4)
+    (cljs-message      "at line \\([0-9]+\\) +\\(.*\\)$" 0 nil 2 1)
+    (reflection        "Reflection warning, +\\(\\([^\n:]+\\):\\([0-9]+\\):[0-9]+\\)" 1 nil 2 3))
   "Alist holding regular expressions for inline location references.
 Each element in the alist has the form (NAME REGEXP HIGHLIGHT VAR FILE
 LINE), where NAME is the identifier of the regexp, REGEXP - regexp matching

--- a/test/cider-repl-tests.el
+++ b/test/cider-repl-tests.el
@@ -183,7 +183,7 @@ PROPERTY shoudl be a symbol of either 'text, 'ansi-context or
       (expect (cider-locref-at-point)
               :to-equal
               '(:type aviso-stacktrace :highlight (121 . 213) :var "clojure.tools.nrepl.middleware.interruptible-eval" :file "interruptible_eval.clj" :line 190))
-      (previous-line)
+      (line-move -1)
       (expect (cider-locref-at-point)
               :to-equal
               '(:type aviso-stacktrace :highlight (26 . 107) :var "java.util.concurrent.ThreadPoolExecutor" :file "ThreadPoolExecutor.java" :line 624))))
@@ -195,7 +195,7 @@ PROPERTY shoudl be a symbol of either 'text, 'ansi-context or
       (expect (cider-locref-at-point)
               :to-equal
               '(:type timbre-log :highlight (138 . 148) :var "errors" :file nil :line 8))
-      (previous-line)
+      (line-move -1)
       (expect (cider-locref-at-point)
               :to-equal
               '(:type timbre-log :highlight (85 . 95) :var "errors" :file nil :line 8))))


### PR DESCRIPTION
Adding long promised tests on this occasion. Couldn't figure out the linter locally, but should be fine.


- [x] The commits are consistent with our [contribution guidelines][1]
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog][3] (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual][4] (if adding/changing user-visible functionality)


#2043