### PR TITLE
cider-format improvements

### DIFF
--- a/cider-format.el
+++ b/cider-format.el
@@ -68,6 +68,7 @@ Uses the following heuristic to try to maintain point position:
              (endp (> (+ pos l) pos-max))
              (snippet (thread-last (buffer-substring-no-properties
                                     pos (min (+ pos l) pos-max))
+                        (regexp-quote)
                         (replace-regexp-in-string "[[:space:]\t\n\r]+" "[[:space:]\t\n\r]*"))))
         (delete-region start end)
         (insert indented)

--- a/cider-format.el
+++ b/cider-format.el
@@ -92,9 +92,8 @@ START and END represent the region's boundaries."
   "Format the code in the current defun."
   (interactive)
   (cider-ensure-connected)
-  (save-excursion
-    (mark-defun)
-    (cider-format-region (region-beginning) (region-end))))
+  (let ((defun-bounds (cider-defun-at-point 't)))
+    (cider-format-region (car defun-bounds) (cadr defun-bounds))))
 
 
 ;;; Format buffer


### PR DESCRIPTION
This fixes 3 issues with code formatting:
 
1) if formatting with `cider-format-defun`/`cider-format-region` did not result in code changes, the mark was not reset
2) with `cider-format-defun` point would be restored outside of the defun instead of the line it was originally
3) depending on the point position, regex errors could occur or the point was not restored properly

See the commit messages for details.