### PR TITLE
A range of connection fixes and support for sesman browser

### DIFF
--- a/cider-connection.el
+++ b/cider-connection.el
@@ -335,7 +335,7 @@ REPL defaults to the current REPL."
 
 (defun cider-restart (&optional repl)
   "Restart CIDER connection associated with REPL.
-REPL defaults to the current REPL. Don't restart the server or other
+REPL defaults to the current REPL.  Don't restart the server or other
 connections within the same session.  Use `sesman-restart' to restart the
 entire session."
   (interactive)
@@ -710,7 +710,7 @@ Error is signaled if no REPL buffer of specified type exists."
 (define-obsolete-function-alias 'cider-repl-buffers 'cider-repls "0.18")
 (define-obsolete-function-alias 'cider-current-session 'cider-nrepl-eval-session "0.18")
 (define-obsolete-function-alias 'cider-current-tooling-session 'cider-nrepl-tooling-session "0.18")
-(define-obsolete-function-alias 'cider-display-connection-info 'cider-describe-current-connection "0.18")
+(define-obsolete-function-alias 'cider-display-connection-info 'cider-describe-connection "0.18")
 (define-obsolete-function-alias 'nrepl-connection-buffer-name 'nrepl-repl-buffer-name "0.18")
 (define-obsolete-function-alias 'cider-repl-set-type 'cider-set-repl-type "0.18")
 

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -553,6 +553,9 @@ Assume that the current buffer is a REPL."
       (setq cider-repl-type type)
       (setq mode-name (format "REPL[%s]" type))
       (let ((params (cider--gather-connect-params)))
+        ;; We need to set current name to something else temporarily to avoid
+        ;; false name duplication in `nrepl-repl-buffer-name`.
+        (rename-buffer (generate-new-buffer-name "*dummy-cider-repl-buffer*"))
         (rename-buffer (nrepl-repl-buffer-name params))
         (when (and nrepl-log-messages nrepl-messages-buffer)
           (with-current-buffer nrepl-messages-buffer

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -297,7 +297,7 @@ If invoked with a prefix ARG eval the expression after inserting it."
     ["Quit" cider-quit :active (cider-connected-p)]
     ["Restart" cider-restart :active (cider-connected-p)]
     "--"
-    ["Connection info" cider-describe-current-connection
+    ["Connection info" cider-describe-connection
      :active (cider-connected-p)]
     ["Select any CIDER buffer" cider-selector]
     "--"
@@ -486,7 +486,7 @@ As it stands Emacs fires these events on <mouse-8> and <mouse-9> on 'x' and
     (define-key map (kbd "C-c ,")   'cider-test-commands-map)
     (define-key map (kbd "C-c C-t") 'cider-test-commands-map)
     (define-key map (kbd "C-c M-s") #'cider-selector)
-    (define-key map (kbd "C-c M-d") #'cider-describe-current-connection)
+    (define-key map (kbd "C-c M-d") #'cider-describe-connection)
     (define-key map (kbd "C-c C-=") 'cider-profile-map)
     (define-key map (kbd "C-c C-q") #'cider-quit)
     (define-key map (kbd "C-c M-r") #'cider-restart)

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1511,7 +1511,7 @@ constructs."
 (cider-repl-add-shortcut "test-project-with-filters" (lambda () (interactive) (cider-test-run-project-tests 'prompt-for-filters)))
 (cider-repl-add-shortcut "test-report" #'cider-test-show-report)
 (cider-repl-add-shortcut "run" #'cider-run)
-(cider-repl-add-shortcut "conn-info" #'cider-describe-current-connection)
+(cider-repl-add-shortcut "conn-info" #'cider-describe-connection)
 (cider-repl-add-shortcut "hasta la vista" #'cider-quit)
 (cider-repl-add-shortcut "adios" #'cider-quit)
 (cider-repl-add-shortcut "sayonara" #'cider-quit)
@@ -1614,7 +1614,7 @@ constructs."
     (define-key map (kbd "C-c C-z") #'cider-switch-to-last-clojure-buffer)
     (define-key map (kbd "C-c M-o") #'cider-repl-switch-to-other)
     (define-key map (kbd "C-c M-s") #'cider-selector)
-    (define-key map (kbd "C-c M-d") #'cider-describe-current-connection)
+    (define-key map (kbd "C-c M-d") #'cider-describe-connection)
     (define-key map (kbd "C-c C-q") #'cider-quit)
     (define-key map (kbd "C-c M-r") #'cider-restart)
     (define-key map (kbd "C-c M-i") #'cider-inspect)
@@ -1681,7 +1681,7 @@ constructs."
         "--"
         ["Interrupt evaluation" cider-interrupt]
         "--"
-        ["Connection info" cider-describe-current-connection]
+        ["Connection info" cider-describe-connection]
         "--"
         ["Close ancillary buffers" cider-close-ancillary-buffers]
         ["Quit" cider-quit]

--- a/cider-selector.el
+++ b/cider-selector.el
@@ -34,6 +34,7 @@
 (require 'cider-client)
 (require 'cider-eval)
 (require 'cider-scratch)
+(require 'cider-profile)
 
 (defconst cider-selector-help-buffer "*CIDER Selector Help*"
   "The name of the selector's help buffer.")

--- a/cider-util.el
+++ b/cider-util.el
@@ -761,7 +761,7 @@ through a stack of help buffers.  Variables `help-back-label' and
     "Press <C-u C-u \\[cider-inspect]> to read Clojure code from the minibuffer and inspect its result."
     "Press <\\[cider-ns-refresh]> to reload modified and unloaded namespaces."
     "You can define Clojure functions to be called before and after `cider-ns-refresh' (see `cider-ns-refresh-before-fn' and `cider-ns-refresh-after-fn'."
-    "Press <\\[cider-describe-current-connection]> to view information about the connection."
+    "Press <\\[cider-describe-connection]> to view information about the connection."
     "Press <\\[cider-undef]> to undefine a symbol in the current namespace."
     "Press <\\[cider-interrupt]> to interrupt an ongoing evaluation."
     "Use <M-x customize-group RET cider RET> to see every possible setting you can customize."

--- a/doc/cider-refcard.tex
+++ b/doc/cider-refcard.tex
@@ -125,7 +125,7 @@
   \item[C-c M-p] cider-insert-last-sexp-in-repl
   \item[C-c C-z] cider-switch-to-repl-buffer
   \item[C-c M-o] cider-find-and-clear-repl-buffer
-  \item[C-c M-d] cider-describe-current-connection
+  \item[C-c M-d] cider-describe-connection
   \item[C-c M-n M-n] cider-repl-set-ns
   \item[C-c C-b] cider-interrupt
   \item[C-c M-n M-r] cider-ns-refresh

--- a/doc/interactive_programming.md
+++ b/doc/interactive_programming.md
@@ -37,7 +37,7 @@ Here's a list of `cider-mode`'s keybindings:
 `cider-switch-to-repl-buffer`                 |<kbd>C-c C-z</kbd>                   | Switch to the relevant REPL buffer. Use a prefix argument to change the namespace of the REPL buffer to match the currently visited source file.
 `cider-switch-to-repl-buffer`                 |<kbd>C-u C-u C-c C-z</kbd>           | Switch to the REPL buffer based on a user prompt for a directory.
 `cider-load-buffer-and-switch-to-repl-buffer` |<kbd>C-c M-z</kbd>                   | Load (eval) the current buffer and switch to the relevant REPL buffer. Use a prefix argument to change the namespace of the REPL buffer to match the currently visited source file.
-`cider-describe-current-connection`            |<kbd>C-c M-d</kbd>                   | Display default REPL connection details, including project directory name, buffer namespace, host and port.
+`cider-describe-connection`            |<kbd>C-c M-d</kbd>                   | Display default REPL connection details, including project directory name, buffer namespace, host and port.
 `cider-find-and-clear-repl-output`            |<kbd>C-c C-o</kbd>                   | Clear the last output in the REPL buffer. With a prefix argument it will clear the entire REPL buffer, leaving only a prompt. Useful if you're running the REPL buffer in a side by side buffer.
 `cider-load-buffer`                           |<kbd>C-c C-k</kbd>                   | Load (eval) the current buffer.
 `cider-load-file`                             |<kbd>C-c C-l</kbd>                   | Load (eval) a Clojure file.

--- a/doc/managing_connections.md
+++ b/doc/managing_connections.md
@@ -50,6 +50,16 @@ Sessions can be linked to contexts (projects, directories and buffers)
   - <kbd>C-c C-s p</kbd> `sesman-link-with-project`
   - <kbd>C-c C-s u</kbd> `sesman-unlink`
 
+## Displaying Session Info
+
+Retrieve info on all linked with the current context sessions with <kbd>C-c C-s
+i</kbd> (`sesman-info`). On <kbd>C-u</kbd>, display info for all CIDER
+sessions. For the connection specific information use CIDER's built-in
+`cider-describe-connection` (<kbd>C-c M-d</kbd>).
+
+An interactive view of all CIDER sessions is available through the
+`sesman-browser` (<kbd>C-c C-s w</kbd>).
+
 ## Current Session
 
 All CIDER commands (evaluation, completion, switching to REPL etc.) operate on
@@ -69,11 +79,6 @@ again, there is no ambiguity.
 By default [Sesman] allows multiple simultaneous links to projects and
 directories, but only one link per buffer. See `sesman-single-link-contexts` if
 you would like to change that.
-
-Retrieve info on the current session with <kbd>C-c C-s i</kbd>
-(`sesman-show-session-info`). With a single prefix <kbd>C-u</kbd> it shows info
-on all linked sessions, and with double prefix <kbd>C-u C-u</kbd> on all CIDER
-sessions. Display active links with <kbd>C-c C-s l</kbd> (`sesman-show-links`).
 
 ## Current REPL
 


### PR DESCRIPTION

  - A range of fixes for various connection problems which I discovered while working on connection browser. 
 - Add support for the new full featured sesman browser.  


Sesman simplified the "info" UI, btw. There are now only two keys `C-c C-s i` for info on linked sessions and `C-c C-s C-w` the the browser. 

Tests will fail till sesman is propagated to MELPA.