### PR TITLE
Add autoloads target to Makefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * **(Breaking)** Rewrote connection management (see http://docs.cider.mx/en/latest/managing_connections/ for details).
 * **(Breaking)** `cider-jack-in-clojurescript` now creates only a ClojureScript REPL (use `cider-jack-in-clj&cljs` to create both REPLs).
 * [#2357](https://github.com/clojure-emacs/cider/issues/2357): Support both keywords and strings as test selectors (previously it was only strings).
+* [#2378](https://github.com/clojure-emacs/cider/pull/2378): Add autoloads target to Makefile.
 
 ## 0.17.0 (2018-05-07)
 

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,12 @@ version:
 test: version build
 	$(CASK) exec buttercup -L . -L ./test/utils/
 
+autoloads:
+	$(CASK) exec $(EMACS) -Q --batch \
+		-l autoload.el \
+		--eval "(let ((generated-autoload-file (expand-file-name \"cider-autoloads.el\"))) \
+                  (update-directory-autoloads (expand-file-name \".\")))"
+
 lint: version elpa
 	$(CASK) exec $(EMACS) -Q --batch \
 		--eval "(setq enable-local-variables :safe)" \
@@ -46,7 +52,7 @@ lint: version elpa
 test-all: lint test
 
 clean:
-	rm -f .depend $(OBJECTS)
+	rm -f .depend $(OBJECTS) cider-autoloads.el
 
 elpaclean: clean
 	rm -f elpa*

--- a/doc/hacking_on_cider.md
+++ b/doc/hacking_on_cider.md
@@ -17,11 +17,15 @@ in advance).
 
 Additionally you will have to generate and require the
 [autoloads](https://www.gnu.org/software/emacs/manual/html_node/elisp/Autoload.html),
-otherwise you'll keep getting errors about missing commands.
-That's done automatically when installing via `package.el`, but you'll
-have to do manually with `M-x update-directory-autoloads`. The
-function will prompt for saving a file, let's call it
-`cider-autoloads.el` that you will then need to require.
+otherwise you'll keep getting errors about missing commands.  That's done
+automatically when installing via `package.el` but you'll have to do it
+manually in this case:
+
+```shell
+make autoloads   # generates cider-autoloads.el
+```
+
+Then:
 
 ```el
 ;; load CIDER from its source code


### PR DESCRIPTION
Helper target to create cider-autoloads.el automatically. Doc updated as well.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [X] You've updated the [user manual](../blog/master/doc) (if adding/changing user-visible functionality)
