### PR TITLE
Edit jack in command with prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+* Allow editing of jack in command with prefix or when `cider-edit-jack-in-command` is truthy.
 * Stop cursor moving when initialising the CIDER REPL, when `cider-repl-pop-to-buffer-on-connect` is nil. This fixes a bug introduced by [commit e0aca78b](https://github.com/clojure-emacs/cider/commit/e0aca78ba56425e50ea895c5adc7c0331cee0b19).
 
 * [#2593](https://github.com/clojure-emacs/cider/issues/2593): The REPL's initial namespace is now set correctly if configured in another tool (e.g. Leiningen's `:init-ns`).

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -223,16 +223,16 @@ With a prefix argument, prompt for function to run instead of -main."
   :group 'cider
   :package-version '(cider . "0.18.0"))
 
+(define-obsolete-variable-alias
+  'cider-switch-to-repl-after-insert-p
+  'cider-switch-to-repl-on-insert
+  "0.21.0")
+
 (defcustom cider-switch-to-repl-on-insert t
   "Whether to switch to the repl when inserting a form into the repl."
   :type 'boolean
   :group 'cider
   :package-version '(cider . "0.21.0"))
-
-(define-obsolete-variable-alias
-  'cider-switch-to-repl-after-insert-p
-  'cider-switch-to-repl-on-insert
-  "0.21.0")
 
 (defcustom cider-invert-insert-eval-p nil
   "Whether to invert the behavior of evaling.
@@ -563,6 +563,8 @@ re-visited."
 (defun cider--get-symbol-indent (symbol-name)
   "Return the indent metadata for SYMBOL-NAME in the current namespace."
   (let* ((ns (let ((clojure-cache-ns t)) ; we force ns caching here for performance reasons
+               ;; silence bytecode warning of unused lexical var
+               (ignore clojure-cache-ns)
                (cider-current-ns))))
     (if-let* ((meta (cider-resolve-var ns symbol-name))
               (indent (or (nrepl-dict-get meta "style/indent")


### PR DESCRIPTION
The current prefix sends `:do-prompt` through the jack in
process. This allows the user to specify: the project directory, the
cljs repl type, the params to the jack in command, and the
endpoint. However, the most common of these are slight edits to the
jack in command to add lein profiles or deps aliases.

This makes a single prefix edit only the jack in command in its
entirety (not the previous command line args only version) rather than
require action on all of the parameters.


For instance, notice here the editing of the jack in command to add the Eastwood profile for cider-nrepl:

<img width="703" alt="screen shot 2019-02-14 at 12 24 03 am" src="https://user-images.githubusercontent.com/6377293/52767367-e3f9d100-2fef-11e9-8c37-9929534fdf27.png">

compared to the previous behavior which lacks clarity about what you are allowed to edit and where:

<img width="703" alt="screen shot 2019-02-14 at 12 32 14 am" src="https://user-images.githubusercontent.com/6377293/52767414-0986da80-2ff0-11e9-902a-d0a654a70b07.png">

I like seeing the whole jack in string as I know where the aliases and profiles go. The current way is rather ambiguous to my eye. Also its annoying to have more questions than what I most commonly want to do.


- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [ ] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)