### PR TITLE
Eval top level defuns inside comment forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### New features
 
+* Allow evaling top level forms in a comment form rather than the entire comment form with `cider-eval-toplevel-inside-comment-form`.
 * Create keymap for inserting forms into the repl at `C-c C-j`.
 * Add new defcustom `cider-invert-insert-eval-p`: Set to cause insert-to-repl commands to eval the forms by default when inserted.
 * Add new defcustom `cider-switch-to-repl-after-insert-p`: Set to prevent cursor from going to the repl when inserting a form in the repl with the insert-to-repl commands.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### New features
 
+* Allow evaling top level forms in a comment form rather than the entire comment form with `cider-eval-toplevel-inside-comment-form`.
+* Create keymap for inserting forms into the repl at `C-c C-j`.
+* Add new defcustom `cider-invert-insert-eval-p`: Set to cause insert-to-repl commands to eval the forms by default when inserted.
+* Add new defcustom `cider-switch-to-repl-after-insert-p`: Set to prevent cursor from going to the repl when inserting a form in the repl with the insert-to-repl commands.
 * Inject piggieback automatically on `cider-jack-in-clojurescript`.
 
 ### Bugs fixed
@@ -17,10 +21,6 @@
 
 ### New features
 
-* Allow evaling top level forms in a comment form rather than the entire comment form with `cider-eval-toplevel-inside-comment-form`.
-* Create keymap for inserting forms into the repl at `C-c C-j`.
-* Add new defcustom `cider-invert-insert-eval-p`: Set to cause insert-to-repl commands to eval the forms by default when inserted.
-* Add new defcustom `cider-switch-to-repl-after-insert-p`: Set to prevent cursor from going to the repl when inserting a form in the repl with the insert-to-repl commands.
 * [#2248](https://github.com/clojure-emacs/cider/pull/2248): `cider-repl` can now display recognized images in the REPL buffer.
 * [#2172](https://github.com/clojure-emacs/cider/pull/2172): Render diffs for expected / actual test results.
 * [#2167](https://github.com/clojure-emacs/cider/pull/2167): Add new defcustom `cider-jdk-src-paths`. Configure it to connect stack trace links to Java source code.

--- a/cider-util.el
+++ b/cider-util.el
@@ -132,9 +132,9 @@ position."
     (save-match-data
       ;; ensure point is against the nearest form
       (when (not (looking-at-p "[[:graph:]]"))
-       (while (not (looking-at-p "[[:graph:]]"))
-         (backward-char 1))
-       (forward-char 1))
+        (while (not (looking-at-p "[[:graph:]]"))
+          (backward-char 1))
+        (forward-char 1))
       (let ((cider-original (point))
             top-level-limits
             cider-comment-end
@@ -146,18 +146,18 @@ position."
         (forward-char 1)                  ;; skip paren so we start at comment
         (clojure-forward-logical-sexp)    ;; skip past the comment form itself
         (condition-case nil
-         (while (and (< (point) cider-comment-end)
-                     (null top-level-limits))
-           (let (cider-sexp-start cider-sexp-end)
-             (clojure-forward-logical-sexp 1) ;; goto end of form
-             (setq cider-sexp-end (point))
-             ;; set beginning of form to exclude whitespace between this and end of last
-             (clojure-backward-logical-sexp 1)
-             (setq cider-sexp-start (point))
-             (goto-char cider-sexp-end)
-             (when (<= cider-sexp-start cider-original cider-sexp-end)
-               (setq top-level-limits (list cider-sexp-start cider-sexp-end)))))
-         (scan-error nil))
+            (while (and (< (point) cider-comment-end)
+                        (null top-level-limits))
+              (let (cider-sexp-start cider-sexp-end)
+                (clojure-forward-logical-sexp 1) ;; goto end of form
+                (setq cider-sexp-end (point))
+                ;; set beginning of form to exclude whitespace between this and end of last
+                (clojure-backward-logical-sexp 1)
+                (setq cider-sexp-start (point))
+                (goto-char cider-sexp-end)
+                (when (<= cider-sexp-start cider-original cider-sexp-end)
+                  (setq top-level-limits (list cider-sexp-start cider-sexp-end)))))
+          (scan-error nil))
         (if top-level-limits
             (cider--text-or-limits bounds (car top-level-limits) (cadr top-level-limits))
           (cider--text-or-limits bounds cider-comment-start cider-comment-end))))))

--- a/cider-util.el
+++ b/cider-util.el
@@ -169,13 +169,12 @@ instead."
   (if (and cider-eval-toplevel-inside-comment-form
            (cider-top-level-comment-p))
       (cider-defun-inside-comment-form bounds)
-    (let ((original-position (point)))
-      (save-excursion
-        (save-match-data
-          (end-of-defun)
-          (let ((end (point)))
-            (clojure-backward-logical-sexp 1)
-            (cider--text-or-limits bounds (point) end)))))))
+    (save-excursion
+      (save-match-data
+        (end-of-defun)
+        (let ((end (point)))
+          (clojure-backward-logical-sexp 1)
+          (cider--text-or-limits bounds (point) end))))))
 
 (defun cider-ns-form ()
   "Retrieve the ns form."

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -160,7 +160,7 @@ and point left there."
               (right)     |
               (wrong))"
          (expect (cider-defun-inside-comment-form) :to-equal "(right)")))
-    (it "attaches to the previous top level comment even if its on the same line"
+    (it "attaches to the next top level comment even if its on the same line"
       (cider-buffer-with-text
           "(comment
               (wrong)
@@ -182,16 +182,16 @@ and point left there."
               (wrong)
               (wrong)
               (right|))"
+          (expect (cider-defun-inside-comment-form) :to-equal "(right)")))
+    (it "works on the last form even after the comment form"
+      (cider-buffer-with-text
+          "(comment (wrong) (wrong) (right)) |"
           (expect (cider-defun-inside-comment-form) :to-equal "(right)"))))
   (describe "returns entire comment form when"
     (it "the comment form is empty"
       (cider-buffer-with-text
           "(comment|)"
-          (expect (cider-defun-inside-comment-form) :to-equal "(comment)")))
-    (it "point is after the comment form"
-      (cider-buffer-with-text
-          "(comment stuff stuff stuff)|"
-          (expect (cider-defun-inside-comment-form) :to-equal "(comment stuff stuff stuff)")))))
+          (expect (cider-defun-inside-comment-form) :to-equal "(comment)")))))
 
 (describe "cider-defun-at-point"
   (describe "when the param 'bounds is not given"

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -126,6 +126,73 @@
         (insert "'")
         (expect (cider-sexp-at-point 'bounds) :to-equal '(5 15))))))
 
+(defmacro cider-buffer-with-text
+    (text &rest body)
+  "Run body in a temporary clojure buffer with TEXT.
+TEXT is a string with a | indicating where point is. The | will be erased
+and point left there."
+  (declare (indent 2))
+  `(progn
+     (with-temp-buffer
+       (erase-buffer)
+       (clojure-mode)
+       (insert ,text)
+       (goto-char (point-min))
+       (re-search-forward "|")
+       (delete-char -1)
+       ,@body)))
+
+(describe "cider-defun-inside-comment-form"
+  (describe "when param 'bounds is not given"
+    (it "returns the form containing point"
+      (cider-buffer-with-text
+          "(comment
+              (wrong)
+              (wrong)
+              (rig|ht)
+              (wrong))"
+          (expect (cider-defun-inside-comment-form) :to-equal "(right)")))
+    (it "attaches to the previous top level comment"
+     (cider-buffer-with-text
+         "(comment
+              (wrong)
+              (wrong)
+              (right)     |
+              (wrong))"
+         (expect (cider-defun-inside-comment-form) :to-equal "(right)")))
+    (it "attaches to the previous top level comment even if its on the same line"
+      (cider-buffer-with-text
+          "(comment
+              (wrong)
+              (wrong)
+              (right)
+    |         (wrong))"
+          (expect (cider-defun-inside-comment-form) :to-equal "(right)")))
+    (it "returns the top level even if heavily nested"
+      (cider-buffer-with-text
+          "(comment
+              (wrong)
+              (wrong)
+              (((((r|ight)))))
+              (wrong))"
+          (expect (cider-defun-inside-comment-form) :to-equal "(((((right)))))")))
+    (it "works even on the last form in a comment"
+      (cider-buffer-with-text
+          "(comment
+              (wrong)
+              (wrong)
+              (right|))"
+          (expect (cider-defun-inside-comment-form) :to-equal "(right)"))))
+  (describe "returns entire comment form when"
+    (it "the comment form is empty"
+      (cider-buffer-with-text
+          "(comment|)"
+          (expect (cider-defun-inside-comment-form) :to-equal "(comment)")))
+    (it "point is after the comment form"
+      (cider-buffer-with-text
+          "(comment stuff stuff stuff)|"
+          (expect (cider-defun-inside-comment-form) :to-equal "(comment stuff stuff stuff)")))))
+
 (describe "cider-defun-at-point"
   (describe "when the param 'bounds is not given"
     (it "returns the defun at point"


### PR DESCRIPTION
Since this is a sensitive codepath (cider-defun-at-point), it is risky
to change its behavior due to introducing bugs or introducing
unexpected behavior. This _should_ only affect evaluation inside a
comment form but we want to be careful. Therefore there is a defcustom
`cider-eval-toplevel-inside-comment-form` while others test this. If
there is a bug, it is easy for users to turn this feature off completely.

The tests are pretty indicative of the desired behavior:

```lisp
      (cider-buffer-with-text
          "(comment
              (wrong)
              (wrong)
              (rig|ht)
              (wrong))"
          (expect (cider-defun-inside-comment-form) :to-equal "(right)"))

     (cider-buffer-with-text
         "(comment
              (wrong)
              (wrong)
              (right)     |
              (wrong))"
         (expect (cider-defun-inside-comment-form) :to-equal "(right)"))

      (cider-buffer-with-text
          "(comment
              (wrong)
              (wrong)
              (((((r|ight)))))
              (wrong))"
          (expect (cider-defun-inside-comment-form) :to-equal "(((((right)))))"))
```

This is a pretty hot codepath so it must be enabled for the time being with `cider-eval-toplevel-inside-comment-form` while we make sure it is both bug free and desired.

This combined with the new insert map `C-c C-j [ednr]` makes comment forms very usable.

@halgari asked for this in https://github.com/clojure-emacs/cider/issues/2255.