### PR TITLE
Feature/insert map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 
 ### New features
 
+* Create keymap for inserting forms into the repl at `C-c C-j`.
+* Add new defcustom `cider-invert-insert-eval-p`: Set to cause insert-to-repl commands to eval the forms by default when inserted.
+* Add new defcustom `cider-switch-to-repl-after-insert-p`: Set to prevent cursor from going to the repl when inserting a form in the repl with the insert-to-repl commands.
 * [#2248](https://github.com/clojure-emacs/cider/pull/2248): `cider-repl` can now display recognized images in the REPL buffer.
 * [#2172](https://github.com/clojure-emacs/cider/pull/2172): Render diffs for expected / actual test results.
 * [#2167](https://github.com/clojure-emacs/cider/pull/2167): Add new defcustom `cider-jdk-src-paths`. Configure it to connect stack trace links to Java source code.

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1570,6 +1570,15 @@ passing arguments."
   :group 'cider
   :package-version '(cider . "0.18.0"))
 
+(defcustom cider-invert-insert-eval-p nil
+  "Whether to invert the behavior of evaling.
+Default behavior when inserting is to NOT eval the form and only eval with
+a prefix. This allows to invert this so that default behavior is to insert
+and eval and the prefix is required to prevent evaluation."
+  :type 'boolean
+  :group 'cider
+  :package-version '(cider . "0.18.0"))
+
 (defun cider-insert-in-repl (form eval)
   "Insert FORM in the REPL buffer and switch to it.
 If EVAL is non-nil the form will also be evaluated."
@@ -1580,10 +1589,12 @@ If EVAL is non-nil the form will also be evaluated."
     (let ((beg (point)))
       (insert form)
       (indent-region beg (point)))
-    (when eval
+    (when (if cider-invert-insert-eval-p
+              (not eval)
+            eval)
       (cider-repl-return)))
   (when cider-switch-to-repl-after-insert-p
-   (cider-switch-to-repl-buffer)))
+    (cider-switch-to-repl-buffer)))
 
 (defun cider-insert-last-sexp-in-repl (&optional arg)
   "Insert the expression preceding point in the REPL buffer.

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1564,6 +1564,12 @@ passing arguments."
 
 ;; Connection and REPL
 
+(defcustom cider-switch-to-repl-after-insert-p t
+  "Whether to switch to the repl after inserting a form into the repl"
+  :type 'boolean
+  :group 'cider
+  :package-version '(cider . "0.18.0"))
+
 (defun cider-insert-in-repl (form eval)
   "Insert FORM in the REPL buffer and switch to it.
 If EVAL is non-nil the form will also be evaluated."
@@ -1576,7 +1582,8 @@ If EVAL is non-nil the form will also be evaluated."
       (indent-region beg (point)))
     (when eval
       (cider-repl-return)))
-  (cider-switch-to-repl-buffer))
+  (when cider-switch-to-repl-after-insert-p
+   (cider-switch-to-repl-buffer)))
 
 (defun cider-insert-last-sexp-in-repl (&optional arg)
   "Insert the expression preceding point in the REPL buffer.

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1565,7 +1565,7 @@ passing arguments."
 ;; Connection and REPL
 
 (defcustom cider-switch-to-repl-after-insert-p t
-  "Whether to switch to the repl after inserting a form into the repl"
+  "Whether to switch to the repl after inserting a form into the repl."
   :type 'boolean
   :group 'cider
   :package-version '(cider . "0.18.0"))
@@ -1573,7 +1573,7 @@ passing arguments."
 (defcustom cider-invert-insert-eval-p nil
   "Whether to invert the behavior of evaling.
 Default behavior when inserting is to NOT eval the form and only eval with
-a prefix. This allows to invert this so that default behavior is to insert
+a prefix.  This allows to invert this so that default behavior is to insert
 and eval and the prefix is required to prevent evaluation."
   :type 'boolean
   :group 'cider

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1536,6 +1536,7 @@ passing arguments."
     (define-key map (kbd "z") #'cider-eval-defun-to-point)
     (define-key map (kbd "c") #'cider-eval-last-sexp-in-context)
     (define-key map (kbd "b") #'cider-eval-sexp-at-point-in-context)
+
     ;; duplicates with C- for convenience
     (define-key map (kbd "C-w") #'cider-eval-last-sexp-and-replace)
     (define-key map (kbd "C-r") #'cider-eval-region)
@@ -1545,6 +1546,20 @@ passing arguments."
     (define-key map (kbd "C-z") #'cider-eval-defun-to-point)
     (define-key map (kbd "C-c") #'cider-eval-last-sexp-in-context)
     (define-key map (kbd "C-b") #'cider-eval-sexp-at-point-in-context)))
+
+(defvar cider-insert-commands-map
+  (let ((map (define-prefix-command 'cider-insert-commands-map)))
+    ;; single key bindings defined last for display in menu
+    (define-key map (kbd "e") #'cider-insert-last-sexp-in-repl)
+    (define-key map (kbd "d") #'cider-insert-defun-in-repl)
+    (define-key map (kbd "r") #'cider-insert-region-in-repl)
+    (define-key map (kbd "n") #'cider-insert-ns-form-in-repl)
+
+    ;; duplicates with C- for convenience
+    (define-key map (kbd "C-e") #'cider-insert-last-sexp-in-repl)
+    (define-key map (kbd "C-d") #'cider-insert-defun-in-repl)
+    (define-key map (kbd "C-r") #'cider-insert-region-in-repl)
+    (define-key map (kbd "C-n") #'cider-insert-ns-form-in-repl)))
 
 
 ;; Connection and REPL

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -331,6 +331,7 @@ Configure `cider-cljs-repl-types' to change the ClojureScript REPL to use for yo
     (define-key map (kbd "C-x C-e") #'cider-eval-last-sexp)
     (define-key map (kbd "C-c C-e") #'cider-eval-last-sexp)
     (define-key map (kbd "C-c C-v") 'cider-eval-commands-map)
+    (define-key map (kbd "C-c C-j") 'cider-insert-commands-map)
     (define-key map (kbd "C-c M-;") #'cider-eval-defun-to-comment)
     (define-key map (kbd "C-c M-e") #'cider-eval-last-sexp-to-repl)
     (define-key map (kbd "C-c M-p") #'cider-insert-last-sexp-in-repl)


### PR DESCRIPTION
I noticed the insert-into-repl commands didn't have an easy map to use those commands so I added them under a map. Allows some defcustoms to tweak the behavior:

- `cider-invert-insert-eval-p`: Previously, the prefix arg was required to have the inserted form evaluated and the default behavior was to just plop the form in the repl. This inverts that so that by default the forms are inserted and then evaluated. The benefit is that now the repl has a sequence of values and the forms that give those values context.
- `cider-switch-to-repl-after-insert-p`: Previously when using an insert command point was moved into the repl buffer unconditionally. Now it is conditional. This is desirable since now that it is easy to have inserted forms evaluated by default the repl often doesn't need focus after each insertion.

The motivation behind these changes is when working with `comment` forms.

Imagine some comment forms that are useful for inspecting your namespace. This makes it easy to eval a sequence of them and put their forms and results in the repl so there is a sense of context. It is also easy to put a prefix arg on them to prevent evaluation and then modify them if you need.

This does some work towards @halgari 's issue in https://github.com/clojure-emacs/cider/issues/2255 in putting a similar behavior to Cursive into CIDER. Notice how the evaluations from the comment form are plopped into the repl to give a sense of context to the state of the repl. That workflow now will work with the caveat that you have to be at the end of the form rather than any point inside of it (but that is next on the roadmap). This felt like a way to get 70% of the functionality there quickly.

To emulate the behavior of that gif, do

```elisp

(setq cider-invert-insert-eval-p t)            ;; eval after inserting by default
(setq cider-switch-to-repl-after-insert-p nil) ;; don't switch to the repl buffer
```

Then the insert map is now at `C-c C-j`. There you will find
- `e`: insert last sexp
- `d` insert top level defun (not modified yet to work with `comment` forms intelligently yet
- `r` insert region
- `n` insert ns form