### PR TITLE
Ensure and mention Cljs Figwheel Main options

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -746,7 +746,10 @@ Figwheel for details."
   (let ((form "(do (require 'figwheel.main) (figwheel.main/start %s))")
         (options (string-trim
                   (or cider-figwheel-main-default-options
-                      (read-from-minibuffer "Select figwheel-main build (e.g. :dev): ")))))
+                      (read-from-minibuffer "Select Figwheel build (e.g. dev): ")))))
+    ;; TODO check for a Clojure map using parseedn
+    (unless (not (string-empty-p options))
+      (user-error "Figwheel Main requires the build-id as string"))
     (format form (cider-normalize-cljs-init-options options))))
 
 (defun cider-custom-cljs-repl-init-form ()

--- a/doc/clojurescript.md
+++ b/doc/clojurescript.md
@@ -236,7 +236,8 @@ You can also use [Figwheel-main](https://github.com/bhauman/figwheel-main) with 
 3. Start the REPL with `cider-jack-in-cljs` (<kbd>C-c C-x (C-)j (C-)s</kbd>). Select
 `figwheel-main` when prompted about the ClojureScript REPL type.
 
-4. Select the Figwheel build to run when prompted for it. (e.g. `:dev`).
+4. Select the Figwheel build as string or specify [the option map](
+https://figwheel.org/docs/scripting_api.html) when prompted (e.g. `:dev`).
 
 ### Using shadow-cljs
 


### PR DESCRIPTION
This patch checks and ensures we send back a sensible error in case of missing
Figwheel Main options and makes sure we mention them and link to the Scripting
API page.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [X] All tests are passing (`make test`)
- [X] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [X] You've updated the [user manual](../blog/master/doc) (if adding/changing user-visible functionality)