### PR TITLE
[Fix #2291] Fix `cider-use-tooltips` custom variable to work as expected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#2286](https://github.com/clojure-emacs/cider/issues/2286): Fix eldoc issue with images in the REPL.
 * [#2307](https://github.com/clojure-emacs/cider/pull/2307): Use a better error when a cljs repl form cannot be found.
 * Fix the broken test selector functionality.
+* [#2291](https://github.com/clojure-emacs/cider/issues/2291): `cider-use-tooltips` custom variable works as expected.
 
 ### Changes
 

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -602,6 +602,10 @@ prompt and whether to use a new window.  Similar to `cider-find-var'."
 
 ;; Rendering
 
+(defun cider-stacktrace-tooltip (tooltip)
+  "Return TOOLTIP if `cider-use-tooltips' is set to true, nil otherwise."
+  (when cider-use-tooltips tooltip))
+
 (defun cider-stacktrace-emit-indented (text &optional indent fill fontify)
   "Insert TEXT, and optionally FILL and FONTIFY as clojure the entire block.
 INDENT is a string to insert before each line.  When INDENT is nil, first
@@ -638,8 +642,9 @@ others."
                           'filter (cadr filter)
                           'follow-link t
                           'action 'cider-stacktrace-filter
-                          'help-echo (format "Toggle %s stack frames"
-                                             (car filter)))
+                          'help-echo (cider-stacktrace-tooltip
+                                       (format "Toggle %s stack frames"
+                                               (car filter))))
       (insert " "))
     (insert "\n")
     (insert "  Hide: ")
@@ -648,8 +653,9 @@ others."
                           'filter (cadr filter)
                           'follow-link t
                           'action 'cider-stacktrace-filter
-                          'help-echo (format "Toggle %s stack frames"
-                                             (car filter)))
+                          'help-echo (cider-stacktrace-tooltip
+                                       (format "Toggle %s stack frames"
+                                               (car filter))))
       (insert " "))
 
     (let ((hidden "(0 frames hidden)"))
@@ -664,7 +670,8 @@ others."
       (insert-text-button "M-x cider-report-bug"
                           'follow-link t
                           'action (lambda (_button) (cider-report-bug))
-                          'help-echo "Report bug to the CIDER team.")
+                          'help-echo (cider-stacktrace-tooltip
+                                       "Report bug to the CIDER team."))
       (insert "`.\n\n")
       (insert "\
   If these stacktraces are occuring frequently, consider using the
@@ -682,8 +689,9 @@ others."
                               'face (if suppressed
                                         'cider-stacktrace-suppressed-button-face
                                       'cider-stacktrace-promoted-button-face)
-                              'help-echo (format "Click to %s these stacktraces."
-                                                 (if suppressed "promote" "suppress"))))
+                              'help-echo (cider-stacktrace-tooltip
+                                           (format "Click to %s these stacktraces."
+                                                   (if suppressed "promote" "suppress")))))
         (insert " ")))))
 
 (defun cider-stacktrace-render-frame (buffer frame)
@@ -700,7 +708,8 @@ This associates text properties to enable filtering and source navigation."
                             'name name 'file file 'line line
                             'flags flags 'follow-link t
                             'action 'cider-stacktrace-navigate
-                            'help-echo "View source at this location"
+                            'help-echo (cider-stacktrace-tooltip
+                                         "View source at this location")
                             'font-lock-face 'cider-stacktrace-face
                             'type 'cider-plain-button)
         (save-excursion
@@ -726,7 +735,9 @@ This associates text properties to enable filtering and source navigation."
                             'file file 'line line 'column column 'follow-link t
                             'action (lambda (_button)
                                       (cider-jump-to (cider-find-file file)
-                                                     (cons line column))))
+                                                     (cons line column)))
+                            'help-echo (cider-stacktrace-tooltip
+                                        "Jump to the line that caused the error"))
         (insert (propertize (format " at (%d:%d)" line column)
                             'font-lock-face message-face))))))
 


### PR DESCRIPTION
I have added a `(when cider-use-tooltips ...)` condition to every `'help-echo` property of `insert-text-button` in `cider-stacktrace-el`. This way all tooltips in stacktrace buffer will be displayed only when `cider-use-tooltips` is set to `t`.

For some reason I get "cider.el:73:1:Error: Cannot open load file: No such file or directory, cider-client" when I run `make lint` and this is the only error.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [ ] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blog/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://cider.readthedocs.io/en/latest/hacking_on_cider/
