### PR TITLE
Deep editing pass on documentation.

### DIFF
--- a/doc/clojurescript.md
+++ b/doc/clojurescript.md
@@ -1,30 +1,34 @@
 ## ClojureScript
 
-CIDER works with ClojureScript, but you should keep in mind that not all
-the functionality available with Clojure exists for ClojureScript (at least
-not yet). To give you a concrete example - things like running tests and
-the debugger are currently Clojure-only features.
+CIDER works well with ClojureScript, but not all CIDER features are
+available in ClojureScript (yet). For instance, the test runner and
+debugger are currently Clojure-only features. Unlike the Clojure
+ecosystem that is dominated by Leiningen and Boot, the ClojureScript
+ecosystem has a number of different choices for REPLs. You'll have to
+decide which one you want to run and how you want CIDER to interact
+with it. This chapter describes some of the more common choices
+and the configurations required to get them working.
 
 
 ### Piggieback
 
 ClojureScript support relies on the [piggieback][] nREPL middleware
 being present in your REPL session. There's one exception to this,
-though - [shadow-cljs][]. It has its own nREPL middleware and doesn't rely
+though: [shadow-cljs][]. It has its own nREPL middleware and doesn't rely
 on piggieback at all.
 
-If `cider-inject-dependencies-at-jack-in` is enabled (which is the default) then
-piggieback will be automatically added and configured for your project when
-doing `cider-jack-in-cljs`.
+If `cider-inject-dependencies-at-jack-in` is enabled, which it is by
+default, then piggieback will be automatically added and configured
+for your project when doing `cider-jack-in-cljs`.
 
-If this configuration option is disabled or you're going to connect to
-an already running nREPL server using `cider-connect-cljs` - continue
-reading ahead.
+If `cider-inject-dependencies-at-jack-in` is disabled or you're going
+to connect to an already running nREPL server using
+`cider-connect-cljs`, use the configuration in the following section.
 
 #### Manual Piggieback Setup
 
-To setup piggieback add the following dependencies to your project
-(`project.clj` in Leiningen based project or `build.boot` in Boot
+To setup piggieback, add the following dependencies to your project
+(`project.clj` in a Leiningen based project or `build.boot` in a Boot
 project):
 
 ```clojure
@@ -50,14 +54,17 @@ or in `build.boot`:
 
 ### Starting a ClojureScript REPL
 
-There are many ClojureScript REPLs out there and it's often hard to wrap your
-head around them and the differences between them. You'd do well to read [this
-awesome article](https://lambdaisland.com/guides/clojure-repls/clojurescript-repls)
-before proceeding with the rest of the instructions listed here.
+!!! Tip
 
-Open a file in your project and issue <kbd>M-x</kbd>
+    There are many ClojureScript REPLs available, each offering a
+    different set of capabilities and features. As background for this
+    section, you might want to read [this awesome
+    article](https://lambdaisland.com/guides/clojure-repls/clojurescript-repls)
+    before proceeding.
+
+Open a file in your project and type <kbd>M-x</kbd>
 `cider-jack-in-cljs` <kbd>RET</kbd>. This will start up the nREPL
-server, and then create a ClojureScript REPL buffer for you, one.
+server and create a ClojureScript REPL buffer.
 
 !!! Note
 
@@ -65,17 +72,19 @@ server, and then create a ClojureScript REPL buffer for you, one.
     a ClojureScript REPL. In CIDER 0.18+ if you want to create both REPLs
     you'll have to use `cider-jack-in-clj&cljs` instead.
 
-When you have a combination of Clojure and ClojureScript REPLs all
-usual CIDER commands will be automatically directed to the appropriate
-REPL, depending on whether you're visiting a `.clj` or a `.cljs` file.
+When you have a combination of Clojure and ClojureScript REPLs, CIDER
+will automatically direct all the usual CIDER commands to the
+appropriate REPL based on whether you're currently visitng a `.clj` or
+`.cljs` file.
 
-`cider-jack-in-cljs` will prompt you about the type of
-ClojureScript to start. Keep in mind that some of the REPLs will
-require some additional setup, before you can make use of them (e.g. you'll
-need to have Node.js installed to be able to start a node REPL).
+`cider-jack-in-cljs` will prompt you for the type of ClojureScript
+REPL you want to start. Keep in mind that some of the REPLs will
+require you to configure additional setup. For example, you'll need to
+have Node.js installed to be able to start a Node REPL.
 
-You can suppress the prompt the REPL to use by setting `cider-default-cljs-repl`.
-Here's an example that will make Nashorn the default:
+If you frequently use the same ClojureScript REPL, you can set
+`cider-default-cljs-repl` and CIDER will skip the prompt and use this
+instead. For example, the following will make Nashorn the default:
 
 ```el
 (setq cider-default-cljs-repl 'nashorn)
@@ -106,20 +115,20 @@ You can also modify the known ClojureScript REPLs on a per-project basis using
   (cider-default-cljs-repl . super-cljs)))
 ```
 
-You can also create a ClojureScript REPL with the command
-`cider-jack-in-sibling-clojurescript` in cases where you already have a
-Clojure REPL running.
+If you already have a Clojure REPL running and want to add a
+ClojureScript REPL, you can invoke
+`cider-jack-in-sibling-clojurescript` to add it.
 
-Continue reading for the additional setup needed for the various ClojureScript
-REPLs out there.
+The following sections describe the configurations for several common
+CloudScript REPL use cases.
 
-### Browser-connected ClojureScript REPL
+### Browser-Connected ClojureScript REPL
 
 Using Weasel, you can also have a browser-connected REPL.
 
 1. Add `[weasel "0.7.0"]` to your project's `:dependencies`.
 
-2. Issue <kbd>M-x</kbd> `cider-jack-in-cljs` <kbd>RET</kbd> and choose
+2. Type <kbd>M-x</kbd> `cider-jack-in-cljs` <kbd>RET</kbd> and choose
    the `Weasel` option when prompted about the ClojureScript REPL type you want
    to use.
 
@@ -131,7 +140,7 @@ Using Weasel, you can also have a browser-connected REPL.
 (repl/connect "ws://localhost:9001")
 ```
 
-4. Open a file in your project and issue <kbd>M-x</kbd> `cider-jack-in-cljs`.
+4. Open a file in your project and type <kbd>M-x</kbd> `cider-jack-in-cljs`.
 
 Provided that a Piggieback-enabled ClojureScript environment is active in your
 REPL session, code loading and evaluation will work seamlessly regardless of the
@@ -139,7 +148,7 @@ presence of the `cider-nrepl` middleware. If the middleware is present then most
 other features of CIDER will also be enabled (including code completion,
 documentation lookup, the namespace browser, and macroexpansion).
 
-### Browser-connected ClojureScript REPL in Boot project
+### Browser-Connected ClojureScript REPL in Boot Projects
 
 1. Add this to your dependencies in `build.boot`:
 
@@ -166,10 +175,10 @@ and this at the end of `build.boot`:
         (cljs)))
 ```
 
-2. Issue <kbd>M-x</kbd> `customize-variable` <kbd>RET</kbd> `cider-boot-parameters`
+2. Type <kbd>M-x</kbd> `customize-variable` <kbd>RET</kbd> `cider-boot-parameters`
    and insert `dev`.
 
-3. Open a file in your project and issue <kbd>M-x</kbd> `cider-jack-in-cljs`.
+3. Open a file in your project and type <kbd>M-x</kbd> `cider-jack-in-cljs`.
 
 5. Connect to the running server with your browser. The address is printed on the terminal, but it's probably `http://localhost:3000`.
 
@@ -195,7 +204,7 @@ You can also use [Figwheel](https://github.com/bhauman/lein-figwheel) with CIDER
 ```
 
 Keep in mind that figwheel 0.5.16 is the first to support piggieback
-0.3. If you're using an older figwheel you should stick to piggieback
+0.3. If you're using an older figwheel, you should stick to piggieback
 0.2.2 (which uses the old `com.cemerick/piggieback` package coordinates).
 
 3. Add this to your dev `:repl-options` (not needed for `cider-jack-in-cljs`):
@@ -205,7 +214,7 @@ Keep in mind that figwheel 0.5.16 is the first to support piggieback
 ```
 
 4. Start the REPL with `cider-jack-in-cljs` (<kbd>C-c C-x (C-)j (C-)s</kbd>). Select
-`figwheel` when prompted about the ClojureScript REPL type.
+`figwheel` when prompted for the ClojureScript REPL type.
 
 5. Open a browser to the Figwheel URL so that it can connect to your application.
 
@@ -221,10 +230,10 @@ You should also check out
 
 You can also use [Figwheel-main](https://github.com/bhauman/figwheel-main) with CIDER.
 
-1. Add this to your dev `:dependencies`:
+1. Add this to your dev `:dependencies` (not needed for `cider-jack-in-cljs`):
 
 ```clojure
-[cider/piggieback "0.3.10"] ; not needed for cider-jack-in-cljs
+[cider/piggieback "0.3.10"]
 ```
 
 2. Add this to your dev `:repl-options` (not needed for `cider-jack-in-cljs`):
@@ -233,30 +242,31 @@ You can also use [Figwheel-main](https://github.com/bhauman/figwheel-main) with 
 :nrepl-middleware [cider.piggieback/wrap-cljs-repl]
 ```
 
-3. Start the REPL with `cider-jack-in-cljs` (<kbd>C-c C-x (C-)j (C-)s</kbd>). Select
-`figwheel-main` when prompted about the ClojureScript REPL type.
+3. Start the REPL with `cider-jack-in-cljs` (<kbd>C-c C-x (C-)j
+(C-)s</kbd>). When CIDER prompts about the ClojureScript REPL type,
+type `figwheel-main`.
 
 4. Select the Figwheel build to run when prompted for it. (e.g. `:dev`).
 
 ### Using shadow-cljs
 
-Provided you've configured your project correctly you can simply use
-`cider-jack-in-cljs` to use `shadow-cljs`.
+Provided you've configured your project correctly, you can simply use
+`cider-jack-in-cljs` for `shadow-cljs`.
 
-This will automatically start the shadow-cljs server and connect to it. You'll also
-be prompted for the build to use.
+This will automatically start the shadow-cljs server and connect to
+it. You'll also be prompted for the build to use.
 
 Alternatively you can start the server manually with something like:
 
-```
-npx shadow-cljs server
+```sh
+$ npx shadow-cljs server
 ```
 
 And connect to it with `cider-connect`.
 
-Lastly, if you already have a running server watching a build, for instance you
-have already run `npx shadow-cljs watch :dev`, you can use the `shadow-select`
-CLJS REPL and specify `:dev` when prompted.
+If you already have a running server watching a build (for instance
+you have already run `npx shadow-cljs watch :dev`), you can use the
+`shadow-select` CLJS REPL and specify `:dev` when prompted.
 
 [leiningen]: http://leiningen.org/
 [boot]: http://boot-clj.com/
@@ -265,14 +275,16 @@ CLJS REPL and specify `:dev` when prompted.
 
 ## Working with `.cljc` files
 
-Ordinarily, CIDER dispatches code from `clj` files to Clojure REPLs and `cljs`
-files to ClojureScript REPLs. However, `cljc` files have two possible connection
-targets. By default, CIDER tries to evaluate `cljc` files in all matching
-connection buffers, both `clj` and `cljs` (if present).
+Ordinarily, CIDER dispatches code from `clj` files to Clojure REPLs
+and `cljs` files to ClojureScript REPLs. But`cljc` files have two
+possible connection targets, both of which are valid. So, by default,
+CIDER tries to evaluate `cljc` files in all matching connection
+buffers, both `clj` and `cljs`, if present.
 
-Simply put - if you're evaluating the code `(+ 2 2)` in a `cljc` file and you
-have an active Clojure and and active ClojureScript REPL, then the code is going
-to be evaluated twice - once for each of the REPLs.  In fact, you can create
-multiple clj and cljs sibling connections (<kbd>C-c C-x C-s C-s/j</kbd>) within
-Cider session and evaluation will be directed into all REPLs simultaneously. See
-[Managing Connections](managing_connections.md) for more details.
+Thus, if you're evaluating the code `(+ 2 2)` in a `cljc` file and you
+have both an active Clojure and ClojureScript REPL then the code is
+going to be evaluated twice, once in each of the REPLs.  In fact, you
+can create multiple clj and cljs sibling connections (<kbd>C-c C-x C-s
+C-s/j</kbd>) within a CIDER session and evaluation will be directed
+into all REPLs simultaneously. See [Managing
+Connections](managing_connections.md) for more details.

--- a/doc/code_completion.md
+++ b/doc/code_completion.md
@@ -18,29 +18,31 @@ dedicated buffer.
 
 ## Auto-completion
 
-CIDER users are advised to use [`company-mode`](http://company-mode.github.io/)
-to enable auto-completion inside of source code and REPL buffers.  To install
-`company-mode` do:
+While the standard Emacs tooling works just fine, we suggest that
+CIDER users consider using
+[`company-mode`](http://company-mode.github.io/) instead. Company mode
+can be used for auto-completion for both source code and REPL buffers.
+To install `company-mode`:
 
 <kbd>M-x</kbd> `package-install` <kbd>RET</kbd> `company` <kbd>RET</kbd>
 
-After installation, company can be turned on  globally, like so --
+After installation, you can turn on `company-mode` globally:
 
 ```el
 (global-company-mode)
 ```
 
--- or through mode-specific hooks:
+or through mode-specific hooks:
 
 ```el
 (add-hook 'cider-repl-mode-hook #'company-mode)
 (add-hook 'cider-mode-hook #'company-mode)
 ```
 
-When `company-mode` is thus enabled, it will receive completion information
-from `cider-complete-at-point`, and requires no additional setup or plugins.
+When `company-mode` is enabled, it will receive completion information
+from `cider-complete-at-point` and requires no additional setup or plugins.
 
-If you'd prefer to trigger completions manually you can add this to you config:
+If you'd prefer to trigger completions manually you can add this to your config:
 
 ```el
 (setq company-idle-delay nil) ; never start completions automatically
@@ -56,22 +58,25 @@ you can add this to your config:
 
 ### Fuzzy candidate matching
 
-By default `company-mode` will provide completion candidates with the assumption
-that whatever you've typed so far (e.g. `map-`) is a completion prefix (meaning
-you'd get only candidates that have `map-` in the beginnings of their names).
-You can get enhanced fuzzy completion with the CIDER-specific completion style
-by adding:
+By default `company-mode` will provide completion candidates with the
+assumption that whatever you've typed so far is a prefix of what
+you're really trying to type. For example, if you type `map-` then
+you'll only get completion candidates that have `map-` as the
+beginning of their names.  Sometimes, you don't know the exact prefix
+for the item you want to type. In this case, you can get
+CIDER-specific "fuzzy completion" by adding:
 
 ```el
 (add-hook 'cider-repl-mode-hook #'cider-company-enable-fuzzy-completion)
 (add-hook 'cider-mode-hook #'cider-company-enable-fuzzy-completion)
 ```
 
-Now `company-mode` will accept certain fuzziness when matching candidates
-against the prefix. For example, typing `mp` will show you `map-indexed` as one
-of the possible completion candidates, `cji` will complete to `clojure.java.io`,
-etc. Different completion examples are
-listed [here](https://github.com/alexander-yakushev/compliment/wiki/Examples).
+Now, `company-mode` will accept certain fuzziness when matching
+candidates against the prefix. For example, typing `mp` will show you
+`map-indexed` as one of the possible completion candidates and `cji`
+will complete to `clojure.java.io`. Different completion examples are
+shown
+[here](https://github.com/alexander-yakushev/compliment/wiki/Examples).
 
 ### Completion annotations
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1,98 +1,113 @@
-In the spirit of Emacs almost every aspect of CIDER's behaviour
-is configurable. We've tried to come up with some reasonable
-defaults, but we've also tried to account for different people's
-preferences, so everyone could make CIDER as comfortable as
-possible for them.
+Like Emacs itself, almost every part of CIDER is configurable. The
+CIDER developers have tried to implement some reasonable defaults that
+should work for a large portion of the Clojure community, but we know
+that there is nothing approaching a "one size fits all" development
+environment and we've tried to create points of customization that can
+account for many different peoples' preferences. In this way, you
+should be able to make CIDER as comfortable as possible for **you**.
 
 You can see every single customizable configuration option with the command
 <kbd>M-x customize-group RET cider</kbd>.
 
-You can certainly use CIDER without configuring it any further,
-but here are some ways other folks are adjusting their CIDER
-experience.
+This section doesn't describe every possible customization that CIDER
+offers, but here are some of the most popular.
 
-## Basic configuration
+## Basic Configuration
 
-### Auto-enabling cider-mode in clojure-mode buffers
+### Disable Automatic cider-mode in clojure-mode Buffers
 
-By default CIDER will enable `cider-mode` in all `clojure-mode` buffers when the
-first CIDER connection is established. It will also add a `clojure-mode` hook to
-enable it on newly created `clojure-mode` buffers. The configuration snippet
-bellow allows you to override this (somewhat non-standard) behavior.
+By default, CIDER enables `cider-mode` in all `clojure-mode` buffers
+after it establishes the first CIDER connection. It will also add a
+`clojure-mode` hook to enable `cider-mode` on newly-created `clojure-mode`
+buffers. You can override this behavior, however:
 
 ```el
-;; Suppress auto-enabling of `cider-mode` in `clojure-mode` buffers, when starting CIDER
 (setq cider-auto-mode nil)
 ```
 
-### Prompt for confirmation of the symbol at point
+### Disable Symbol Confirmation
 
-By default, interactive commands that require a symbol (e.g. `cider-doc`) will
-prompt for the symbol, with the prompt defaulting to the symbol at point. You
-can set `cider-prompt-for-symbol` to `nil` to instead try the command with the
-symbol at point first, and only prompt if that fails (this used to be the
-default behavior in older CIDER releases).
+By default, CIDER prompts you for a symbol when it executes
+interactive commands that require a symbol (e.g. `cider-doc`). The
+default symbol will be the one at point. If you set
+`cider-prompt-for-symbol` to `nil`, CIDER will try the symbol at point
+first, and only prompt if that fails (this was the behavior in older
+CIDER releases).
 
 ```el
 (setq cider-prompt-for-symbol nil)
 ```
 
-### Log communication with the nREPL server
+### Log nREPL Communications
+
+If you want to see all communications between CIDER and the nREPL
+server:
 
 ```el
 (setq nrepl-log-messages t)
 ```
 
-Basically, this will result in the creation of buffers like `*nrepl-messages
-conn-name*`. The communication log is invaluable for debugging CIDER issues, so
-you're generally advised to enable logging when you need to debug something
-nREPL related.
+CIDER will then create buffers named `*nrepl-messages conn-name*` for
+each connection.
 
-### Hide special nREPL buffers
+The communication log is tremendously valuable for
+debugging CIDER-to-nREPL problems and we recommend you enable it when
+you are facing such issues.
 
-You can hide the `*nrepl-connection*` and `*nrepl-server*` buffers
-from appearing in some buffer switching commands like
-`switch-to-buffer`(<kbd>C-x b</kbd>) like this:
+### Hide Special nREPL Buffers
+
+If you're finding that `*nrepl-connection*` and `*nrepl-server*`
+buffers are cluttering up your development environment, you can
+suppress them from appearing in some buffer switching commands like
+`switch-to-buffer`(<kbd>C-x b</kbd>):
 
 ```el
 (setq nrepl-hide-special-buffers t)
 ```
 
-When using `switch-to-buffer`, pressing <kbd>SPC</kbd> after the command will
-make the hidden buffers visible. They'll always be visible in
-`list-buffers` (<kbd>C-x C-b</kbd>).
+If you need to make the hidden buffers appear When using
+`switch-to-buffer`, type <kbd>SPC</kbd> after issing the command. The
+hidden buffers will always be visible in `list-buffers` (<kbd>C-x
+C-b</kbd>).
 
-### Prefer local resources over remote ones
+### Prefer Local Resources Over Remote Resources
 
-To prefer local resources to remote (tramp) ones when both are available:
+To prefer local resources to remote resources (tramp) when both are available:
 
 ```el
 (setq cider-prefer-local-resources t)
 ```
 
-### Auto-save Clojure buffers on load
+### Auto-Save Clojure Buffers on Load
 
-Normally CIDER would prompt you to save a modified Clojure buffer on <kbd>C-c C-k</kbd> (`cider-load-buffer`).
-You can change this behaviour by adjusting `cider-save-file-on-load`:
+Normally, CIDER prompts you to save a modified Clojure buffer when you
+type <kbd>C-c C-k</kbd> (`cider-load-buffer`).  You can change this
+behaviour by adjusting `cider-save-file-on-load`.
+
+Don't prompt and don't save:
 
 ```el
-;; Don't prompt and don't save
 (setq cider-save-file-on-load nil)
-;; Just save without prompting
+```
+
+Just save without prompting:
+
+```el
 (setq cider-save-file-on-load t)
 ```
 
-### Changing the result prefix for interactive evaluation
+### Change the Result Prefix for Interactive Evaluation
 
-Change the result prefix for interactive evaluation (by default it's `=> `):
+Change the result prefix for interactive evaluation (not the REPL
+prefix). By default the prefix is `=> `.
 
 ```el
 (setq cider-eval-result-prefix ";; => ")
 ```
 
-To remove the prefix altogether just set it to an empty string(`""`).
+To remove the prefix altogether, just set it to the empty string (`""`).
 
-### Use a local copy of the JDK API documentation
+### Use a Local Copy of the JDK API Documentation
 
 If you are targeting the JVM and prefer a local copy of the JDK API
 documentation over Oracle's official copy (e.g., for
@@ -105,19 +120,19 @@ you can arrange your project to include the **root** path of the local API doc
 path being `/usr/share/doc/java/api/`, put the following line in
 `project.clj`:
 
-```clj
+```clojure
 :dev {:resource-paths ["/usr/share/doc/java/api/"]}
 ```
 
 **or** the following line in `$HOME/.lein/profiles.clj`:
 
-```clj
+```clojure
 :user {:resource-paths ["/usr/share/doc/java/api/"]}
 ```
 
 More details can be found [here](https://github.com/clojure-emacs/cider/issues/930).
 
-### Use a local copy of the Java source code
+### Use a Local Copy of the Java Source Code
 
 When an exception is thrown, e.g. when eval-ing `(. clojure.lang.RT foo)`, a
 stack trace pops up. Some places of the stack trace link to Clojure files,
@@ -292,7 +307,7 @@ a macro should be indented.
 Here's a simple example of how someone would specify the indent spec for a macro
 they've written (using an example in core):
 
-```clj
+```clojure
 (defmacro with-in-str
   "[DOCSTRING]"
   {:style/indent 1}
@@ -302,7 +317,7 @@ they've written (using an example in core):
 
 And here's a more complex one:
 
-```clj
+```clojure
 (defmacro letfn
   "[DOCSTRING]"
   {:style/indent [1 [[:defn]] :form]}

--- a/doc/debugging.md
+++ b/doc/debugging.md
@@ -1,4 +1,4 @@
-CIDER ships with a powerful interactive Clojure debugger inspired by Emacs's own
+CIDER ships with a **powerful** interactive Clojure debugger inspired by Emacs's own
 [Edebug][]. You're going to love it!
 
 ![CIDER Debugger](images/cider_debugger.gif)
@@ -11,18 +11,24 @@ CIDER ships with a powerful interactive Clojure debugger inspired by Emacs's own
 
 ## Debugging
 
-The debugger can be invoked in several ways, the simplest one is to type
-<kbd>C-u C-M-x</kbd>. This will take the current top-level form, place as many
-breakpoints inside it as possible (instrument it), and then evaluate it as
-normal. Whenever a breakpoint is reached, you'll be shown the value and asked
-for input (see below). Note that if the current form is a `defn`, it will stay
-instrumented, so the debugger will be triggered every time the function is
-called. To uninstrument `defn` (or similar forms), you just have to evaluate it
-again as you'd normally do (e.g. with <kbd>C-M-x</kbd>).
+During normal CIDER development, it's common for a programmer to
+evaluate a form, often a function definition, by typing
+<kbd>C-M-x</kbd> (`cider-eval-defun-at-point`). CIDER can also
+instrument a form for debugging when you add a prefix to the
+evaluation command: <kbd>C-u C-M-x</kbd>. During the instrumentation
+process, CIDER will insert as many breakpoints as possible into the
+form. Whenever execution reaches a breakpoint, CIDER will drop into
+debugging mode and will prompt you for what to do next. You can remove
+the instrumentation by evaluating the form again normally, using
+<kbd>C-M-x</kbd>.
 
-Another way to trigger the debugger is by placing breakpoints yourself. Just
-write `#break` before a form, and the debugger will popup every time that form is
-evaluated. For instance, if you hit <kbd>C-M-x</kbd> on the following, a
+You can also trigger insert a breakpoint manually into any code
+manually by placing `#break` in front of the form where you want the
+breakpoint to trigger and then evaluating the form with
+<kbd>C-M-x</kbd>. When execution reaches the form after the `#break`,
+you'll be dropped into the debugger.
+
+For instance, if you hit <kbd>C-M-x</kbd> on the following, a
 breakpoint is triggered every time `(inspector msg)` is evaluated.
 
 ```clojure
@@ -32,22 +38,40 @@ breakpoint is triggered every time `(inspector msg)` is evaluated.
     msg))
 ```
 
-Instead of `#break` you can also write `#dbg` before a form, this will not only
-breakpoint the form but also everything inside it. In the example above, this
-places a breakpoint around `(inspector msg)` and another around `msg`. If you've
-been paying attention, you may have noticed that the first option (<kbd>C-u
-C-M-x</kbd>) is a quick way of evaluating the current top-level form with `#dbg`
-in front.
+Instead of `#break`, you can also write `#dbg` before a form. This
+will place a breakpoint both in front of the form, as with `#break`,
+and also everything inside it. In the example above, this places one
+breakpoint around `(inspector msg)` and another around `msg`. In fact,
+typing <kbd>C-u C-M-x</kbd> to instrument a top-level form is just a
+convenient way to evaluate the form with an implicit `#dbg` in front
+of it; the behavior is the same.
 
 At any point, you can bring up a list of all currently instrumented `def`s with
 the command <kbd>M-x</kbd> `cider-browse-instrumented-defs`. Protocols and types
-can be instrumented as well, but they will not be listed by this command.
+can be instrumented as well, but they will not be listed by this
+command.
+
+## Understanding Breakpoints
+
+In the CIDER debugger, the term "breakpoint" refers to a place where
+the debugger can halt execution and display the value of an
+expression. You can set a single breakpoint with `#break`, or set
+breakpoints throughout a form with `#dbg` (or by evaluating with <kbd>C-u
+C-M-x</kbd>), as described previously.
+
+When using `#dbg` or <kbd>C-u C-M-x</kbd>, not every form is wrapped
+in a breakpoint. The debugger tries to avoid setting breakpoints on
+expressions that are not interesting. For example, there is little
+point in stopping execution at a literal number 23 in your code and
+showing you that its value is 23 - you already know that.
 
 ## Keys
 
-`cider-debug` tries to be consistent with [Edebug][], although there are some
-differences. It makes available the following bindings while stepping through
-code.
+Once you drop into the CIDER debugger, you have a number of commands
+available to you to step through your code, evaluate other forms,
+inspect values, inject new values, or view the current
+stack. `cider-debug` tries to be consistent with [Edebug] command
+keys, although there are some differences.
 
 Keyboard shortcut               | Description
 --------------------------------|-------------------------------
@@ -66,32 +90,20 @@ Keyboard shortcut               | Description
 <kbd>t</kbd> | Trace. Continue, printing expressions and their values.
 <kbd>q</kbd> | Quit execution
 
-In addition, all the usual evaluation commands (such as <kbd>C-x C-e</kbd> or
-<kbd>C-c M-:</kbd>) will use the current lexical context (local variables) while
-the debugger is active.
+Additionally, all the usual evaluation commands such as <kbd>C-x
+C-e</kbd> or <kbd>C-c M-:</kbd> will be scoped to the current lexical
+context while the debugger is active, allowing you to access local
+variables.
 
-## Command Details
-
-Here are some more details about what each of the above commands does.
-
-### Stepping Commands
+## Stepping Command Details
 
 These commands continue execution until reaching a breakpoint.
-
-In the cider debugger, the term "breakpoint" refers to a place where the
-debugger can halt execution and display the value of an expression. You can set
-a single breakpoint with `#break`, or set breakpoints throughout a form with
-`#dbg` (or by evaluating with `C-u C-M-x`). Not every form is wrapped in a
-breakpoint; the debugger tries to avoid setting breakpoints on expressions that
-would not be interesting to stop at, such as constants. For example, there would
-not be much point in stopping execution at a literal number 23 in your code and
-showing that its value is 23 - you already know that.
 
 - **next**: Steps to the next breakpoint
 - **in**: Steps in to the function about to be called. If the next breakpoint is
   not around a function call, does the same as `next`. Note that not all
   functions can be stepped in to - only normal functions stored in vars, for
-  which cider can find the source. You cannot currently step in to multimethods,
+  which CIDER can find the source. You cannot currently step in to multimethods,
   protocol functions, or functions in clojure.core (although multimethods and
   protocols can be instrumented manually).
 - **out**: Steps to the next breakpoint that is outside of the current sexp.
@@ -105,7 +117,7 @@ showing that its value is 23 - you already know that.
 - **Here**: Same as `h`, but skips breakpoints in other functions, as with `O`.
 - **continue**: Continues without stopping, skipping all breakpoints.
 
-### Other Commands
+## Other Command Details
 
 - **eval**: Prompts for a clojure expression, which can reference local
   variables that are in scope where the debugger is stopped. Displays the result
@@ -124,7 +136,7 @@ showing that its value is 23 - you already know that.
 - **quit**: Quits execution immediately. Unlike with `continue`, the rest of the
   code in the debugged function is not executed.
 
-### Conditional Breakpoints
+## Conditional Breakpoints
 
 Breakpoints can be conditional, such that the debugger will only stop when the
 condition is true.
@@ -137,47 +149,51 @@ Conditions are specified using `:break/when` metadata attached to a form.
   (prn i))
 ```
 
-Evaluating the above with `C-M-x`, the debugger will stop only once, when i
-is 7.
+Evaluating the above with `C-M-x`, the debugger will stop only once, when `i`
+equals 7.
 
-You can also have cider insert the break-condition into your code for you. Place
-the point where you want the condition to go and evaluate with `C-u C-u
-C-M-x` or `C-u C-u C-c C-c`.
+You can also have CIDER insert the break condition into your code for
+you. Place the point where you want the condition to go and evaluate
+with `C-u C-u C-M-x` or `C-u C-u C-c C-c`. CIDER will then prompt you
+for the condition in the minibuffer and insert the appropriate `#dbg`
+plus metadata annotation in your code. Note that you'll have to delete
+this annotation by hand; you cannot simply use <kbd>C-M-x</kbd> as you
+can to un-instrument <kbd>C-u C-M-x</kbd>.
 
-## Internal Details
+## Debugger Internals
 
 !!! Note
 
     This section explains a bit of the inner workings of the debugger. It is
-    intended mostly to help those who are interested in contributing, and doesn't
+    intended to help those who are interested in contributing, and doesn't
     teach anything about the debugger's usage.
 
-The CIDER debugger works in several steps:
+CIDER works in several steps as it instruments your code:
 
-1. First it walks through the user's code, adding metadata to forms and symbols
+1. First, CIDER walks through the code, adding metadata to forms and symbols
    that identify their position (coordinate) in the code.
-2. Then it macroexpands everything to get rid of macros.
-3. Then it walks through the code again, instrumenting it. That involves a few things.
-    - It understands all existing special forms, and takes care not to instrument
-      where it's not supposed to. For instance, the arglist of a `fn*` or the
-      left-side of a `let`-binding.
-    - Wherever it finds the previously-injected metadata (if that place is valid
-      for instrumentation) it wraps the form/symbol in a macro called
-      `breakpoint-if-interesting`.
+2. Then, it macroexpands everything to get rid of macros.
+3. Then, it walks through the code again, instrumenting it.
+    - CIDER understands all existing special forms and takes care not
+      to instrument where it's not supposed to. For instance, CIDER
+      does not instrument the arglist of `fn*` or the left-side of a
+      `let`-binding.
+    - Wherever it finds the previously-injected metadata, assuming
+      that location is valid for instrumentation, it wraps the
+      form or symbol in a macro called `breakpoint-if-interesting`.
+4. When the resulting code actually gets compiled, the Clojure
+   compiler will expand the `breakpoint-if-interesting` macros. This
+   macro decides whether the return value of the form or symbol is
+   actually something the user might want to see. If it is, the
+   form or symbol gets wrapped in a `breakpoint` macro, otherwise it's
+   returned as is.
+5. The `breakpoint` macro takes the coordinate information that was
+   provided in step `1.` and sends it over to Emacs (the
+   front-end). It also sends the return value of the form and a prompt
+   of available commands. Emacs then uses this information to show the
+   value of actual code forms and prompt for the next action.
 
-4. When the resulting code actually gets evaluated by the Clojure compiler, the
-   `breakpoint-if-interesting` macro will be expanded.  This macro decides
-   whether the return value of the form/symbol in question is actually something
-   the user wants to see (see below). If it is, the form/symbol gets wrapped in
-   the `breakpoint` macro, otherwise it's returned as is.
-5. The `breakpoint` macro takes that coordinate information that was provided in
-   step `1.` and sends it over to Emacs (the front-end). It also sends the return
-   value of the form and a prompt of available commands. Emacs then uses this
-   information to show the value of actual code forms and prompt for the next
-   action.
-
-
-A few example of forms that don't have interesting return values (and so are not
+A few example forms that don't have interesting return values (and so are not
 wrapped in a `breakpoint`):
 
 - In `(fn [x] (inc x))` the return value is a function object and carries no
@@ -185,8 +201,9 @@ wrapped in a `breakpoint`):
   **call** this function (which **is** interesting). Also, even those this form
   is not wrapped in a breakpoint, the forms inside it **are** (`(inc x)` and
   `x`).
-- Similarly, in a form like `(map inc (range 10))`, the symbol `inc` points to a
-  function in `clojure.core`. That's also irrelevant (unless it's being shadowed
-  by a local, but the debugger can identify that).
+- Similarly, in a form like `(map inc (range 10))`, the symbol `inc`
+  points to a function in `clojure.core`. That's also irrelevant
+  (unless it's being shadowed by a local, but the debugger can
+  identify that).
 
 [Edebug]: http://www.gnu.org/software/emacs/manual/html_node/elisp/Edebug.html

--- a/doc/indent_spec.md
+++ b/doc/indent_spec.md
@@ -4,7 +4,7 @@ An indent spec can be used to specify intricate indentation rules for the more
 complex macros (or functions). It is provided as a value in the var metadata,
 under the `:style/indent` key.
 
-```clj
+```clojure
 (defmacro with-in-str
   "[DOCSTRING]"
   {:style/indent 1}
@@ -43,7 +43,7 @@ One very simple example is the `do` form. All of its arguments get the same
 indentation, and none of them are special. So its indent spec is simply `[0]`,
 or `0` for short.
 
-```clj
+```clojure
 (do
   (something)
   (quick))
@@ -67,7 +67,7 @@ Let's see something more sophisticated. If the `defrecord` indent spec used by
 - All remaining arguments have an internal indent spec of `[1]` (which means
   only the arglist is indented specially and the rest is the body).
 
-```clj
+```clojure
 (defrecord Thing [a]
   FileNameMap
   (getContentTypeFor [_ file-name]
@@ -84,7 +84,7 @@ For something even more complicated: `letfn` is `[1 [[:defn]] :form]`. This mean
   _inside_ the first arg have an indent spec of `[:defn]`.
 - The second argument, and all other arguments, are regular forms.
 
-```clj
+```clojure
 (letfn [(twice [x]
           (* x 2))
         (six-times [y]
@@ -102,7 +102,7 @@ placed on a separate line with additional indentation.
 
 For instance, `defrecord` has two special arguments, and here's how it might be indented:
 
-```clj
+```clojure
 (defrecord TheNameOfTheRecord
     [a pretty long argument list]
   SomeType
@@ -112,7 +112,7 @@ For instance, `defrecord` has two special arguments, and here's how it might be 
 
 Here's another way one could do it:
 
-```clj
+```clojure
 (defrecord TheNameOfTheRecord
            [a pretty long argument list]
   SomeType

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -4,8 +4,8 @@ as `el-get`.
 
 ## Prerequisites
 
-You'll need to have Emacs installed (preferably the latest stable
-release). If you're new to Emacs you might want to go through
+You'll need to have Emacs installed, preferably the latest stable
+release. If you're new to Emacs you might want to go through
 [the guided tour of Emacs](https://www.gnu.org/software/emacs/tour/index.html)
 and the built-in tutorial (just press <kbd>C-h t</kbd>).
 
@@ -14,8 +14,8 @@ CIDER officially supports Emacs 25.1+, Java 8+ and Clojure(Script)
 Java 7 and Clojure(Script) 1.7.
 
 You'll also need a recent version of either the Clojure CLI tools or your
-favorite build tool (Leiningen, Boot or Gradle) to be able to start CIDER via
-`cider-jack-in`. Generally it's a good idea to use their latest stable versions.
+favorite build tool (Leiningen, Boot, or Gradle) to be able to start CIDER via
+`cider-jack-in`. Generally it's a good idea to use the latest stable versions.
 
 !!! warning
 
@@ -44,11 +44,20 @@ If the installation doesn't work try refreshing the package list:
 
 <kbd>M-x package-refresh-contents [RET]</kbd>
 
-Keep in mind that MELPA packages are built automatically from
-the `master` branch, meaning bugs might creep in there from time to
-time. Never-the-less, installing from MELPA is a reasonable way of
-obtaining CIDER, as the `master` branch is normally quite stable
-and serious regressions there are usually fixed pretty quickly.
+It's important to note that MELPA packages are built automatically
+from the `master` branch, and that means you'll be right on the
+leading edge of development. This has upsides and downsides; you'll
+see new features first, but you might experience some bugs from
+time to time. Nevertheless, installing from MELPA is a reasonable way
+to obtain CIDER. The `master` branch is normally quite stable
+and serious regressions there are usually fixed quickly.
+
+If you have concerns about living on the leading edge of CIDER
+deveopment, you can always pin CIDER to use MELPA Stable like this:
+
+```el
+(add-to-list 'package-pinned-packages '(cider . "melpa-stable") t)
+```
 
 !!! Tip
 
@@ -56,15 +65,6 @@ and serious regressions there are usually fixed pretty quickly.
     you can easily build and install an up-to-date MELPA package locally yourself. Check out
     [this article](http://emacsredux.com/blog/2015/05/10/building-melpa-packages-locally/)
     for details on the subject.
-
-Generally, users of the non-adventurous kind are advised to stick
-with the stable releases, available from MELPA Stable.
-You can pin CIDER to always use MELPA
-Stable by adding this to your Emacs initialization:
-
-```el
-(add-to-list 'package-pinned-packages '(cider . "melpa-stable") t)
-```
 
 !!! note
 
@@ -112,7 +112,7 @@ following command:
 
 <kbd>M-x el-get-install [RET] cider [RET]</kbd>
 
-## Manual installation
+## Manual Installation
 
 Installing CIDER manually is discouraged unless you plan to work with
 CIDER's codebase. The manual installation is relatively involved as it
@@ -120,15 +120,18 @@ requires manual installation of the dependencies and manual generation
 of the package autoloads. Check out the section [Hacking on
 CIDER](hacking_on_cider.md) for more details.
 
-## CIDER's nREPL middleware
+## CIDER's nREPL Middleware
 
-Much of CIDER's functionality depends on the presence of CIDER's own
-[nREPL
+Much of CIDER's functionality depends on its own [nREPL
 middleware](https://github.com/clojure-emacs/cider-nrepl). Starting
-with version 0.11, When `cider-jack-in` (<kbd>C-c C-x (C-)j (C-)j</kbd>) is used,
-CIDER takes care of injecting it and its other dependencies.
+with version 0.11, `cider-jack-in` (<kbd>C-c C-x (C-)j (C-)j</kbd>)
+automatically injects this middle and other dependencies as required.
 
-**`profiles.clj` or `profile.boot` don't need to be modified anymore for the above use case!**
+!!! Note 
+    In the past, if you were setting up CIDER, you might have had to
+    modify `profiles.clj` or `profile.boot`. CIDER now handles
+    everything automatically and you don't need to add anything
+    special to these files.
 
 !!! Tip
 
@@ -141,11 +144,12 @@ for example, if your project defaults to an older version of Clojure than that
 supported by the CIDER middleware. Set `cider-jack-in-auto-inject-clojure`
 appropriately to enable this.
 
-If a standalone REPL is preferred, you need to invoke `cider-connect` (instead
-of `cider-jack-in`) and you'll need to manually add the dependencies to your
-Clojure project (explained in the following section).
+If you prefer a standalone REPL, you will need to invoke
+`cider-connect` instead of `cider-jack-in` and manually add the
+dependencies to your Clojure project (explained in the following
+section).
 
-### Setting up a standalone REPL
+### Setting Up a Standalone REPL
 
 #### Using Leiningen
 
@@ -190,9 +194,9 @@ all of their projects using a `~/.boot/profile.boot` file like so:
 
 For more information visit [boot-clj wiki](https://github.com/boot-clj/boot/wiki/Cider-REPL).
 
-### Using embedded nREPL server
+### Using Embedded nREPL Server
 
-If you're embedding nREPL in your application you'll have to start the
+If you're embedding nREPL in your application, you'll have to start the
 server with CIDER's own nREPL handler.
 
 ```clojure
@@ -209,8 +213,12 @@ It goes without saying that your project should depend on `cider-nrepl`.
 
 !!! note
 
-    `x.y.z` should be compatible with the version of CIDER you're currently using.
-    The required version can be checked in `cider-required-middleware-version`.
     Prior to CIDER 0.18, CIDER and cider-nrepl were always released together
-    and their versions had to match for things to work, but as the prominence
-    of cider-nrepl grew and many other tools started using, this was changed.
+    and their versions had to match for things to work. But as the prominence
+    of cider-nrepl grew and many other tools started using it, the two
+    projects evolved separately and are no longer in tight
+    lock-step. Any recent version of cider-nrepl should be compatible
+    with a recent version of CIDER. You can check the required version
+    of cider-nrepl for your version of CIDER by looking at
+    `cider-required-middleware-version`.
+    

--- a/doc/interactive_programming.md
+++ b/doc/interactive_programming.md
@@ -1,16 +1,36 @@
-The idea of interactive programming is at the very heart of CIDER.
+Traditional programming languages and development environments often
+use a [Edit, Compile, Run
+Cycle](http://wiki.c2.com/?EditCompileLinkRun). In this environment,
+the programmer modifies the code, compiles it, and then runs it to see
+if it does what she wants. The program is then terminated, and the
+programmer goes back to editing the program further. This cycle is
+repeated over and over until the program behavior conforms to what the
+programmer desires. While modern IDEs have optimized this process to
+be quick and relatively painless, it's still a slow way to work.
 
-Programmers are expected to program in a very dynamic and incremental manner,
-constantly re-evaluating existing Clojure definitions and adding new ones to
-their running applications. You never stop/start a Clojure application while
-using CIDER - you're constantly interacting with it and changing it.
+Clojure and CIDER offer a better way to work called *interactive
+programming*. Indeed, this idea is at the very heart of CIDER.
 
-CIDER comes with a handy minor mode called `cider-mode` (complementing
-`clojure-mode`) that allows you to evaluate code in your Clojure source
-files and load it directly in the REPL. `cider-mode` is the primary
-way you're supposed to be interacting with your REPL process. If you
-want to get productive with CIDER, you'll have to get intimately familiar
-with it.
+Using CIDER's interactive programming environment, a programmer works
+in a very dynamic and incremental manner. Instead of repeatedly
+editing, compiling, and restarting an application, the programmer
+starts the application once and then adds and updates individual
+Clojure defintions as the program continues to run. Using the CIDER
+REPL, the programmer can access the value of different definitions and
+invoke program functions with test data, immediately seeing the
+result. This methodology is far more efficient than the typical Edit,
+Compile, and Run Cycle because the program continues to run and keeps
+its state intact while the programmer interacts with it. Indeed, some
+Clojure programmers have been known to keep a CIDER session running
+for weeks or even months as they continue to write code.
+
+CIDER's interactive programming environment is partially implemented
+using an Emacs minor mode called `cider-mode`. `cider-mode`
+complements `clojure-mode` and allows you to evaluate Clojure code
+from your source file buffers and send it directly to your running
+program through the CIDER REPL. Using the functions offered by
+`cider-mode` will improve your productivity and make you a more
+efficient Clojure programmer.
 
 ## Using cider-mode
 
@@ -72,8 +92,8 @@ Here's a list of `cider-mode`'s keybindings:
 
 !!! Tip
 
-    There's no need to memorize this list. In any Clojure buffer with `cider-mode`
-    active you'll have a CIDER menu available, which lists all the most important
+    There's no need to memorize this list. If you're in a Clojure buffer with `cider-mode`
+    active you'll have a CIDER menu available. The menu lists all the most important
     commands and their keybindings. You can also invoke `C-h f RET cider-mode` to
     get a list of the keybindings for `cider-mode`.
 
@@ -84,8 +104,9 @@ Here's a list of `cider-mode`'s keybindings:
 
     An even better solution would be to install [which-key][], which will
     automatically show you a list of available keybindings as you start typing some
-    keys. This will simplify your interactions with CIDER quite a lot (especially in
-    the beginning). Here's what you'd see if you typed <kbd>C-c C-d</kbd> in a
+    keys. This will simplify your interactions with CIDER quite a lot,
+    especially in
+    the beginning. Here's what you'd see if you typed <kbd>C-c C-d</kbd> in a
     Clojure buffer:
 
 ![CIDER which-key](images/cider-which-key.png)
@@ -93,26 +114,28 @@ Here's a list of `cider-mode`'s keybindings:
 
 !!! Tip
 
-    `cider-find-var` has built-in support for [AVFS]().  AVFS is an a virtual
+    `cider-find-var` has built-in support for [AVFS][].  AVFS is an a virtual
     file system which allows seamless navigation within archives as if they were 
     normal directories. When AVFS is mounted, `cider-find-var` automatically
     opens `jar` and `zip` files inside AVFS folder instead of attempting to
-    uncompressed the archive.
+    uncompress the archive.
 
-    On linux based systems AVFS comes through the distribution managers. For 
-    example on Debian derivatives:
+    On Linux-based systems, AVFS is available through the standard
+    package managers. For example, on Debian derivatives:
 
        `sudo apt-get install avfs`
 
-    Once installed mount with `mountavfs` in a place where it could be started
-    automatically during the startup (`.bash_profile` would do). Or initialize the
-    `avfsd` daemon directly like this
+    Once installed, you can put `mountavfs` in a place where it will
+    be invoked
+    automatically during the startup (`.bash_profile`, for
+    instance). You can also initialize the
+    `avfsd` daemon directly like this:
 
       `/usr/bin/avfsd -o allow_root -o intr -o sync_read .avfs` 
 
-    [AVFS]() is not available on Windows but could be installed on MacOS with [some
+    [AVFS][] is not available on Windows but can be installed on MacOS with [some
     effort](http://blog.breadncup.com/tag/sunrise-commander/). Some other uses of
-    [AVFS]() in Emacs include
+    [AVFS][] in Emacs include
     [dired-avfs](https://github.com/Fuco1/dired-hacks#dired-avfs) and
     [sunrise-commander](https://www.emacswiki.org/emacs/Sunrise_Commander_Tips#toc12).
 

--- a/doc/miscellaneous_features.md
+++ b/doc/miscellaneous_features.md
@@ -1,64 +1,59 @@
-CIDER packs a ton of extra functionality, besides basic Clojure code
-evaluation. Much of the functionality is centered around additional major modes,
-which provide you with convenient ways to get something done or inspect
-something.
+As the infomercials always say, "But wait, there's more!" If
+simultaneous Clojure and ClojureScript REPLs, interactive programming,
+code completion, stacktrace navigation, test running, and debugging
+weren't enough for you, CIDER delievers several additional
+features. 
 
-## Evaluating Clojure code in the minibuffer
+## Evaluating Clojure Code in the Minibuffer
 
-You can evaluate Clojure code in the minibuffer from pretty much everywhere by
+You can evaluate Clojure code in the minibuffer at almost any time
 using <kbd>M-x</kbd> `cider-read-and-eval` (bound in `cider-mode` buffers to
 <kbd>C-c M-:</kbd>).  <kbd>TAB</kbd> completion will work in the minibuffer,
-just as in a REPL/source buffer.
+just as in REPL and source buffers.
 
-Pressing <kbd>C-c C-v .</kbd> in a Clojure buffer will insert the defun
+Typing <kbd>C-c C-v .</kbd> in a Clojure buffer will insert the defun
 at point into the minibuffer for evaluation. This way you can pass arguments
 to the function and evaluate it and see the result in the minibuffer.
 
-You can also enable `eldoc-mode` in the minibuffer by adding the following to your
-config:
+You can also enable other convenient modes in the minibuffer. For
+instance, you might want to have both `eldoc-mode` and `paredit-mode`
+available to you:
 
 ```el
 (add-hook 'eval-expression-minibuffer-setup-hook #'eldoc-mode)
-```
-
-You can also enable `paredit` or `smartparens` for minibuffer evaluations:
-
-```el
 (add-hook 'eval-expression-minibuffer-setup-hook #'paredit-mode)
 ```
 
-## Using a scratchpad
+## Using a Scratchpad
 
 CIDER provides a simple way to create a Clojure scratchpad via the
-<kbd>M-x</kbd> `cider-scratch` command. It provides a great way to
-play around with some code, without having to create source files
-or pollute the REPL buffer.
+<kbd>M-x</kbd> `cider-scratch` command. This is a great way to play
+around with some code without having to create source files or pollute
+the REPL buffer and is very similar to Emacs's own `*scratch*` buffer.
 
-In many ways the CIDER scratchpad is similar to Emacs's own `*scratch*` buffer.
+## Expanding Macros
 
-## Macroexpansion
-
-Pressing <kbd>C-c C-m</kbd> after some form in a source buffer or the REPL will
-result in a new buffer, showing the macroexpansion of the form in
-question. You'll have access to additional keybindings in the macroexpansion
-buffer (which is internally using `cider-macroexpansion-mode`):
+Typing <kbd>C-c C-m</kbd> after some form in a source buffer or the
+REPL will show you the macro expansion of the form in a new
+buffer. You'll have access to additional keybindings in the macro
+expansion buffer (which is internally using
+`cider-macroexpansion-mode`):
 
 Keyboard shortcut                 | Description
 ----------------------------------|-------------------------------
 <kbd>m</kbd>                      | Invoke `macroexpand-1` on the form at point and replace the original form with its expansion.  If invoked with a prefix argument, `macroexpand` is used instead of `macroexpand-1`.
 <kbd>a</kbd>                      | Invoke `clojure.walk/macroexpand-all` on the form at point and replace the original form with its expansion.
-<kbd>g</kbd>                      | The prior macroexpansion is performed again and the current contents of the macroexpansion buffer are replaced with the new expansion.
-<kbd>C-/</kbd> <br/> <kbd>u</kbd> | Undo the last inplace expansion performed in the macroexpansion buffer.
+<kbd>g</kbd>                      | The prior macro expansion is performed again and the current contents of the macro expansion buffer are replaced with the new expansion.
+<kbd>C-/</kbd> <br/> <kbd>u</kbd> | Undo the last in-place expansion performed in the macroexpansion buffer.
 
-## Value inspection
+## Inspecting Values
 
-Pressing <kbd>C-c M-i</kbd> after some form in a source buffer or the REPL will
-result in a new buffer, showing the structure of the result of the form in question.
-You can also use <kbd>C-u C-c M-i</kbd> to inspect the result of the current top-level
-form and <kbd>C-u C-u C-c M-i</kbd> to read an expression from the minibuffer and
-inspect its result.
-
-You'll have access to additional keybindings in the inspector buffer (which is
+Typing <kbd>C-c M-i</kbd> after some form in a source buffer or the
+REPL will show you the structure for the result of the form in a new
+buffer.  You can also use <kbd>C-u C-c M-i</kbd> to inspect the result
+of the current top-level form and <kbd>C-u C-u C-c M-i</kbd> to read
+an expression from the minibuffer and inspect its result. You'll have
+access to additional keybindings in the inspector buffer (which is
 internally using `cider-inspector-mode`):
 
 Keyboard shortcut                       | Description
@@ -71,20 +66,20 @@ Keyboard shortcut                       | Description
 <kbd>M-SPC</kbd>                        | Jump to previous page in paginated view
 <kbd>s</kbd>                            | Set a new page size in paginated view
 
-## Enlighten (display local values)
+## Displaying Local Values with Enlighten Mode
 
-This feature displays the value of locals in realtime, as your code is being
-executed. This is somewhat akin to one of the features of the Light Table
+Enlighten Mode displays the value of locals in realtime, as your code
+runs. This feature is somewhat similar to a feature in the Light Table
 editor.
 
-- To turn it on, issue <kbd>M-x</kbd> `cider-enlighten-mode`.
-- To use it, evaluate your functions one at a time (e.g., use <kbd>C-M-x</kbd> or
-<kbd>C-x  C-e</kbd>, because <kbd>C-c C-k</kbd> won't work).
+To turn it on, issue <kbd>M-x</kbd> `cider-enlighten-mode`. Then,
+evaluate your functions one at a time using <kbd>C-M-x</kbd> or
+<kbd>C-x  C-e</kbd>. Note that <kbd>C-c C-k</kbd> won't work.
 
 That's it! Once your code executes, the regular old buffer on the left will turn
 into the brilliant show of lights on the right.
 
-Enlighten Disabled                         | Enlighten Enabled
+Enlighten Mode Disabled                    | Enlighten Mode Enabled
 -------------------------------------------|---------------------------------------
 ![Disabled](images/enlighten_disabled.png) | ![Enabled](images/enlighten_enabled.png)
 
@@ -92,9 +87,31 @@ To stop displaying the locals you'll have to disable `cider-enlighten-mode`
 and reevaluate the definitions you had instrumented previously.
 
 You can also trigger this on specific functions (without having to turn on the
-minor mode) by writing `#light` before the `(def` and reevaluating it.
+minor mode) by writing `#light` before the `(def` and re-evaluating
+it.
 
-## Code reloading
+## Reloading Code
+
+While Clojure's and CIDER's interactive programming style means you'll
+restart your application far less often than with other languages and
+development environments, sometimes you'll want to clean everything up
+and reload one or more namespaces to ensure that they are up to date
+and there are no temporary definitions hanging around.
+
+Typing <kbd>C-c M-n r</kbd> or <kbd>C-c M-n M-r</kbd> will invoke
+`cider-ns-refresh` and reload all modified Clojure files on the
+classpath.
+
+Adding a prefix argument, <kbd>C-u C-c M-n n</kbd>, will reload all
+the namespaces on the classpath unconditionally, regardless of their
+modification status.
+
+Adding a double prefix argument, <kbd>C-u C-u M-n n</kbd>, will first
+clear the state of the namespace tracker before reloading. This is
+sueful for recovering from some classes of error that nomral reloads
+would otherwise not recover from. A good example is circular
+dependencies. The trade-off is that stale code from any deleted files
+may not be completely unloaded.
 
 `cider-ns-refresh` wraps
 [clojure.tools.namespace](https://github.com/clojure/tools.namespace), and as
@@ -104,11 +121,6 @@ and
 [caveats](https://github.com/clojure/tools.namespace#reloading-code-preparing-your-application)
 regarding writing reloadable code also apply.
 
-Calling `cider-ns-refresh` will cause all modified Clojure files on the classpath
-to be reloaded. You can also provide a single prefix argument to reload all
-Clojure files on the classpath unconditionally, or a double prefix argument to
-first clear the state of the namespace tracker before reloading.
-
 The above three operations are analogous to
 [`clojure.tools.namespace.repl/refresh`](http://clojure.github.io/tools.namespace/#clojure.tools.namespace.repl/refresh),
 [`clojure.tools.namespace.repl/refresh-all`](http://clojure.github.io/tools.namespace/#clojure.tools.namespace.repl/refresh-all)
@@ -116,55 +128,62 @@ and
 [`clojure.tools.namespace.repl/clear`](http://clojure.github.io/tools.namespace/#clojure.tools.namespace.repl/clear)
 (followed by a normal refresh), respectively.
 
-* You can define Clojure functions to be called before reloading, and after a
-  successful reload, when using `cider-ns-refresh`:
+You can define Clojure functions to be called before reloading, and after a
+successful reload, when using `cider-ns-refresh`:
 
 ```el
 (setq cider-ns-refresh-before-fn "user/stop-system!"
       cider-ns-refresh-after-fn "user/start-system!")
 ```
 
-* These must be set to the namespace-qualified names of vars bound to functions
-  of no arguments. The functions must be synchronous (blocking), and are
-  expected to be side-effecting - they will always be executed serially, without
-  retries.
+These must be set to the namespace-qualified names of vars bound to
+functions of no arguments. The functions must be synchronous
+(blocking), and are expected to be side-effecting - they will always
+be executed serially, without retries.
 
-* By default, messages regarding the status of the in-progress reload will be
-  displayed in the echo area after you call `cider-ns-refresh`. The same
-  information will also be recorded in the `*cider-ns-refresh-log*` buffer, along
-  with anything printed to `*out*` or `*err*` by `cider-ns-refresh-before-fn` and
-  `cider-ns-refresh-start-fn`.
+By default, messages regarding the status of the in-progress reload
+will be displayed in the echo area after you call
+`cider-ns-refresh`. The same information will also be recorded in the
+`*cider-ns-refresh-log*` buffer, along with anything printed to
+`*out*` or `*err*` by `cider-ns-refresh-before-fn` and
+`cider-ns-refresh-start-fn`.
 
-* You can make the `*cider-ns-refresh-log*` buffer display automatically after you
-  call `cider-ns-refresh` by setting the `cider-ns-refresh-show-log-buffer` variable
-  to a non-nil value (this will also prevent any related messages from also
-  being displayed in the echo area):
+You can make the `*cider-ns-refresh-log*` buffer display automatically
+after you call `cider-ns-refresh` by setting the
+`cider-ns-refresh-show-log-buffer` variable to a non-nil value. This
+will also prevent any related messages from also being displayed in
+the echo area.
 
 ```el
 (setq cider-ns-refresh-show-log-buffer t)
 ```
 
-* By default, all modified Clojure buffers are prompted to be saved. This
-  behaviour can be customized using `cider-ns-save-files-on-refresh`.
+By default, CIDER will prompt for whether to save all modified Clojure
+buffers. You can customize this behavior with
+`cider-ns-save-files-on-refresh`.
 
-In case `cider-ns-refresh` does not work for you the
-`cider-ns-reload`|`cider-ns-reload-all` commands can be used instead: they will
-evaluate the Clojure's out of the box `(require ... :reload|:reload-all)` at
-the REPL.
+Sometimes, `cider-ns-refresh` may not work for you. If you're looking
+for a bit more forceful reloading the `cider-ns-reload`
+and `cider-ns-reload-all` commands can be used instead. These commands
+invoke Clojure's `(require ... :reload)` and `(require
+... :reload-all)` commands at the REPL.
 
-## Tracing function execution
+## Tracing Function Execution
 
-You can trace the results produced by functions using <kbd>C-c M-t v</kbd>.  The
-command will prompt you for the name of the function you want to trace.
-Evaluating the command again for the same function will result in the function
-being untraced.
+You can trace the arguments supplied to and the result values produced
+by functions using <kbd>C-c M-t v</kbd>. CIDER will prompt you for the
+name of the function you want to trace, defaulting to the previous
+top-level definition.
 
 ![Tracing](images/tracing.png)
 
-You can also use <kbd>C-c M-t n</kbd> to toggle tracing on and off for an entire
-namespace.
+Invoking <kbd>C-c M-t v</kbd> again for the same function will result
+in the function being untraced.
 
-## Classpath browser
+You can also use <kbd>C-c M-t n</kbd> to toggle tracing on and off for
+an entire namespace.
+
+## Browsing the Classpath
 
 You can easily browse the items on your classpath with the command
 <kbd>M-x</kbd> `cider-classpath`.
@@ -175,10 +194,10 @@ Here you can see it in action:
 
 Press <kbd>RET</kbd> on a classpath entry to navigate into it.
 
-## Namespace browser
+## Browsing Namespaces
 
 You can browse the contents of any loaded namespace with the command
-<kbd>M-x</kbd> `cider-browse-ns`.  The command will prompt you for the namespace
+<kbd>M-x</kbd> `cider-browse-ns`. CIDER will prompt you for the namespace
 to browse.
 
 ![Namespace Browser](images/ns_browser.png)
@@ -197,22 +216,24 @@ Keyboard shortcut               | Description
 <kbd>n</kbd>                    | Go to next line.
 <kbd>p</kbd>                    | Go to previous line.
 
-## Spec browser
+## Browsing the Clojure Spec Registry
 
-If you are using Clojure 1.9 or newer you can browse the Clojure specs registry.
+If you are using Clojure 1.9 or newer you can browse the Clojure spec registry.
 
-If you know what you are looking for, you can type <kbd>M-x</kbd> `cider-browse-spec`.
-It will prompt you for a spec name to browse to, hit <kbd>RET</kbd> and you will find yourself
-at the spec browser.
+If you already know which spec you're looking for, you can type
+<kbd>M-x</kbd> `cider-browse-spec` and CIDER will prompt you for a
+spec name and then drop you into the spec browser.
 
 ![Spec Browser](images/spec_browser.png)
 
-You can also type the command <kbd>M-x</kbd> `cider-browse-spec-all`. This command will prompt you for
-a regex you can use to filter out the specs you are interested in, and will also take you to the spec browser.
+If you aren't quite sure which spec you want, you can type
+<kbd>M-x</kbd> `cider-browse-spec-all`. CIDER will then prompt you for
+a regex and will filter out all the spec names that don't match.
 
 ![Spec Browser](images/spec_browser_all.png)
 
-Once in the browser you can use your mouse or the keybindings below to navigate deeper into sub specs.
+Once in the browser you can use your mouse or the keybindings below to
+navigate deeper.
 
 Keyboard shortcut               | Description
 --------------------------------|-------------------------------
@@ -222,27 +243,22 @@ Keyboard shortcut               | Description
 <kbd>p</kbd>                    | Go to previous spec.
 <kbd>e</kbd>                    | Generate an example for the current browser spec.
 
-If your project contains a version of `org.clojure/test.check`, you can type <kbd>e</kbd> when browsing
-a spec to generate and print an example of it.
+If your project includes the `org.clojure/test.check` library, you can
+type <kbd>e</kbd> when browsing a spec to generate an example that
+meets the spec.
 
 ![Spec Browser Example](images/spec_browser_gen_example.png)
 
-## Documentation buffers include "See Also" references
+## Generating Documentation Cross References
 
-You can add references to other vars by including their names in `` ` `` in the docstring.
-If the var is in another namespace, then you'll have to include the full
-namespace qualified name in the docstring. If you want to use some other delimiter instead
-of the backticks, you'll have to update the value of `cider-doc-xref-regexp` to match that.
-The first group of the regexp should always match the var name.
+Sometimes in your documentation strings, you'd like to be able to
+point other programmers at different definitions. If you specify the
+name of a definition in backticks (`` ` ``), CIDER will convert these
+references into live links when it displays the documentation string
+in the documentation buffer. 
 
-As an example, if you want to want to use the delimiter style used by
-[Codox](https://github.com/weavejester/codox) (`[[...]]`)  the regexp would be;
-
-```
-(setq cider-doc-xref-regexp "\\[\\[\\(.*?\\)\\]\\]")
-```
-
-![CIDER See Also](images/cider_see_also.gif)
+If the name is in another namespace, then you'll have to include the
+fully qualified name in the docstring.
 
 Example function with a docstring containing references:
 
@@ -255,3 +271,18 @@ Example function with a docstring containing references:
   []
   (+ 1 1))
 ```
+
+You can change the delimiters that CIDER uses to find references if
+you don't like using backticks.  Simply update the regexp in
+`cider-doc-xref-regexp` to match your preferred format. The first
+group of the regexp should always match the cross-reference name. For
+example, if you want to want to use
+[Codox's](https://github.com/weavejester/codox) delimiter style
+(`[[...]]`) instead of backticks, the regexp would be:
+
+```
+(setq cider-doc-xref-regexp "\\[\\[\\(.*?\\)\\]\\]")
+```
+
+![CIDER See Also](images/cider_see_also.gif)
+

--- a/doc/navigating_stacktraces.md
+++ b/doc/navigating_stacktraces.md
@@ -1,8 +1,10 @@
-CIDER comes with a powerful solution to the problem of verbose Clojure
-stacktraces.  Stacktraces are presented in a special major mode
-(`cider-stacktrace-mode`), which gives you the possibility to filter out certain
-stack frames and some handy ways to navigate causes.  You'll also be able to go
-to the code in question with a single keystroke.
+CIDER comes with a powerful solution for dealing with Clojure
+stacktraces. CIDER presents stack traces in a special major mode,
+`cider-stacktrace-mode`, which gives you gives you some key features:
+
+- the ability to filter out certain stack frames to reduce clutter
+- some handy ways to navigate to the cause of the exception
+- the ability to jump straight to code with a single keystroke
 
 Command                                | Keyboard shortcut                   | Description
 ---------------------------------------|-------------------------------------|--------------
@@ -24,33 +26,33 @@ Command                                | Keyboard shortcut                   | D
 `cider-stacktrace-show-only-project`   |<kbd>p</kbd>                         | Toggle display only project frames
 `cider-stacktrace-toggle-all`          |<kbd>a</kbd>                         | Toggle display of all frames
 
-You can configure whether the error buffer with stacktraces should be automatically
-shown on error. By default it will be displayed, but you can change this:
+By default, when an exception occurs, CIDER will display the exception
+in an error buffer using `cider-stacktrace-mode`. You can suppress
+this behavior, however:
 
 ```el
 (setq cider-show-error-buffer nil)
 ```
 
-At times, the error being displayed will originate from a bug in the
-CIDER code itself. These internal errors might frequently occur and
-interrupt your workflow, but you might not want to suppress **all**
-stacktrace buffers via the `cider-show-error-buffer` variable as
-above; instead, you might only want to suppress *this specific type*
-of internal error. The stacktrace buffers provide such an option when
-displaying an internal error. A toggle button will be displayed with
-the error type's name, and you can toggle whether this particular type
-of error will cause the stacktrace buffer to automatically show
-itself.  The toggle button controls this behavior only during the
-current Emacs session, but if you would like to make the suppression
-more permanent, you can do so by customizing the
-`cider-stacktrace-suppressed-errors` variable.  The buffer will also
-provide a direct link to the bug reporting page to help facilitate its
-diagnosis and repair.
+At times, the error being displayed will originate from a bug in CIDER
+itself. These internal errors might frequently occur and interrupt
+your workflow, but you might not want to suppress **all** stacktrace
+buffers by using `cider-show-error-buffer`. Instead, you might only
+want to suppress *this specific type* of internal error. The
+stacktrace buffers provide such an option when displaying an internal
+error. A toggle button will be displayed with the error type's name,
+and you can toggle whether this particular type of error will cause
+the stacktrace buffer to automatically show itself.  The toggle button
+controls this behavior only during the current Emacs session, but if
+you would like to make the suppression more permanent, you can do so
+by customizing the `cider-stacktrace-suppressed-errors` variable.  The
+buffer will also provide a direct link to the bug reporting page to
+help facilitate its diagnosis and repair.
 
 Independently of the value of `cider-show-error-buffer` or
-`cider-stacktrace-suppressed-errors`, the error buffer is always
-generated in the background. Use `cider-selector` (`C-c M-s`) to visit
-this buffer.
+`cider-stacktrace-suppressed-errors`, CIDER always generates the error
+buffer in the background. You can use `cider-selector` (<kbd>C-c M-s</kbd>) to
+visit this buffer if you decide that you need to.
 
 There are two more selective strategies for the error buffer:
 
@@ -59,18 +61,23 @@ There are two more selective strategies for the error buffer:
 (setq cider-show-error-buffer 'only-in-repl)
 ```
 
-* To disable auto-selection of the error buffer when it's displayed:
+To disable auto-selection of the error buffer when it's displayed:
 
 ```el
 (setq cider-auto-select-error-buffer nil)
 ```
 
-* Error buffer stacktraces may be filtered by default. Valid filter
-types include `java`, `clj`, `repl`, `tooling`, and `dup`. There are
-also "positive" filtering types. The value `project` will cause only
-project frames to be shown or `all` will force all stackframes to be
-shown. Note that `project` and `all` are mutually exclusive. Whichever
-one is first will determine the behavior if they are both present.
+CIDER helps you cut through the clutter of Clojure stacktraces by
+allowing you to apply a list of filters using the
+`cider-stacktrace-default-filters` variable. Valid filter types
+include `java`, `clj`, `repl`, `tooling`, and `dup`. Specifying one of
+these filters will remove the corresponding frames from the stacktrace
+display. There are also "positive" filtering types (reverse filters)
+that specify what should be shown. The value of `project`, for
+instance, will cause only project frames to be shown, and `all` will
+force all stackframes to be shown. Note that `project` and `all` are
+mutually exclusive. Whichever one is first will determine the behavior
+if they are both present.
 
 ```el
 (setq cider-stacktrace-default-filters '(tooling dup))
@@ -78,9 +85,18 @@ one is first will determine the behavior if they are both present.
 (setq cider-stacktrace-default-filters '(project))
 ```
 
-* Error messages may be wrapped for readability. If this value is nil, messages
-will not be wrapped; if it is truthy but non-numeric, the default `fill-column`
-will be used.
+Finally, CIDER can wrap error messages when they are displayed in a
+buffer to help improve their readability. CIDER uses
+`cider-stack-trade-fill-column` for this, which can take on three
+types of values:
+
+- `nil`: The error is not wrapped.
+- numeric: The error message is wrapped to the specified fill column.
+- Something truthy but non-numeric: The error message is wrapped using
+  the value of `fill-column`.
+
+The following will cause error messages to be wrapped to 80 columns,
+for instance:
 
 ```el
 (setq cider-stacktrace-fill-column 80)

--- a/doc/running_tests.md
+++ b/doc/running_tests.md
@@ -1,50 +1,84 @@
-## Running tests
+The Clojure ecosystem provides a lot of support for test-driven
+development (TDD) and other test-centric patterns. First, Clojure
+provides a standardized framework for developing tests called
+[clojure.test]. Many other testing libraries plug into this
+framework. Second, tools like Leiningen create standardized
+application and library project structures that provide locations and
+idiomatic naming for test code. Finally, CIDER provides several easy
+ways to run these tests, view the test results, and quickly jump to
+code that is failing to pass a given test.
 
-!!! WARNING
+!!! NOTE
 
-    CIDER supports only clojure.test and libraries,
+    CIDER only supports clojure.test and other libraries
     providing integration with clojure.test.
 
-You can run `clojure.test` tests pretty quickly in CIDER. Pressing <kbd>C-c C-t
-n</kbd> or <kbd>C-c C-t C-n</kbd> in a source buffer or a REPL buffer will run
-the tests for the namespace you're currently in. CIDER is smart enough to figure
-out the namespace containing the tests. The inference logic works in a pretty
-simple manner - if you're in an implementation namespace (e.g. `some.ns`) CIDER
-will try to find a matching test namespace (by default `some.ns-test`) and run
-the tests there. On the other hand - if you're in something that looks like a
-test namespace (e.g. `some.ns-test`), then the command will simply run the tests
-in that namespace. From time to time, however, you might want to suppress the
-test namespace inference logic (e.g. you have some tests in the implementation
-namespace that were defined with `clojure.test/with-test`)
-- in such cases you should use <kbd>C-u C-c C-t C-n</kbd>, which will simply run
-whatever tests are present in the currently visited/active namespace.
+## Running Tests
 
-You can also press <kbd>C-c C-t C-s</kbd> to run a subset of the tests defined in
-the namespace filtered by test selectors. CIDER will ask you for those test selectors
-in the minibuffer. If you call this command with a prefix (<kbd>C-u C-c C-t C-s</kbd>)
-you can suppress the inference logic as for run tests for the namespace.
-
-You can also run all loaded tests with <kbd>C-c C-t l</kbd> or <kbd>C-c C-t
-C-l</kbd> and all tests within a project with <kbd>C-c C-t p</kbd> or <kbd>C-c
-C-t C-p</kbd> (note that this will load **all** namespaces in your
-project). If you call these two with a prefix CIDER will ask for test selector filters
-and only run those tests in the project which match the selector inclusions/exclusions. Using
-<kbd>C-c C-t t</kbd> or <kbd>C-c C-t C-t</kbd>, you can execute only the
-test at point.
-
-Test selectors are originally a `leiningen` feature - see `lein help test` for some explanation.
-People use them to define subsets of tests usually run together for different purposes. For
-example you can mark some of your tests with the `^:smoke` metadata marker others with
-`^:integration`. This enables you to run these tests separately in your build pipeline.
-This feature in CIDER helps you to run these test subsets in your development environment.
-
-All test commands are available in REPL buffers as well. There you can also use
+CIDER has several functions that help you run all your tests or a
+selected subset of them. All of the CIDER test commands are available
+in both source code and REPL buffers. In REPL buffers you can also use
 <kbd>,</kbd> to invoke some of the testing commands.
 
-## Interacting with result reports
+First, you can run all the tests in your project with <kbd>C-c C-t p</kbd>
+or <kbd>C-c C-t C-p</kbd>. It's important to realize that this will
+load **all** the namespaces in your project, which might be more than
+you're expecting.
 
-In the buffer displaying the test execution results (`*cider-test-results*`)
-you'll have a bit of additional functionality at your disposal.
+You can run all *loaded* tests with <kbd>C-c C-t l</kbd> or
+<kbd>C-c C-t C-l</kbd>.
+
+If you invoke either of these commands with a prefix CIDER, will
+prompt for test selector filters and only run those tests that match
+the selector inclusions/exclusions. 
+
+Test developers use selectors to define subsets of the total test
+suite that are run together for different testing tasks. For example
+you can mark some of your tests with the `^:smoke` metadata marker
+and others with `^:integration`. This enables you to run these tests
+separately in your build pipeline.  CIDER helps you to run these same
+test subsets in your development environment.
+
+Test selectors were originally a `leiningen` feature and you can get
+more information by executing:
+
+```sh
+$ lein help test
+```
+
+You can run all the tests in the current namespace, whether specified
+by a source file or by the REPL, using <kbd>C-c C-t n</kbd> or
+<kbd>C-c C-t C-n</kbd>. Note that it's idiomatic for Clojure projects
+to locate tests in a separate namespace than the code that is being
+tested. CIDER uses a simple algorithm to figure out where the tests
+are located. The algorithm works as follows.  If you're in an
+implementation namespace (e.g. `some.ns`), CIDER will try to find a
+matching test namespace (by default `some.ns-test`) and run the tests
+there. But if you're in something that already looks like a test
+namespace (e.g. `some.ns-test`), CIDER will simply run the tests in
+that namespace. If you have put some of your tests into your
+implementation namespace, using `clojure.test/with-test`, for
+instance, you might want to suppress the namespace inference logic and
+force CIDER to run tests in the current namespace unconditionally.
+You can do this by adding a prefix to the namespace commands: <kbd>C-u
+C-c C-t C-n</kbd>. This will simply run whatever tests are present in
+the currently visited or active namespace.
+
+You can also run a subset of the tests defined in the namespace,
+filtered by test selectors, using <kbd>C-c C-t C-s</kbd>. CIDER will
+prompt for the selectors in the minibuffer. If you call this
+command with a prefix (<kbd>C-u C-c C-t C-s</kbd>) you can suppress
+the namespace inference logic as for <kbd>C-u C-c C-t C-n</kbd>
+
+Finally, you can execute the specific test at the point using 
+<kbd>C-c C-t t</kbd> or <kbd>C-c C-t C-t</kbd>.
+
+## Interacting with Test Result Reports
+
+After running your tests, CIDER displays a test result report in the
+`*cider-test-report*` buffer. This buffer uses `test-report-mode`,
+which makes it easy to review any failures that might have occurred
+and jump directly to the definition of failing tests.
 
 Keyboard shortcut               | Description
 --------------------------------|-------------------------------
@@ -62,26 +96,28 @@ Keyboard shortcut               | Description
 
 ## Configuration
 
-Certain aspects of the test execution behavior are configurable:
+You can configure CIDER's test excution behavior in multiple ways.
 
-* If your tests are not following the `some.ns-test` naming convention you can
-customize the variable `cider-test-infer-test-ns`. It should be bound to a
-function that takes the current namespace and returns the matching test
-namespace (which may be the same as the current namespace).
+If your tests are not following the `some.ns-test` naming convention
+you can set the variable `cider-test-infer-test-ns` to a function that
+takes the current namespace and returns the matching test namespace
+(which may be the same as the current namespace). This provides
+complete flexibility to structure your test suite using whatever
+conventions you might want.
 
-* If your individual tests are not defined by `deftest` or `defspec`, CIDER will
+If your individual tests are not defined by `deftest` or `defspec`, CIDER will
 not recognize them when searching for a test at point in `cider-test-run-test`.
 You can customize the variable `cider-test-defining-forms` to add additional
 forms for CIDER to recognize as individual test definitions.
 
-* If you want to view the test report regardless of whether the tests have
+If you want to view the test report regardless of whether the tests have
 passed or failed:
 
 ```el
 (setq cider-test-show-report-on-success t)
 ```
 
-## Running tests automatically (test-driven development)
+## Running Tests Automatically (Test-Driven Development)
 
 CIDER provides a minor-mode that automatically runs all tests for a namespace
 whenever you load a file (with <kbd>C-c C-k</kbd>). You can toggle it
@@ -91,30 +127,35 @@ manually with <kbd>M-x</kbd> `cider-auto-test-mode`, or you can use:
 (cider-auto-test-mode 1)
 ```
 
-This is completely equivalent to manually typing <kbd>C-c C-t C-n</kbd> every
-time you load a Clojure buffer. Also, as described above before, CIDER is smart
-enough to figure out the namespace containing the tests.
+This is identical to manually typing <kbd>C-c C-t C-n</kbd> every time
+you load a Clojure buffer. As described previously, CIDER will try to
+automatically determine the namespace containing the tests.
 
-## Using cider-test with alternative test libraries
+## Using cider-test with Alternative Test Libraries
 
-The `clojure.test` machinery is designed to be pluggable. Any test library
-can implement it if so desired, and therefore leverage `cider-test`. For
-instance, [test.check](https://github.com/clojure/test.check/) does this, and
-`cider-test` handles `defspec` just like `deftest`.
+The `clojure.test` machinery is designed to be pluggable. Any test
+library can integrate with it and leverage the `cider-test`
+ecosystem.
 
 As a test framework author, supporting the built-in `clojure.test` machinery
 (and hence `cider-test`) is pretty straightforward:
 
-1. Assoc each test fn as `:test` metadata on some var. These are what get run.
+1. Add `:test` metadata to the vars corresponding to the test
+   functions. The `clojure-test` machinery uses this metadata to
+   find tests.
 2. Implement the `clojure.test/report` multimethod to capture the test results.
 
-The `test.check` library is a good example here. It was also designed completely
-independently of `clojure.test`. It just adds compatibility in this
+For example, [test.check] was designed independently of `clojure.test`
+but integrates with it. Because of this, `cider-test` handles
+`defspec` just like `deftest`. `test.check` just adds compatibility in this
 [namespace](https://github.com/clojure/test.check/blob/24f74b83f1c7a032f98efdcc1db9d74b3a6a794d/src/main/clojure/clojure/test/check/clojure_test.cljc).
 
 ### Supported Libraries
 
-* `test.check`
+* [test-check]
 * [clojure-expectations](https://github.com/clojure-expectations/expectations) added
 support for `clojure.test` in version 2.2 and should also work with CIDER.
 * [fudge](https://github.com/jimpil/fudje)
+
+[clojure.test]: https://clojure.github.io/clojure/clojure.test-api.html "`clojure.test`"
+[test.check]: https://github.com/clojure/test.check "`test.check`"

--- a/doc/up_and_running.md
+++ b/doc/up_and_running.md
@@ -1,42 +1,38 @@
-The only requirement to use CIDER is to have an nREPL server to which it may
-connect. Many Clojurians favour the use of tools like Leiningen, Boot or Gradle
-to start an nREPL server, but the use of one of them is not a prerequisite to
-use CIDER.
-
-## Setting up a Clojure project (optional)
-
-CIDER features a command called `cider-jack-in` that will start an nREPL server
-for a particular Clojure project and connect to it automatically. Most
-popular Clojure project management tools are supported by default - namely
-Leiningen, Boot, `clj` (`tools.deps`) and Gradle.
+To use CIDER, you'll need to connect it to a running nREPL server that
+is associated with your program. Most Clojure developers use standard
+build tooling such as Leiningen, Boot, or Gradle, and CIDER can
+automatically work with those tools to get you up and running
+quickly. But those tools are not required; CIDER can connect to an
+nREPL server that is already started and is managed separately.
 
 !!! Note
 
-    This functionality depends on Leiningen 2.5.2+ or Boot
+    CIDER will automatically work with Leiningen 2.5.2+ or Boot
     2.7.0+. Older versions are not supported.
 
-Let's create a simple Clojure project using Leiningen now. Provided you've installed
-it already, all you need to do is:
+There are two ways to connect CIDER to an nREPL server:
 
-```
-$ lein new demo
-```
+1. CIDER can launch an nREPL server for your project from Emacs.
+2. You can connect CIDER to an already-running nREPL server, managed separately.
 
-The two main ways to obtain an nREPL connection are discussed in the following sections of the manual.
+The following sections describe each of these methods.
 
-## Launch an nREPL server and client from Emacs
+## Launch an nREPL Server From Emacs
 
-Simply open in Emacs a file belonging to your project (like `foo.clj`) and type
-<kbd>M-x</kbd> `cider-jack-in` <kbd>RET</kbd>. This will start an nREPL server
-and CIDER will automatically connect to it.
+If you have a Clojure project in your file system and want CIDER to
+launch an nREPL session for it, simply visit a file that belongs to
+the project, and type <kbd>M-x</kbd> `cider-jack-in`
+<kbd>RET</kbd>. CIDER will start an nREPL server and automatically
+connect to it.
 
 !!! Note
 
-    If it is a `lein`, `boot` or `tools.deps (deps.edn)` project nREPL will be
-    started with all dependencies loaded. Dependency auto-injection is currently
-    not supported for Gradle projects.
+    If your project uses `lein`, `boot` or `tools.deps (deps.edn)`,
+    CIDER will automatically inject all the necessary nREPL
+    dependencies when it starts the server. CIDER does not currently support
+    dependency auto-injection for Gradle projects.
 
-Alternatively you can use <kbd>C-u M-x</kbd> `cider-jack-in` <kbd>RET</kbd> to
+Alternatively, you can use <kbd>C-u M-x</kbd> `cider-jack-in` <kbd>RET</kbd> to
 specify the name of a `lein`, `boot` or `tools.deps` project, without having to
 visit any file in it. This option is also useful if your project contains some
 combination of `project.clj`, `build.boot` and `deps.edn` and you want to launch
@@ -46,67 +42,73 @@ a REPL for one or the other.
 
     In Clojure(Script) buffers the command `cider-jack-in` is bound to <kbd>C-c C-x (C-)j (C-)j</kbd>.
 
-For further customizing the command line used for `cider-jack-in`, you can
-change the following (all string options):
+You can further customize the command line CIDER uses for `cider-jack-in` by
+modifying the following string options:
 
- * `cider-lein-global-options`, `cider-boot-global-options`,
-   `cider-clojure-cli-global-options`, `cider-gradle-global-options`:
-   these are passed to the command directly, in first position
-   (e.g. `-o` to `lein` enables offline mode).
- * `cider-lein-parameters`, `cider-boot-parameters`,
-   `cider-clojure-cli-parameters`, `cider-gradle-parameters`: these
-   are usually tasks names and their parameters (e.g.: `dev` for
-   launching boot's dev task instead of the standard `repl -s wait`).
+* `cider-lein-global-options`, `cider-boot-global-options`,
+  `cider-clojure-cli-global-options`, `cider-gradle-global-options`:
+  these are passed to the command directly, in first position
+  (e.g., `-o` to `lein` enables offline mode).
+* `cider-lein-parameters`, `cider-boot-parameters`,
+  `cider-clojure-cli-parameters`, `cider-gradle-parameters`: these are
+  usually task names and their parameters (e.g., `dev` for launching
+  boot's dev task instead of the standard `repl -s wait`).
 
 Note that if you try to run `cider-jack-in` outside a project
-directory normally you'd get a warning to confirm you really want to
-do this, as more often than not you'd probably do this
-accidentally. If you decide to proceed, CIDER will invoke the command
-configured in `cider-jack-in-default`. This used to be `lein` prior to
-CIDER 0.17 and it was switched to Clojure's CLI (`clj`) afterwards.
+directory, CIDER will warn you and ask you to confirm whether you
+really want to do this; more often than not, this is an accident.  If
+you decide to proceed, CIDER will invoke the command configured in
+`cider-jack-in-default`. Prior to CIDER 0.17, this defaulted to `lein`
+but was subsequently switched to `clj`, Clojure's basic startup command.
 
 !!! Tip
 
     You can set `cider-allow-jack-in-without-project` to `t` if you'd like to
     disable the warning displayed when jacking-in outside a project.
 
-## Connect to a running nREPL server
+## Connect to a Running nREPL Server
 
-Go to your project's directory in a terminal and type there:
+If you have an nREPL server already running, CIDER can connect to
+it. For instance, if you have a Leiningen-based project, go to your
+project's directory in a terminal session and type:
 
-```
+```sh
 $ lein repl :headless
 ```
 
-Or for `boot`:
+This will start the project's nREPL server.
 
-```
+If your project uses `boot`, do this instead:
+
+```sh
 $ boot repl -s wait (or whatever task launches a repl)
 ```
 
 It is also possible for plain `clj`, although the command is somewhat longer:
 
-```
+```sh
 $ clj -Sdeps '{:deps {nrepl {:mvn/version "0.4.5"} cider/cider-nrepl {:mvn/version "0.18.0"}}}' -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"
 ```
 
-Alternatively you can start nREPL either manually or by the facilities
+Alternatively, you can start nREPL either manually or using the facilities
 provided by your project's build tool (Gradle, Maven, etc).
 
-After you get your nREPL server running, go back to Emacs.  Type there
-<kbd>M-x</kbd> `cider-connect` <kbd>RET</kbd> to connect to the
-running nREPL server.
+After you get your nREPL server running, go back to Emacs and connect
+to it: <kbd>M-x</kbd> `cider-connect` <kbd>RET</kbd>. CIDER will
+prompt you for the host and port information, which should have been
+printed when the previous commands started the nREPL server in your
+project.
 
 !!! Tip
 
     In Clojure(Script) buffers the command `cider-connect` is bound to <kbd>C-c C-x c s</kbd>.
 
-You can configure known endpoints used by the `cider-connect` command offered
-via a completing read. This is useful if you have a list of common host/ports
-you want to establish remote nREPL connections to. Using an optional label is
-helpful for identifying each host.
+If you frequently connect to the same hosts and ports, you can tell
+CIDER about them and it will use the information to do completing
+reads for the host and port prompts when you invoke
+`cider-connect`. You can identify each host with an optional label.
 
-```
+```el
 (setq cider-known-endpoints
   '(("host-a" "10.10.10.1" "7888")
     ("host-b" "7888")))

--- a/doc/using_the_repl.md
+++ b/doc/using_the_repl.md
@@ -1,6 +1,7 @@
-CIDER comes with a powerful REPL, which is quite handy when you want to
-experiment with the code you're working on or just explore some stuff (e.g. a
-library you're playing with).  The REPL offers a number of advanced features:
+CIDER comes with a powerful REPL that complements the interactive
+development functionality in `cider-mode`. Using the CIDER REPL you
+can experiment with your running program, test functions, or just
+explore a new library you're interested in using. The CIDER REPL offers a number of advanced features:
 
 * auto-completion
 * font-locking (the same as in `clojure-mode`)
@@ -64,8 +65,9 @@ character used to trigger the shortcuts is configurable via
 
 #### Behavior on connect
 
-Normally, the REPL buffer is auto-displayed in a separate window after
-  a connection is established. You can suppress this behaviour like this:
+Normally, when you first establish a REPL connection, the REPL buffer is
+auto-displayed in a separate window. You can suppress this behaviour
+like this:
 
 ```el
 (setq cider-repl-pop-to-buffer-on-connect nil)
@@ -80,9 +82,9 @@ focused, use this:
 
 #### Behavior on switch
 
-By default <kbd>C-c C-z</kbd> will display the REPL buffer in a different window.
-You can make <kbd>C-c C-z</kbd> switch to the CIDER REPL buffer in the current
-window:
+By default <kbd>C-c C-z</kbd> will display the REPL buffer in a
+different window.  You can make <kbd>C-c C-z</kbd> switch to the CIDER
+REPL buffer in the current window:
 
 ```el
 (setq cider-repl-display-in-current-window t)
@@ -99,12 +101,10 @@ It's extremely useful! Enable `eldoc` in REPL buffers like this:
 
 #### Customizing the REPL prompt
 
-You can customize the prompt in REPL buffer. To do that you can customize
-`cider-repl-prompt-function` and set it to a function that takes one argument,
-a namespace name. For convenience, three functions are already provided:
-`cider-repl-prompt-lastname`, `cider-repl-prompt-abbreviated`,
-`cider-repl-prompt-default` and by default the last one is being used.
-Prompt for each of them for namespace `leiningen.core.ssl`:
+You can customize the REPL buffer prompt by setting
+`cider-repl-prompt-function` to a function that takes one
+argument, a namespace name. For convenience, CIDER provides three
+functions that implement common formats:
 
 * `cider-repl-prompt-lastname`:
 
@@ -124,6 +124,8 @@ l.c.ssl>
 leiningen.core.ssl>
 ```
 
+By default, CIDER uses `cider-repl-prompt-default`.
+
 You may, of course, write your own function. For example, in `leiningen` there
 are two namespaces with similar names - `leiningen.classpath` and
 `leiningen.core.classpath`. To make them easily recognizable you can either
@@ -140,13 +142,13 @@ namespace. Here is an example function that will do exactly that:
 
 #### TAB Completion
 
-You can control the <kbd>TAB</kbd> key behavior in the REPL via the
+You can control the <kbd>TAB</kbd> key behavior in the REPL using the
 `cider-repl-tab-command` variable.  While the default command
 `cider-repl-indent-and-complete-symbol` should be an adequate choice for
 most users, it's very easy to switch to another command if you wish
 to. For instance if you'd like <kbd>TAB</kbd> to only indent (maybe
 because you're used to completing with <kbd>M-TAB</kbd>) use the
-following snippet:
+following:
 
 ```el
 (setq cider-repl-tab-command #'indent-for-tab-command)
@@ -154,7 +156,7 @@ following snippet:
 
 #### Auto-scrolling the REPL on Output
 
-By default if the REPL buffer contains more lines than the size of the
+By default, if the REPL buffer contains more lines than the size of the
 (Emacs) window, the buffer is automatically re-centered upon
 completion of evaluating an expression, so that the bottom line of
 output is on the bottom line of the window.
@@ -173,30 +175,33 @@ If you don't like this re-centering you can disable it like this:
 
 #### Result Prefix
 
-Change the result prefix for REPL evaluation (by default there's no prefix):
+You can change the string used to prefix REPL results:
 
 ```el
 (setq cider-repl-result-prefix ";; => ")
 ```
 
-And here's the result of that change:
+Which then results in the following REPL output:
 
 ```
 user> (+ 1 2)
 ;; => 3
 ```
 
+By default, REPL results have no prefix.
+
 #### Customize the REPL Buffer's Name
 
-The REPL buffer name has the format `*cider-repl project-name*`.
-You can change the separator from space to something else by overriding `nrepl-buffer-name-separator`.
+The REPL buffer name has the format `*cider-repl project-name*`.  You
+can change the separator from a space character to something else by
+setting `nrepl-buffer-name-separator`.
 
 ```el
 (setq nrepl-buffer-name-separator "-")
 ```
 
 The REPL buffer name can also display the port on which the nREPL server is running.
-Buffer name will look like `*cider-repl project-name:port*`.
+The buffer name will look like `*cider-repl project-name:port*`.
 
 ```el
 (setq nrepl-buffer-name-show-port t)
@@ -204,10 +209,12 @@ Buffer name will look like `*cider-repl project-name:port*`.
 
 #### Font-locking
 
-Normally code in the REPL is font-locked the same way as in
-`clojure-mode`. Before CIDER 0.10 by default REPL input was font-locked with
-`cider-repl-input-face` (after you press `RET`) and results were font-locked with
-`cider-repl-result-face`. If you want to restore the old behaviour use:
+Normally, code in the REPL is font-locked the same way as in
+`clojure-mode`. Before CIDER 0.10, by default, REPL input was
+font-locked with `cider-repl-input-face` (after pressing
+<kbd>Return</kbd>) and results were font-locked with
+`cider-repl-result-face`. If you want to restore the old behaviour
+use:
 
 ```el
 (setq cider-repl-use-clojure-font-lock nil)
@@ -215,9 +222,8 @@ Normally code in the REPL is font-locked the same way as in
 
 #### Pretty printing in the REPL
 
-Make the REPL always pretty-print the results of your evaluations.
-
-<kbd>M-x cider-repl-toggle-pretty-printing</kbd>
+You can make the REPL always pretty-print the results of your
+evaluations using <kbd>M-x cider-repl-toggle-pretty-printing</kbd>.
 
 To make this behavior the default:
 
@@ -235,11 +241,11 @@ behavior if you don't like it.
 (setq cider-repl-use-content-types nil)
 ```
 
-Alternatively you can toggle this behaviour on and off using <kbd>M-x
+Alternatively, you can toggle this behaviour on and off using <kbd>M-x
 cider-repl-toggle-content-types</kbd>.
 
-Currently the feature doesn't work well with pretty-printing in the REPL,
-so you're advised not to enable both of them at the same time.
+Currently, the feature doesn't work well with pretty-printing in the REPL,
+so we don't advise you to enable both features at the same time.
 
 #### Limiting printed output in the REPL
 
@@ -253,17 +259,20 @@ section of your Leiningen project's configuration.
 :repl-options {:init (set! *print-length* 50)}
 ```
 
-or via `cider-repl-print-length` (set to 100 by default). In case both are
-present, CIDER's config will take precedence over what came from Lein.
+You can also set `cider-repl-print-length` to an appropriate value (it
+defaults to 100). If both `*print-length` and
+`cider-repl-print-length` are set, CIDER's setting will take precedence
+over the value set through Leiningen.
 
-All of this applies to `*print-level*` as well. CIDER's configuration
-variable for it is named `cider-repl-print-level` (set to `nil` by default).
+The preceeding discussion also applies to Clojure's `*print-level*`
+variable. The corresponding CIDER variable is
+`cider-repl-print-level`, set to `nil` by default.
 
 #### Customizing the initial REPL namespace
 
-Normally the CIDER REPL will start with the `user` namespace.
-You can supply a default value for REPL sessions via the `repl-options` section
-of your Leiningen project's configuration.
+Normally, the CIDER REPL will start in the `user` namespace.  You can
+supply an initial namespace for REPL sessions in the `repl-options`
+section of your Leiningen project configuration:
 
 ```clojure
 :repl-options {:init-ns 'my-ns}
@@ -271,23 +280,23 @@ of your Leiningen project's configuration.
 
 #### Customizing newline interaction
 
-Ordinarily <kbd>Return</kbd> sends a form for evaluation meaning entering a
-newline requires a special chord: <kbd>C-j</kbd>. When entering forms that span
-multiple lines, it may be desirable to make evaluation require the special
-invocation and have entering a new-line be the default.
-
-The following customization of the `cider-repl-mode-map` will change these
-keybindings so that <kbd>Return</kbd> will introduce a new-line and
-<kbd>C-<return></kbd> will send the form off for evaluation.
+Ordinarily, <kbd>Return</kbd> immediate sends a form for
+evaluation. If you want to insert a newline into the REPL buffer as
+you're editing, you can do so using <kbd>C-j</kbd>. If you are
+entering a lot of longer forms that span multiple lines, it may be
+more convenient to change the keybindings:
 
 ``` el
 (define-key cider-repl-mode-map (kbd "RET") #'cider-repl-newline-and-indent)
 (define-key cider-repl-mode-map (kbd "C-<return>") #'cider-repl-return)
 ```
 
+This will make <kbd>Return</kbd> insert a newline into the REPL buffer
+and <kbd>C-<Return></kbd> send the form off for evaluation.
+
 #### REPL history
 
-* To make the REPL history wrap around when its end is reached:
+* To make the REPL history wrap around when CIDER reaches the end:
 
 ```el
 (setq cider-repl-wrap-history t)
@@ -305,51 +314,66 @@ keybindings so that <kbd>Return</kbd> will introduce a new-line and
 (setq cider-repl-history-file "path/to/file")
 ```
 
-Note that the history is written to the file when you kill the REPL
-buffer (which includes invoking `cider-quit`) or you quit Emacs.
+Note that CIDER writes the history to the file when you kill the REPL
+buffer, which includes invoking `cider-quit`, or when you quit Emacs.
 
 ### REPL history browser
 
 You can browse your REPL input history with the command <kbd>M-x</kbd>
-`cider-repl-history`.  It is also bound in `cider-repl-mode` buffers to
-<kbd>C-c M-p</kbd>, and is also available via the `history` shortcut.
+`cider-repl-history`.  This command is bound to <kbd>C-c M-p</kbd> 
+in `cider-repl-mode` buffers and is also available via the
+`history` shortcut.
 
-The history is displayed in order, with the most recent input at the top of the
-buffer, and the oldest one at the bottom.  You can scroll through the history,
-and when you find the history item you were looking for, you can insert it from
-the history buffer into your REPL buffer.
+The history is displayed in reverse order, with the most recent input
+at the top of the buffer, and the oldest input at the bottom.  You can
+scroll through the history, and when you find the history item you
+were looking for, you can insert it from the history buffer into your
+REPL buffer.
 
 ![History Browser](images/history_browser.png)
 
 #### Mode
 
-The history buffer has its own major mode, `cider-repl-history-mode` which is derived
-from `clojure-mode`, so you get fontification in the history buffer. It supports
-the expected defcustom hook variable, `cider-repl-history-hook`.
+The history buffer has its own major mode,
+`cider-repl-history-mode`. This is derived from `clojure-mode`, so you
+get fontification in the history buffer. This mode supports the
+expected defcustom hook variable, `cider-repl-history-hook`.
 
 #### Insertion
 
-Typically your cursor will be at the bottom of the REPL buffer (`point-max`)
-when you use this feature; if that's the case, the text is inserted, and point
-is advanced to the end of the inserted text. In the unusual case where you
-invoke the history browser when your cursor is _not_ at the end of the buffer,
-the text is _still_ inserted at point-max, but point is not modified.
+Where you use the history buffer to insert text into the REPL buffer,
+the exact behavior depends on the location of the cursor in the buffer
+prior to the insertion.
 
-The text is inserted without a final newline, meaning you can edit the form
-if you wish, and you must explicitly hit <kbd>Enter</kbd> to have it evaluated
-by the REPL.
+Typically, when you're actively using the REPL, your cursor will be at
+the end of the REPL buffer (`point-max`). In this case, the text is
+inserted at the end of the buffer and the point advances to the end of
+the inserted text (as if point was pushed by along by the text as it
+was inserted).
+
+In the unusual case where you invoke the history browser when your
+cursor is _not_ at the end of the REPL buffer, the inserted text will
+still be inserted at the end of the buffer (`point-max`), but the
+point is not modified.
+
+CIDER inserts the text without a final newline, allowing you to edit
+it. When you are ready, hit <kbd>Return</kbd> to have it evaluated by
+the REPL.
 
 #### Quitting
 
-After text is inserted, the history buffer is automatically quit. If you decide
-you don't want to insert any text after all, you can explicitly quit by running
-`cider-repl-history-quit` (see keyboard shortcuts).  Due to the initialization and
-cleanup done, it is better to properly quit, rather than just switch away from
-the history buffer.
+If you select an input, the text will be inserted into the REPL buffer
+and the history buffer will automatically quit. If you decide you want
+to quit without inserting any text at all, you can explicitly quit by
+running `cider-repl-history-quit` (see keyboard shortcuts).  Because
+of the initialization and cleanup that is done when using the history
+buffer, it is better to quit properly rather than just switch away
+from the history buffer.
 
-When you quit the history buffer, there are several different ways for the
-buffers and windows to be restored. This is controlled by the custom variable
-`cider-repl-history-quit-action`, which can be assigned one of several values:
+When you quit the history buffer, CIDER can restore the buffer and
+window configuration in a few different ways. The behavior is
+controlled by `cider-repl-history-quit-action`, which can be assigned
+one of several values:
 
 - `quit-window` restores the window configuration to what it was before.
   This is the default.
@@ -359,39 +383,44 @@ buffers and windows to be restored. This is controlled by the custom variable
   deletes the window.
 - `bury-buffer` simply buries the `*cider-repl-history*` buffer, but keeps the
   window.
-- `bury-and-delete-window` buries the buffer, and (if there is more than one
-  window) deletes the window.
+- `bury-and-delete-window` buries the buffer, and deletes the window
+  if there is more than one window.
 - any other value is interpreted as the name of a function to call
 
 #### Filtering
 
-By invoking `cider-repl-history-occur` from the history buffer, you will be prompted
-for a regular expression, and the history buffer will be filtered to only those
-inputs that match the regexp.
+By invoking `cider-repl-history-occur` from the history buffer, you
+will be prompted for a regular expression. The history buffer will be
+filtered to only those inputs that match the regexp.
 
 #### Preview and Highlight
 
-When `cider-repl-history-show-preview` is non-nil, we display an [`overlay`]
+When `cider-repl-history-show-preview` is non-nil, CIDER displays an [`overlay`]
 (https://www.gnu.org/software/emacs/manual/html_node/elisp/Overlays.html)
 of the currently selected history entry, in the REPL buffer.
 
-This is a nice feature; the only thing to be careful of is that if you do not
-properly quit from browsing the history (i.e., if you just <kbd>C-x b</kbd>
-away from the buffer), you may be left with an unwanted overlay in your REPL
-buffer. It can be eliminated with <kbd>M-x</kbd> `cider-repl-history-clear-preview`.
+If you do not properly quit from browsing the history (i.e., if you
+just <kbd>C-x b</kbd> away from the buffer), you may be left with an
+unwanted overlay in your REPL buffer. If this happens, you can clean
+it up with <kbd>M-x</kbd> `cider-repl-history-clear-preview`.
 
-By default, the variable is nil and the feature is off.
+By default, `cider-repl-history-show-preview` is nil (disabled).
 
-A related feature is to highlight the entry once it is actually inserted into
-the REPL buffer. This is controlled by the variable
-`cider-repl-history-highlight-inserted-item`. The non-nil value selected controls how
-the inserted item is highlighted, possible values are `solid` (highlight the
-inserted text for a fixed period of time), or `pulse` (fade out the highlighting
-gradually).  Setting this variable to the value t will select the default
-highlighting style, which currently `pulse`. Default is nil.
+There is a related feature to highlight the entry once it is actually
+inserted into the REPL buffer, controlled by the variable
+`cider-repl-history-highlight-inserted-item`, which can be set to the
+following values:
 
-When "highlight-inserted" is turned on, you can customize the face of the
-inserted text with the variable `cider-repl-history-inserted-item-face`.
+- `solid` highlights the inserted text for a fixed period of time.
+- `pulse` causes the highlighting to fade out gradually.
+- `t` selects the default highlighting style, which is currently
+  `pulse`.
+- `nil` disables highlighting. This is the default value for
+  `cider-repl-history-highlight-inserted-item`.
+
+When `cider-repl-history-highlight-inserted-item` is non-nil, you
+can customize the face used for the inserted text with the variable
+`cider-repl-history-inserted-item-face`.
 
 #### Additional Customization
 


### PR DESCRIPTION
I've done a deep editing pass on most of the chapters of the CIDER manual, correcting spelling, punctuation, grammar, and overall consistency. In some cases I've rewritten paragraphs and rearranged sections to smooth it out. I have tried not to alter any of the technical content. If anybody notices any errors that I have introduced, let me know.