### PR TITLE
[Fix #2408] Auto-link to sesman session on cider-find-var

### DIFF
--- a/cider-find.el
+++ b/cider-find.el
@@ -59,13 +59,18 @@ the results to be displayed in a different window.  The default value is
 thing at point."
   (interactive "P")
   (cider-ensure-op-supported "info")
-  (if var
-      (cider--find-var var line)
-    (funcall (cider-prompt-for-symbol-function arg)
-             "Symbol"
-             (if (cider--open-other-window-p arg)
-                 #'cider--find-var-other-window
-               #'cider--find-var))))
+  (let ((orig-buff (current-buffer))
+        (session (sesman-current-session 'CIDER)))
+    (if var
+        (cider--find-var var line)
+      (funcall (cider-prompt-for-symbol-function arg)
+               "Symbol"
+               (if (cider--open-other-window-p arg)
+                   #'cider--find-var-other-window
+                 #'cider--find-var)))
+    (when (and (not (eq orig-buff (current-buffer)))
+               session)
+      (sesman-link-session 'CIDER session))))
 
 ;;;###autoload
 (defun cider-find-dwim-at-mouse (event)


### PR DESCRIPTION
- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blog/master/doc) (if adding/changing user-visible functionality)