### PR TITLE
Fixed unsynchronized README.md on cider-connect.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,12 @@ by your project's build tool (Gradle, Maven, etc).
 After you get your nREPL server running go back to Emacs.  Typing there <kbd>M-x</kbd>
 `cider-connect` will allow you to connect to the running nREPL server.
 
-In Clojure(Script) buffers the command `cider-connect` is bound to
-<kbd>C-c C-x (C-)c (C-)c</kbd>.
+In Clojure buffers the command `cider-connect | cider-connect-clj` is bound to
+<kbd>C-c C-x (C-)c (C-)j</kbd>.
+
+In ClojureScript buffers the command `cider-connect-cljs` is bound to
+<kbd>C-c C-x (C-)c (C-)s</kbd>.
+
 
 ## Diving Deeper
 


### PR DESCRIPTION
or For synchronize, add cider-connect keybinding `C-c C-x (C-)c (C-)c` to cider.el/cider-start-map

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blog/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://cider.readthedocs.io/en/latest/hacking_on_cider/
