### PR TITLE
[Fix #2474] Fix end-of-output detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bug fixes
 
+* [#2474](https://github.com/clojure-emacs/cider/issues/2474): Fix incorrect detection of output and out-of-order printing.
 * [#2514](https://github.com/clojure-emacs/cider/issues/2514): Don't auto-jump to warnings when `cider-auto-jump-to-error` is set to 'errors-only.
 * [#2453](https://github.com/clojure-emacs/cider/issues/2453): Make it possible to debug deftype methods by direct insertion of #dbg and #break readers into the deftype methods.
 * [#1869](https://github.com/clojure-emacs/cider/issues/1869),[cider-nrepl#460](https://github.com/clojure-emacs/cider-nrepl/issues/460): Fix `continue` debugger command which was stopping entering debugger on repeated invocations.


### PR DESCRIPTION
The original issue comes down to the incorrect end-of-output detection (rationale of why #2474 should be fixed on emacs side and not on nrepl side is [here](https://github.com/nrepl/nrepl/issues/62#issuecomment-441015237)). 

I am renaming `cider-repl--end-of-line-before-input-start` into `cider-repl--end-of-output` because the former is less suggestive of what that function is supposed to do. 