### PR TITLE
Detect the repl type in cider-sync-request:info based on the current buffer

### DIFF
--- a/cider-client.el
+++ b/cider-client.el
@@ -458,7 +458,8 @@ CONTEXT represents a completion context for compliment."
                                     "ns" ,(cider-current-ns)
                                     "symbol" ,str
                                     "context" ,context)
-                      (cider-nrepl-send-sync-request nil 'abort-on-input))))
+                      (cider-nrepl-send-sync-request (cider-current-repl)
+                                                     'abort-on-input))))
     (nrepl-dict-get dict "completions")))
 
 (defun cider-sync-request:complete-flush-caches ()
@@ -486,7 +487,8 @@ CONTEXT represents a completion context for compliment."
                                      ,@(when symbol `("symbol" ,symbol))
                                      ,@(when class `("class" ,class))
                                      ,@(when member `("member" ,member)))
-                       (cider-nrepl-send-sync-request nil 'abort-on-input))))
+                       (cider-nrepl-send-sync-request (cider-current-repl)
+                                                      'abort-on-input))))
     (if (member "no-eldoc" (nrepl-dict-get eldoc "status"))
         nil
       eldoc)))

--- a/cider-client.el
+++ b/cider-client.el
@@ -474,7 +474,7 @@ CONTEXT represents a completion context for compliment."
                                   ,@(when symbol `("symbol" ,symbol))
                                   ,@(when class `("class" ,class))
                                   ,@(when member `("member" ,member)))
-                    (cider-nrepl-send-sync-request))))
+                    (cider-nrepl-send-sync-request (cider-current-repl)))))
     (if (member "no-info" (nrepl-dict-get var-info "status"))
         nil
       var-info)))


### PR DESCRIPTION
`cider-sync-request:info` is using `cider-nrepl-send-sync-request` without a connection argument, which leads to `(cider-current-repl 'any)` being used to determine the current connection. This means that when M-. (`cider-find-var`) is used in a cljs buffer it still sometimes tries to (unsuccessfully) find vars via the clj session of the project. I've added an explicit connection argument to the `cider-nrepl-send-sync-request` call in `cider-sync-request:info` using `(cider-current-repl)` (which determines the repl type based on the current buffer). This resolved the issue for me.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/en/latest/hacking_on_cider/
