### PR TITLE
[Fix #2105] Fix no comment syntax defined message when loading buffer after running failing test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Fix jack-in from inside of remote buffers.
 * [#2454](https://github.com/clojure-emacs/cider/pull/2454): Fix erratic inspector behavior when multiple REPLs are connected
 * [#2467](https://github.com/clojure-emacs/cider/pull/2467): Make generic CIDER ops use any available nREPL connection.
+* [#2105](https://github.com/clojure-emacs/cider/issues/2105): Fix no comment syntax defined message when loading buffer after running a failing test.
 
 ### Changes
 

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -168,7 +168,8 @@ When invoked with a prefix ARG the command doesn't prompt for confirmation."
 (defun cider--quit-error-window ()
   "Buries the `cider-error-buffer' and quits its containing window."
   (when-let* ((error-win (get-buffer-window cider-error-buffer)))
-    (quit-window nil error-win)))
+    (save-excursion
+      (quit-window nil error-win))))
 
 
 ;;; Dealing with compilation (evaluation) errors and warnings
@@ -1055,10 +1056,9 @@ for the project, it is evaluated in both REPLs."
                    (or (eq cider-save-file-on-load t)
                        (y-or-n-p (format "Save file %s? " buffer-file-name))))
           (save-buffer))
-        (save-excursion
-          (remove-overlays nil nil 'cider-temporary t)
-          (cider--clear-compilation-highlights)
-          (cider--quit-error-window))
+        (remove-overlays nil nil 'cider-temporary t)
+        (cider--clear-compilation-highlights)
+        (cider--quit-error-window)
         (let ((filename (buffer-file-name buffer))
               (ns-form  (cider-ns-form)))
           (cider-map-repls :auto

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -1055,9 +1055,10 @@ for the project, it is evaluated in both REPLs."
                    (or (eq cider-save-file-on-load t)
                        (y-or-n-p (format "Save file %s? " buffer-file-name))))
           (save-buffer))
-        (remove-overlays nil nil 'cider-temporary t)
-        (cider--clear-compilation-highlights)
-        (cider--quit-error-window)
+        (save-excursion
+          (remove-overlays nil nil 'cider-temporary t)
+          (cider--clear-compilation-highlights)
+          (cider--quit-error-window))
         (let ((filename (buffer-file-name buffer))
               (ns-form  (cider-ns-form)))
           (cider-map-repls :auto


### PR DESCRIPTION
This PR fixes the no comment syntax defined message when loading a buffer after running a failing test, by adding a `save-excursion` to make sure the loaded buffer does not lose focus.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blog/master/doc) (if adding/changing user-visible functionality)
