### PR TITLE
Re-set the current buffer after display-buffer

### DIFF
--- a/cider-repl.el
+++ b/cider-repl.el
@@ -315,7 +315,15 @@ client process connection.  Unless NO-BANNER is non-nil, insert a banner."
   (when cider-repl-display-in-current-window
     (add-to-list 'same-window-buffer-names (buffer-name buffer)))
   (pcase cider-repl-pop-to-buffer-on-connect
-    (`display-only (display-buffer buffer))
+    (`display-only
+     (let ((orig-buffer (current-buffer)))
+       (display-buffer buffer)
+       ;; User popup-rules (specifically `:select nil') can cause the call to
+       ;; `display-buffer' to reset the current Emacs buffer to the clj/cljs
+       ;; buffer that the user ran `jack-in' from - we need the current-buffer
+       ;; to be the repl to initialize, so reset it back here to be resilient
+       ;; against user config
+       (set-buffer orig-buffer)))
     ((pred identity) (pop-to-buffer buffer)))
   (cider-repl-set-initial-ns buffer)
   (cider-repl-require-repl-utils)


### PR DESCRIPTION
If the user has `:select nil` in their popup rules for the Cider REPL
buffer, the call to `display-buffer` to display the repl buffer while
initializing it will reset the `current-buffer` to the buffer the user
ran `jack-in` from, which breaks any successive calls to
`cider-current-repl`. Resetting the current buffer back to the original
buffer after `display-buffer` is resilient against this config change,
without breaking anything else in the case the config is absent.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`make test`)
- [X] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blog/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://cider.readthedocs.io/en/latest/hacking_on_cider/
