### PR TITLE
Improve the Makefile autoload and compilation sections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,15 @@ export EMACS ?= emacs
 EMACSFLAGS = -L .
 CASK = cask
 VERSION = $(shell git describe --tags --abbrev=0 | sed 's/^v//')
-PACKAGE_NAME = cider-$(VERSION)
+PKG = cider
 
-ELS = $(wildcard *.el)
-LINTELS = $(filter-out cider-autoloads.el,$(ELS))
+ELS_ALL = $(wildcard *.el)
+ELS = $(filter-out $(PKG)-autoloads.el,$(ELS_ALL))
 OBJECTS = $(ELS:.el=.elc)
 
-.PHONY: elpa build version test lint clean elpaclean run-cider
+.PHONY: elpa build version test lint clean elpaclean autoloads run-$(PKG)
+
+all: build
 
 .depend: $(ELS)
 	@echo Compute dependencies
@@ -26,7 +28,21 @@ elpa-$(EMACS):
 
 elpa: elpa-$(EMACS)
 
-build: version elpa
+autoloads: $(PKG)-autoloads.el
+
+$(PKG)-autoloads.el: $(ELS)
+	@printf "Generating $@\n"
+	@printf "%s" "$$LOADDEFS_TMPL" > $@
+	@$(CASK) exec $(EMACS) -Q --batch -l autoload.el --eval "(progn\
+	(fset 'message (lambda (&rest _)))\
+	(setq make-backup-files nil)\
+	(setq vc-handled-backends nil)\
+	(setq default-directory (file-truename default-directory))\
+	(setq generated-autoload-file (expand-file-name \"$@\"))\
+	(setq find-file-visit-truename t)\
+	(update-directory-autoloads default-directory))"
+
+build: version elpa autoloads
 	$(CASK) build
 
 version:
@@ -35,31 +51,45 @@ version:
 test: version build
 	$(CASK) exec buttercup -L . -L ./test/utils/
 
-autoloads:
-	$(CASK) exec $(EMACS) -Q --batch \
-		-l autoload.el \
-		--eval "(let ((generated-autoload-file (expand-file-name \"cider-autoloads.el\"))) \
-                  (update-directory-autoloads (expand-file-name \".\")))"
-
 lint: version elpa
 	$(CASK) exec $(EMACS) -Q --batch \
 		--eval "(setq enable-local-variables :safe)" \
 		-l elisp-lint.el -f elisp-lint-files-batch \
 		--no-package-format \
                 --no-fill-column \
-		$(LINTELS)
+		$(ELS)
 
 test-all: lint test
 
 clean:
-	rm -f .depend $(OBJECTS) cider-autoloads.el
+	rm -f .depend $(OBJECTS) $(PKG)-autoloads.el
 
 elpaclean: clean
 	rm -f elpa*
 	rm -rf .cask # Clean packages installed for development
 
-run-cider: elpa
-	cask exec $(EMACS) -Q -L . --eval "(require 'cider)"
+run-$(PKG): elpa
+	cask exec $(EMACS) -Q -L . --eval "(require '$(PKG))"
 
 html:
 	mkdocs build
+
+## Templates #########################################################
+
+define LOADDEFS_TMPL
+;;; $(PKG)-autoloads.el --- automatically extracted autoloads
+;;
+;;; Code:
+(add-to-list 'load-path (directory-file-name \
+(or (file-name-directory #$$) (car load-path))))
+
+;; Local Variables:
+;; version-control: never
+;; no-byte-compile: t
+;; no-update-autoloads: t
+;; End:
+;;; $(PKG)-autoloads.el ends here
+
+endef
+export LOADDEFS_TMPL
+#'

--- a/doc/hacking_on_cider.md
+++ b/doc/hacking_on_cider.md
@@ -30,9 +30,10 @@ Then:
 ```el
 ;; load CIDER from its source code
 (add-to-list 'load-path "~/projects/cider")
-(require 'cider)
-(require 'cider-autoloads)
+(load "cider-autoloads" t t)
 ```
+
+If you want to compile **and** generate autoloads, just run `make`.
 
 ### Changing the code
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -114,11 +114,10 @@ following command:
 
 ## Manual installation
 
-Installing CIDER manually is discouraged unless you plan to work with
-CIDER's codebase. The manual installation is relatively involved as it
-requires manual installation of the dependencies and manual generation
-of the package autoloads. Check out the section [Hacking on
-CIDER](hacking_on_cider.md) for more details.
+Installing CIDER manually is discouraged unless you plan to work with CIDER's
+codebase. The manual installation is relatively involved as it requires manual
+installation of the dependencies. Check out the section
+[Hacking on CIDER](hacking_on_cider.md) for more details.
 
 ## CIDER's nREPL middleware
 


### PR DESCRIPTION
Inspired by the immense magit, we now have a similar way to build the
autoloads.el file and additionally we combine both autoload and compilation
steps under the build target. With this change, manual installation and tools
like borg can just call make and have everything ready for consumption.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [X] All tests are passing (`make test`)
- [X] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [X] You've updated the [user manual](../blog/master/doc) (if adding/changing user-visible functionality)