### PR TITLE
[inspector] Use visual-line-mode instead of truncate-lines

### DIFF
--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -85,8 +85,7 @@ The page size can be also changed interactively within the inspector."
   (set-syntax-table clojure-mode-syntax-table)
   (setq-local electric-indent-chars nil)
   (setq-local sesman-system 'CIDER)
-  (when cider-special-mode-truncate-lines
-    (setq-local truncate-lines t)))
+  (visual-line-mode 1))
 
 ;;;###autoload
 (defun cider-inspect-last-sexp ()


### PR DESCRIPTION
I'm not really sure what `truncate-lines` has been achieving here. I removed it, but I can bring it back if it is still useful.

Before:

<img width="1275" alt="screen shot 2018-11-07 at 00 28 40" src="https://user-images.githubusercontent.com/468477/48098259-d54b9300-e224-11e8-972a-69f609d1b614.png">

After:

<img width="1276" alt="screen shot 2018-11-07 at 00 28 57" src="https://user-images.githubusercontent.com/468477/48098267-d977b080-e224-11e8-8943-ea73575e2386.png">