### PR TITLE
Fix values for `cider-preferred-build-tool` and `cider-allow-jack-in-without-project`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### New features
 
 ### Changes
+* Fix values for `cider-preferred-build-tool` variable.
+* Fix value and safe property for `cider-allow-jack-in-without-project` variable.
 
 ### Bug fixes
 

--- a/cider.el
+++ b/cider.el
@@ -224,11 +224,11 @@ project.clj for leiningen or build.boot for boot, could be found.
 As the Clojure CLI is bundled with Clojure itself, it's the default.
 In the absence of the Clojure CLI (e.g. on Windows), we fallback
 to Leiningen."
-  :type '(choice (const 'lein)
-                 (const 'boot)
-                 (const 'clojure-cli)
-                 (const 'shadow-cljs)
-                 (const 'gradle))
+  :type '(choice (const lein)
+                 (const boot)
+                 (const clojure-cli)
+                 (const shadow-cljs)
+                 (const gradle))
   :group 'cider
   :safe #'symbolp
   :package-version '(cider . "0.9.0"))
@@ -242,11 +242,11 @@ variable will suppress this behavior and will select whatever build system
 is indicated by the variable if present.  Note, this is only when CIDER
 cannot decide which of many build systems to use and will never override a
 command when there is no ambiguity."
-  :type '(choice (const 'lein)
-                 (const 'boot)
-                 (const 'clojure-cli)
-                 (const 'shadow-cljs)
-                 (const 'gradle)
+  :type '(choice (const lein)
+                 (const boot)
+                 (const clojure-cli)
+                 (const shadow-cljs)
+                 (const gradle)
                  (const :tag "Always ask" nil))
   :group 'cider
   :safe #'symbolp
@@ -258,10 +258,10 @@ When set to 'warn you'd prompted to confirm the command.
 When set to t `cider-jack-in' will quietly continue.
 When set to nil `cider-jack-in' will fail."
   :type '(choice (const :tag "always" t)
-                 (const 'warn)
+                 (const warn)
                  (const :tag "never" nil))
   :group 'cider
-  :safe #'stringp
+  :safe #'symbolp
   :package-version '(cider . "0.15.0"))
 
 (defcustom cider-known-endpoints nil


### PR DESCRIPTION
The values for `cider-preferred-build-tool` were quoted, which resulted in the
variable getting the value `(quote lein)`.  This caused an error in
`cider-maybe-intern` when checking the value for stringness.

`cider-allow-jack-in-without-project` had a similarly quoted value, and a safe
property that checked for strings, even though the value should be a symbol.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`make test`)
- [X] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
