### PR TITLE
Modify cider-boot-parameters to match the new boot task

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -129,7 +129,7 @@ version from the CIDER package or library.")
   :package-version '(cider . "0.14.0"))
 
 (defcustom cider-boot-parameters
-  "repl -s -H :: wait"
+  "nrepl-server -b :: wait"
   "Params passed to boot to start an nREPL server via `cider-jack-in'."
   :type 'string
   :group 'cider


### PR DESCRIPTION
This follows changes in `cider-nrepl` introducing the new `nrepl-server` boot
task.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)