### PR TITLE
Initialize sesman earlier in REPL buffers and add support for sesman-project

### DIFF
--- a/cider-connection.el
+++ b/cider-connection.el
@@ -500,6 +500,7 @@ function with the repl buffer set as current."
   (let ((buffer (or (plist-get params :repl-buffer)
                     (get-buffer-create (generate-new-buffer-name "*cider-uninitialized-repl*")))))
     (with-current-buffer buffer
+      (setq-local sesman-system 'CIDER)
       (let ((ses-name (or (plist-get params :session-name)
                           (cider-new-session-name params))))
         (sesman-add-object 'CIDER ses-name buffer t))

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -370,6 +370,9 @@ Don't restart the server or other connections within the same session.  Use
 
 ;;; Sesman's Session-Wise Management UI
 
+(cl-defmethod sesman-project ((_system (eql CIDER)))
+  (clojure-project-dir (cider-current-dir)))
+
 (cl-defmethod sesman-more-relevant-p ((_system (eql CIDER)) session1 session2)
   (sesman-more-recent-p (cdr session1) (cdr session2)))
 

--- a/cider.el
+++ b/cider.el
@@ -1153,9 +1153,9 @@ non-nil, don't start if ClojureScript requirements are not met."
 
 (defun cider-current-host ()
   "Retrieve the current host."
-  (if (stringp buffer-file-name)
-      (file-remote-p buffer-file-name 'host)
-    "localhost"))
+  (or (when (stringp buffer-file-name)
+        (file-remote-p buffer-file-name 'host))
+      "localhost"))
 
 (defun cider-select-endpoint ()
   "Interactively select the host and port to connect to."
@@ -1171,9 +1171,8 @@ non-nil, don't start if ClojureScript requirements are not met."
                                   (list (list (cider-current-host)))
                                   cider-known-endpoints
                                   ssh-hosts
-                                  (when (file-remote-p default-directory)
-                                    ;; add localhost even in remote buffers
-                                    '(("localhost"))))))
+                                  ;; always add localhost
+                                  '(("localhost")))))
          (sel-host (cider--completing-read-host hosts))
          (host (car sel-host))
          (port (or (cadr sel-host)


### PR DESCRIPTION
Fixes vspinu/sesman#6 and adds support for sesman-project. After discovering a few more issues with project.el I am no longer relying on it.