### PR TITLE
Improve session and REPL buffer naming

### DIFF
--- a/cider-connection.el
+++ b/cider-connection.el
@@ -563,9 +563,11 @@ function with the repl buffer set as current."
                     (get-buffer-create (generate-new-buffer-name "*cider-uninitialized-repl*")))))
     (with-current-buffer buffer
       (setq-local sesman-system 'CIDER)
+      (setq-local default-directory (or (plist-get params :project-dir) default-directory))
       (let ((ses-name (or (plist-get params :session-name)
                           (cider-make-session-name params))))
-        (sesman-add-object 'CIDER ses-name buffer t))
+        ;; creates a new session if session with ses-name doesn't already exist
+        (sesman-add-object 'CIDER ses-name buffer 'allow-new))
       (unless (derived-mode-p 'cider-repl-mode)
         (cider-repl-mode))
       (setq nrepl-err-handler #'cider-default-err-handler

--- a/test/cider-connection-tests.el
+++ b/test/cider-connection-tests.el
@@ -307,3 +307,17 @@
          (expect (buffer-live-p b) :not :to-be-truthy)
          (expect (cider-repls) :to-equal (list a))
          (sesman-unregister 'CIDER session))))))
+
+(describe "cider-format-connection-params"
+  (describe "correctly abbreviates short directory names"
+    (expect (cider-format-connection-params "%J" '(:project-dir "~"))
+            :to-equal "~")
+    (expect (cider-format-connection-params "%j" '(:project-dir "~"))
+            :to-equal "~")
+    (expect (cider-format-connection-params "%J" '(:project-dir "~/"))
+            :to-equal "~")
+    (expect (cider-format-connection-params "%J" '(:project-dir "/"))
+            :to-equal "/")
+    (expect (cider-format-connection-params "%J" '(:project-dir "/etc/"))
+            :to-equal "/etc")))
+


### PR DESCRIPTION
- better abbreviation of directory names
 - re-create context buffer on every connect instead of `kill-all-local-variables` which could fail

-----------------

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.