### PR TITLE
[sesman] Expand paths before link registration

### DIFF
--- a/cider-connection.el
+++ b/cider-connection.el
@@ -70,7 +70,7 @@ PARAMS is a plist containing :host, :port, :server and other parameters for
 
 (defun cider-connected-p ()
   "Return t if CIDER is currently connected, nil otherwise."
-  (sesman-has-links-p 'CIDER))
+  (process-live-p (get-buffer-process (cider-current-repl))))
 
 (defun cider-ensure-connected ()
   "Ensure there is a linked CIDER session."


### PR DESCRIPTION
Fixes #2330 and #2331. It was `default-directory` abbreviation issue. 

Also make `(cider-connected-p)` more reliable.

// fix #2330, fix #2331