### PR TITLE
Fix shortcut for REPL buffers when type is "any"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@
 ### Changes
 
 * [#2482](https://github.com/clojure-emacs/cider/issues/2482): Don't bind nREPL server started by `cider-jack-in` to `::` (use `localhost` instead).
+* [#2484](https://github.com/clojure-emacs/cider/pull/2484): Fix issues where some functionality in REPL buffers (like eldoc) was broken.
+
+### Changes
+
+* [#2484](https://github.com/clojure-emacs/cider/pull/2484): REPL types are now symbols instead of strings.
 
 ## 0.18.0 (2018-09-02)
 

--- a/cider-client.el
+++ b/cider-client.el
@@ -153,7 +153,7 @@ REQUEST is a pair list of the form (\"op\" \"operation\" \"par1-name\"
                                     \"par1\" ... ).
 If CONNECTION is provided dispatch to that connection instead of
 the current connection.  Return the id of the sent message."
-  (nrepl-send-request request callback (or connection (cider-current-repl "any"))))
+  (nrepl-send-request request callback (or connection (cider-current-repl 'any))))
 
 (defun cider-nrepl-send-sync-request (request &optional connection abort-on-input)
   "Send REQUEST to the nREPL server synchronously using CONNECTION.
@@ -163,13 +163,13 @@ If ABORT-ON-INPUT is non-nil, the function will return nil
 at the first sign of user input, so as not to hang the
 interface."
   (nrepl-send-sync-request request
-                           (or connection (cider-current-repl "any"))
+                           (or connection (cider-current-repl 'any))
                            abort-on-input))
 
 (defun cider-nrepl-send-unhandled-request (request &optional connection)
   "Send REQUEST to the nREPL CONNECTION and ignore any responses.
 Immediately mark the REQUEST as done.  Return the id of the sent message."
-  (let* ((conn (or connection (cider-current-repl "any")))
+  (let* ((conn (or connection (cider-current-repl 'any)))
          (id (nrepl-send-request request #'ignore conn)))
     (with-current-buffer conn
       (nrepl--mark-id-completed id))

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -728,6 +728,7 @@ are synonyms.  If ENSURE is non-nil, throw an error if either there is
 no linked session or there is no REPL of TYPE within the current session."
   (if (and (derived-mode-p 'cider-repl-mode)
            (or (null type)
+               (string= "any" type)
                (string= cider-repl-type type)))
       ;; shortcut when in REPL buffer
       (current-buffer)

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -644,13 +644,13 @@ PARAMS is a plist as received by `cider-repl-create'."
     (let* ((proj-dir (plist-get params :project-dir))
            (host (plist-get params :host))
            (port (plist-get params :port))
-           (cljsp (string-match-p "cljs" (symbol-name (plist-get params :repl-type))))
+           (cljsp (member (plist-get params :repl-type) '(cljs pending-cljs)))
            (scored-repls
             (delq nil
                   (mapcar (lambda (b)
                             (let ((bparams (cider--gather-connect-params nil b)))
-                              (when (eq cljsp (string-match-p "cljs"
-                                                              (symbol-name (plist-get bparams :repl-type))))
+                              (when (eq cljsp (member (plist-get bparams :repl-type)
+                                                      '(cljs pending-cljs)))
                                 (cons (buffer-name b)
                                       (+
                                        (if (equal proj-dir (plist-get bparams :project-dir)) 8 0)

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -712,7 +712,7 @@ function with the repl buffer set as current."
 (defun cider--no-repls-user-error (type)
   "Throw \"No REPL\" user error customized for TYPE."
   (let ((type (cond
-               ((equal type "multi")
+               ((or (equal type "multi") (equal type "any"))
                 "clj or cljs")
                ((listp type)
                 (mapconcat #'identity type " or "))
@@ -723,8 +723,8 @@ function with the repl buffer set as current."
 (defun cider-current-repl (&optional type ensure)
   "Get the most recent REPL of TYPE from the current session.
 TYPE is either \"clj\", \"cljs\", \"multi\" or \"any\".
-When nil, infer the type from the current buffer.  \"multi\" or \"any\"
-are synonyms.  If ENSURE is non-nil, throw an error if either there is
+When nil, infer the type from the current buffer.
+If ENSURE is non-nil, throw an error if either there is
 no linked session or there is no REPL of TYPE within the current session."
   (if (and (derived-mode-p 'cider-repl-mode)
            (or (null type)
@@ -732,8 +732,7 @@ no linked session or there is no REPL of TYPE within the current session."
                (string= cider-repl-type type)))
       ;; shortcut when in REPL buffer
       (current-buffer)
-    (let* ((type (if (equal type "any") "multi" type))
-           (type (or type (cider-repl-type-for-buffer)))
+    (let* ((type (or type (cider-repl-type-for-buffer)))
            (repls (cider-repls type ensure))
            (repl (if (<= (length repls) 1)
                      (car repls)
@@ -749,7 +748,7 @@ no linked session or there is no REPL of TYPE within the current session."
   "Return non-nil if TYPE matches BUFFER's REPL type."
   (let ((buffer-repl-type (cider-repl-type buffer)))
     (cond ((null buffer-repl-type) nil)
-          ((or (null type) (equal type "multi")) t)
+          ((or (null type) (equal type "multi") (equal type "any")) t)
           ((listp type) (member buffer-repl-type type))
           (t (string= type buffer-repl-type)))))
 

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -54,7 +54,7 @@ Info contains the connection type, project name and host:port endpoint."
   (if-let* ((current-connection (ignore-errors (cider-current-repl))))
       (with-current-buffer current-connection
         (concat
-         cider-repl-type
+         (symbol-name cider-repl-type)
          (when cider-mode-line-show-connection
            (format ":%s@%s:%s"
                    (or (cider--project-name nrepl-project-dir) "<no project>")
@@ -133,8 +133,8 @@ Clojure buffer and the REPL buffer."
                                       (when-let* ((type (cider-repl-type-for-buffer b)))
                                         (unless a-buf
                                           (setq a-buf b))
-                                        (or (equal type "multi")
-                                            (equal type repl-type)))))
+                                        (or (eq type 'multi)
+                                            (eq type repl-type)))))
                                   (buffer-list)))))
         (if-let* ((buf (or the-buf a-buf)))
             (if cider-repl-display-in-current-window
@@ -674,7 +674,10 @@ the LIMIT in `cider--anchored-search-suppressed-forms`"
 An unused reader conditional expression is an expression for a platform
 that does not match the CIDER connection for the buffer.  Search is done
 with the given LIMIT."
-  (let ((repl-types (seq-uniq (seq-map #'cider-repl-type (cider-repls))))
+  (let ((repl-types (seq-uniq (seq-map
+                               (lambda (repl)
+                                 (symbol-name (cider-repl-type repl)))
+                               (cider-repls))))
         (result 'retry))
     (while (and (eq result 'retry) (<= (point) limit))
       (condition-case condition

--- a/cider-resolve.el
+++ b/cider-resolve.el
@@ -107,7 +107,7 @@ This will be clojure.core or cljs.core depending on the return value of the
 function `cider-repl-type'."
   (when-let* ((repl (cider-current-repl)))
     (with-current-buffer repl
-      (cider-resolve--get-in (if (equal cider-repl-type "cljs")
+      (cider-resolve--get-in (if (eq cider-repl-type 'cljs)
                                  "cljs.core"
                                "clojure.core")))))
 

--- a/cider.el
+++ b/cider.el
@@ -1008,7 +1008,7 @@ server is created."
        (cider--update-do-prompt)
        (append other-params)
        (plist-put :repl-init-function nil)
-       (plist-put :repl-type "clj")
+       (plist-put :repl-type 'clj)
        (plist-put :session-name ses-name)))))
 
 ;;;###autoload
@@ -1030,7 +1030,7 @@ server buffer, in which case a new session for that server is created."
        (cider--update-cljs-type)
        (cider--update-cljs-init-function)
        (plist-put :session-name ses-name)
-       (plist-put :repl-type "pending-cljs")))))
+       (plist-put :repl-type 'pending-cljs)))))
 
 ;;;###autoload
 (defun cider-connect-clj (&optional params)
@@ -1045,7 +1045,7 @@ prefix argument, prompt for all the parameters."
      (cider--check-existing-session)
      (plist-put :repl-init-function nil)
      (plist-put :session-name nil)
-     (plist-put :repl-type "clj"))))
+     (plist-put :repl-type 'clj))))
 
 ;;;###autoload
 (defun cider-connect-cljs (&optional params)
@@ -1062,7 +1062,7 @@ parameters regardless of their supplied or default values."
      (cider--update-cljs-type)
      (cider--update-cljs-init-function)
      (plist-put :session-name nil)
-     (plist-put :repl-type "pending-cljs"))))
+     (plist-put :repl-type 'pending-cljs))))
 
 ;;;###autoload
 (defun cider-connect-clj&cljs (params &optional soft-cljs-start)

--- a/test/cider-client-tests.el
+++ b/test/cider-client-tests.el
@@ -63,20 +63,20 @@
     ;; clojure mode
     (with-temp-buffer
       (clojure-mode)
-      (expect (cider-repl-type-for-buffer) :to-equal "clj"))
+      (expect (cider-repl-type-for-buffer) :to-equal 'clj))
     ;; clojurescript mode
     (with-temp-buffer
       (clojurescript-mode)
-      (expect (cider-repl-type-for-buffer) :to-equal "cljs")))
+      (expect (cider-repl-type-for-buffer) :to-equal 'cljs)))
 
   (it "returns the connection type based on `cider-repl-type'"
     ;; clj
-    (setq cider-repl-type "clj")
-    (expect (cider-repl-type-for-buffer) :to-equal "clj")
+    (setq cider-repl-type 'clj)
+    (expect (cider-repl-type-for-buffer) :to-equal 'clj)
 
     ;; cljs
-    (setq cider-repl-type "cljs")
-    (expect (cider-repl-type-for-buffer) :to-equal "cljs"))
+    (setq cider-repl-type 'cljs)
+    (expect (cider-repl-type-for-buffer) :to-equal 'cljs))
 
   (it "returns nil as its default value"
     (setq cider-repl-type nil)
@@ -85,7 +85,7 @@
 (describe "cider-nrepl-send-unhandled-request"
   (it "returns the id of the request sent to nREPL server and ignores the response"
     (spy-on 'process-send-string :and-return-value nil)
-    (with-repl-buffer "cider-nrepl-send-request" "clj" b
+    (with-repl-buffer "cider-nrepl-send-request" 'clj b
       (setq-local nrepl-pending-requests (make-hash-table :test 'equal))
       (setq-local nrepl-completed-requests (make-hash-table :test 'equal))
       (let ((id (cider-nrepl-send-unhandled-request '("op" "t" "extra" "me"))))

--- a/test/cider-connection-tests.el
+++ b/test/cider-connection-tests.el
@@ -43,7 +43,7 @@
 
   (it "returns nil when a cider connection is available"
     (let ((default-directory "/tmp/a-dir"))
-      (with-repl-buffer "cider-ensure-session" "clj" b
+      (with-repl-buffer "cider-ensure-session" 'clj b
         (expect (cider-ensure-connected) :to-equal
                 (list "cider-ensure-session" b)))))
 
@@ -63,22 +63,22 @@
   (describe "when there are no active connections"
     (it "returns nil"
       (expect (cider-current-repl) :not :to-be-truthy)
-      (expect (cider-current-repl "clj") :not :to-be-truthy)
-      (expect (cider-current-repl "cljs") :not :to-be-truthy)))
+      (expect (cider-current-repl 'clj) :not :to-be-truthy)
+      (expect (cider-current-repl 'cljs) :not :to-be-truthy)))
 
   (describe "when active connections are available"
 
     (it "always returns the latest connection"
       (let ((default-directory "/tmp/a-dir"))
-        (with-repl-buffer ses-name "clj" bb1
-          (with-repl-buffer ses-name "cljs" bb2
-            (with-repl-buffer ses-name "clj" b1
-              (with-repl-buffer ses-name "cljs" b2
+        (with-repl-buffer ses-name 'clj bb1
+          (with-repl-buffer ses-name 'cljs bb2
+            (with-repl-buffer ses-name 'clj b1
+              (with-repl-buffer ses-name 'cljs b2
                 (expect (cider-current-repl) :to-equal b2)
 
                 ;; follows type arguments
-                (expect (cider-current-repl "clj") :to-equal b1)
-                (expect (cider-current-repl "cljs") :to-equal b2)
+                (expect (cider-current-repl 'clj) :to-equal b1)
+                (expect (cider-current-repl 'cljs) :to-equal b2)
 
                 ;; follows file type
                 (with-temp-buffer
@@ -91,19 +91,19 @@
 
     (it "always returns the most recently used connection"
       (let ((default-directory "/tmp/a-dir"))
-        (with-repl-buffer ses-name "clj" bb1
-          (with-repl-buffer ses-name "cljs" bb2
-            (with-repl-buffer ses-name "clj" b1
-              (with-repl-buffer ses-name "cljs" b2
+        (with-repl-buffer ses-name 'clj bb1
+          (with-repl-buffer ses-name 'cljs bb2
+            (with-repl-buffer ses-name 'clj b1
+              (with-repl-buffer ses-name 'cljs b2
 
                 (switch-to-buffer bb2)
                 (switch-to-buffer bb1)
                 (expect (cider-current-repl) :to-equal bb1)
 
                 ;; follows type arguments
-                (expect (cider-current-repl "clj") :to-equal bb1)
+                (expect (cider-current-repl 'clj) :to-equal bb1)
                 (message "%S" (seq-take (buffer-list) 10))
-                (expect (cider-current-repl "cljs") :to-equal bb2)
+                (expect (cider-current-repl 'cljs) :to-equal bb2)
 
                 ;; follows file type
                 (with-temp-buffer
@@ -118,13 +118,13 @@
       (describe "when there is only one connection available"
         (it "returns the only connection"
           (let ((default-directory "/tmp/a-dir"))
-            (with-repl-buffer ses-name "clj" b
+            (with-repl-buffer ses-name 'clj b
               (with-temp-buffer
                 (clojure-mode)
-                (expect (cider-current-repl "clj") :to-equal b))
+                (expect (cider-current-repl 'clj) :to-equal b))
               (with-temp-buffer
                 (clojurec-mode)
-                (expect (cider-current-repl "clj") :to-equal b)))))))
+                (expect (cider-current-repl 'clj) :to-equal b)))))))
 
     (describe "when type argument is given"
 
@@ -132,23 +132,23 @@
         (it "returns that connection buffer"
           (let ((default-directory "/tmp/a-dir"))
             ;; for clj
-            (with-repl-buffer ses-name "clj" b1
-              (with-repl-buffer ses-name "cljs" b2
-                (expect (cider-current-repl "clj") :to-equal b1)))
+            (with-repl-buffer ses-name 'clj b1
+              (with-repl-buffer ses-name 'cljs b2
+                (expect (cider-current-repl 'clj) :to-equal b1)))
             ;; for cljs
-            (with-repl-buffer ses-name "cljs" b1
-              (with-repl-buffer ses-name "clj" b2
-                (expect (cider-current-repl "cljs") :to-equal b1))))))
+            (with-repl-buffer ses-name 'cljs b1
+              (with-repl-buffer ses-name 'clj b2
+                (expect (cider-current-repl 'cljs) :to-equal b1))))))
 
       (describe "when connection of that type doesn't exists"
         (it "returns nil"
           ;; for clj
-          (with-repl-buffer ses-name "cljs" b1
-            (expect (cider-current-repl "clj") :to-equal nil))
+          (with-repl-buffer ses-name 'cljs b1
+            (expect (cider-current-repl 'clj) :to-equal nil))
 
           ;; for cljs
-          (with-repl-buffer ses-name "clj" b2
-            (expect (cider-current-repl "cljs") :to-equal nil))))
+          (with-repl-buffer ses-name 'clj b2
+            (expect (cider-current-repl 'cljs) :to-equal nil))))
 
       (describe "when type argument is not given"
 
@@ -156,15 +156,15 @@
           (it "returns that connection buffer"
             (let ((default-directory "/tmp/a-dir"))
               ;; for clj
-              (with-repl-buffer ses-name "clj" b1
-                (with-repl-buffer ses-name "cljs" b2
+              (with-repl-buffer ses-name 'clj b1
+                (with-repl-buffer ses-name 'cljs b2
                   (with-temp-buffer
                     (setq major-mode 'clojure-mode)
                     (expect (cider-current-repl) :to-equal b1))))
 
               ;; for cljs
-              (with-repl-buffer ses-name "cljs" b1
-                (with-repl-buffer ses-name "clj" b2
+              (with-repl-buffer ses-name 'cljs b1
+                (with-repl-buffer ses-name 'clj b2
                   (with-temp-buffer
                     (setq major-mode 'clojurescript-mode)
                     (expect (cider-current-repl) :to-equal b1)))))))
@@ -172,13 +172,13 @@
         (describe "when a connection matching current file extension doesn't exist"
           (it "returns nil"
             ;; for clj
-            (with-repl-buffer ses-name "clj" b1
+            (with-repl-buffer ses-name 'clj b1
               (with-temp-buffer
                 (setq major-mode 'clojurescript-mode)
                 (expect (cider-current-repl) :to-equal nil)))
 
             ;; for cljs
-            (with-repl-buffer ses-name "cljs" b2
+            (with-repl-buffer ses-name 'cljs b2
               (with-temp-buffer
                 (setq major-mode 'clojure-mode)
                 (expect (cider-current-repl) :to-equal nil))))))))
@@ -188,19 +188,19 @@
       (let ((a-dir "/tmp/a-dir")
             (b-dir "/tmp/b-dir"))
         (let ((default-directory a-dir))
-          (with-repl-buffer ses-name "clj" bb1
-            (with-repl-buffer ses-name "cljs" bb2
+          (with-repl-buffer ses-name 'clj bb1
+            (with-repl-buffer ses-name 'cljs bb2
               (let ((default-directory a-dir))
-                (with-repl-buffer ses-name2 "clj" b1
-                  (with-repl-buffer ses-name2 "cljs" b2
+                (with-repl-buffer ses-name2 'clj b1
+                  (with-repl-buffer ses-name2 'cljs b2
 
                     (switch-to-buffer bb2)
                     (switch-to-buffer bb1)
                     (expect (cider-current-repl) :to-equal bb1)
 
                     ;; follows type arguments
-                    (expect (cider-current-repl "clj") :to-equal bb1)
-                    (expect (cider-current-repl "cljs") :to-equal bb2)
+                    (expect (cider-current-repl 'clj) :to-equal bb1)
+                    (expect (cider-current-repl 'cljs) :to-equal bb2)
 
                     ;; follows file type
                     (with-temp-buffer
@@ -234,19 +234,19 @@
   (describe "when there are no active connections"
     (it "returns nil"
       (expect (cider-repls) :to-equal nil)
-      (expect (cider-repls "clj") :to-equal nil)
-      (expect (cider-repls "cljs") :to-equal nil)))
+      (expect (cider-repls 'clj) :to-equal nil)
+      (expect (cider-repls 'cljs) :to-equal nil)))
 
   (describe "when multiple sessions exist"
     (it "always returns the most recently used connection"
       (let ((a-dir "/tmp/a-dir")
             (b-dir "/tmp/b-dir"))
         (let ((default-directory a-dir))
-          (with-repl-buffer ses-name "clj" bb1
-            (with-repl-buffer ses-name "cljs" bb2
+          (with-repl-buffer ses-name 'clj bb1
+            (with-repl-buffer ses-name 'cljs bb2
               (let ((default-directory b-dir))
-                (with-repl-buffer ses-name2 "clj" b1
-                  (with-repl-buffer ses-name2 "cljs" b2
+                (with-repl-buffer ses-name2 'clj b1
+                  (with-repl-buffer ses-name2 'cljs b2
 
                     (expect (cider-repls) :to-equal (list b2 b1))
 
@@ -254,8 +254,8 @@
                     (expect (cider-repls) :to-equal (list bb2 bb1))
 
                     ;; follows type arguments
-                    (expect (cider-repls "clj") :to-equal (list bb1))
-                    (expect (cider-repls "cljs") :to-equal (list bb2))
+                    (expect (cider-repls 'clj) :to-equal (list bb1))
+                    (expect (cider-repls 'cljs) :to-equal (list bb2))
 
                     (switch-to-buffer bb2)
                     ;; follows file type
@@ -263,13 +263,13 @@
                       (with-temp-buffer
                         (setq major-mode 'clojure-mode)
                         (expect (cider-repls) :to-equal (list b2 b1))
-                        (expect (cider-repls "clj") :to-equal (list b1))))
+                        (expect (cider-repls 'clj) :to-equal (list b1))))
 
                     (let ((default-directory a-dir))
                       (with-temp-buffer
                         (setq major-mode 'clojurescript-mode)
                         (expect (cider-repls) :to-equal (list bb2 bb1))
-                        (expect (cider-repls "cljs") :to-equal (list bb2)))))))))))))
+                        (expect (cider-repls 'cljs) :to-equal (list bb2)))))))))))))
 
   (describe "killed buffers"
     (it "do not show up in it"
@@ -278,9 +278,9 @@
          (a b)
          (let ((session (list "some-session" a b)))
            (with-current-buffer a
-             (setq cider-repl-type "clj"))
+             (setq cider-repl-type 'clj))
            (with-current-buffer b
-             (setq cider-repl-type "clj"))
+             (setq cider-repl-type 'clj))
            (sesman-register 'CIDER session)
            (expect (cider-repls) :to-equal (list a b))
            (kill-buffer b)
@@ -297,7 +297,7 @@
       (with-temp-buffer
         (setq-local nrepl-endpoint '(:host "localhost" :port 4005))
         (setq-local nrepl-project-dir "proj")
-        (setq-local cider-repl-type "clj")
+        (setq-local cider-repl-type 'clj)
         (expect (cider--connection-info (current-buffer))
                 :to-equal "CLJ proj@localhost:4005 (Java 1.7, Clojure 1.7.0, nREPL 0.2.1)"))))
 
@@ -305,7 +305,7 @@
     (it "returns information about the connection buffer without project name"
       (with-temp-buffer
         (setq-local nrepl-endpoint '(:host "localhost" :port 4005))
-        (setq-local cider-repl-type "clj")
+        (setq-local cider-repl-type 'clj)
         (expect (cider--connection-info (current-buffer))
                 :to-equal "CLJ <no project>@localhost:4005 (Java 1.7, Clojure 1.7.0, nREPL 0.2.1)")))))
 
@@ -316,9 +316,9 @@
        (a b)
        (let ((session (list "some-session" a b)))
          (with-current-buffer a
-           (setq cider-repl-type "clj"))
+           (setq cider-repl-type 'clj))
          (with-current-buffer b
-           (setq cider-repl-type "clj"))
+           (setq cider-repl-type 'clj))
          (sesman-register 'CIDER session)
          (expect (cider-repls) :to-equal (list a b))
          (cider--close-connection b)

--- a/test/cider-font-lock-tests.el
+++ b/test/cider-font-lock-tests.el
@@ -68,7 +68,7 @@
     (it "uses cider-reader-conditional-face"
       (spy-on 'cider-connected-p :and-return-value t)
       (spy-on 'cider-repls :and-return-value '(list t))
-      (spy-on 'cider-repl-type :and-return-value "clj")
+      (spy-on 'cider-repl-type :and-return-value 'clj)
       (cider--test-with-temp-buffer "#?(:clj 'clj :cljs 'cljs :cljr 'cljr)"
         (let ((cider-font-lock-reader-conditionals t)
               (found (cider--face-exists-in-range-p (point-min) (point-max)
@@ -78,7 +78,7 @@
     (it "highlights unmatched reader conditionals"
       (spy-on 'cider-connected-p :and-return-value t)
       (spy-on 'cider-repls :and-return-value '(list t))
-      (spy-on 'cider-repl-type :and-return-value "clj")
+      (spy-on 'cider-repl-type :and-return-value 'clj)
       (cider--test-with-temp-buffer "#?(:clj 'clj :cljs 'cljs :cljr 'cljr)"
         (let ((cider-font-lock-reader-conditionals t))
           (expect (cider--face-exists-in-range-p 4 12 'cider-reader-conditional-face)
@@ -91,7 +91,7 @@
     (it "works with splicing"
       (spy-on 'cider-connected-p :and-return-value t)
       (spy-on 'cider-repls :and-return-value '(list t))
-      (spy-on 'cider-repl-type :and-return-value "clj")
+      (spy-on 'cider-repl-type :and-return-value 'clj)
       (cider--test-with-temp-buffer "[1 2 #?(:clj [3 4] :cljs [5 6] :cljr [7 8])]"
         (let ((cider-font-lock-reader-conditionals t))
           (expect (cider--face-exists-in-range-p 1 18 'cider-reader-conditional-face)
@@ -104,7 +104,7 @@
     (it "does not apply inside strings or comments"
       (spy-on 'cider-connected-p :and-return-value t)
       (spy-on 'cider-repls :and-return-value '(list t))
-      (spy-on 'cider-repl-type :and-return-value "clj")
+      (spy-on 'cider-repl-type :and-return-value 'clj)
       (cider--test-with-temp-buffer "\"#?(:clj 'clj :cljs 'cljs :cljr 'cljr)\" ;; #?(:clj 'clj :cljs 'cljs :cljr 'cljr)"
         (let ((cider-font-lock-reader-conditionals t))
           (expect (cider--face-exists-in-range-p (point-min) (point-max) 'cider-reader-conditional-face)
@@ -113,7 +113,7 @@
     (it "highlights all unmatched reader conditionals"
       (spy-on 'cider-connected-p :and-return-value t)
       (spy-on 'cider-repls :and-return-value '(list t))
-      (spy-on 'cider-repl-type :and-return-value "cljs")
+      (spy-on 'cider-repl-type :and-return-value 'cljs)
       (cider--test-with-temp-buffer
           "#?(:clj 'clj :cljs 'cljs :cljr 'cljr)\n#?(:clj 'clj :cljs 'cljs :cljr 'cljr)\n"
         (let ((cider-font-lock-reader-conditionals t))
@@ -129,7 +129,7 @@
     (it "does not highlight beyond the limits of the reader conditional group"
       (spy-on 'cider-connected-p :and-return-value t)
       (spy-on 'cider-repls :and-return-value '(list t))
-      (spy-on 'cider-repl-type :and-return-value "clj")
+      (spy-on 'cider-repl-type :and-return-value 'clj)
       (cider--test-with-temp-buffer
           "#?(:clj 'clj :cljs 'cljs :cljr 'cljr)\n#?(:clj 'clj :cljs 'cljs :cljr 'cljr)\n"
         (let ((cider-font-lock-reader-conditionals t))
@@ -144,7 +144,7 @@
     (it "is disabled"
       (spy-on 'cider-connected-p :and-return-value nil)
       (spy-on 'cider-repls :and-return-value '(list t))
-      (spy-on 'cider-repl-type :and-return-value '("clj" "cljs"))
+      (spy-on 'cider-repl-type :and-return-value '(clj cljs))
       (cider--test-with-temp-buffer "#?(:clj 'clj :cljs 'cljs :cljr 'cljr)"
         (let ((cider-font-lock-reader-conditionals t))
           (expect (cider--face-exists-in-range-p (point-min) (point-max) 'cider-reader-conditional-face)

--- a/test/cider-interaction-tests.el
+++ b/test/cider-interaction-tests.el
@@ -77,7 +77,7 @@
   (it "works as expected in empty Clojure buffers"
     (spy-on 'cider-request:load-file :and-return-value nil)
     (let ((default-directory "/tmp/a-dir"))
-      (with-repl-buffer "load-file-session" "clj" b
+      (with-repl-buffer "load-file-session" 'clj b
         (with-temp-buffer
           (clojure-mode)
           (setq buffer-file-name (make-temp-name "tmp.clj"))
@@ -87,7 +87,7 @@
   (it "works as expected in empty Clojure buffers"
     (spy-on 'cider-nrepl-request:eval :and-return-value nil)
     (let ((default-directory "/tmp/a-dir"))
-      (with-repl-buffer "interaction-session" "clj" b
+      (with-repl-buffer "interaction-session" 'clj b
         (with-temp-buffer
           (clojure-mode)
           (expect (cider-interactive-eval "(+ 1)") :not :to-throw))))))

--- a/test/cider-selector-tests.el
+++ b/test/cider-selector-tests.el
@@ -65,7 +65,7 @@
 ;; (describe "cider-selector-method-m"
 ;;   (it "switches to current connection's *nrepl-messages* buffer"
 ;;     (let ((buf (get-buffer-create "*nrepl-messages some-id*")))
-;;       (with-repl-buffer "a-session" "clj" _
+;;       (with-repl-buffer "a-session" 'clj _
 ;;         (setq-local nrepl-messages-buffer buf)
 ;;         (message "%S" (nrepl-messages-buffer (cider-current-repl)))
 ;;         (cider--test-selector-method ?m nil "*nrepl-messages some-id*")))))

--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -78,14 +78,14 @@
   (it "understands all formats"
     (with-temp-buffer
       (let ((params '(:project-dir "path/to/dirB" :host "localhost" :port 100
-                                   :repl-type "cljs" :cljs-repl-type "node")))
+                                   :repl-type cljs :cljs-repl-type "node")))
         (expect (nrepl-make-buffer-name "*buff-name %j:%J:%h:%H:%p:%r:%S*" params)
                 :to-equal "*buff-name dirB:to/dirB:localhost:100:cljs:node*"))))
 
   (it "strips trailing separators"
     (with-temp-buffer
       (let ((params '(:project-dir "path/to/dirB" :host "localhost" :port 100
-                                   :repl-type "cljs" :cljs-repl-type nil)))
+                                   :repl-type cljs :cljs-repl-type nil)))
         (expect (nrepl-make-buffer-name "*buff-name [%r:%S]*" params)
                 :to-equal "*buff-name [cljs]*")
         (expect (nrepl-make-buffer-name "*buff-name (%r:%S)*" params)


### PR DESCRIPTION
This fixes a regression from #2467 where in clojure repl buffers the cider eldoc feature stopped working.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blog/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://cider.readthedocs.io/en/latest/hacking_on_cider/
