### PR TITLE
Correctly format shadow command when it is "npx shadow-cljs"

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -327,7 +327,9 @@ Throws an error if PROJECT-TYPE is unknown.  Known types are
     ("clojure-cli" (cider--resolve-command cider-clojure-cli-command))
     ;; here we have to account for the possibility that the command is either
     ;; "npx shadow-cljs" or just "shadow-cljs"
-    ("shadow-cljs" (cider--resolve-command (car (split-string cider-shadow-cljs-command))))
+    ("shadow-cljs" (let ((parts (split-string cider-shadow-cljs-command)))
+                     (when-let* ((command (cider--resolve-command (car parts))))
+                       (mapconcat #'identity (cons command (cdr parts)) " "))))
     ("gradle" (cider--resolve-command cider-gradle-command))
     (_ (user-error "Unsupported project type `%s'" project-type))))
 


### PR DESCRIPTION
Previously called `(cider--resolve-command (car (split-string
cider-shadow-cljs-command)))` on "npx shadow-cljs" would return "npx"
and drop the shadow-cljs. This would lead to the error message that
server was not a valid option as the command was "npx [cider-stuff]
server" instead of "npx shadow-cljs [cider-stuff] server"

Old version would create commands like
```bash
/home/dan/.nvm/versions/node/v8.9.2/bin/npx -d org.clojure/tools.nrepl:0.2.13 -d cider/piggieback:0.3.5 -d cider/cider-nrepl:0.18.0-SNAPSHOT server
```

which omits the all-important `shadow-cljs` binary to run with npx