### PR TITLE
Add missing cider-default-cljs-repl defcustom entries

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -809,10 +809,12 @@ relatively unlikely you'd like to use the same type of REPL in each project
 you're working on."
   :type '(choice (const :tag "Nashorn"  nashorn)
                  (const :tag "Figwheel" figwheel)
+                 (const :tag "Figwheel Main" figwheel-main)
                  (const :tag "Node"     node)
                  (const :tag "Weasel"   weasel)
                  (const :tag "Boot"     boot)
                  (const :tag "Shadow"   shadow)
+                 (const :tag "Shadow w/o Server" shadow-select)
                  (const :tag "Custom"   custom))
   :group 'cider
   :safe #'symbolp


### PR DESCRIPTION
Both Figwheel Main and Shadow w/o Server, aka shadow-select were missing.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [X] All tests are passing (`make test`)
- [X] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
