### PR TITLE
accept plain symbol as figwheel-main build, normalizing to keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [#2378](https://github.com/clojure-emacs/cider/pull/2378): Add autoloads target to Makefile.
 * **(Breaking)** Move `cider-pprint-eval-last-sexp`, previously on `C-c C-p`, to `C-c C-v (C-)f (C-)e` in the `cider-eval-commands-map`.
 * **(Breaking)** Move `cider-pprint-eval-defun-at-point`, previously on `C-c C-f`, to `C-c C-v (C-)f (C-)d` in the `cider-eval-commands-map`.
+* Accept bare figwheel-main build names (e.g., `dev`). Previously, a keyword (e.g., `:dev`) was required.
 
 ## 0.17.0 (2018-05-07)
 

--- a/cider.el
+++ b/cider.el
@@ -704,8 +704,11 @@ Figwheel for details."
   "Produce the figwheel-main ClojureScript init form."
   (let ((form "(do (require 'figwheel.main) (figwheel.main/start %s))")
         (options (or cider-figwheel-main-default-options
-                     (read-from-minibuffer "Select figwheel-main build (e.g. :dev): "))))
-    (format form options)))
+                     (read-from-minibuffer "Select figwheel-main build (e.g. :dev): ")))
+        (normalized-options (if (or (string-match-p "{" options) (string-prefix-p ":" options))
+                                options
+                              (concat ":" options))))
+    (format form normalized-options)))
 
 (defun cider-custom-cljs-repl-init-form ()
   "Prompt for a form that would start a ClojureScript REPL.

--- a/cider.el
+++ b/cider.el
@@ -702,12 +702,15 @@ Figwheel for details."
 
 (defun cider-figwheel-main-init-form ()
   "Produce the figwheel-main ClojureScript init form."
-  (let ((form "(do (require 'figwheel.main) (figwheel.main/start %s))")
-        (options (or cider-figwheel-main-default-options
-                     (read-from-minibuffer "Select figwheel-main build (e.g. :dev): ")))
-        (normalized-options (if (or (string-match-p "{" options) (string-prefix-p ":" options))
-                                options
-                              (concat ":" options))))
+  (let* ((form "(do (require 'figwheel.main) (figwheel.main/start %s))")
+         (options (string-trim
+                   (or cider-figwheel-main-default-options
+                       (read-from-minibuffer "Select figwheel-main build (e.g. :dev): "))))
+         (normalized-options (if (or (string-prefix-p "{" options)
+                                     (string-prefix-p "(" options)
+                                     (string-prefix-p ":" options))
+                                 options
+                               (concat ":" options))))
     (format form normalized-options)))
 
 (defun cider-custom-cljs-repl-init-form ()

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -207,6 +207,38 @@
               :and-return-value '())
       (expect (cider-project-type) :to-equal cider-default-repl-command))))
 
+(describe "cider-figwheel-main-init-form"
+  ;; whitespace checks sprinkled amongst other tests
+  (describe "from options"
+    (it "leaves keywords from options alone"
+        (setq-local cider-figwheel-main-default-options ":dev ")
+        (expect (cider-figwheel-main-init-form) :to-equal "(do (require 'figwheel.main) (figwheel.main/start :dev))"))
+    (it "leaves maps from options alone"
+        (setq-local cider-figwheel-main-default-options " {:a 1 :b 2}")
+        (expect (cider-figwheel-main-init-form) :to-equal "(do (require 'figwheel.main) (figwheel.main/start {:a 1 :b 2}))"))
+    (it "leaves s-expr from options alone"
+        (setq-local cider-figwheel-main-default-options " (hashmap :a 1 :b 2)")
+        (expect (cider-figwheel-main-init-form) :to-equal "(do (require 'figwheel.main) (figwheel.main/start (hashmap :a 1 :b 2)))"))
+    (it "adds colon when necessary from options"
+        (setq-local cider-figwheel-main-default-options " dev")
+        (expect (cider-figwheel-main-init-form) :to-equal "(do (require 'figwheel.main) (figwheel.main/start :dev))")))
+
+  (describe "from minibuffer"
+    (before-each
+     (setq-local cider-figwheel-main-default-options nil))
+    (it "leaves keywords entered in minibuffer alone"
+        (spy-on 'read-from-minibuffer :and-return-value " :prod ")
+        (expect (cider-figwheel-main-init-form) :to-equal "(do (require 'figwheel.main) (figwheel.main/start :prod))"))
+    (it "leaves keywords entered in minibuffer alone"
+        (spy-on 'read-from-minibuffer :and-return-value " {:c 3 :d 4}")
+        (expect (cider-figwheel-main-init-form) :to-equal "(do (require 'figwheel.main) (figwheel.main/start {:c 3 :d 4}))"))
+    (it "leaves keywords entered in minibuffer alone"
+        (spy-on 'read-from-minibuffer :and-return-value "(keyword \"dev\") ")
+        (expect (cider-figwheel-main-init-form) :to-equal "(do (require 'figwheel.main) (figwheel.main/start (keyword \"dev\")))"))
+    (it "adds colon when necessary in minibuffer"
+        (spy-on 'read-from-minibuffer :and-return-value "prod ")
+        (expect (cider-figwheel-main-init-form) :to-equal "(do (require 'figwheel.main) (figwheel.main/start :prod))"))))
+
 (provide 'cider-tests)
 
 ;;; cider-tests.el ends here


### PR DESCRIPTION
When using cider-jack-in-cljs and choosing figwheel-main as the REPL type, you are prompted to select a figwheel build (although in principle you could enter a map of options there). If you provide the bare build name (i.e., `dev` instead of `:dev`), you get an exception and the operation fails.  This patch normalizes build names so they are passed to `figwheel/start` as keywords, but it won't modify anything that looks like a keyword, map, or s-expr.

Known edge case: if you prepend commas (,) to your figwheel-main options then a colon will be prepended to them, causing a `RuntimeException: Invalid Token: :`.  I don't expect this to ever happen in practice, since there's no point in prepending commas anyway.  This PR should be robust to other leading or trailing whitespace, including trailing commas (whitespace liberally added in tests.)

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md) **I couldn't find this doc**
- [X] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`make test`)
- [X] All code passes the linter (`make lint`) **cider.el does, which is where I put my additions.  there are some other failures but I'm remiss to touch unrelated code in my first PR**
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blog/master/doc) (if adding/changing user-visible functionality) **not necessary since old behavior should keep working**.

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: _https://cider.readthedocs.io/en/latest/hacking_on_cider/_
