### PR TITLE
Initialize CLJS repls as having type "cljs"

### DIFF
--- a/cider-connection.el
+++ b/cider-connection.el
@@ -625,8 +625,7 @@ function with the repl buffer set as current."
             mode-name nil
             cider-session-name ses-name
             nrepl-project-dir (plist-get params :project-dir)
-            ;; REPLs start with clj and then "upgrade" to a different type
-            cider-repl-type "clj"
+            cider-repl-type (or (plist-get params :repl-type) "clj")
             ;; ran at the end of cider--connected-handler
             cider-repl-init-function (plist-get params :repl-init-function))
       (cider-repl-reset-markers)


### PR DESCRIPTION
cider-connect-sibling-cljs already passes down the correct :repl-type. Honoring
that prevents issues with uninitialized CLJS repls that haven't yet "upgraded"
to be mistaken for CLJ repls.

Closes #2425 

Not sure if this is a good approach so it's more of a proposal. I'm also not sure what's up with the tests, some of them are failing but I'm not sure if that's related.

Test output:

https://gist.github.com/plexus/29bea9044b77c40f04c158a83270cc28

e.g.

```
nrepl-make-buffer-name strips trailing separators

Traceback (most recent call last):
  (save-current-buffer (set-buffer temp-buffer) (unwind-protect (progn (let ...
  (unwind-protect (progn (let ((params '(:project-dir "path/to/dirB" :host "...
  (progn (let ((params '(:project-dir "path/to/dirB" :host "localhost" :port...
  (let ((params '(:project-dir "path/to/dirB" :host "localhost" :port 100 :r...
  (buttercup-expect (lambda nil '(nrepl-make-buffer-name "*buff-name [%r:%S]...
  (buttercup--apply-matcher :to-equal ((lambda nil '(nrepl-make-buffer-name ...
  (apply #[514 "\300\301D\"\211G\302U\203\211A\262\242\202\303\304\3...
  (#[514 "\300\301D\"\211G\302U\203\211A\262\242\202\303\304\305GD\...
  (mapcar buttercup--expr-and-value ((lambda nil '(nrepl-make-buffer-name "*...
  (buttercup--expr-and-value (lambda nil '(nrepl-make-buffer-name "*buff-nam...
  ((lambda nil '(nrepl-make-buffer-name "*buff-name [%r:%S]*" params) (nrepl...
  (nrepl-make-buffer-name "*buff-name [%r:%S]*" (:project-dir "path/to/dirB"...
  (cider-format-connection-params "*buff-name [%r:%S]*" (:project-dir "path/...
  (abbreviate-file-name "path/to/dirB")
  (file-name-case-insensitive-p "path/to/dirB")
error: (error "Variable binding depth exceeds max-specpdl-size")
```

-----------------

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blog/master/doc) (if adding/changing user-visible functionality)

