### PR TITLE
Support Kotlin DSL for Gradle Projects.

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -1392,7 +1392,8 @@ PROJECT-DIR defaults to current project."
                         (boot        . "build.boot")
                         (clojure-cli . "deps.edn")
                         (shadow-cljs . "shadow-cljs.edn")
-                        (gradle      . "build.gradle"))))
+                        (gradle      . "build.gradle")
+                        (gradle      . "build.gradle.kts"))))
     (delq nil
           (mapcar (lambda (candidate)
                     (when (file-exists-p (cdr candidate))


### PR DESCRIPTION
With [Gradle 5.0](https://docs.gradle.org/5.0/release-notes.html), the Kotlin DSL left beta status. Projects making use of this DSL have build scripts named `build.gradle.kts`

It is necessary to recognize these files as Gradle projects to allow for running REPLS, tests, etc. from Gradle projects making use of this alternative build scripts.
