### PR TITLE
Require cider-find from cider.el

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -79,6 +79,7 @@
 (require 'cider-common)
 (require 'cider-compat)
 (require 'cider-debug)
+(require 'cider-find)
 
 (require 'tramp-sh)
 (require 'subr-x)


### PR DESCRIPTION
Nothing loaded this code from cider previously leading to
cider-find-var being undefined. Probably other things broken as well.
