### PR TITLE
 [Fix #2415] Filter out killed buffers in `cider-repls` 

### DIFF
--- a/cider-connection.el
+++ b/cider-connection.el
@@ -658,6 +658,13 @@ session."
                       type (car (sesman-current-session 'CIDER)))
         repl))))
 
+(defun cider--match-repl-type (type buffer)
+  "Return non-nil if TYPE matches BUFFER's REPL type."
+  (let ((buffer-repl-type (cider-repl-type buffer)))
+    (cond ((null buffer-repl-type) nil)
+          ((or (null type) (equal type "multi")) t)
+          (t (string= type buffer-repl-type)))))
+
 (defun cider-repls (&optional type ensure)
   "Return cider REPLs of TYPE from the current session.
 If TYPE is nil or \"multi\", return all repls.  If ENSURE is non-nil, throw
@@ -665,11 +672,8 @@ an error if no linked session exists."
   (let ((repls (cdr (if ensure
                         (sesman-ensure-session 'CIDER)
                       (sesman-current-session 'CIDER)))))
-    (if (or (null type) (equal type "multi"))
-        repls
-      (seq-filter (lambda (b)
-                    (string= type (cider-repl-type b)))
-                  repls))))
+    (seq-filter (lambda (b)
+                  (cider--match-repl-type type b)) repls)))
 
 (defun cider-map-repls (which function)
   "Call FUNCTION once for each appropriate REPL as indicated by WHICH.

--- a/test/cider-connection-tests.el
+++ b/test/cider-connection-tests.el
@@ -271,7 +271,23 @@
                       (with-temp-buffer
                         (setq major-mode 'clojurescript-mode)
                         (expect (cider-repls) :to-equal (list bb2 bb1))
-                        (expect (cider-repls "cljs") :to-equal (list bb2))))))))))))))
+                        (expect (cider-repls "cljs") :to-equal (list bb2)))))))))))))
+
+  (describe "killed buffers"
+    (it "do not show up in it"
+      (let ((default-directory "/tmp/some-dir"))
+        (cider-test-with-buffers
+         (a b)
+         (let ((session (list "some-session" a b)))
+           (with-current-buffer a
+             (setq cider-repl-type "clj"))
+           (with-current-buffer b
+             (setq cider-repl-type "clj"))
+           (sesman-register 'CIDER session)
+           (expect (cider-repls) :to-equal (list a b))
+           (kill-buffer b)
+           (expect (cider-repls) :to-equal (list a))
+           (sesman-unregister 'CIDER session)))))))
 
 (describe "cider--connection-info"
   (spy-on 'cider--java-version :and-return-value "1.7")

--- a/test/cider-connection-tests.el
+++ b/test/cider-connection-tests.el
@@ -301,7 +301,12 @@
       (cider-test-with-buffers
        (a b)
        (let ((session (list "some-session" a b)))
+         (with-current-buffer a
+           (setq cider-repl-type "clj"))
+         (with-current-buffer b
+           (setq cider-repl-type "clj"))
          (sesman-register 'CIDER session)
+         (expect (cider-repls) :to-equal (list a b))
          (cider--close-connection b)
          (message "%S" sesman-links-alist)
          (expect (buffer-live-p b) :not :to-be-truthy)


### PR DESCRIPTION
If a REPL buffer is killed manually it will leak out of `cider-repls` for .cljc
files, so make sure `cider-repls` only return live REPL buffers.

- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [ ] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blog/master/doc) (if adding/changing user-visible functionality)

[1]: https://cider.readthedocs.io/en/latest/hacking_on_cider/
