### PR TITLE
Indicate support for Clojure CLI tools in docs

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -13,9 +13,9 @@ CIDER officially supports Emacs 24.4+, Java 8+ and Clojure(Script)
 1.8+.  CIDER 0.17 (Andalucía) was the final release which supported
 Java 7 and Clojure(Script) 1.7.
 
-You'll also need a recent version of your favorite build tool (Leiningen, Boot
-or Gradle) to be able to start CIDER via `cider-jack-in`. Generally it's a good
-idea to use their latest stable versions.
+You'll also need a recent version of either the Clojure CLI tools or your
+favorite build tool (Leiningen, Boot or Gradle) to be able to start CIDER via
+`cider-jack-in`. Generally it's a good idea to use their latest stable versions.
 
 **CIDER does not support ClojureCLR.**
 

--- a/doc/up_and_running.md
+++ b/doc/up_and_running.md
@@ -1,13 +1,12 @@
 The only requirement to use CIDER is to have an nREPL server to which it may
 connect. Many Clojurians favour the use of tools like Leiningen, Boot or Gradle
 to start an nREPL server, but the use of one of them is not a prerequisite to
-use CIDER (however, it *is* required if you want to use the `cider-jack-in`
-command).
+use CIDER.
 
 ## Setting up a Leiningen or Boot project (optional)
 
-[Leiningen][] is the de-facto standard build/project
-management tool for Clojure. [Boot][] is a newer build tool
+[Leiningen](https://leiningen.org) is the de-facto standard build/project
+management tool for Clojure. [Boot](http://boot-clj.com) is a newer build tool
 offering abstractions and libraries to construct more complex build
 scenarios. Both have a similar scope to the Maven build tool favoured by Java
 developers (and they actually reuse many things from the Maven ecosystem).
@@ -27,15 +26,18 @@ The two main ways to obtain an nREPL connection are discussed in the following s
 
 ## Launch an nREPL server and client from Emacs
 
-Simply open in Emacs a file belonging to your `lein` or `boot` project (like
-`foo.clj`) and type <kbd>M-x</kbd> `cider-jack-in` <kbd>RET</kbd>. This will
-start an nREPL server with all the project dependencies loaded in and CIDER will
-automatically connect to it.
+Simply open in Emacs a file belonging to your project (like `foo.clj`) and type
+<kbd>M-x</kbd> `cider-jack-in` <kbd>RET</kbd>. This will start an nREPL server
+and CIDER will automatically connect to it.
+
+If it is a `lein`, `boot` or `tools.deps (deps.edn)` project nREPL will be
+started with all dependencies loaded.
 
 Alternatively you can use <kbd>C-u M-x</kbd> `cider-jack-in` <kbd>RET</kbd> to
-specify the name of a `lein` or `boot` project, without having to visit any file
-in it. This option is also useful if your project contains both `project.clj`
-and `build.boot` and you want to launch a repl for one or the other.
+specify the name of a `lein`, `boot` or `tools.deps` project, without having to
+visit any file in it. This option is also useful if your project contains some
+combination of `project.clj`, `build.boot` and `deps.edn` and you want to launch
+a repl for one or the other.
 
 In Clojure(Script) buffers the command `cider-jack-in` is bound to <kbd>C-c M-j</kbd>.
 
@@ -53,10 +55,16 @@ You can go to your project's directory in a terminal and type there:
 $ lein repl
 ```
 
-Or:
+Or for `boot`:
 
 ```
 $ boot repl -s wait (or whatever task launches a repl)
+```
+
+It is also possible for plain `clj`, although the command is somewhat longer:
+
+```
+$ clj -Sdeps '{:deps {cider/cider-nrepl {:mvn/version "0.18.0-SNAPSHOT"} }}' -e '(require (quote cider-nrepl.main)) (cider-nrepl.main/init ["cider.nrepl/cider-middleware"])'
 ```
 
 Alternatively you can start nREPL either manually or by the facilities provided by your


### PR DESCRIPTION
This is a quick contribution for #2295 . The only changes are to markdown files in `./doc` so I think most of the checks below are not applicable. I have not updated the changelog because looking through it I didn't see any entries just about documentation - hope that's ok.

-----------------

- [x] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog][3] (if adding/changing user-visible functionality)
- [x] You've updated the [user manual][4] (if adding/changing user-visible functionality)