### PR TITLE
Fix "save before refresh" functionality and use `files.el` for path comparisons/operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist
 .vagrant/
 cider-autoloads.el
 .dir-locals?.el
+cider-pkg.el
 cider-refcard.aux
 cider-refcard.log
 doc/auto/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 ### Changes
+* [#2546](https://github.com/clojure-emacs/cider/pull/2546): New defcustom `cider-ns-save-files-on-refresh-modes` to control for which buffers `cider-ns-refresh` should save before refreshing.
 
 ### Bug fixes
 * Fix values for `cider-preferred-build-tool` variable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@
 ### New features
 
 ### Changes
-* Fix values for `cider-preferred-build-tool` variable.
-* Fix value and safe property for `cider-allow-jack-in-without-project` variable.
 
 ### Bug fixes
+* Fix values for `cider-preferred-build-tool` variable.
+* Fix value and safe property for `cider-allow-jack-in-without-project` variable.
+* `cider-ns-save-files-on-refresh` will now save any modified buffers visiting files on the classpath, rather than just in the current project.
 
 ## 0.20.0 (2019-01-14)
 
@@ -40,6 +41,7 @@
 
 ### Bug fixes
 
+* `cider-expected-ns` no longer requires an absolute path as its argument, and now internally handles paths canonically and consistently.
 * [#2474](https://github.com/clojure-emacs/cider/issues/2474): Fix incorrect detection of output and out-of-order printing.
 * [#2514](https://github.com/clojure-emacs/cider/issues/2514): Don't auto-jump to warnings when `cider-auto-jump-to-error` is set to 'errors-only.
 * [#2453](https://github.com/clojure-emacs/cider/issues/2453): Make it possible to debug deftype methods by direct insertion of #dbg and #break readers into the deftype methods.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix values for `cider-preferred-build-tool` variable.
 * Fix value and safe property for `cider-allow-jack-in-without-project` variable.
 * `cider-ns-save-files-on-refresh` will now save any modified buffers visiting files on the classpath, rather than just in the current project.
+* `cider-expected-ns` no longer requires an absolute path as its argument, and now internally handles paths canonically and consistently.
 
 ## 0.20.0 (2019-01-14)
 
@@ -41,7 +42,6 @@
 
 ### Bug fixes
 
-* `cider-expected-ns` no longer requires an absolute path as its argument, and now internally handles paths canonically and consistently.
 * [#2474](https://github.com/clojure-emacs/cider/issues/2474): Fix incorrect detection of output and out-of-order printing.
 * [#2514](https://github.com/clojure-emacs/cider/issues/2514): Don't auto-jump to warnings when `cider-auto-jump-to-error` is set to 'errors-only.
 * [#2453](https://github.com/clojure-emacs/cider/issues/2453): Make it possible to debug deftype methods by direct insertion of #dbg and #break readers into the deftype methods.

--- a/cider-ns.el
+++ b/cider-ns.el
@@ -163,12 +163,12 @@ namespace-qualified function of zero arity."
 
 (defun cider-ns-refresh--save-modified-buffers ()
   "Ensure any relevant modified buffers are saved before refreshing.
-Its behavior is controlled by `cider-save-files-on-cider-ns-refresh'."
-  (when cider-save-files-on-cider-ns-refresh
+Its behavior is controlled by `cider-ns-save-files-on-refresh'."
+  (when cider-ns-save-files-on-refresh
     (let ((dirs (seq-filter #'file-directory-p
                             (cider-sync-request:classpath))))
       (save-some-buffers
-       (not (eq cider-save-files-on-cider-ns-refresh 'prompt))
+       (not (eq cider-ns-save-files-on-refresh 'prompt))
        (lambda ()
          (and (derived-mode-p 'clojure-mode)
               (seq-some (lambda (dir)

--- a/doc/miscellaneous_features.md
+++ b/doc/miscellaneous_features.md
@@ -160,9 +160,9 @@ the echo area.
 (setq cider-ns-refresh-show-log-buffer t)
 ```
 
-By default, CIDER will prompt for whether to save all modified Clojure
-buffers. You can customize this behavior with
-`cider-ns-save-files-on-refresh`.
+By default, CIDER will prompt for whether to save all modified `clojure-mode`
+buffers visiting files on the classpath. You can customize this behavior with
+`cider-ns-save-files-on-refresh` and `cider-ns-save-files-on-refresh-modes`.
 
 Sometimes, `cider-ns-refresh` may not work for you. If you're looking
 for a bit more forceful reloading the `cider-ns-reload`

--- a/test/cider-client-tests.el
+++ b/test/cider-client-tests.el
@@ -109,10 +109,15 @@
             :to-throw 'user-error)))
 
 (describe "cider-expected-ns"
-  (before-all
+  (before-each
     (spy-on 'cider-connected-p :and-return-value t)
     (spy-on 'cider-sync-request:classpath :and-return-value
-            '("/a" "/b" "/c" "/c/inner" "/base/clj" "/base/clj-dev")))
+            '("/a" "/b" "/c" "/c/inner" "/base/clj" "/base/clj-dev"))
+    (spy-on 'file-directory-p :and-return-value t)
+    (spy-on 'file-in-directory-p :and-call-fake (lambda (file dir)
+                                                  (string-prefix-p dir file)))
+    (spy-on 'file-relative-name :and-call-fake (lambda (file dir)
+                                                 (substring file (+ 1 (length dir))))))
 
   (it "returns the namespace matching the given string path"
     (expect (cider-expected-ns "/a/foo/bar/baz_utils.clj") :to-equal


### PR DESCRIPTION
I tried setting `cider-ns-save-files-on-refresh` to both `t` and `'prompt` but found neither had any effect. It turns out that `clojure-project-dir` returns a non-canonical path (e.g. `~/clojure/...`), whereas the predicate passed to `save-some-buffers` was using `(file-truename default-directory)` which _does_ return canonical paths (e.g. `/Users/griffithsm/clojure/...`).

I then made the further observation that `tools.namespace` actually reloads all modified Clojure files on the entire classpath - not just those inside the current project!

To solve this I have modified `cider-ns-refresh--save-project-buffers` to:

* Check modified file-visiting buffers against _all_ classpath directories, not just the current project directory.
* Use proper file/directory path handling functions from `files.el` rather than `string-prefix-p`. This means we get rid of the Windows-specific workaround for case-insensitivity there too.

Similarly, the use of string comparisons in `cider-expected-ns` meant we had to be sure that its input was a canonical path. Again by using functions from `files.el` we can avoid any platform-related headaches or similar.

-----------------

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blog/master/doc) (if adding/changing user-visible functionality)
