### PR TITLE
Fix cider-format-defun leaving marks when code doesn't change

### DIFF
--- a/cider-format.el
+++ b/cider-format.el
@@ -92,7 +92,7 @@ START and END represent the region's boundaries."
   "Format the code in the current defun."
   (interactive)
   (cider-ensure-connected)
-  (save-excursion
+  (save-mark-and-excursion
     (mark-defun)
     (cider-format-region (region-beginning) (region-end))))
 


### PR DESCRIPTION
Running cider-format-defun on code which is properly formatted results
in the marked region from mark-defun being kept around. `save-excursion`
rolled the mark back in Emacs versions before 25.1, but now
save-mark-and-excursion is needed.

From the `save-excursion` docs:

> Before Emacs 25.1, ‘save-excursion’ used to save the mark state.
> To save the mark state as well as point and the current buffer, use
> ‘save-mark-and-excursion’.
