### PR TITLE
Update to nREPL 0.6.0 / cider-nrepl 0.21.0

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -22,7 +22,6 @@
                               (cider--jack-in . 1)
                               (cider--make-result-overlay . 1)
                               ;; need better solution for indenting cl-flet bindings
-                              (multiline-comment-handler . defun) ;; cl-flet
                               (insert-label . defun)              ;; cl-flet
                               (insert-align-label . defun)        ;; cl-flet
                               (insert-rect . defun)               ;; cl-flet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,20 @@
 
 ### New features
 
-* The `cider-test-run-*` and `cider-ns-refresh-*` commands are now interruptible with the `cider-interrupt` command.
+* The `cider-test-run-*` and `cider-ns-refresh-*` commands are now interruptible by the `cider-interrupt` command.
+* Many commands now stream printed results back to the client incrementally – meaning it's now possible to, for example, interrupt evaluations while their result is being rendered.
+* New option: `cider-repl-init-code`. This is a list of strings containing Clojure code to evaluate when the REPL starts (with bindings for any `set!`-able vars in place). Replaces `cider-print-length` and `cider-print-level`, which are now obsolete.
+* New option: `cider-print-quota`. This is a hard limit on the number of bytes that will be returned by any printing operation. This defaults to one megabyte and can be set to `nil` if no limit is desired.
 
 ### Changes
 
-* [#2546](https://github.com/clojure-emacs/cider/pull/2546): New defcustom `cider-ns-save-files-on-refresh-modes` to control for which buffers `cider-ns-refresh` should save before refreshing.
 * **(Breaking)** Upgrade to nREPL 0.6.0. This is now the minimum required version.
 * **(Breaking)** Upgrade to piggieback 0.4.0. This is now the minimum required version.
 * **(Breaking)** Remove `cider.nrepl.middleware.pprint`. All functionality has been replaced by the built-in printing support in nREPL 0.6.
+* Option `cider-repl-scroll-on-output` is now obsolete, and the default REPL behaviour has changed to _not_ recenter the window. The built-in variable `scroll-conservatively` can be set to 101 (either globally or locally in the REPL buffer) to restore the old behaviour. This change has a dramatic positive effect on REPL performance.
+* `cider-pprint-fn` and `cider-pprint-options` are now obsolete, replaced by `cider-print-fn` and `cider-print-options`.
+* `cider-debug-print-options`, `cider-stacktrace-print-options`, and `cider-repl-pretty-print-width` are now all obsolete, replaced by `cider-print-options`.
+* [#2546](https://github.com/clojure-emacs/cider/pull/2546): New defcustom `cider-ns-save-files-on-refresh-modes` to control for which buffers `cider-ns-refresh` should save before refreshing.
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * `cider-ns-save-files-on-refresh` will now save any modified buffers visiting files on the classpath, rather than just in the current project.
 * `cider-expected-ns` no longer requires an absolute path as its argument, and now internally handles paths canonically and consistently.
 * Fixed a bug causing REPL output to be inserted after the prompt.
+* Fixed a bug causing `cider-pprint-eval-last-sexp-to-comment` and `cider-pprint-eval-defun-to-comment` to not insert anything.
 
 ## 0.20.0 (2019-01-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Fix value and safe property for `cider-allow-jack-in-without-project` variable.
 * `cider-ns-save-files-on-refresh` will now save any modified buffers visiting files on the classpath, rather than just in the current project.
 * `cider-expected-ns` no longer requires an absolute path as its argument, and now internally handles paths canonically and consistently.
+* Fixed a bug causing REPL output to be inserted after the prompt.
 
 ## 0.20.0 (2019-01-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,17 @@
 
 ### New features
 
+* The `cider-test-run-*` and `cider-ns-refresh-*` commands are now interruptible with the `cider-interrupt` command.
+
 ### Changes
+
 * [#2546](https://github.com/clojure-emacs/cider/pull/2546): New defcustom `cider-ns-save-files-on-refresh-modes` to control for which buffers `cider-ns-refresh` should save before refreshing.
+* **(Breaking)** Upgrade to nREPL 0.6.0. This is now the minimum required version.
+* **(Breaking)** Upgrade to piggieback 0.4.0. This is now the minimum required version.
+* **(Breaking)** Remove `cider.nrepl.middleware.pprint`. All functionality has been replaced by the built-in printing support in nREPL 0.6.
 
 ### Bug fixes
+
 * Fix values for `cider-preferred-build-tool` variable.
 * Fix value and safe property for `cider-allow-jack-in-without-project` variable.
 * `cider-ns-save-files-on-refresh` will now save any modified buffers visiting files on the classpath, rather than just in the current project.

--- a/cider-client.el
+++ b/cider-client.el
@@ -246,6 +246,13 @@ able to handle those.  Here's an example for `pprint':
 (defun cider--pprint-fn ()
   "Return the value to send in the pprint-fn slot of messages."
   (pcase cider-pprint-fn
+(defcustom cider-print-quota (* 1024 1024)
+  "A hard limit on the number of bytes to return from any printing operation.
+Set to nil for no limit."
+  :type 'integer
+  :group 'cider
+  :package-version '(cider . "0.21.0"))
+
     (`pprint "cider.nrepl.pprint/pprint")
     (`fipp "cider.nrepl.pprint/fipp-pprint")
     (`puget "cider.nrepl.pprint/puget-pprint")
@@ -283,6 +290,8 @@ result, and is included in the request if non-nil."
       (setq print-options (nrepl-dict-put print-options (cider--pprint-option "right-margin" cider-pprint-fn) right-margin)))
     (append `("nrepl.middleware.print/print" ,(or pprint-fn (cider--pprint-fn))
               "nrepl.middleware.print/stream?" "1")
+            (when cider-print-quota
+              `("nrepl.middleware.print/quota" ,cider-print-quota))
             (and (not (nrepl-dict-empty-p print-options)) `("nrepl.middleware.print/options" ,print-options)))))
 
 (defun cider--nrepl-content-type-plist ()

--- a/cider-client.el
+++ b/cider-client.el
@@ -281,8 +281,9 @@ result, and is included in the request if non-nil."
   (let* ((print-options (or cider-pprint-options (nrepl-dict))))
     (when right-margin
       (setq print-options (nrepl-dict-put print-options (cider--pprint-option "right-margin" cider-pprint-fn) right-margin)))
-    (nconc `("printer" ,(or pprint-fn (cider--pprint-fn)))
-           (and (not (nrepl-dict-empty-p print-options)) `("print-options" ,print-options)))))
+    (append `("nrepl.middleware.print/print" ,(or pprint-fn (cider--pprint-fn))
+              "nrepl.middleware.print/stream?" "1")
+            (and (not (nrepl-dict-empty-p print-options)) `("nrepl.middleware.print/options" ,print-options)))))
 
 (defun cider--nrepl-content-type-plist ()
   "Plist to be appended to an eval request to make it use content-types."

--- a/cider-debug.el
+++ b/cider-debug.el
@@ -25,18 +25,21 @@
 
 ;;; Code:
 
-(require 'nrepl-dict)
-(require 'nrepl-client) ; `nrepl--mark-id-completed'
-(require 'cider-eval)
-(require 'cider-client)
-(require 'cider-util)
-(require 'cider-inspector)
-(require 'cider-browse-ns)
-(require 'cider-common)
-(require 'subr-x)
-(require 'cider-compat)
+(require 'map)
 (require 'seq)
+(require 'subr-x)
+
 (require 'spinner)
+
+(require 'cider-browse-ns)
+(require 'cider-client)
+(require 'cider-eval)
+(require 'cider-inspector)
+(require 'cider-util)
+(require 'cider-common)
+(require 'cider-compat)
+(require 'nrepl-client) ; `nrepl--mark-id-completed'
+(require 'nrepl-dict)
 
 
 ;;; Customization
@@ -103,13 +106,7 @@ configure `cider-debug-prompt' instead."
 
 (make-obsolete 'cider-debug-print-length 'cider-debug-print-options "0.20")
 (make-obsolete 'cider-debug-print-level 'cider-debug-print-options "0.20")
-
-(defcustom cider-debug-print-options '(dict "length" 10 "level" 10)
-  "The print options for values displayed by the debugger.
-This variable must be set before starting the repl connection."
-  :type 'listp
-  :group 'cider-stacktrace
-  :package-version '(cider . "0.20.0"))
+(make-obsolete-variable 'cider-debug-print-options 'cider-print-options "0.21")
 
 
 ;;; Implementation
@@ -156,9 +153,11 @@ This variable must be set before starting the repl connection."
 (defun cider--debug-init-connection ()
   "Initialize a connection with the cider.debug middleware."
   (cider-nrepl-send-request
-   (nconc '("op" "init-debugger")
-          (when cider-debug-print-options
-            `("print-options" ,cider-debug-print-options)))
+   (thread-last
+       (map-merge 'list
+                  '(("op" "init-debugger"))
+                  (cider--nrepl-print-request-map fill-column))
+     (seq-mapcat #'identity))
    #'cider--debug-response-handler))
 
 

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -278,9 +278,9 @@ into a new error buffer."
     (cider-nrepl-send-request
      (nconc '("op" "stacktrace")
             (when (cider--pprint-fn)
-              `("pprint-fn" ,(cider--pprint-fn)))
+              `("nrepl.middleware.print/print" ,(cider--pprint-fn)))
             (when cider-stacktrace-print-options
-              `("print-options" ,cider-stacktrace-print-options)))
+              `("nrepl.middleware.print/options" ,cider-stacktrace-print-options)))
      (lambda (response)
        ;; While the return value of `cider--handle-stacktrace-response' is not
        ;; meaningful for the last message, we do not need the value of `causes'

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -40,20 +40,23 @@
 
 ;;; Code:
 
-(require 'cider-client)
-(require 'cider-repl)
-(require 'cider-popup)
-(require 'cider-common)
-(require 'cider-util)
-(require 'cider-stacktrace)
-(require 'cider-overlays)
-(require 'cider-compat)
-
-(require 'clojure-mode)
 (require 'ansi-color)
 (require 'cl-lib)
-(require 'subr-x)
 (require 'compile)
+(require 'map)
+(require 'seq)
+(require 'subr-x)
+
+(require 'clojure-mode)
+
+(require 'cider-client)
+(require 'cider-common)
+(require 'cider-compat)
+(require 'cider-overlays)
+(require 'cider-popup)
+(require 'cider-repl)
+(require 'cider-stacktrace)
+(require 'cider-util)
 
 (defconst cider-read-eval-buffer "*cider-read-eval*")
 (defconst cider-result-buffer "*cider-result*")
@@ -276,11 +279,11 @@ into a new error buffer."
   ;; Causes are returned as a series of messages, which we aggregate in `causes'
   (let (causes)
     (cider-nrepl-send-request
-     (nconc '("op" "stacktrace")
-            (when (cider--pprint-fn)
-              `("nrepl.middleware.print/print" ,(cider--pprint-fn)))
-            (when cider-stacktrace-print-options
-              `("nrepl.middleware.print/options" ,cider-stacktrace-print-options)))
+     (thread-last
+         (map-merge 'list
+                    '(("op" "stacktrace"))
+                    (cider--nrepl-print-request-map fill-column))
+       (seq-mapcat #'identity))
      (lambda (response)
        ;; While the return value of `cider--handle-stacktrace-response' is not
        ;; meaningful for the last message, we do not need the value of `causes'
@@ -561,17 +564,19 @@ COMMENT-POSTFIX is the text to output after the last line."
 (defun cider-popup-eval-handler (&optional buffer)
   "Make a handler for printing evaluation results in popup BUFFER.
 This is used by pretty-printing commands."
-  (nrepl-make-response-handler (or buffer (current-buffer))
-                               (lambda (buffer value)
-                                 (cider-emit-into-popup-buffer buffer
-                                                               (ansi-color-apply value)
-                                                               nil
-                                                               t))
-                               (lambda (_buffer out)
-                                 (cider-emit-interactive-eval-output out))
-                               (lambda (_buffer err)
-                                 (cider-emit-interactive-eval-err-output err))
-                               '()))
+  (nrepl-make-response-handler
+   (or buffer (current-buffer))
+   (lambda (buffer value)
+     (cider-emit-into-popup-buffer buffer (ansi-color-apply value) nil t))
+   (lambda (_buffer out)
+     (cider-emit-interactive-eval-output out))
+   (lambda (_buffer err)
+     (cider-emit-interactive-eval-err-output err))
+   nil
+   nil
+   nil
+   (lambda (buffer warning)
+     (cider-emit-into-popup-buffer buffer warning 'font-lock-warning-face t))))
 
 
 ;;; Interactive valuation commands
@@ -617,7 +622,7 @@ API.  Most other interactive eval functions should rely on this function.
 If CALLBACK is nil use `cider-interactive-eval-handler'.
 BOUNDS, if non-nil, is a list of two numbers marking the start and end
 positions of FORM in its buffer.
-ADDITIONAL-PARAMS is a plist to be appended to the request message.
+ADDITIONAL-PARAMS is a map to be merged into the request message.
 
 If `cider-interactive-eval-override' is a function, call it with the same
 arguments and only proceed with evaluation if it returns nil."
@@ -640,13 +645,16 @@ arguments and only proceed with evaluation if it returns nil."
            (if (cider-ns-form-p form) "user" (cider-current-ns))
            (when start (line-number-at-pos start))
            (when start (cider-column-number-at-pos start))
-           additional-params
+           (seq-mapcat #'identity additional-params)
            connection))))))
 
 (defun cider-eval-region (start end)
   "Evaluate the region between START and END."
   (interactive "r")
-  (cider-interactive-eval nil nil (list start end)))
+  (cider-interactive-eval nil
+                          nil
+                          (list start end)
+                          (cider--nrepl-pr-request-map)))
 
 (defun cider-eval-last-sexp (&optional output-to-current-buffer)
   "Evaluate the expression preceding point.
@@ -655,7 +663,8 @@ buffer."
   (interactive "P")
   (cider-interactive-eval nil
                           (when output-to-current-buffer (cider-eval-print-handler))
-                          (cider-last-sexp 'bounds)))
+                          (cider-last-sexp 'bounds)
+                          (cider--nrepl-pr-request-map)))
 
 (defun cider-eval-last-sexp-and-replace ()
   "Evaluate the expression preceding point and replace it with its result."
@@ -665,7 +674,10 @@ buffer."
     (cider-nrepl-sync-request:eval last-sexp)
     ;; seems like the sexp is valid, so we can safely kill it
     (backward-kill-sexp)
-    (cider-interactive-eval last-sexp (cider-eval-print-handler))))
+    (cider-interactive-eval last-sexp
+                            (cider-eval-print-handler)
+                            nil
+                            (cider--nrepl-pr-request-map))))
 
 (defun cider-eval-sexp-at-point (&optional output-to-current-buffer)
   "Evaluate the expression around point.
@@ -686,7 +698,10 @@ That's set by commands like `cider-eval-last-sexp-in-context'.")
                         (format "Evaluation context (let-style) for `%s': " code)
                         cider-previous-eval-context))
          (code (concat "(let [" eval-context "]\n  " code ")")))
-    (cider-interactive-eval code)
+    (cider-interactive-eval code
+                            nil
+                            nil
+                            (cider--nrepl-pr-request-map))
     (setq-local cider-previous-eval-context eval-context)))
 
 (defun cider-eval-last-sexp-in-context ()
@@ -719,7 +734,8 @@ With the prefix arg INSERT-BEFORE, insert before the form, otherwise afterwards.
                              (current-buffer)
                              insertion-point
                              cider-comment-prefix)
-                            bounds)))
+                            bounds
+                            (cider--nrepl-pr-request-map))))
 
 (defun cider-pprint-form-to-comment (form-fn insert-before)
   "Evaluate the form selected by FORM-FN and insert result as comment.
@@ -749,7 +765,7 @@ If INSERT-BEFORE is non-nil, insert before the form, otherwise afterwards."
                              cider-comment-continued-prefix
                              comment-postfix)
                             bounds
-                            (cider--nrepl-pprint-request-plist (cider--pretty-print-width)))))
+                            (cider--nrepl-print-request-map fill-column))))
 
 (defun cider-pprint-eval-last-sexp-to-comment (&optional insert-before)
   "Evaluate the last sexp and insert result as comment.
@@ -791,7 +807,8 @@ If invoked with a PREFIX argument, switch to the REPL buffer."
   (interactive "P")
   (cider-interactive-eval nil
                           (cider-insert-eval-handler (cider-current-repl))
-                          (cider-last-sexp 'bounds))
+                          (cider-last-sexp 'bounds)
+                          (cider--nrepl-pr-request-map))
   (when prefix
     (cider-switch-to-repl-buffer)))
 
@@ -802,7 +819,7 @@ If invoked with a PREFIX argument, switch to the REPL buffer."
   (cider-interactive-eval nil
                           (cider-insert-eval-handler (cider-current-repl))
                           (cider-last-sexp 'bounds)
-                          (cider--nrepl-pprint-request-plist (cider--pretty-print-width)))
+                          (cider--nrepl-print-request-map fill-column))
   (when prefix
     (cider-switch-to-repl-buffer)))
 
@@ -814,8 +831,9 @@ With an optional PRETTY-PRINT prefix it pretty-prints the result."
   (cider-interactive-eval nil
                           (cider-eval-print-handler)
                           (cider-last-sexp 'bounds)
-                          (when pretty-print
-                            (cider--nrepl-pprint-request-plist (cider--pretty-print-width)))))
+                          (if pretty-print
+                              (cider--nrepl-print-request-map fill-column)
+                            (cider--nrepl-pr-request-map))))
 
 (defun cider--pprint-eval-form (form)
   "Pretty print FORM in popup buffer."
@@ -824,7 +842,7 @@ With an optional PRETTY-PRINT prefix it pretty-prints the result."
     (cider-interactive-eval (when (stringp form) form)
                             handler
                             (when (consp form) form)
-                            (cider--nrepl-pprint-request-plist (cider--pretty-print-width)))))
+                            (cider--nrepl-print-request-map fill-column))))
 
 (defun cider-pprint-eval-last-sexp (&optional output-to-current-buffer)
   "Evaluate the sexp preceding point and pprint its value.
@@ -875,7 +893,9 @@ command `cider-debug-defun-at-point'."
         (cider--prompt-and-insert-inline-dbg)))
     (cider-interactive-eval (when (and debug-it (not inline-debug))
                               (concat "#dbg\n" (cider-defun-at-point)))
-                            nil (cider-defun-at-point 'bounds))))
+                            nil
+                            (cider-defun-at-point 'bounds)
+                            (cider--nrepl-pr-request-map))))
 
 (defun cider--calculate-opening-delimiters ()
   "Walks up the list of expressions to collect all sexp opening delimiters.
@@ -918,9 +938,11 @@ buffer.  It constructs an expression to eval in the following manner:
   (let* ((beg-of-defun (save-excursion (beginning-of-defun) (point)))
          (code (buffer-substring-no-properties beg-of-defun (point)))
          (code (concat code (cider--calculate-closing-delimiters))))
-    (cider-interactive-eval
-     code
-     (when output-to-current-buffer (cider-eval-print-handler)))))
+    (cider-interactive-eval code
+                            (when output-to-current-buffer
+                              (cider-eval-print-handler))
+                            nil
+                            (cider--nrepl-pr-request-map))))
 
 (defun cider-eval-sexp-up-to-point (&optional  output-to-current-buffer)
   "Evaluate the current sexp form up to point.
@@ -938,7 +960,10 @@ buffer.  It constructs an expression to eval in the following manner:
          (code (if (= beg-set? ?#) (concat (list beg-set?) code) code))
          (code (concat code (list (cider--matching-delimiter beg-delimiter)))))
     (cider-interactive-eval code
-                            (when output-to-current-buffer (cider-eval-print-handler)))))
+                            (when output-to-current-buffer
+                              (cider-eval-print-handler))
+                            nil
+                            (cider--nrepl-pr-request-map))))
 
 (defun cider-pprint-eval-defun-at-point (&optional output-to-current-buffer)
   "Evaluate the \"top-level\" form at point and pprint its value.
@@ -971,7 +996,10 @@ If VALUE is non-nil, it is inserted into the minibuffer as initial input."
         (insert ns-form "\n\n"))
       (insert form)
       (let ((cider-interactive-eval-override override))
-        (cider-interactive-eval form)))))
+        (cider-interactive-eval form
+                                nil
+                                nil
+                                (cider--nrepl-pr-request-map))))))
 
 (defun cider-read-and-eval-defun-at-point ()
   "Insert the toplevel form at point in the minibuffer and output its result.

--- a/cider-format.el
+++ b/cider-format.el
@@ -26,6 +26,8 @@
 
 ;;; Code:
 
+(require 'map)
+(require 'seq)
 (require 'subr-x)
 
 (require 'cider-client)
@@ -117,8 +119,6 @@ of the buffer into a formatted string."
 
 ;;; Format EDN
 
-(declare-function cider--pretty-print-width "cider-repl")
-
 ;;;###autoload
 (defun cider-format-edn-buffer ()
   "Format the EDN data in the current buffer."
@@ -126,7 +126,7 @@ of the buffer into a formatted string."
   (check-parens)
   (cider-ensure-connected)
   (cider--format-buffer (lambda (edn)
-                          (cider-sync-request:format-edn edn (cider--pretty-print-width)))))
+                          (cider-sync-request:format-edn edn fill-column))))
 
 ;;;###autoload
 (defun cider-format-edn-region (start end)
@@ -135,7 +135,7 @@ START and END represent the region's boundaries."
   (interactive "r")
   (cider-ensure-connected)
   (let* ((start-column (save-excursion (goto-char start) (current-column)))
-         (right-margin (- (cider--pretty-print-width) start-column)))
+         (right-margin (- fill-column start-column)))
     (cider--format-region start end
                           (lambda (edn)
                             (cider-sync-request:format-edn edn right-margin)))))

--- a/cider-ns.el
+++ b/cider-ns.el
@@ -258,9 +258,9 @@ refresh functions (defined in `cider-ns-refresh-before-fn' and
           (cider-nrepl-send-request
            (nconc `("op" ,(if refresh-all? "refresh-all" "refresh"))
                   (when (cider--pprint-fn)
-                    `("pprint-fn" ,(cider--pprint-fn)))
+                    `("nrepl.middleware.print/print" ,(cider--pprint-fn)))
                   (when cider-stacktrace-print-options
-                    `("print-options" ,cider-stacktrace-print-options))
+                    `("nrepl.middleware.print/options" ,cider-stacktrace-print-options))
                   (when (and (not inhibit-refresh-fns) cider-ns-refresh-before-fn)
                     `("before" ,cider-ns-refresh-before-fn))
                   (when (and (not inhibit-refresh-fns) cider-ns-refresh-after-fn)

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -681,7 +681,8 @@ If BOL is non-nil insert at the beginning of line.  Run
   "Using BUFFER, emit STRING font-locked with FACE.
 If BOL is non-nil, emit at the beginning of the line."
   (with-current-buffer buffer
-    (cider-repl--emit-output-at-pos buffer string face cider-repl-input-start-mark bol)))
+    (let ((pos (cider-repl--end-of-output)))
+      (cider-repl--emit-output-at-pos buffer string face pos bol))))
 
 (defun cider-repl-emit-stdout (buffer string)
   "Using BUFFER, emit STRING as standard output."

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -872,7 +872,7 @@ nREPL ops, it may be convenient to prevent inserting a prompt.")
     (nrepl-make-response-handler
      buffer
      (lambda (buffer value)
-       (cider-repl-emit-result buffer value (not after-first-result-chunk) t)
+       (cider-repl-emit-result buffer value (not after-first-result-chunk))
        (setq after-first-result-chunk t))
      (lambda (buffer out)
        (cider-repl-emit-stdout buffer out))

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -873,13 +873,11 @@ nREPL ops, it may be convenient to prevent inserting a prompt.")
 
 (defun cider-repl-handler (buffer)
   "Make an nREPL evaluation handler for the REPL BUFFER."
-  (let (after-first-result-chunk
-        (show-prompt t))
+  (let ((show-prompt t))
     (nrepl-make-response-handler
      buffer
      (lambda (buffer value)
-       (cider-repl-emit-result buffer value (not after-first-result-chunk))
-       (setq after-first-result-chunk t))
+       (cider-repl-emit-result buffer value t))
      (lambda (buffer out)
        (cider-repl-emit-stdout buffer out))
      (lambda (buffer err)
@@ -893,11 +891,8 @@ nREPL ops, it may be convenient to prevent inserting a prompt.")
                  (content-type* (car content-type))
                  (handler (cdr (assoc content-type*
                                       cider-repl-content-type-handler-alist))))
-           (setq after-first-result-chunk t
-                 show-prompt (funcall handler content-type buffer value
-                                      (not after-first-result-chunk) t))
-         (progn (cider-repl-emit-result buffer value (not after-first-result-chunk) t)
-                (setq after-first-result-chunk t)))))))
+           (setq show-prompt (funcall handler content-type buffer value nil t))
+         (cider-repl-emit-result buffer value t t))))))
 
 (defun cider--repl-request-plist (right-margin &optional pprint-fn)
   "Plist to be appended to generic eval requests, as for the REPL.

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -788,7 +788,7 @@ the symbol."
                t)))
           (t t))))
 
-(defun cider-repl--display-image (buffer image &optional show-prefix bol string)
+(defun cider-repl--display-image (buffer image &optional show-prefix bol)
   "Insert IMAGE into BUFFER at the current point.
 
 For compatibility with the rest of CIDER's REPL machinery, supports
@@ -809,7 +809,7 @@ SHOW-PREFIX and BOL."
                 (props (nconc `(display ,image rear-nonsticky (display))
                               (when (boundp 'image-map)
                                 `(keymap ,image-map)))))
-            (insert-before-markers string)
+            (insert-before-markers " ")
             (add-text-properties start (point) props)))))
     (cider-repl--show-maximum-output))
   t)
@@ -836,14 +836,14 @@ raw image data or a filename.  Returns an image instance with a margin per
 Part of the default `cider-repl-content-type-handler-alist'."
   (cider-repl--display-image buffer
                              (cider-repl--image image 'jpeg t)
-                             show-prefix bol " "))
+                             show-prefix bol))
 
 (defun cider-repl-handle-png (_type buffer image &optional show-prefix bol)
   "A handler for inserting a png IMAGE into a repl BUFFER.
 Part of the default `cider-repl-content-type-handler-alist'."
   (cider-repl--display-image buffer
                              (cider-repl--image image 'png t)
-                             show-prefix bol " "))
+                             show-prefix bol))
 
 (defun cider-repl-handle-external-body (type buffer _ &optional _show-prefix _bol)
   "Handler for slurping external content into BUFFER.

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -25,17 +25,18 @@
 
 ;;; Code:
 
-(require 'cl-lib)
-(require 'cider-popup)
 (require 'button)
+(require 'cl-lib)
 (require 'easymenu)
-(require 'cider-common)
+(require 'map)
+(require 'seq)
 (require 'subr-x)
+
+(require 'cider-common)
 (require 'cider-compat)
 (require 'cider-client)
+(require 'cider-popup)
 (require 'cider-util)
-
-(require 'seq)
 
 ;; Variables
 
@@ -60,20 +61,7 @@ If nil, messages will not be wrapped.  If truthy but non-numeric,
 
 (make-obsolete 'cider-stacktrace-print-length 'cider-stacktrace-print-options "0.20")
 (make-obsolete 'cider-stacktrace-print-level 'cider-stacktrace-print-options "0.20")
-
-(defcustom cider-stacktrace-print-options '(dict "length" 50 "level" 50)
-  "Set the maximum length of sequences in displayed cause data.
-
-This sets the value of Clojure's `*print-length*` when pretty printing the
-`ex-data` map for exception causes in the stacktrace that are instances of
-`IExceptionInfo`.
-
-Be advised that setting \"print-length\" to `nil` will cause the attempted
-printing of infinite data structures and that setting \"print-level\" to
-nil cause the attempted printing of cyclical data structures."
-  :type 'listp
-  :group 'cider-stacktrace
-  :package-version '(cider . "0.20.0"))
+(make-obsolete-variable 'cider-stacktrace-print-options 'cider-print-options "0.21")
 
 (defvar cider-stacktrace-detail-max 2
   "The maximum detail level for causes.")

--- a/cider-test.el
+++ b/cider-test.el
@@ -283,9 +283,9 @@ prompt and whether to use a new window.  Similar to `cider-find-var'."
               "var" ,var
               "index" ,index)
             (when (cider--pprint-fn)
-              `("pprint-fn" ,(cider--pprint-fn)))
+              `("nrepl.middleware.print/print" ,(cider--pprint-fn)))
             (when cider-stacktrace-print-options
-              `("print-options" ,cider-stacktrace-print-options)))
+              `("nrepl.middleware.print/options" ,cider-stacktrace-print-options)))
      (lambda (response)
        (nrepl-dbind-response response (class status)
          (cond (class  (setq causes (cons response causes)))

--- a/cider-test.el
+++ b/cider-test.el
@@ -28,18 +28,19 @@
 
 ;;; Code:
 
+(require 'button)
+(require 'cl-lib)
+(require 'easymenu)
+(require 'map)
+(require 'seq)
+(require 'subr-x)
+
 (require 'cider-common)
 (require 'cider-client)
 (require 'cider-popup)
 (require 'cider-stacktrace)
-(require 'subr-x)
 (require 'cider-compat)
 (require 'cider-overlays)
-
-(require 'button)
-(require 'cl-lib)
-(require 'easymenu)
-(require 'seq)
 
 ;;; Variables
 
@@ -278,14 +279,14 @@ prompt and whether to use a new window.  Similar to `cider-find-var'."
   "Display stacktrace for the erring NS VAR test with the assertion INDEX."
   (let (causes)
     (cider-nrepl-send-request
-     (nconc `("op" "test-stacktrace"
-              "ns" ,ns
-              "var" ,var
-              "index" ,index)
-            (when (cider--pprint-fn)
-              `("nrepl.middleware.print/print" ,(cider--pprint-fn)))
-            (when cider-stacktrace-print-options
-              `("nrepl.middleware.print/options" ,cider-stacktrace-print-options)))
+     (thread-last
+         (map-merge 'list
+                    `(("op" "test-stacktrace")
+                      ("ns" ,ns)
+                      ("var" ,var)
+                      ("index" ,index))
+                    (cider--nrepl-print-request-map fill-column))
+       (seq-mapcat #'identity))
      (lambda (response)
        (nrepl-dbind-response response (class status)
          (cond (class  (setq causes (cons response causes)))

--- a/cider.el
+++ b/cider.el
@@ -383,7 +383,7 @@ Throws an error if PROJECT-TYPE is unknown."
   "List of dependencies where elements are lists of artifact name and version.
 Added to `cider-jack-in-dependencies' when doing `cider-jack-in-cljs'.")
 (put 'cider-jack-in-cljs-dependencies 'risky-local-variable t)
-(cider-add-to-alist 'cider-jack-in-cljs-dependencies "cider/piggieback" "0.3.10")
+(cider-add-to-alist 'cider-jack-in-cljs-dependencies "cider/piggieback" "0.4.0")
 
 (defvar cider-jack-in-dependencies-exclusions nil
   "List of exclusions for jack in dependencies.
@@ -655,7 +655,7 @@ Generally you should not disable this unless you run into some faulty check."
 (defun cider-verify-piggieback-is-present ()
   "Check whether the piggieback middleware is present."
   (unless (cider-library-present-p "cider/piggieback")
-    (user-error "Piggieback 0.3.x (aka cider/piggieback) is not available.  See https://docs.cider.mx/en/latest/clojurescript for details")))
+    (user-error "Piggieback 0.4.x (aka cider/piggieback) is not available.  See https://docs.cider.mx/en/latest/clojurescript for details")))
 
 (defun cider-check-nashorn-requirements ()
   "Check whether we can start a Nashorn ClojureScript REPL."

--- a/cider.el
+++ b/cider.el
@@ -377,7 +377,7 @@ Throws an error if PROJECT-TYPE is unknown."
 ;; We inject the newest known version of nREPL just in case
 ;; your version of Boot or Leiningen is bundling an older one.
 (cider-add-to-alist 'cider-jack-in-dependencies
-                    "nrepl" "0.5.3")
+                    "nrepl" "0.6.0")
 
 (defvar cider-jack-in-cljs-dependencies nil
   "List of dependencies where elements are lists of artifact name and version.
@@ -399,10 +399,10 @@ Elements of the list are artifact name and list of exclusions to apply for the a
 (defconst cider-latest-clojure-version "1.10.0"
   "Latest supported version of Clojure.")
 
-(defconst cider-required-middleware-version "0.20.0"
+(defconst cider-required-middleware-version "0.21.0"
   "The minimum CIDER nREPL version that's known to work properly with CIDER.")
 
-(defconst cider-latest-middleware-version "0.20.0"
+(defconst cider-latest-middleware-version "0.21.0"
   "The latest CIDER nREPL version that's known to work properly with CIDER.")
 
 (defcustom cider-jack-in-auto-inject-clojure nil

--- a/doc/clojurescript.md
+++ b/doc/clojurescript.md
@@ -33,7 +33,7 @@ project):
 
 ```clojure
 ;; use whatever are the most recent versions here
-[cider/piggieback "0.3.10"]
+[cider/piggieback "0.4.0"]
 [org.clojure/clojure "1.9.0"]
 ```
 
@@ -157,7 +157,7 @@ documentation lookup, the namespace browser, and macroexpansion).
 [adzerk/boot-cljs-repl   "X.Y.Z"  :scope "test"]
 [pandeiro/boot-http      "X.Y.Z"  :scope "test"]
 [weasel                  "0.7.0"  :scope "test"]
-[cider/piggieback "0.3.10"  :scope "test"] ; not needed for cider-jack-in-cljs
+[cider/piggieback "0.4.0"  :scope "test"] ; not needed for cider-jack-in-cljs
 ```
 
 and this at the end of `build.boot`:
@@ -199,14 +199,13 @@ You can also use [Figwheel](https://github.com/bhauman/lein-figwheel) with CIDER
 2. Add these to your dev `:dependencies`:
 
 ```clojure
-[cider/piggieback "0.3.10"] ; not needed for cider-jack-in-cljs
-[figwheel-sidecar "0.5.16"] ; use here whatever the current version of figwheel is
+[cider/piggieback "0.4.0"] ; not needed for cider-jack-in-cljs
+[figwheel-sidecar "0.5.19"] ; use here whatever the current version of figwheel is
 ```
 
 !!! Warning
 
-    Keep in mind that figwheel 0.5.16 is the first to support piggieback
-    0.3. CIDER does not support older versions of Piggieback.
+    Keep in mind that CIDER does not support versions versions of Piggieback older than 0.4. Make sure that you use a compatible version of Figwheel.
 
 3. Add this to your dev `:repl-options` (not needed for `cider-jack-in-cljs`):
 
@@ -234,7 +233,7 @@ You can also use [Figwheel-main](https://github.com/bhauman/figwheel-main) with 
 1. Add this to your dev `:dependencies` (not needed for `cider-jack-in-cljs`):
 
 ```clojure
-[cider/piggieback "0.3.10"]
+[cider/piggieback "0.4.0"]
 ```
 
 2. Add this to your dev `:repl-options` (not needed for `cider-jack-in-cljs`):

--- a/doc/repl/basic_usage.md
+++ b/doc/repl/basic_usage.md
@@ -50,9 +50,10 @@ Please, avoid killing REPL buffers with <kbd>C-c C-k</kbd>
 ## Known Limitations
 
 Performance can degrade when the REPL buffer grows very large. This is
-especially true if `cider-repl-use-clojure-font-lock` is enabled. You can use
-`cider-repl-clear-output` to either clear the result of the previous evaluation,
-or with a prefix argument clear the entire REPL buffer.
+especially true if either `cider-repl-use-clojure-font-lock` or
+`nrepl-log-messages` are enabled. You can use `cider-repl-clear-output` to
+either clear the result of the previous evaluation, or with a prefix argument
+clear the entire REPL buffer.
 
 Very long lines are guaranteed to bring Emacs to a crawl, so using a value of
 `cider-print-fn` that wraps lines beyond a certain width (i.e. any of the

--- a/doc/repl/basic_usage.md
+++ b/doc/repl/basic_usage.md
@@ -8,7 +8,7 @@ explore a new library you're interested in using. The CIDER REPL offers a number
 * auto-completion
 * font-locking (the same as in `clojure-mode`)
 * quick access to many CIDER commands (e.g. definition and documentation lookup, tracing, etc)
-* (optional) pretty-printing of evaluation results
+* pretty-printing of evaluation results
 * eldoc support
 * highly customizable REPL prompt
 
@@ -53,3 +53,7 @@ Performance can degrade when the REPL buffer grows very large. This is
 especially true if `cider-repl-use-clojure-font-lock` is enabled. You can use
 `cider-repl-clear-output` to either clear the result of the previous evaluation,
 or with a prefix argument clear the entire REPL buffer.
+
+Very long lines are guaranteed to bring Emacs to a crawl, so using a value of
+`cider-print-fn` that wraps lines beyond a certain width (i.e. any of the
+built-in options except for `pr`) is advised.

--- a/doc/repl/basic_usage.md
+++ b/doc/repl/basic_usage.md
@@ -49,7 +49,7 @@ Please, avoid killing REPL buffers with <kbd>C-c C-k</kbd>
 
 ## Known Limitations
 
-Unfortunately the REPL doesn't handle very well big output and they can cause slowdowns and even lockups.
-Make sure to clean your REPL buffers from time to time if you notice any slowdowns related to lots of
-content in the REPL. It's also prudent to configure result printing with some reasonable setting for
-`*print-length*` and `*print-level*` (or `cider-pprint-options` if you're making use of pretty-printing).
+Performance can degrade when the REPL buffer grows very large. This is
+especially true if `cider-repl-use-clojure-font-lock` is enabled. You can use
+`cider-repl-clear-output` to either clear the result of the previous evaluation,
+or with a prefix argument clear the entire REPL buffer.

--- a/doc/repl/configuration.md
+++ b/doc/repl/configuration.md
@@ -141,6 +141,8 @@ use:
 (setq cider-repl-use-clojure-font-lock nil)
 ```
 
+Note that enabling font-locking in the REPL can negatively impact performance.
+
 ## Pretty printing in the REPL
 
 By default the REPL always prints the results of your evaluations using the

--- a/doc/repl/configuration.md
+++ b/doc/repl/configuration.md
@@ -143,33 +143,29 @@ use:
 
 ## Pretty printing in the REPL
 
-By default the REPL always pretty-prints the results of your
-evaluations using whatever pretty-printer is specified in `cider-pprint-fn`.
+By default the REPL always prints the results of your evaluations using the
+printing function specified by `cider-print-fn`.
 
 !!! Note
 
     This behaviour was changed in CIDER 0.20. In prior CIDER releases
     pretty-printing was disabled by default.
 
-You can temporary disable this behaviour and revert to the default
-printer using <kbd>M-x cider-repl-toggle-pretty-printing</kbd>.
+You can temporarily disable this behaviour and revert to the default behaviour
+(equivalent to `clojure.core/pr`) using <kbd>M-x cider-repl-toggle-pretty-printing</kbd>.
 
-If you want to disable pretty-printing of results completely use:
+If you want to disable using `cider-print-fn` entirely, use:
 
 ```el
 (setq cider-repl-use-pretty-printing nil)
 ```
 
-The variable `cider-repl-pretty-print-width` (`fill-column` by default) controls
-the print width. You can adjust if you want:
+Note well that disabling pretty-printing is not advised. Emacs does not handle
+well very long lines, so using a printing function that wraps lines beyond a
+certain width (i.e. any of them except for `pr`) will keep your REPL running
+smoothly.
 
-```el
-;; this will try to print data in 20 columns per line
-(setq cider-repl-pretty-print-width 20)
-```
-
-See [this](../pretty_printing) for more
-information on pretty printing.
+See [this](../pretty_printing) for more information on configuring printing.
 
 ## Displaying images in the REPL
 

--- a/doc/repl/configuration.md
+++ b/doc/repl/configuration.md
@@ -84,21 +84,14 @@ following:
 
 ## Auto-scrolling the REPL on Output
 
-By default, if the REPL buffer contains more lines than the size of the
-(Emacs) window, the buffer is automatically re-centered upon
-completion of evaluating an expression, so that the bottom line of
-output is on the bottom line of the window.
-
-The default has the nice advantage that you always see as much as you
-can from your previous REPL interactions, but can be pretty annoying
-if you're a heavy user of `C-l` (`M-x recenter-top-bottom`), as even
-if you're at the top of the REPL buffer the next output will scroll it all
-the way down.
-
-If you don't like this re-centering you can disable it like this:
+Prior to version 0.21.0, the REPL buffer would be automatically re-centered
+whenever any output was printed, so that the prompt was on the bottom line of
+the window, displaying the maximum possible amount of output above it. This is
+no longer the default behaviour – you can now replicate it by setting the
+built-in option `scroll-conservatively`, for example:
 
 ```el
-(setq cider-repl-scroll-on-output nil)
+(add-hook 'cider-repl-mode-hook '(lambda () (setq scroll-conservatively 101)))
 ```
 
 ## Result Prefix

--- a/doc/repl/configuration.md
+++ b/doc/repl/configuration.md
@@ -184,30 +184,6 @@ behavior if you don't like it.
 Alternatively, you can toggle this behaviour on and off using <kbd>M-x
 cider-repl-toggle-content-types</kbd>.
 
-Currently, the feature doesn't work well with pretty-printing in the REPL,
-so we don't advise you to enable both features at the same time.
-
-## Limiting printed output in the REPL
-
-Accidentally printing large objects can be detrimental to your
-productivity. Clojure provides the `*print-length*` var which, if set,
-controls how many items of each collection the printer will print. You
-can supply a default value for REPL sessions via the `repl-options`
-section of your Leiningen project's configuration.
-
-```clojure
-:repl-options {:init (set! *print-length* 50)}
-```
-
-You can also set `cider-repl-print-length` to an appropriate value (it
-defaults to 100). If both `*print-length` and
-`cider-repl-print-length` are set, CIDER's setting will take precedence
-over the value set through Leiningen.
-
-The preceeding discussion also applies to Clojure's `*print-level*`
-variable. The corresponding CIDER variable is
-`cider-repl-print-level`, set to `nil` by default.
-
 ## Customizing the initial REPL namespace
 
 Normally, the CIDER REPL will start in the `user` namespace.  You can

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -68,9 +68,11 @@ you can step forward until you find the problem.
 
 ### Missing `*nrepl-messages*` buffer
 
-nREPL message logging is not enabled by default.  Set `nrepl-log-messages` to
-`t` to activate it. Alternatively you can use <kbd>M-x</kbd> `nrepl-toggle-message-logging`
-to enable/disable logging temporary within your current Emacs session.
+nREPL message logging is not enabled by default. Set `nrepl-log-messages` to `t`
+to activate it. Alternatively you can use <kbd>M-x</kbd>
+`nrepl-toggle-message-logging` to enable/disable logging temporary within your
+current Emacs session. Note that enabling message logging can impact
+performance.
 
 ### `cider-debug` complains that it “failed to instrument ...”
 

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -326,10 +326,7 @@ object is a root list or dict."
         (goto-char end)
         ;; normalise any platform-specific newlines
         (let* ((original (buffer-substring-no-properties beg end))
-               ;; handle both \n\r and \r\n
-               (result (replace-regexp-in-string "\r\n\\|\n\r" "\n" original))
-               ;; we don't handle single carriage returns, insert newline
-               (result (replace-regexp-in-string "\r" "\n" result)))
+               (result (replace-regexp-in-string "\r\n\\|\n\r\\|\r" "\n" original)))
           (cons nil (nrepl--push result stack))))))
    ;; integer
    ((looking-at "i\\(-?[0-9]+\\)e")

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -741,7 +741,8 @@ to the REPL."
 (defun nrepl-make-response-handler (buffer value-handler stdout-handler
                                            stderr-handler done-handler
                                            &optional eval-error-handler
-                                           content-type-handler)
+                                           content-type-handler
+                                           truncated-handler)
   "Make a response handler for connection BUFFER.
 A handler is a function that takes one argument - response received from
 the server process.  The response is an alist that contains at least 'id'
@@ -754,8 +755,8 @@ example, if 'value' key is present, the response is of type 'value', if
 
 Depending on the type, the handler dispatches the appropriate value to one
 of the supplied handlers: VALUE-HANDLER, STDOUT-HANDLER, STDERR-HANDLER,
-DONE-HANDLER, EVAL-ERROR-HANDLER and
-CONTENT-TYPE-HANDLER.
+DONE-HANDLER, EVAL-ERROR-HANDLER, CONTENT-TYPE-HANDLER, and
+TRUNCATED-HANDLER.
 
 Handlers are functions of the buffer and the value they handle, except for
 the optional CONTENT-TYPE-HANDLER which should be a function of the buffer,
@@ -787,10 +788,10 @@ the corresponding type of response."
              (when stderr-handler
                (funcall stderr-handler buffer err)))
             (status
-             (when (and stderr-handler (member "nrepl.middleware.print/truncated" status))
+             (when (and truncated-handler (member "nrepl.middleware.print/truncated" status))
                (let ((warning (format "\n... output truncated to %sB ..."
                                       (file-size-human-readable cider-print-quota))))
-                 (funcall stderr-handler buffer warning)))
+                 (funcall truncated-handler buffer warning)))
              (when (member "notification" status)
                (nrepl-dbind-response response (msg type)
                  (nrepl-notify msg type)))

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -379,7 +379,9 @@ containing the remainder of the input strings which could not be
 decoded.  RESPONSE-Q is the original queue with successfully decoded messages
 enqueued and with slot STUB containing a nested stack of an incompletely
 decoded message or nil if the strings were completely decoded."
-  (with-temp-buffer
+  (with-current-buffer (get-buffer-create " *nrepl-decoding*")
+    (fundamental-mode)
+    (erase-buffer)
     (if (queue-p string-q)
         (while (queue-head string-q)
           (insert (queue-dequeue string-q)))
@@ -400,6 +402,7 @@ decoded message or nil if the strings were completely decoded."
           (setf (nrepl-response-queue-stub response-q) (cdr istack))
         (queue-enqueue response-q (cadr istack))
         (setf (nrepl-response-queue-stub response-q) nil))
+      (erase-buffer)
       (cons string-q response-q))))
 
 (defun nrepl-bencode (object)

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -787,6 +787,10 @@ the corresponding type of response."
              (when stderr-handler
                (funcall stderr-handler buffer err)))
             (status
+             (when (and stderr-handler (member "nrepl.middleware.print/truncated" status))
+               (let ((warning (format "\n... output truncated to %sB ..."
+                                      (file-size-human-readable cider-print-quota))))
+                 (funcall stderr-handler buffer warning)))
              (when (member "notification" status)
                (nrepl-dbind-response response (msg type)
                  (nrepl-notify msg type)))

--- a/test/cider-repl-tests.el
+++ b/test/cider-repl-tests.el
@@ -142,18 +142,6 @@ PROPERTY shoudl be a symbol of either 'text, 'ansi-context or
       (expect (cider--pretty-print-width)
               :to-equal fill-column))))
 
-(describe "cider-repl--build-config-expression"
-  (it "returns nil when all the config values are nil"
-    (let ((cider-repl-print-length nil)
-          (cider-repl-print-level nil))
-      (expect (cider-repl--build-config-expression) :to-equal nil)))
-  (it "returns an when any the config values are non-nil"
-    (let ((cider-repl-print-length 10)
-          (cider-repl-print-level 10))
-      (expect (cider-repl--build-config-expression)
-              :to-equal
-              "(do (set! *print-length* 10) (set! *print-level* 10))"))))
-
 (describe "cider-locref-at-point"
   (it "works with stdout-stacktrace refs"
     (with-temp-buffer

--- a/test/cider-repl-tests.el
+++ b/test/cider-repl-tests.el
@@ -131,17 +131,6 @@ PROPERTY shoudl be a symbol of either 'text, 'ansi-context or
       (let ((context (simulate-cider-output "[30ma[0mb[31mcd" 'ansi-context)))
         (expect context :to-equal '((31) nil))))))
 
-(describe "cider--pretty-print-width"
-  (it "prefers cider-repl-pretty-print-width"
-    (let ((cider-repl-pretty-print-width 40))
-      (expect (cider--pretty-print-width)
-              :to-equal cider-repl-pretty-print-width)))
-  (it "falls back to fill-column"
-    (let ((cider-repl-pretty-print-width nil)
-          (fill-column 80))
-      (expect (cider--pretty-print-width)
-              :to-equal fill-column))))
-
 (describe "cider-locref-at-point"
   (it "works with stdout-stacktrace refs"
     (with-temp-buffer

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -180,8 +180,7 @@
     (it "ignores plugins whose predicates return false"
       (spy-on 'plugins-predicate :and-return-value nil)
       (expect (cider-jack-in-normalized-lein-plugins)
-              :to-equal '(("cider/cider-nrepl" "0.11.0"))))
-    (it "ignores plugins whose predicates return false"
+              :to-equal '(("cider/cider-nrepl" "0.11.0")))
       (spy-on 'middlewares-predicate :and-return-value nil)
       (expect (cider-jack-in-normalized-nrepl-middlewares)
               :to-equal '("cider.nrepl/cider-middleware" "another/middleware")))

--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -46,7 +46,7 @@
               :to-equal " *nrepl-server localhost:1*"))))
 
 
-(describe "nrepl-dbing-response"
+(describe "nrepl-dbind-response"
   (it "destructures a nREPL response dict and binds values to given vars"
     (expect (nrepl-dbind-response
                 '(dict


### PR DESCRIPTION
Please see the commit messages for more detail, but find a summary of the
changes below:

* The printing config is now controlled by three options: `cider-print-fn`,
  `cider-print-options`, and `cider-print-quota`. Now-redundant printing options
  have been made obsolete.

* There are now functions for constructing partial requests for both the
  pretty-print and non-pretty-print case – we need to ensure we force
  `clojure.core/pr` printing for all the non-`pprint` commands.

* `cider-print-options` can now be any map representation that `map.el` accepts
  (seeing as we support Emacs 25+ now). We use `map-merge` to combine the
  partial requests that specify the printing config. 

  * `map.el` has been updated in ELPA to support plists. Once it has a new
    release we can depend on, we could change `nrepl-send-request` to accept any
    map representation as its `request` argument. There are probably many other
    places where we use ad-hoc representations of maps that we should change to
    use `map.el`.
&nbsp;

* Some general enhancements to the REPL experience, mostly focused on performance:

  * Simplify insertion of images so we don't need to manually fix up any markers
    or the point.

  * New option `cider-repl-init-code` replaces `cider-repl-print-length` and
    `cider-repl-print-level`. This offers a more general way to configurably
    `set!` any dynamic vars or do anything else needed to prep the REPL
    environment.

  * Remove redundant `cider-scroll-on-output` option (and its associated custom
    recentering logic) and document how to restore the old behaviour by setting
    `scroll-conservatively`.

  * I spent some time profiling printing of some large results at the REPL and
    found a couple of easy wins around excessive object allocation (we spend a
    surprising amount of time in GC when the REPL is printing):

    * Reuse the same buffer in `nrepl-bdecode` rather than creating a new one
      each time.

    * Combine calls to `replace-regexp-in-string`.


  * Ensure we always insert output _before_ the REPL prompt.

    
* Also fixed a bug causing `cider-pprint-eval-last-sexp-to-comment` and
  `cider-pprint-eval-defun-to-comment` to not insert anything.