### PR TITLE
Added `cider-eval-sexp-to-point` for [Feature #2328]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs fixed
 
+* [#2328](https://github.com/clojure-emacs/cider/issues/2328): Added `cider-eval-sexp-to-point`.
 * [#2310](https://github.com/clojure-emacs/cider/issues/2310): `cider-format-edn-last-sexp` will format the last sexp.
 * [#2294](https://github.com/clojure-emacs/cider/issues/2294): Fix setting default stacktrace filters.
 * [#2286](https://github.com/clojure-emacs/cider/issues/2286): Fix eldoc issue with images in the REPL.

--- a/cider-interaction.el
+++ b/cider-interaction.el
@@ -1440,6 +1440,24 @@ It constructs an expression to eval in the following manner:
          (code (concat code (cider--calculate-closing-delimiters))))
     (cider-interactive-eval code)))
 
+(defun cider-eval-sexp-to-point (&optional  output-to-current-buffer)
+  "Evaluate the current sexp form up to point.
+If invoked with OUTPUT-TO-CURRENT-BUFFER, print the result in the current buffer.
+It constructs an expression to eval in the following manner:
+
+- It finds the code between the point and the start of the sexp expression;
+- It balances this bit of code by closing the expression;
+- It evaluates the resulting code using `cider-interactive-eval'."
+  (interactive "P")
+  (let* ((beg-of-sexp (save-excursion (up-list) (backward-list) (point)))
+         (beg-delimiter (save-excursion (up-list) (backward-list) (char-after)))
+         (beg-set?  (save-excursion (up-list) (backward-list) (char-before)))
+         (code (buffer-substring-no-properties beg-of-sexp (point)))
+         (code (if (= beg-set? ?#) (concat (list beg-set?) code) code))
+         (code (concat code (list (cider--matching-delimiter beg-delimiter)))))
+    (cider-interactive-eval code
+                            (when output-to-current-buffer (cider-eval-print-handler)))))
+
 (defun cider-pprint-eval-defun-at-point (&optional output-to-current-buffer)
   "Evaluate the \"top-level\" form at point and pprint its value.
 If invoked with OUTPUT-TO-CURRENT-BUFFER, insert as comment in the current
@@ -1491,6 +1509,7 @@ passing arguments."
     (define-key map (kbd "r") #'cider-eval-region)
     (define-key map (kbd "n") #'cider-eval-ns-form)
     (define-key map (kbd "v") #'cider-eval-sexp-at-point)
+    (define-key map (kbd "o") #'cider-eval-sexp-to-point)
     (define-key map (kbd ".") #'cider-read-and-eval-defun-at-point)
     (define-key map (kbd "z") #'cider-eval-defun-to-point)
     (define-key map (kbd "c") #'cider-eval-last-sexp-in-context)
@@ -1501,6 +1520,7 @@ passing arguments."
     (define-key map (kbd "C-r") #'cider-eval-region)
     (define-key map (kbd "C-n") #'cider-eval-ns-form)
     (define-key map (kbd "C-v") #'cider-eval-sexp-at-point)
+    (define-key map (kbd "C-o") #'cider-eval-sexp-to-point)
     (define-key map (kbd "C-.") #'cider-read-and-eval-defun-at-point)
     (define-key map (kbd "C-z") #'cider-eval-defun-to-point)
     (define-key map (kbd "C-c") #'cider-eval-last-sexp-in-context)

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -212,6 +212,7 @@ Configure `cider-cljs-repl-types' to change the ClojureScript REPL to use for yo
     ["Eval top-level sexp" cider-eval-defun-at-point]
     ["Eval top-level sexp to point" cider-eval-defun-to-point]
     ["Eval current sexp" cider-eval-sexp-at-point]
+    ["Eval current sexp to point" cider-eval-sexp-to-point]
     ["Eval current sexp in context" cider-eval-sexp-at-point-in-context]
     ["Eval last sexp" cider-eval-last-sexp]
     ["Eval last sexp in context" cider-eval-last-sexp-in-context]


### PR DESCRIPTION

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines][1]
- [X] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`make test`)
- [X] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [X] You've updated the [changelog][3] (if adding/changing user-visible functionality)
- [X] You've updated the [user manual][4] (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][2] extremely useful.*

[1]: https://github.com/clojure-emacs/cider/blob/master/.github/CONTRIBUTING.md
[2]: https://cider.readthedocs.io/en/latest/hacking_on_cider/
[3]: https://github.com/clojure-emacs/cider/blob/master/CHANGELOG.md
[4]: https://github.com/clojure-emacs/cider/tree/master/doc
