### PR TITLE
Load all files (clj, cljc, & cljs) on `cider-load-all-files`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Changes
 
 * [#2496](https://github.com/clojure-emacs/cider/issues/2496): Replace CIDER's pprint implementation with nREPL 0.5's built-in pprint support.
-* [#2558](https://github.com/clojure-emacs/cider/pull/2558): Load clj & cljc files on `cider-load-all-files`.
+* [#2558](https://github.com/clojure-emacs/cider/pull/2558): Load clj, cljc, & cljs (if cljs repl available) files on `cider-load-all-files` (`C-c C-M-l`). Previously, this only loaded clj files.
 
 ## 0.19.0 (2019-01-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changes
 
 * [#2496](https://github.com/clojure-emacs/cider/issues/2496): Replace CIDER's pprint implementation with nREPL 0.5's built-in pprint support.
+* [#2558](https://github.com/clojure-emacs/cider/pull/2558): Load clj & cljc files on `cider-load-all-files`.
 
 ## 0.19.0 (2019-01-01)
 

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -798,7 +798,10 @@ session."
                    (:auto (if (eq cur-type 'multi)
                               '(clj cljs)
                             cur-type))))
-           (repls (cider-repls type 'ensure)))
+           (ensure (cl-case which
+                     (:auto nil)
+                     (t 'ensure)))
+           (repls (cider-repls type ensure)))
       (mapcar function repls))))
 
 ;; REPLs double as connections in CIDER, so it's useful to be able to refer to

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -1087,11 +1087,11 @@ is done by `cider-load-buffer'."
     (cider-load-buffer (find-file-noselect filename))))
 
 (defun cider-load-all-files (directory)
-  "Load all files in DIRECTORY (recursively).
+  "Load all files (clj and cljc) in DIRECTORY (recursively).
 Useful when the running nREPL on remote host."
   (interactive "DLoad files beneath directory: ")
   (mapcar #'cider-load-file
-          (directory-files-recursively directory ".clj$")))
+          (directory-files-recursively directory "\\.cljc?$")))
 
 (defalias 'cider-eval-file 'cider-load-file
   "A convenience alias as some people are confused by the load-* names.")

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -1087,11 +1087,11 @@ is done by `cider-load-buffer'."
     (cider-load-buffer (find-file-noselect filename))))
 
 (defun cider-load-all-files (directory)
-  "Load all files (clj and cljc) in DIRECTORY (recursively).
+  "Load all files in DIRECTORY (recursively).
 Useful when the running nREPL on remote host."
   (interactive "DLoad files beneath directory: ")
   (mapcar #'cider-load-file
-          (directory-files-recursively directory "\\.cljc?$")))
+          (directory-files-recursively directory "\\.clj[cs]?$")))
 
 (defalias 'cider-eval-file 'cider-load-file
   "A convenience alias as some people are confused by the load-* names.")

--- a/doc/interactive_programming.md
+++ b/doc/interactive_programming.md
@@ -61,7 +61,7 @@ Here's a list of `cider-mode`'s keybindings:
 `cider-find-and-clear-repl-output`            |<kbd>C-c C-o</kbd>                   | Clear the last output in the REPL buffer. With a prefix argument it will clear the entire REPL buffer, leaving only a prompt. Useful if you're running the REPL buffer in a side by side buffer.
 `cider-load-buffer`                           |<kbd>C-c C-k</kbd>                   | Load (eval) the current buffer.
 `cider-load-file`                             |<kbd>C-c C-l</kbd>                   | Load (eval) a Clojure file.
-`cider-load-all-files`                        |<kbd>C-c C-M-l</kbd>                 | Load (eval) all Clojure files below a directory.
+`cider-load-all-files`                        |<kbd>C-c C-M-l</kbd>                 | Load (eval) all Clojure files (clj and cljc) below a directory.
 `cider-ns-refresh`                            |<kbd>C-c M-n (M-)r</kbd>                   | Reload all modified files on the classpath. If invoked with a prefix argument, reload all files on the classpath. If invoked with a double prefix argument, clear the state of the namespace tracker before reloading.
 `cider-doc`                                   |<kbd>C-c C-d d</kbd> <br/> <kbd>C-c C-d C-d</kbd> | Display doc string for the symbol at point.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.
 `cider-javadoc`                               |<kbd>C-c C-d j</kbd> <br/> <kbd>C-c C-d C-j</kbd> | Display JavaDoc (in your default browser) for the symbol at point.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.

--- a/doc/interactive_programming.md
+++ b/doc/interactive_programming.md
@@ -61,7 +61,7 @@ Here's a list of `cider-mode`'s keybindings:
 `cider-find-and-clear-repl-output`            |<kbd>C-c C-o</kbd>                   | Clear the last output in the REPL buffer. With a prefix argument it will clear the entire REPL buffer, leaving only a prompt. Useful if you're running the REPL buffer in a side by side buffer.
 `cider-load-buffer`                           |<kbd>C-c C-k</kbd>                   | Load (eval) the current buffer.
 `cider-load-file`                             |<kbd>C-c C-l</kbd>                   | Load (eval) a Clojure file.
-`cider-load-all-files`                        |<kbd>C-c C-M-l</kbd>                 | Load (eval) all Clojure files (clj and cljc) below a directory.
+`cider-load-all-files`                        |<kbd>C-c C-M-l</kbd>                 | Load (eval) all Clojure files below a directory.
 `cider-ns-refresh`                            |<kbd>C-c M-n (M-)r</kbd>                   | Reload all modified files on the classpath. If invoked with a prefix argument, reload all files on the classpath. If invoked with a double prefix argument, clear the state of the namespace tracker before reloading.
 `cider-doc`                                   |<kbd>C-c C-d d</kbd> <br/> <kbd>C-c C-d C-d</kbd> | Display doc string for the symbol at point.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.
 `cider-javadoc`                               |<kbd>C-c C-d j</kbd> <br/> <kbd>C-c C-d C-j</kbd> | Display JavaDoc (in your default browser) for the symbol at point.  If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.


### PR DESCRIPTION
#1983 adds `cider-load-all-files`; the current pull request touches it up to include cljc files in addition to clj files.

There's a larger discussion on ClojureScript repls, especially since loading cljc will eval in all active cljs repls. But cljc is needed in order to load "all files" in a Clojure repl. Before the current pull request, `cider-load-all-files` is incomplete for clj repls. If this proposed change does not have consensus, then let's discuss options to `cider-load-all-files` or variations for `clj`/`clj+cljc`/`cljs+cljc`.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [N/A] You've added tests (if possible) to cover your change(s).
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/en/latest/hacking_on_cider/
