### PR TITLE
Add command for finding variable using mouse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,3 +60,6 @@ elpaclean: clean
 
 run-cider: elpa
 	cask exec $(EMACS) -Q -L . --eval "(require 'cider)"
+
+html:
+	mkdocs build

--- a/cider-find.el
+++ b/cider-find.el
@@ -67,6 +67,17 @@ thing at point."
                  #'cider--find-var-other-window
                #'cider--find-var))))
 
+;;;###autoload
+(defun cider-find-var-at-mouse (event)
+  "Find the definition of variable using mouse EVENT."
+  (interactive "e")
+  (cider-ensure-op-supported "info")
+  (if-let* ((symbol-file (save-excursion
+                           (mouse-set-point event)
+                           (cider-symbol-at-point 'look-back))))
+      (cider-find-dwim symbol-file)
+    (user-error "No variable or resource here")))
+
 (defun cider--find-dwim (symbol-file callback &optional other-window)
   "Find the SYMBOL-FILE at point.
 CALLBACK upon failure to invoke prompt if not prompted previously.

--- a/cider-find.el
+++ b/cider-find.el
@@ -68,8 +68,8 @@ thing at point."
                #'cider--find-var))))
 
 ;;;###autoload
-(defun cider-find-var-at-mouse (event)
-  "Find the definition of variable using mouse EVENT."
+(defun cider-find-dwim-at-mouse (event)
+  "Find and display variable or resource at mouse EVENT."
   (interactive "e")
   (cider-ensure-op-supported "info")
   (if-let* ((symbol-file (save-excursion

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -440,11 +440,20 @@ If invoked with a prefix ARG eval the expression after inserting it."
 (declare-function cider-find-resource "cider-find")
 (declare-function cider-find-keyword "cider-find")
 (declare-function cider-find-var "cider-find")
+(declare-function cider-find-dwim-at-mouse "cider-find")
+
+(defconst cider--has-many-mouse-buttons (not (memq window-system '(mac ns)))
+  "Non-nil if system binds forward and back buttons to <mouse-8> and <mouse-9>.
+
+As it stands Emacs fires these events on <mouse-8> and <mouse-9> on 'x' and
+'w32'systems while on macOS it presents them on <mouse-4> and <mouse-5>.")
 
 (defconst cider-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c C-d") 'cider-doc-map)
     (define-key map (kbd "M-.") #'cider-find-var)
+    (define-key map (kbd (if cider--has-many-mouse-buttons "<mouse-8>" "<mouse-4>")) #'xref-pop-marker-stack)
+    (define-key map (kbd (if cider--has-many-mouse-buttons "<mouse-9>" "<mouse-5>")) #'cider-find-dwim-at-mouse)
     (define-key map (kbd "C-c C-.") #'cider-find-ns)
     (define-key map (kbd "C-c C-:") #'cider-find-keyword)
     (define-key map (kbd "M-,") #'cider-pop-back)

--- a/doc/interactive_programming.md
+++ b/doc/interactive_programming.md
@@ -62,6 +62,8 @@ Here's a list of `cider-mode`'s keybindings:
 `cider-test-rerun-failed-tests`               |<kbd>C-c C-t r</kbd> <br/> <kbd>C-c C-t C-r</kbd> | Re-run test failures/errors.
 `cider-test-show-report`                      |<kbd>C-c C-t b</kbd> <br/> <kbd>C-c C-t C-b</kbd> | Show the test report buffer.
 `cider-find-var`                              |<kbd>M-.</kbd>                       | Jump to the definition of a symbol.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.
+`cider-find-dwim-at-mouse`                    |<kbd>mouse-5</kbd> or <kbd>mouse-9</kbd>   | Jump to the definition of a symbol using mouse.
+`xref-pop-marker-stack`                       |<kbd>mouse-4</kbd> or <kbd>mouse-8</kbd>   | Jump back to where `cider-find-dwim-at-mouse` was invoked.
 `cider-find-resource`                         |<kbd>C-c M-.</kbd>                   | Jump to the resource referenced by the string at point.
 `cider-find-ns`                               |<kbd>C-c C-.</kbd>                   | Jump to some namespace on the classpath.
 `cider-pop-back`                              |<kbd>M-,</kbd>                       | Return to your pre-jump location.


### PR DESCRIPTION
Being able to navigate code using the mouse is convenient. I have this command bound like so:
```
(defun cider-mode-hook ()
  (local-set-key [C-mouse-1] 'cider-find-var-at-mouse)
  (local-set-key [C-down-mouse-1] nil))
```
Other popular IDEs such as VS Code and IntelliJ offers this so I do not think this addition is very controversial.

To enable keyboard-free navigation I also find the following very convenient (which seems to work for CIDER as well):
```
(global-set-key [C-mouse-3] 'xref-pop-marker-stack)
(global-set-key [C-down-mouse-3] nil)
```
As you can see binding the actual mouse events is out of the scope of this patch and would perhaps necessitate discussion, but the above matches other modern IDEs.

Any plans to make CIDER a proper xref-backend? I'm asking because I just submitted a patch to Emacs with a `xref.el`-version of this command, which would have covered CIDER as well in that case.