### PR TITLE
Refactor in order to solve linting problems

### DIFF
--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -100,6 +100,8 @@ ns forms manually themselves."
   :group 'cider
   :package-version '(cider . "0.15.0"))
 
+(define-obsolete-variable-alias 'cider-prompt-save-file-on-load 'cider-save-file-on-load "0.15.0")
+
 (defcustom cider-save-file-on-load 'prompt
   "Controls whether to prompt to save the file when loading a buffer.
 If nil, files are not saved.
@@ -110,8 +112,6 @@ If t, save the file without confirmation."
                  (const t :tag "Save the file without confirmation"))
   :group 'cider
   :package-version '(cider . "0.6.0"))
-
-(define-obsolete-variable-alias 'cider-prompt-save-file-on-load 'cider-save-file-on-load "0.15.0")
 
 (defcustom cider-save-files-on-cider-refresh 'prompt
   "Controls whether to prompt to save Clojure files on `cider-refresh'.

--- a/cider-profile.el
+++ b/cider-profile.el
@@ -26,6 +26,7 @@
 ;;; Code:
 
 (require 'cider-client)
+(require 'cider-interaction)
 
 (defconst cider-profile-buffer "*cider-profile*")
 

--- a/cider-test.el
+++ b/cider-test.el
@@ -619,6 +619,7 @@ This uses the Leiningen convention of appending '-test' to the namespace name."
 
 (declare-function cider-emit-interactive-eval-output "cider-interaction")
 (declare-function cider-emit-interactive-eval-err-output "cider-interaction")
+(declare-function cider-read-from-minibuffer "cider-interaction")
 
 (defun cider-test-execute (ns &optional tests silent prompt-for-filters)
   "Run tests for NS, which may be a keyword, optionally specifying TESTS.


### PR DESCRIPTION
Move the cider-save-file-on-load alias up and require cider-interaction in
cider-profiles in order to make the linter happy again.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines][1]
- [X] All tests are passing (`make test`)
- [X] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.