### PR TITLE
[Fix #2466] Make generic cider ops use any available nrepl connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 * Fix jack-in from inside of remote buffers.
 * [#2454](https://github.com/clojure-emacs/cider/pull/2454): Fix erratic inspector behavior when multiple REPLs are connected
+* [#2467](https://github.com/clojure-emacs/cider/pull/2467): Make generic cider ops use any available nrepl connection
 
 ## 0.18.0 (2018-09-02)
 

--- a/cider-client.el
+++ b/cider-client.el
@@ -153,7 +153,7 @@ REQUEST is a pair list of the form (\"op\" \"operation\" \"par1-name\"
                                     \"par1\" ... ).
 If CONNECTION is provided dispatch to that connection instead of
 the current connection.  Return the id of the sent message."
-  (nrepl-send-request request callback (or connection (cider-current-repl))))
+  (nrepl-send-request request callback (or connection (cider-current-repl "any"))))
 
 (defun cider-nrepl-send-sync-request (request &optional connection abort-on-input)
   "Send REQUEST to the nREPL server synchronously using CONNECTION.
@@ -163,13 +163,13 @@ If ABORT-ON-INPUT is non-nil, the function will return nil
 at the first sign of user input, so as not to hang the
 interface."
   (nrepl-send-sync-request request
-                           (or connection (cider-current-repl))
+                           (or connection (cider-current-repl "any"))
                            abort-on-input))
 
 (defun cider-nrepl-send-unhandled-request (request &optional connection)
   "Send REQUEST to the nREPL CONNECTION and ignore any responses.
 Immediately mark the REQUEST as done.  Return the id of the sent message."
-  (let* ((conn (or connection (cider-current-repl)))
+  (let* ((conn (or connection (cider-current-repl "any")))
          (id (nrepl-send-request request #'ignore conn)))
     (with-current-buffer conn
       (nrepl--mark-id-completed id))

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -696,16 +696,17 @@ function with the repl buffer set as current."
 
 (defun cider-current-repl (&optional type ensure)
   "Get the most recent REPL of TYPE from the current session.
-TYPE is either \"clj\", \"cljs\" or \"multi\".  When nil, infer the type
-from the current buffer.  If ENSURE is non-nil, throw an error if either
-there is no linked session or there is no REPL of TYPE within the current
-session."
+TYPE is either \"clj\", \"cljs\", \"multi\" or \"any\".
+When nil, infer the type from the current buffer.  \"multi\" or \"any\"
+are synonyms.  If ENSURE is non-nil, throw an error if either there is
+no linked session or there is no REPL of TYPE within the current session."
   (if (and (derived-mode-p 'cider-repl-mode)
            (or (null type)
                (string= cider-repl-type type)))
       ;; shortcut when in REPL buffer
       (current-buffer)
-    (let* ((type (or type (cider-repl-type-for-buffer)))
+    (let* ((type (if (equal type "any") "multi" type))
+           (type (or type (cider-repl-type-for-buffer)))
            (repls (cider-repls type ensure))
            (repl (if (<= (length repls) 1)
                      (car repls)


### PR DESCRIPTION
This makes formatting code always use the clj repl type, which makes the `cider-format-*` commands work in cljs buffers even if there is no cljs repl active.

Fixes #2466 

[This is my first contribution to cider, discussion & feedback very welcome]