### PR TITLE
Fix typo in navigating_stacktraces.md

### DIFF
--- a/doc/navigating_stacktraces.md
+++ b/doc/navigating_stacktraces.md
@@ -87,7 +87,7 @@ if they are both present.
 
 Finally, CIDER can wrap error messages when they are displayed in a
 buffer to help improve their readability. CIDER uses
-`cider-stack-trade-fill-column` for this, which can take on three
+`cider-stacktrace-fill-column` for this, which can take on three
 types of values:
 
 - `nil`: The error is not wrapped.


### PR DESCRIPTION
    cider-stack-trade-fill-column -> 
    cider-stacktrace-fill-column

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md) - **Broken link**, but the change should not be violating any sensible guidelines
- [ ] You've added tests (if possible) to cover your change(s) - **N/A, doc change**
- [ ] All tests are passing (`make test`) - **N/A, doc change**
- [ ] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes  - **N/A, doc change**
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality) - **N/A, doc change**
- [ ] You've updated the [user manual](../blog/master/doc) (if adding/changing user-visible functionality) - **N/A, doc change**

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://cider.readthedocs.io/en/latest/hacking_on_cider/
