### PR TITLE
[Fix #2294] simplify stacktrace filter mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs fixed
 
+* [#2294](https://github.com/clojure-emacs/cider/issues/2294): Fix setting default stacktrace filters.
 * [#2286](https://github.com/clojure-emacs/cider/issues/2286): Fix eldoc issue with images in the REPL.
 
 ## 0.17.0 (2018-05-07)

--- a/doc/navigating_stacktraces.md
+++ b/doc/navigating_stacktraces.md
@@ -64,12 +64,17 @@ There are two more selective strategies for the error buffer:
 (setq cider-auto-select-error-buffer nil)
 ```
 
-* Error buffer stacktraces may be filtered by default. Valid filter types
-include `java`, `clj`, `repl`, `tooling`, and `dup`. Setting this to `nil` will
-show all stacktrace frames.
+* Error buffer stacktraces may be filtered by default. Valid filter
+types include `java`, `clj`, `repl`, `tooling`, and `dup`. There are
+also "positive" filtering types. The value `project` will cause only
+project frames to be shown or `all` will force all stackframes to be
+shown. Note that `project` and `all` are mutually exclusive. Whichever
+one is first will determine the behavior if they are both present.
 
 ```el
 (setq cider-stacktrace-default-filters '(tooling dup))
+;; or
+(setq cider-stacktrace-default-filters '(project))
 ```
 
 * Error messages may be wrapped for readability. If this value is nil, messages


### PR DESCRIPTION
previously there were two separate lists of positive and negative
filters and complicated logic spread throughout of how these
interacted. Now there is a single list that you can toggle flags on or
off and their interaction is dictated inside of a single function
`cider-stacktrace-apply-filters`. Since their interaction is here we
no longer need to remember previous flags as they are just toggled on
and off.

Positive filters are 'all or 'project. These dictate that all frames
should be shown or only any frame from a project namespace should be
shown, despite other filters. Also, these two cannot exist at the same
time, so we need to check which is most "recent". Since if 'project is
selected, it hides all but project frames and if 'all is selected it
must show all. We do what was most recently selected in this case
then.

So the frame filtering is quite simply a list of tags you want to
filter by: '(java clj tooling repl dup project all). These are toggled
on and off as desired.

- [x] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [ ] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog][3] (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual][4] (if adding/changing user-visible functionality)