### PR TITLE
Fix face names in docstring of cider-font-lock-dynamically variable

### DIFF
--- a/cider-mode.el
+++ b/cider-mode.el
@@ -573,9 +573,9 @@ variable to nil you'll still see basic syntax highlighting.
 
 The value is a list of symbols, each one indicates a different type of var
 that should be font-locked:
-   `macro' (default): Any defined macro gets the `font-lock-builtin-face'.
+   `macro' (default): Any defined macro gets the `font-lock-keyword-face'.
    `function': Any defined function gets the `font-lock-function-face'.
-   `var': Any non-local var gets the `font-lock-variable-face'.
+   `var': Any non-local var gets the `font-lock-variable-name-face'.
    `deprecated' (default): Any deprecated var gets the `cider-deprecated-face'
    face.
    `core' (default): Any symbol from clojure.core (face depends on type).


### PR DESCRIPTION
This PR fixes the names of the faces that are used for macros and vars in the docstring of the `cider-font-lock-dynamically` variable.

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blog/master/doc) (if adding/changing user-visible functionality)
