### PR TITLE
Correct spelling errors in docs

### DIFF
--- a/doc/caveats.md
+++ b/doc/caveats.md
@@ -21,7 +21,7 @@ ClojureScript source code (file, line & column) is set only when evaluating the
 entire source buffer (<kbd>C-c C-k</kbd>). All other interactive code evaluation
 commands (e.g. <kbd>C-c C-e</kbd>) don't set this metadata and you won't be able
 to use commands like `find-var` on such vars.  This is a limitation of nREPL and
-piggieback, that's beyond CIDER. You can find some discussions on the subject
+Piggieback, that's beyond CIDER. You can find some discussions on the subject
 [here](http://dev.clojure.org/jira/browse/NREPL-59) and
 [here](https://github.com/clojure-emacs/cider/issues/830).
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -66,7 +66,7 @@ suppress them from appearing in some buffer switching commands like
 ```
 
 If you need to make the hidden buffers appear When using
-`switch-to-buffer`, type <kbd>SPC</kbd> after issing the command. The
+`switch-to-buffer`, type <kbd>SPC</kbd> after issuing the command. The
 hidden buffers will always be visible in `list-buffers` (<kbd>C-x
 C-b</kbd>).
 

--- a/doc/miscellaneous_features.md
+++ b/doc/miscellaneous_features.md
@@ -1,7 +1,7 @@
 As the infomercials always say, "But wait, there's more!" If
 simultaneous Clojure and ClojureScript REPLs, interactive programming,
 code completion, stacktrace navigation, test running, and debugging
-weren't enough for you, CIDER delievers several additional
+weren't enough for you, CIDER delivers several additional
 features. 
 
 ## Evaluating Clojure Code in the Minibuffer
@@ -108,7 +108,7 @@ modification status.
 
 Adding a double prefix argument, <kbd>C-u C-u M-n n</kbd>, will first
 clear the state of the namespace tracker before reloading. This is
-sueful for recovering from some classes of error that nomral reloads
+useful for recovering from some classes of error that normal reloads
 would otherwise not recover from. A good example is circular
 dependencies. The trade-off is that stale code from any deleted files
 may not be completely unloaded.

--- a/doc/running_tests.md
+++ b/doc/running_tests.md
@@ -96,7 +96,7 @@ Keyboard shortcut               | Description
 
 ## Configuration
 
-You can configure CIDER's test excution behavior in multiple ways.
+You can configure CIDER's test execution behavior in multiple ways.
 
 If your tests are not following the `some.ns-test` naming convention
 you can set the variable `cider-test-infer-test-ns` to a function that


### PR DESCRIPTION
Six simple spelling and grammatical fixes to the documentation.