### PR TITLE
Avoid setting the repl type on each and every nRepl message

### DIFF
--- a/cider-repl.el
+++ b/cider-repl.el
@@ -233,8 +233,6 @@ via `cider-current-connection'.")
   (with-demoted-errors "Error in `cider-repl--state-handler': %s"
     (when (member "state" (nrepl-dict-get response "status"))
       (nrepl-dbind-response response (repl-type changed-namespaces)
-        (when repl-type
-          (cider-repl-set-type repl-type))
         (unless (nrepl-dict-empty-p changed-namespaces)
           (setq cider-repl-ns-cache (nrepl-dict-merge cider-repl-ns-cache changed-namespaces))
           (dolist (b (buffer-list))


### PR DESCRIPTION
This PR has been opened mainly to discuss about this behavior.

When these two lines are in, the `cider-repl-type` variable is always set to
what is coming to nRepl - we trust that nRepl knows if it is in a cljs rather
then a clj REPL.

This seems not to be that true, according to my tests with a `shadow-cljs` REPL:

```
<cider-connect-clojurescript>

(do (require 'shadow.cljs.devtools.api) (shadow.cljs.devtools.api/nrepl-select
:dev))

;; in ielm
<cider-repl-type>
"cljs"

<send some cljs to the repl>
*cider-repl--state-handler called on the nrepl op return*

<cljs-repl-type>
"clj"
```

This is not what I would expect. To be honest I haven't tried other repls, but
I will.

In the meantime, any thoughts?