### PR TITLE
New session and REPL buffer naming system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * **(Breaking)** Move `cider-ns-refresh`, previously on `C-c C-x`, on `C-c M-n (M-)r` in the `cider-ns-map`.
 * **(Breaking)** Bump the minimum required Emacs version to 25.1.
 * **(Breaking)** Drop support for Java 7 and Clojure(Script) 1.7.
+* **(Breaking)** Use session name as part of CIDER buffers names (REPL, server, messages), and obsolete `nrepl-buffer-name-separator` and `nrepl-buffer-name-show-port`. See `cider-session-name-template` and `cider-format-connection-params` for how to customize CIDER buffer names. 
 * Rename `cider-eval-defun-to-point` to `cider-eval-defun-up-to-point`.
 * Add support for printing to the current buffer to `cider-eval-defun-up-to-point`.
 * Remove `cider-ping` command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* Add new `cider-session-name-template` variable for flexible customization of cider session and REPL buffer names.
 * Bind `C-c M-r` to `cider-restart`.
 * Add new `cider-start-map` keymap (`C-c C-x`) for jack-in and connection commands.
 * Add new `cider-ns-map` keymap (`C-c M-n`) for namespace related functionality.

--- a/cider-ns.el
+++ b/cider-ns.el
@@ -33,6 +33,7 @@
 (require 'cider-popup)
 (require 'cider-stacktrace)
 
+(define-obsolete-variable-alias 'cider-save-files-on-cider-ns-refresh 'cider-ns-save-files-on-refresh "0.18")
 (defcustom cider-ns-save-files-on-refresh 'prompt
   "Controls whether to prompt to save Clojure files on `cider-ns-refresh'.
 If nil, files are not saved.
@@ -44,10 +45,9 @@ If t, save the files without confirmation."
   :group 'cider
   :package-version '(cider . "0.15.0"))
 
-(define-obsolete-variable-alias 'cider-save-files-on-cider-ns-refresh 'cider-ns-save-files-on-refresh "0.18")
-
 (defconst cider-ns-refresh-log-buffer "*cider-ns-refresh-log*")
 
+(define-obsolete-variable-alias 'cider-refresh-show-log-buffer 'cider-ns-refresh-show-log-buffer "0.18")
 (defcustom cider-ns-refresh-show-log-buffer nil
   "Controls when to display the refresh log buffer.
 If non-nil, the log buffer will be displayed every time `cider-ns-refresh' is
@@ -59,8 +59,7 @@ displayed in the echo area."
   :group 'cider
   :package-version '(cider . "0.10.0"))
 
-(define-obsolete-variable-alias 'cider-refresh-show-log-buffer 'cider-ns-refresh-show-log-buffer "0.18")
-
+(define-obsolete-variable-alias 'cider-refresh-before-fn 'cider-ns-refresh-before-fn "0.18")
 (defcustom cider-ns-refresh-before-fn nil
   "Clojure function for `cider-ns-refresh' to call before reloading.
 If nil, nothing will be invoked before reloading.  Must be a
@@ -70,8 +69,7 @@ prevent reloading from occurring."
   :group 'cider
   :package-version '(cider . "0.10.0"))
 
-(define-obsolete-variable-alias 'cider-refresh-before-fn 'cider-ns-refresh-before-fn "0.18")
-
+(define-obsolete-variable-alias 'cider-refresh-after-fn 'cider-ns-refresh-after-fn "0.18")
 (defcustom cider-ns-refresh-after-fn nil
   "Clojure function for `cider-ns-refresh' to call after reloading.
 If nil, nothing will be invoked after reloading.  Must be a
@@ -79,8 +77,6 @@ namespace-qualified function of zero arity."
   :type 'string
   :group 'cider
   :package-version '(cider . "0.10.0"))
-
-(define-obsolete-variable-alias 'cider-refresh-after-fn 'cider-ns-refresh-after-fn "0.18")
 
 (defun cider-ns-refresh--handle-response (response log-buffer)
   "Refresh LOG-BUFFER with RESPONSE."

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -601,7 +601,7 @@ prompt and whether to use a new window.  Similar to `cider-find-var'."
 
 
 ;; Rendering
-
+(defvar cider-use-tooltips)
 (defun cider-stacktrace-tooltip (tooltip)
   "Return TOOLTIP if `cider-use-tooltips' is set to true, nil otherwise."
   (when cider-use-tooltips tooltip))

--- a/cider.el
+++ b/cider.el
@@ -1117,6 +1117,8 @@ non-nil, don't start if ClojureScript requirements are not met."
     (plist-put params :repl-init-function
                (lambda ()
                  (cider--check-cljs cljs-type)
+                 ;; FIXME: ideally this should be done in the state handler
+                 (setq-local cider-cljs-repl-type cljs-type)
                  (cider-nrepl-send-request
                   (list "op" "eval"
                         "ns" (cider-current-ns)

--- a/doc/managing_connections.md
+++ b/doc/managing_connections.md
@@ -93,5 +93,16 @@ The single prefix <kbd>C-u C-c C-z</kbd>, will switch to the current REPL buffer
 and set the namespace in that buffer based on namespace in the current
 Clojure(Script) buffer.
 
+## Customizing Session and REPL Names
+
+By default session names consist of abbreviated project name, host and port
+(e.g. `project/dir:localhost:1234`). REPL buffer name consist of the session
+name and the REPL type specification post-fix
+(e.g. `*project/dir:localhost:1234(cljs:node)*`).
+
+You can customize session names with `cider-session-name-template` and REPL
+names with `nrepl-repl-buffer-name-template`. See also
+`cider-format-connection-params` for available formats.
+
 
 [Sesman]: https://github.com/vspinu/sesman


### PR DESCRIPTION
Make session names arbitrarily customisable and make REPL buffer (and satellites) use session name as part of their name. 

By default session names look like this `project/dir:localhost:1234` and buffer names like `*project/dir:localhost:1234(cljs:node)*`. See the docstring of `cider-format-connection-params` for what is available.  


I believe the only potentially contentious change is that I made `nrepl-buffer-name-template` not to start with `cider-repl`. The new names are rather long and `cider-repl` prefix is not particularly useful, especially that the mode-line already displays [REPL(cljs)]. I am not very sure about this change though, nor I am able to find a shorter prefix than `cider-repl `.

-----------------

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blog/master/doc) (if adding/changing user-visible functionality)

