### PR TITLE
Make content-type work when using eval-last-sexp-to-repl

### DIFF
--- a/cider-eval.el
+++ b/cider-eval.el
@@ -791,8 +791,9 @@ If INSERT-BEFORE is non-nil, insert before the form, otherwise afterwards."
 If invoked with a PREFIX argument, switch to the REPL buffer."
   (interactive "P")
   (cider-interactive-eval nil
-                          (cider-insert-eval-handler (cider-current-repl))
-                          (cider-last-sexp 'bounds))
+                          (cider-repl-handler (cider-current-repl))
+                          (cider-last-sexp 'bounds)
+                          (cider--repl-request-plist (cider--pretty-print-width)))
   (when prefix
     (cider-switch-to-repl-buffer)))
 


### PR DESCRIPTION
This change makes cider-eval-last-sexp-to-repl use the regular REPL handler for
handling the result. So content-type (displaying of images) works, and you get a
prompt again after the result.

Context: I think the content-type stuff that @arrdem did is very cool, but it currently *only* works if you actually evaluate a form inside the REPL. I often use things like `cider-pprint-eval-last-sexp`, and there it doesn't work.

I couldn't manage to get `cider-pprint-eval-last-sexp` working (although I think I know what I did wrong now), but so this is a first step to bring the content-types to other evaluation operations.

This does change the behaviour of `eval-last-sexp-to-repl`, since before it did a very naive `(with-current-buffer (insert value))`, whereas now it will e.g. print a new prompt. I think that's an improvement because willy nilly adding stuff to the REPL buffer means that when I go to the REPL and press enter it will re-evaluate the previous result, which is almost never what I want, but I'm sure this will break someone's workflow...

Feedback appreciated.

-----------------

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blog/master/doc) (if adding/changing user-visible functionality)

