### PR TITLE
Use a better error when a cljs repl form cannot be found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs fixed
 
 * [#2286](https://github.com/clojure-emacs/cider/issues/2286): Fix eldoc issue with images in the REPL.
+* [#2307](https://github.com/clojure-emacs/cider/pull/2307): Use a better error when a cljs repl form cannot be found.
 
 ## 0.17.0 (2018-05-07)
 

--- a/cider.el
+++ b/cider.el
@@ -755,14 +755,15 @@ you're working on."
 
 (defun cider-cljs-repl-form (repl-type)
   "Get the cljs REPL form for REPL-TYPE."
-  (let ((repl-form (cadr (seq-find
-                          (lambda (entry)
-                            (eq (car entry) repl-type))
-                          cider-cljs-repl-types))))
-    ;; repl-form can be either a string or a function producing a string
-    (if (symbolp repl-form)
-        (funcall repl-form)
-      repl-form)))
+  (if-let* ((repl-form (cadr (seq-find
+                              (lambda (entry)
+                                (eq (car entry) repl-type))
+                              cider-cljs-repl-types))))
+      ;; repl-form can be either a string or a function producing a string
+      (if (symbolp repl-form)
+          (funcall repl-form)
+        repl-form)
+    (user-error "No ClojureScript REPL type %s found.  Please make sure that `cider-cljs-repl-types' has an entry for it" repl-type)))
 
 (defun cider-verify-cljs-repl-requirements (repl-type)
   "Verify that the requirements for REPL-TYPE are met."


### PR DESCRIPTION
Without this fix cider throws an error but it is not a very clear one.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines][1]
- [X] All tests are passing (`make test`)
- [X] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - This fails with exit = 2 but I don't think it due to my change.

- [X] You've updated the [changelog][3] (if adding/changing user-visible functionality)