### PR TITLE
add defcustom cider-use-ssh-to-infer-remote-ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 ### Changes
 
 * [#2484](https://github.com/clojure-emacs/cider/pull/2484): REPL types are now symbols instead of strings.
+* [#1544](https://github.com/clojure-emacs/cider/issues/1544): Add a new defcustom `cider-infer-remote-nrepl-ports` to control whether we use tramp/ssh to infer remote ports.  Now defaulting to `nil` (previously it always tried to infer).
 
 ## 0.18.0 (2018-09-02)
 

--- a/doc/up_and_running.md
+++ b/doc/up_and_running.md
@@ -111,3 +111,22 @@ helpful for identifying each host.
   '(("host-a" "10.10.10.1" "7888")
     ("host-b" "7888")))
 ```
+
+## SSH
+
+In some circumstances, cider can try to use SSH to either:
+
+* Tunnel a connection over SSH.
+* Infer the remote nREPL port for a direct connection.
+
+This behavior is controlled by two options (both default `nil`):
+
+* `nrepl-use-ssh-fallback-for-remote-hosts`: When true, attempt to connect via ssh
+  to remote hosts when unable to connect directly.
+* `cider-infer-remote-nrepl-ports`: When true, cider will use ssh to try to infer
+  nREPL ports on remote hosts (for a direct connection).
+
+Note that enabling either of these causes cider to use
+[tramp](https://www.gnu.org/software/tramp/) for some SSH operations, which parses
+config files such as `~/.ssh/config` and `~/.ssh/known_hosts`. This is known to
+cause problems with complex or nonstandard ssh configs.


### PR DESCRIPTION
This is just an idea to address #1544.  If the cider maintainers want it, I can update this PR to also include documentation of the new defcustom.