### PR TITLE
Added cider-format-edn-last-sexp for [Feature #2310]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs fixed
 
+* [#2310](https://github.com/clojure-emacs/cider/issues/2310): `cider-format-edn-last-sexp` will format the last sexp.
 * [#2294](https://github.com/clojure-emacs/cider/issues/2294): Fix setting default stacktrace filters.
 * [#2286](https://github.com/clojure-emacs/cider/issues/2286): Fix eldoc issue with images in the REPL.
 

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1981,6 +1981,11 @@ START and END represent the region's boundaries."
                           (lambda (edn)
                             (cider-sync-request:format-edn edn right-margin)))))
 
+(defun cider-format-edn-last-sexp ()
+  "Format the EDN data of the last sexp."
+  (interactive)
+  (apply 'cider-format-edn-region (cider-sexp-at-point 'bounds)))
+
 
 ;;; Interrupt evaluation
 

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -290,6 +290,10 @@ Configure `cider-cljs-repl-types' to change the ClojureScript REPL to use for yo
      ["Browse REPL input history" cider-repl-history]
      ["Browse classpath" cider-classpath]
      ["Browse classpath entry" cider-open-classpath-entry])
+    ("Format"
+     ["Format EDN last sexp" cider-format-edn-last-sexp]
+     ["Format EDN region" cider-format-edn-region]
+     ["Format EDN buffer" cider-format-edn-buffer])
     ("Macroexpand"
      ["Macroexpand-1" cider-macroexpand-1]
      ["Macroexpand-all" cider-macroexpand-all])


### PR DESCRIPTION
This allows for easier formatting of data in the repl. It combines `cider-eval-last-sexp` and `cider-format-edn-region` to be able to format in-place.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines][1]
- [NA] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`make test`)
- [X] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [X] You've updated the [changelog][3] (if adding/changing user-visible functionality)
- [X] You've updated the [user manual][4] (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][2] extremely useful.*

[1]: https://github.com/clojure-emacs/cider/blob/master/.github/CONTRIBUTING.md
[2]: https://cider.readthedocs.io/en/latest/hacking_on_cider/
[3]: https://github.com/clojure-emacs/cider/blob/master/CHANGELOG.md
[4]: https://github.com/clojure-emacs/cider/tree/master/doc
