### PR TITLE
#2387 fix - localhost is returned when connecting to local nREPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@
 
 ### Bugs fixed
 
-* [#2387](https://github.com/clojure-emacs/cider/issues/2387): `localhost` as first host returned when connecting to local nREPL
 * [#2317](https://github.com/clojure-emacs/cider/issues/2317): The stdin prompt can now be cancelled.
 * [#2328](https://github.com/clojure-emacs/cider/issues/2328): Added `cider-eval-sexp-to-point`.
 * [#2310](https://github.com/clojure-emacs/cider/issues/2310): `cider-format-edn-last-sexp` will format the last sexp.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### Bugs fixed
 
-* [#2387](https://github.com/clojure-emacs/cider/issues/2387): `localhost` returned when connecting to local nREPL
+* [#2387](https://github.com/clojure-emacs/cider/issues/2387): `localhost` as first host returned when connecting to local nREPL
 * [#2317](https://github.com/clojure-emacs/cider/issues/2317): The stdin prompt can now be cancelled.
 * [#2328](https://github.com/clojure-emacs/cider/issues/2328): Added `cider-eval-sexp-to-point`.
 * [#2310](https://github.com/clojure-emacs/cider/issues/2310): `cider-format-edn-last-sexp` will format the last sexp.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Bugs fixed
 
+* [#2387](https://github.com/clojure-emacs/cider/issues/2387): `localhost` returned when connecting to local nREPL
 * [#2317](https://github.com/clojure-emacs/cider/issues/2317): The stdin prompt can now be cancelled.
 * [#2328](https://github.com/clojure-emacs/cider/issues/2328): Added `cider-eval-sexp-to-point`.
 * [#2310](https://github.com/clojure-emacs/cider/issues/2310): `cider-format-edn-last-sexp` will format the last sexp.

--- a/cider.el
+++ b/cider.el
@@ -1153,7 +1153,8 @@ non-nil, don't start if ClojureScript requirements are not met."
 
 (defun cider-current-host ()
   "Retrieve the current host."
-  (if (stringp buffer-file-name)
+  (if (and (stringp buffer-file-name)
+           (file-remote-p buffer-file-name))
       (file-remote-p buffer-file-name 'host)
     "localhost"))
 


### PR DESCRIPTION
Fix of #2387 

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html) - compiled manually with `byte-compile-file`

I run tests but `cider-load-file` fails on my environment (cider). Test fails also on master without my fix.