### PR TITLE
Add cider-figwheel and figwheel-main REPL type

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -649,6 +649,12 @@ Generally you should not disable this unless you run into some faulty check."
   (unless (cider-library-present-p "figwheel-sidecar/figwheel-sidecar")
     (user-error "Figwheel-sidecar is not available.  Please check http://cider.readthedocs.io/en/latest/clojurescript")))
 
+(defun cider-check-figwheel-main-requirements ()
+  "Check whether we can start a Figwheel ClojureScript REPL."
+  (cider-verify-piggieback-is-present)
+  (unless (cider-library-present-p "bhauman/figwheel-main")
+    (user-error "Figwheel-main is not available.  Please check http://cider.readthedocs.io/en/latest/clojurescript")))
+
 (defun cider-check-weasel-requirements ()
   "Check whether we can start a Weasel ClojureScript REPL."
   (cider-verify-piggieback-is-present)
@@ -675,6 +681,22 @@ this is a command, not just a string."
         (build (string-remove-prefix ":" (read-from-minibuffer "Select shadow-cljs build: "))))
     (format form build build)))
 
+(defcustom cider-figwheel-main-default-options nil
+  "Defines the `figwheel.main/start' options.
+
+Note that figwheel-main/start can also accept a map of options, refer to
+Figwheel for details."
+  :type 'string
+  :safe (lambda (s) (or (null s) (stringp s)))
+  :package-version '(cider . "0.18.0"))
+
+(defun cider-figwheel-main-init-form ()
+  "Produce the figwheel-main ClojureScript init form."
+  (let ((form "(do (require 'figwheel.main) (figwheel.main/start %s))")
+        (options (or cider-figwheel-main-default-options
+                     (read-from-minibuffer "Select figwheel-main build: "))))
+    (format form options)))
+
 (defun cider-custom-cljs-repl-init-form ()
   "Prompt for a form that would start a ClojureScript REPL.
 
@@ -691,6 +713,7 @@ The supplied string will be wrapped in a do form if needed."
              cider-check-nashorn-requirements)
     (figwheel "(do (require 'figwheel-sidecar.repl-api) (figwheel-sidecar.repl-api/start-figwheel!) (figwheel-sidecar.repl-api/cljs-repl))"
               cider-check-figwheel-requirements)
+    (figwheel-main cider-figwheel-main-init-form cider-check-figwheel-main-requirements)
     (node "(do (require 'cljs.repl.node) (cider.piggieback/cljs-repl (cljs.repl.node/repl-env)))"
           cider-check-node-requirements)
     (weasel "(do (require 'weasel.repl.websocket) (cider.piggieback/cljs-repl (weasel.repl.websocket/repl-env :ip \"127.0.0.1\" :port 9001)))"


### PR DESCRIPTION
This is more like a proposal, and something hacked quickly together. It mainly
adds `figwheel-main` as cljs REPL, now that it works. Note that
`cider/piggieback` needs releasing + bumping as well.

The `cider-figwheel.el` file will contain any custom configuration that Bruce
deems necessary. The `defcustom`s can of course be shared between "normal"
fighweel and figwheel-main.

I decided to create a file there, which might not necessary if we don't grow
the options at all. That `defcustom` and function can easily go into
`cider.el`.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines][1]
- [X] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog][3] (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual][4] (if adding/changing user-visible functionality)

Thanks!