### PR TITLE
Free connect-siblings C-c M-s key and bind C-c M-r to cider-restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### New features
 
+* Bind `C-c M-r` to `cider-restart`.
+* Add new `cider-start-map` keymap (`C-c C-x`) for jack-in and connection commands.
+* Add new `cider-ns-map` keymap (`C-c M-n`) for namespace related functionality.
 * Allow evaling top level forms in a comment form rather than the entire comment form with `cider-eval-toplevel-inside-comment-form`.
 * Create keymap for inserting forms into the repl at `C-c C-j`.
 * Add new defcustom `cider-invert-insert-eval-p`: Set to cause insert-to-repl commands to eval the forms by default when inserted.
@@ -26,6 +29,7 @@
 
 ### Changes
 
+* **(Breaking)** Move `cider-repl-set-ns`, previously on `C-c M-n`, on `C-c M-n M-n` in the `cider-ns-map`.
 * **(Breaking)** Bump the minimum required Emacs version to 25.1.
 * **(Breaking)** Drop support for Java 7 and Clojure(Script) 1.7.
 * Rename `cider-eval-defun-to-point` to `cider-eval-defun-up-to-point`.

--- a/cider-browse-ns.el
+++ b/cider-browse-ns.el
@@ -79,6 +79,7 @@
 
 \\{cider-browse-ns-mode-map}"
   (setq-local electric-indent-chars nil)
+  (setq-local sesman-system 'CIDER)
   (when cider-special-mode-truncate-lines
     (setq-local truncate-lines t))
   (setq-local cider-browse-ns-current-ns nil))

--- a/cider-browse-spec.el
+++ b/cider-browse-spec.el
@@ -64,6 +64,7 @@
 
 \\{cider-browse-spec-mode-map}"
   (setq-local electric-indent-chars nil)
+  (setq-local sesman-system 'CIDER)
   (when cider-special-mode-truncate-lines
     (setq-local truncate-lines t)))
 
@@ -86,6 +87,7 @@
 \\{cider-browse-spec-view-mode-map}"
   (setq-local cider-browse-spec--current-spec nil)
   (setq-local electric-indent-chars nil)
+  (setq-local sesman-system 'CIDER)
   (when cider-special-mode-truncate-lines
     (setq-local truncate-lines t)))
 
@@ -104,6 +106,7 @@
 \\{cider-browse-spec-example-mode-map}"
   (setq-local electric-indent-chars nil)
   (setq-local revert-buffer-function #'cider-browse-spec--example-revert-buffer-function)
+  (setq-local sesman-system 'CIDER)
   (when cider-special-mode-truncate-lines
     (setq-local truncate-lines t)))
 

--- a/cider-classpath.el
+++ b/cider-classpath.el
@@ -48,6 +48,7 @@
 
 \\{cider-classpath-mode-map}"
   (setq-local electric-indent-chars nil)
+  (setq-local sesman-system 'CIDER)
   (when cider-special-mode-truncate-lines
     (setq-local truncate-lines t)))
 

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -377,10 +377,11 @@ Don't restart the server or other connections within the same session.  Use
             (cider--connection-info repl t)
             (mapconcat #'buffer-name (cdr session) ", "))))
 
-(declare-function cider-jack-in-clj&cljs "cider")
+(declare-function cider "cider")
 (cl-defmethod sesman-start-session ((_system (eql CIDER)))
-  "Start a clj session with a cljs REPL if cljs requirements are met."
-  (cider-jack-in-clj&cljs nil t))
+  "Start a connection of any type interactively.
+Fallback on `cider' command."
+  (call-interactively #'cider))
 
 (cl-defmethod sesman-quit-session ((_system (eql CIDER)) session)
   (mapc #'cider--close-connection (cdr session))

--- a/cider-doc.el
+++ b/cider-doc.el
@@ -184,6 +184,7 @@
 
 \\{cider-docview-mode-map}"
   (setq buffer-read-only t)
+  (setq-local sesman-system 'CIDER)
   (when cider-special-mode-truncate-lines
     (setq-local truncate-lines t))
   (setq-local electric-indent-chars nil)

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -84,6 +84,7 @@ The page size can be also changed interactively within the inspector."
 \\{cider-inspector-mode-map}"
   (set-syntax-table clojure-mode-syntax-table)
   (setq-local electric-indent-chars nil)
+  (setq-local sesman-system 'CIDER)
   (when cider-special-mode-truncate-lines
     (setq-local truncate-lines t)))
 

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -463,6 +463,7 @@ If invoked with a prefix ARG eval the expression after inserting it."
     (define-key map (kbd "C-c C-=") 'cider-profile-map)
     (define-key map (kbd "C-c C-x") #'cider-ns-refresh)
     (define-key map (kbd "C-c C-q") #'cider-quit)
+    (define-key map (kbd "C-c M-r") #'cider-restart)
     (dolist (variable '(cider-mode-interactions-menu
                         cider-mode-eval-menu
                         cider-mode-menu))

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -408,6 +408,28 @@ If invoked with a prefix ARG eval the expression after inserting it."
      ["Flush completion cache" cider-completion-flush-caches]))
   "Menu for CIDER interactions.")
 
+
+(declare-function cider-ns-refresh "cider-ns")
+(declare-function cider-browse-ns "cider-browse-ns")
+(declare-function cider-eval-ns-form "cider-eval")
+(declare-function cider-repl-set-ns "cider-repl")
+(declare-function cider-find-ns "cider-find")
+
+(defvar cider-ns-map
+  (let ((map (define-prefix-command 'cider-ns-map)))
+    (define-key map (kbd "b") #'cider-browse-ns)
+    (define-key map (kbd "M-b") #'cider-browse-ns)
+    (define-key map (kbd "e") #'cider-eval-ns-form)
+    (define-key map (kbd "M-e") #'cider-eval-ns-form)
+    (define-key map (kbd "f") #'cider-find-ns)
+    (define-key map (kbd "M-f") #'cider-find-ns)
+    (define-key map (kbd "n") #'cider-repl-set-ns)
+    (define-key map (kbd "M-n") #'cider-repl-set-ns)
+    (define-key map (kbd "r") #'cider-ns-refresh)
+    (define-key map (kbd "M-r") #'cider-ns-refresh)
+    map)
+  "CIDER NS keymap.")
+
 ;; Those declares are needed, because we autoload all those commands when first
 ;; used. That optimizes CIDER's initial load time.
 (declare-function cider-macroexpand-1 "cider-macroexpansion")
@@ -415,9 +437,7 @@ If invoked with a prefix ARG eval the expression after inserting it."
 (declare-function cider-selector "cider-selector")
 (declare-function cider-toggle-trace-ns "cider-tracing")
 (declare-function cider-toggle-trace-var "cider-tracing")
-(declare-function cider-ns-refresh "cider-ns")
 (declare-function cider-find-resource "cider-find")
-(declare-function cider-find-ns "cider-find")
 (declare-function cider-find-keyword "cider-find")
 (declare-function cider-find-var "cider-find")
 
@@ -445,7 +465,7 @@ If invoked with a prefix ARG eval the expression after inserting it."
     (define-key map (kbd "C-c C-u") #'cider-undef)
     (define-key map (kbd "C-c C-m") #'cider-macroexpand-1)
     (define-key map (kbd "C-c M-m") #'cider-macroexpand-all)
-    (define-key map (kbd "C-c M-n") #'cider-repl-set-ns)
+    (define-key map (kbd "C-c M-n") 'cider-ns-map)
     (define-key map (kbd "C-c M-i") #'cider-inspect)
     (define-key map (kbd "C-c M-t v") #'cider-toggle-trace-var)
     (define-key map (kbd "C-c M-t n") #'cider-toggle-trace-ns)
@@ -461,7 +481,6 @@ If invoked with a prefix ARG eval the expression after inserting it."
     (define-key map (kbd "C-c M-s") #'cider-selector)
     (define-key map (kbd "C-c M-d") #'cider-describe-current-connection)
     (define-key map (kbd "C-c C-=") 'cider-profile-map)
-    (define-key map (kbd "C-c C-x") #'cider-ns-refresh)
     (define-key map (kbd "C-c C-q") #'cider-quit)
     (define-key map (kbd "C-c M-r") #'cider-restart)
     (dolist (variable '(cider-mode-interactions-menu

--- a/cider-repl-history.el
+++ b/cider-repl-history.el
@@ -692,6 +692,7 @@ text from the *cider-repl-history* buffer."
   "Major mode for browsing the entries in the command input history.
 
 \\{cider-repl-history-mode-map}"
+  (setq-local sesman-system 'CIDER)
   (define-key cider-repl-history-mode-map (kbd "n") 'cider-repl-history-forward)
   (define-key cider-repl-history-mode-map (kbd "p") 'cider-repl-history-previous)
   (define-key cider-repl-history-mode-map (kbd "SPC") 'cider-repl-history-insert-and-quit)

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1618,6 +1618,7 @@ constructs."
     (define-key map (kbd "C-c M-s") #'cider-selector)
     (define-key map (kbd "C-c M-d") #'cider-describe-current-connection)
     (define-key map (kbd "C-c C-q") #'cider-quit)
+    (define-key map (kbd "C-c M-r") #'cider-restart)
     (define-key map (kbd "C-c M-i") #'cider-inspect)
     (define-key map (kbd "C-c M-p") #'cider-repl-history)
     (define-key map (kbd "C-c M-t v") #'cider-toggle-trace-var)

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1578,8 +1578,6 @@ constructs."
 (declare-function cider-jack-in-cljs "cider")
 (declare-function cider-connect-clj "cider")
 (declare-function cider-connect-cljs "cider")
-(declare-function cider-connect-sibling-clj "cider")
-(declare-function cider-connect-sibling-cljs "cider")
 
 (defvar cider-repl-mode-map
   (let ((map (make-sparse-keymap)))
@@ -1623,7 +1621,7 @@ constructs."
     (define-key map (kbd "C-c M-p") #'cider-repl-history)
     (define-key map (kbd "C-c M-t v") #'cider-toggle-trace-var)
     (define-key map (kbd "C-c M-t n") #'cider-toggle-trace-ns)
-    (define-key map (kbd "C-c C-x") #'cider-ns-refresh)
+    (define-key map (kbd "C-c C-x") 'cider-start-map)
     (define-key map (kbd "C-x C-e") #'cider-eval-last-sexp)
     (define-key map (kbd "C-c C-r") 'clojure-refactor-map)
     (define-key map (kbd "C-c C-v") 'cider-eval-commands-map)
@@ -1631,8 +1629,6 @@ constructs."
     (define-key map (kbd "C-c M-J") #'cider-jack-in-cljs)
     (define-key map (kbd "C-c M-c") #'cider-connect-clj)
     (define-key map (kbd "C-c M-C") #'cider-connect-cljs)
-    (define-key map (kbd "C-c M-s") #'cider-connect-sibling-clj)
-    (define-key map (kbd "C-c M-S") #'cider-connect-sibling-cljs)
 
     (define-key map (string cider-repl-shortcut-dispatch-char) #'cider-repl-handle-shortcut)
     (easy-menu-define cider-repl-mode-menu map

--- a/cider-scratch.el
+++ b/cider-scratch.el
@@ -73,7 +73,8 @@
 Like clojure-mode except that \\[cider-eval-print-last-sexp] evals the Lisp expression
 before point, and prints its value into the buffer, advancing point.
 
-\\{cider-clojure-interaction-mode-map}")
+\\{cider-clojure-interaction-mode-map}"
+  (setq-local sesman-system 'CIDER))
 
 (defun cider-scratch--insert-welcome-message ()
   "Insert the welcome message for the scratch buffer."

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -235,6 +235,7 @@ The error types are represented as strings."
 \\{cider-stacktrace-mode-map}"
   (when cider-special-mode-truncate-lines
     (setq-local truncate-lines t))
+  (setq-local sesman-system 'CIDER)
   (setq-local electric-indent-chars nil)
   (setq-local cider-stacktrace-hidden-frame-count 0)
   (setq-local cider-stacktrace-filters cider-stacktrace-default-filters)

--- a/cider-test.el
+++ b/cider-test.el
@@ -224,6 +224,7 @@ Add to this list to have CIDER recognize additional test defining macros."
   (setq buffer-read-only t)
   (when cider-special-mode-truncate-lines
     (setq-local truncate-lines t))
+  (setq-local sesman-system 'CIDER)
   (setq-local electric-indent-chars nil))
 
 ;; Report navigation

--- a/cider.el
+++ b/cider.el
@@ -1233,7 +1233,8 @@ assume the command is available."
      (define-key clojure-mode-map (kbd "C-c C-x") 'cider-start-map)
      (define-key clojure-mode-map (kbd "C-c C-s") 'sesman-map)
      (require 'sesman)
-     (sesman-install-menu clojure-mode-map)))
+     (sesman-install-menu clojure-mode-map)
+     (add-hook 'clojure-mode-hook (lambda () (setq-local sesman-system 'CIDER)))))
 
 (provide 'cider)
 

--- a/cider.el
+++ b/cider.el
@@ -890,6 +890,39 @@ nil."
 
 ;;; User Level Connectors
 
+(defvar cider-start-map
+  (let ((map (define-prefix-command 'cider-start-map)))
+
+    (define-key map (kbd "j j") #'cider-jack-in-clj)
+    (define-key map (kbd "j s") #'cider-jack-in-cljs)
+    (define-key map (kbd "j m") #'cider-jack-in-clj&cljs)
+    (define-key map (kbd "C-j j") #'cider-jack-in-clj)
+    (define-key map (kbd "C-j s") #'cider-jack-in-cljs)
+    (define-key map (kbd "C-j m") #'cider-jack-in-clj&cljs)
+    (define-key map (kbd "C-j C-j") #'cider-jack-in-clj)
+    (define-key map (kbd "C-j C-s") #'cider-jack-in-cljs)
+    (define-key map (kbd "C-j C-m") #'cider-jack-in-clj&cljs)
+
+    (define-key map (kbd "c j") #'cider-connect-clj)
+    (define-key map (kbd "c s") #'cider-connect-cljs)
+    (define-key map (kbd "c m") #'cider-connect-clj&cljs)
+    (define-key map (kbd "C-c j") #'cider-connect-clj)
+    (define-key map (kbd "C-c s") #'cider-connect-cljs)
+    (define-key map (kbd "C-c m") #'cider-connect-clj&cljs)
+    (define-key map (kbd "C-c C-j") #'cider-connect-clj)
+    (define-key map (kbd "C-c C-s") #'cider-connect-cljs)
+    (define-key map (kbd "C-c C-m") #'cider-connect-clj&cljs)
+
+    (define-key map (kbd "s j") #'cider-connect-sibling-clj)
+    (define-key map (kbd "s s") #'cider-connect-sibling-cljs)
+    (define-key map (kbd "C-s j") #'cider-connect-sibling-clj)
+    (define-key map (kbd "C-s s") #'cider-connect-sibling-cljs)
+    (define-key map (kbd "C-s C-j") #'cider-connect-sibling-clj)
+    (define-key map (kbd "C-s C-s") #'cider-connect-sibling-cljs)
+
+    map)
+  "CIDER jack-in and connect keymap.")
+
 ;;;###autoload
 (defun cider-jack-in-clj (&optional do-prompt)
   "Start an nREPL server for the current project and connect to it.
@@ -1197,8 +1230,7 @@ assume the command is available."
      (define-key clojure-mode-map (kbd "C-c M-J") #'cider-jack-in-cljs)
      (define-key clojure-mode-map (kbd "C-c M-c") #'cider-connect-clj)
      (define-key clojure-mode-map (kbd "C-c M-C") #'cider-connect-cljs)
-     (define-key clojure-mode-map (kbd "C-c M-s") #'cider-connect-sibling-clj)
-     (define-key clojure-mode-map (kbd "C-c M-S") #'cider-connect-sibling-cljs)
+     (define-key clojure-mode-map (kbd "C-c C-x") 'cider-start-map)
      (define-key clojure-mode-map (kbd "C-c C-s") 'sesman-map)
      (require 'sesman)
      (sesman-install-menu clojure-mode-map)))

--- a/doc/managing_connections.md
+++ b/doc/managing_connections.md
@@ -11,16 +11,18 @@ server.
 
 Start new sessions with
 
-   - <kbd>C-c M-j</kbd> `cider-jack-in-clj`
-   - <kbd>C-c M-J</kbd> `cider-jack-in-cljs`
-   - <kbd>C-c M-c</kbd> `cider-connect-clj`
-   - <kbd>C-c M-C</kbd> `cider-connect-cljs`
-   - <kbd>M-x</kbd> `cider-jack-in-clj&cljs`
+   - <kbd>C-c C-x j j</kbd> `cider-jack-in-clj`
+   - <kbd>C-c C-x j s</kbd> `cider-jack-in-cljs`
+   - <kbd>C-c C-x j m</kbd> `cider-jack-in-clj&cljs`
+
+   - <kbd>C-c C-x c j</kbd> `cider-connect-clj`
+   - <kbd>C-c C-x c s</kbd> `cider-connect-cljs`
+   - <kbd>C-c C-x c m</kbd> `cider-connect-clj&cljs`
 
 Add new REPLs to the current session with
 
-   - <kbd>C-c M-s</kbd> `cider-connect-sibling-clj`
-   - <kbd>C-c M-S</kbd> `cider-connect-sibling-cljs`
+   - <kbd>C-c C-x s j</kbd> `cider-connect-sibling-clj`
+   - <kbd>C-c C-x s s</kbd> `cider-connect-sibling-cljs`
 
 !!! Tip
 

--- a/doc/managing_connections.md
+++ b/doc/managing_connections.md
@@ -24,11 +24,6 @@ Add new REPLs to the current session with
    - <kbd>C-c C-x s j</kbd> `cider-connect-sibling-clj`
    - <kbd>C-c C-x s s</kbd> `cider-connect-sibling-cljs`
 
-!!! Tip
-
-    There's also the `cider` command, which is a wrapper around all the
-    aforementioned commands. You can invoke it with <kbd>C-C M-x</kbd>.
-
 Session life-cycle management commands live in the [Sesman] map (<kbd>C-c
 C-s</kbd>)
 
@@ -36,8 +31,9 @@ C-s</kbd>)
    - <kbd>C-c C-s r</kbd> `sesman-restart`
    - <kbd>C-c C-s q</kbd> `sesman-quit`
 
-The command `sesman-start` is similar to `cider-jack-in-clj&cljs` except that
-the `cljs` REPL is started only if ClojureScript requirements have been met.
+The command `sesman-start` wraps around all of the aforementioned `jack-in` and
+`connect` commands. You can also invoke same functionality with <kbd>M-x</kbd>
+`cider` or <kbd>C-c M-x</kbd>.
 
 To quit or restart individual connections use cider commands
 

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -1136,6 +1136,7 @@ operations.")
 \\{nrepl-messages-mode-map}"
   (when cider-special-mode-truncate-lines
     (setq-local truncate-lines t))
+  (setq-local sesman-system 'CIDER)
   (setq-local electric-indent-chars nil)
   (setq-local comment-start ";")
   (setq-local comment-end "")


### PR DESCRIPTION
From #2337 looks like the best idea so far was to rename `cider-selector` into `cider-buffer-selector` and bind it to C-c M-b in order to free C-c M-s for `cider-connect-sibling-clj` command.

I am also binding C-c M-r to cider-restart for the sake of connection API completeness. It was freed after the refactoring. 