### PR TITLE
classpath libs support on Windows

### DIFF
--- a/cider-client.el
+++ b/cider-client.el
@@ -273,9 +273,10 @@ clobber *1/2/3)."
   "Return a list of all libs on the classpath."
   (let ((libs (seq-filter (lambda (cp-entry)
                             (string-suffix-p ".jar" cp-entry))
-                          (cider-sync-request:classpath))))
+                          (cider-sync-request:classpath)))
+        (dir-sep (if (string-equal system-type "windows-nt") "\\\\" "/")))
     (thread-last libs
-      (seq-map (lambda (s) (split-string s "/")))
+      (seq-map (lambda (s) (split-string s dir-sep)))
       (seq-map #'reverse)
       (seq-map (lambda (l) (reverse (seq-take l 4)))))))
 

--- a/cider.el
+++ b/cider.el
@@ -1190,6 +1190,7 @@ In case `default-directory' is non-local we assume the command is available."
      (define-key clojure-mode-map (kbd "C-c M-x") #'cider)
      (define-key clojure-mode-map (kbd "C-c M-j") #'cider-jack-in-clj)
      (define-key clojure-mode-map (kbd "C-c M-J") #'cider-jack-in-cljs)
+     (define-key clojure-mode-map (kbd "C-C M-J") #'cider-jack-in-clj&cljs)
      (define-key clojure-mode-map (kbd "C-c M-c") #'cider-connect-clj)
      (define-key clojure-mode-map (kbd "C-c M-C") #'cider-connect-cljs)
      (define-key clojure-mode-map (kbd "C-c M-s") #'cider-connect-sibling-clj)

--- a/cider.el
+++ b/cider.el
@@ -1190,7 +1190,6 @@ In case `default-directory' is non-local we assume the command is available."
      (define-key clojure-mode-map (kbd "C-c M-x") #'cider)
      (define-key clojure-mode-map (kbd "C-c M-j") #'cider-jack-in-clj)
      (define-key clojure-mode-map (kbd "C-c M-J") #'cider-jack-in-cljs)
-     (define-key clojure-mode-map (kbd "C-C M-J") #'cider-jack-in-clj&cljs)
      (define-key clojure-mode-map (kbd "C-c M-c") #'cider-connect-clj)
      (define-key clojure-mode-map (kbd "C-c M-C") #'cider-connect-cljs)
      (define-key clojure-mode-map (kbd "C-c M-s") #'cider-connect-sibling-clj)


### PR DESCRIPTION
handle classpath on windows with directory seperator `\` when call cider-classpath-libs.