### PR TITLE
Scroll buffer after using cider-insert-X-in-repl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Changes
 
+* * Add new defcustom `cider-switch-to-repl-on-insert-p`: Set to prevent cursor from going to the repl when inserting a form in the repl with the insert-to-repl commands. Replaces obsoleted `cider-switch-to-repl-after-insert-p`
 * **(Breaking)** Upgrade to nREPL 0.6.0. This is now the minimum required version.
 * **(Breaking)** Upgrade to piggieback 0.4.0. This is now the minimum required version.
 * **(Breaking)** Remove `cider.nrepl.middleware.pprint`. All functionality has been replaced by the built-in printing support in nREPL 0.6.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Changes
 
-* * Add new defcustom `cider-switch-to-repl-on-insert-p`: Set to prevent cursor from going to the repl when inserting a form in the repl with the insert-to-repl commands. Replaces obsoleted `cider-switch-to-repl-after-insert-p`
+* * Add new defcustom `cider-switch-to-repl-on-insert`: Set to prevent cursor from going to the repl when inserting a form in the repl with the insert-to-repl commands. Replaces obsoleted `cider-switch-to-repl-after-insert-p`
 * **(Breaking)** Upgrade to nREPL 0.6.0. This is now the minimum required version.
 * **(Breaking)** Upgrade to piggieback 0.4.0. This is now the minimum required version.
 * **(Breaking)** Remove `cider.nrepl.middleware.pprint`. All functionality has been replaced by the built-in printing support in nREPL 0.6.

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -223,6 +223,17 @@ With a prefix argument, prompt for function to run instead of -main."
   :group 'cider
   :package-version '(cider . "0.18.0"))
 
+(defcustom cider-switch-to-repl-on-insert-p t
+  "Whether to switch to the repl when inserting a form into the repl."
+  :type 'boolean
+  :group 'cider
+  :package-version '(cider . "0.21.0"))
+
+(define-obsolete-variable-alias
+  'cider-switch-to-repl-after-insert-p
+  'cider-switch-to-repl-on-insert-p
+  "0.21.0")
+
 (defcustom cider-invert-insert-eval-p nil
   "Whether to invert the behavior of evaling.
 Default behavior when inserting is to NOT eval the form and only eval with
@@ -238,7 +249,7 @@ If EVAL is non-nil the form will also be evaluated.  Use
 `cider-invert-insert-eval-p' to invert this behavior."
   (while (string-match "\\`[ \t\n\r]+\\|[ \t\n\r]+\\'" form)
     (setq form (replace-match "" t t form)))
-  (when cider-switch-to-repl-after-insert-p
+  (when cider-switch-to-repl-on-insert-p
     (cider-switch-to-repl-buffer))
   (let ((repl (cider-current-repl)))
     (with-selected-window (or (get-buffer-window repl)

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -121,7 +121,7 @@ Clojure buffer."
 (defun cider-switch-to-last-clojure-buffer ()
   "Switch to the last Clojure buffer.
 The default keybinding for this command is
-the same as `cider-switch-to-repl-buffer',
+the same as variable `cider-switch-to-repl-buffer',
 so that it is very convenient to jump between a
 Clojure buffer and the REPL buffer."
   (interactive)
@@ -234,18 +234,23 @@ and eval and the prefix is required to prevent evaluation."
 
 (defun cider-insert-in-repl (form eval)
   "Insert FORM in the REPL buffer and switch to it.
-If EVAL is non-nil the form will also be evaluated."
+If EVAL is non-nil the form will also be evaluated.  Use
+`cider-invert-insert-eval-p' to invert this behavior."
   (while (string-match "\\`[ \t\n\r]+\\|[ \t\n\r]+\\'" form)
     (setq form (replace-match "" t t form)))
-  (with-current-buffer (cider-current-repl)
-    (goto-char (point-max))
-    (let ((beg (point)))
-      (insert form)
-      (indent-region beg (point)))
-    (when (if cider-invert-insert-eval-p
-              (not eval)
-            eval)
-      (cider-repl-return)))
+  (let ((repl (cider-current-repl)))
+    (with-selected-window (or (get-buffer-window repl)
+                              (selected-window))
+      (with-current-buffer repl
+        (goto-char (point-max))
+        (let ((beg (point)))
+          (insert form)
+          (indent-region beg (point)))
+        (when (if cider-invert-insert-eval-p
+                  (not eval)
+                eval)
+          (cider-repl-return))
+        (goto-char (point-max)))))
   (when cider-switch-to-repl-after-insert-p
     (cider-switch-to-repl-buffer)))
 

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -258,7 +258,8 @@ If EVAL is non-nil the form will also be evaluated.  Use
         (goto-char (point-max))
         (let ((beg (point)))
           (insert form)
-          (indent-region beg (point)))
+          (indent-region beg (point))
+          (cider--font-lock-ensure beg (point)))
         (when (if cider-invert-insert-eval-p
                   (not eval)
                 eval)

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -223,7 +223,7 @@ With a prefix argument, prompt for function to run instead of -main."
   :group 'cider
   :package-version '(cider . "0.18.0"))
 
-(defcustom cider-switch-to-repl-on-insert-p t
+(defcustom cider-switch-to-repl-on-insert t
   "Whether to switch to the repl when inserting a form into the repl."
   :type 'boolean
   :group 'cider
@@ -231,7 +231,7 @@ With a prefix argument, prompt for function to run instead of -main."
 
 (define-obsolete-variable-alias
   'cider-switch-to-repl-after-insert-p
-  'cider-switch-to-repl-on-insert-p
+  'cider-switch-to-repl-on-insert
   "0.21.0")
 
 (defcustom cider-invert-insert-eval-p nil
@@ -249,7 +249,7 @@ If EVAL is non-nil the form will also be evaluated.  Use
 `cider-invert-insert-eval-p' to invert this behavior."
   (while (string-match "\\`[ \t\n\r]+\\|[ \t\n\r]+\\'" form)
     (setq form (replace-match "" t t form)))
-  (when cider-switch-to-repl-on-insert-p
+  (when cider-switch-to-repl-on-insert
     (cider-switch-to-repl-buffer))
   (let ((repl (cider-current-repl)))
     (with-selected-window (or (get-buffer-window repl)

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -238,6 +238,8 @@ If EVAL is non-nil the form will also be evaluated.  Use
 `cider-invert-insert-eval-p' to invert this behavior."
   (while (string-match "\\`[ \t\n\r]+\\|[ \t\n\r]+\\'" form)
     (setq form (replace-match "" t t form)))
+  (when cider-switch-to-repl-after-insert-p
+    (cider-switch-to-repl-buffer))
   (let ((repl (cider-current-repl)))
     (with-selected-window (or (get-buffer-window repl)
                               (selected-window))
@@ -250,9 +252,7 @@ If EVAL is non-nil the form will also be evaluated.  Use
                   (not eval)
                 eval)
           (cider-repl-return))
-        (goto-char (point-max)))))
-  (when cider-switch-to-repl-after-insert-p
-    (cider-switch-to-repl-buffer)))
+        (goto-char (point-max))))))
 
 (defun cider-insert-last-sexp-in-repl (&optional arg)
   "Insert the expression preceding point in the REPL buffer.


### PR DESCRIPTION
As it stood, buffer would not scroll, even if you included a
`(goto-char (point-max))` call at the end. Using solution from
https://stackoverflow.com/questions/13530025/emacs-scroll-automatically-when-inserting-text

Have to watch out if the buffer is visible or not. If it is, we can
scroll it with `with-selected-window`. Otherwise, the best we can do
is the current behavior. Note `get-buffer-window` returns nil if
something is not visible which is why we need to branch on it.

## Currently

Using the `cider-insert-[last-sexp|defun|region]-inrepl` commands (C-c M-j [e,d,r]) were very convenient but would not scroll the buffer, limiting their usability.

<img width="703" alt="before" src="https://user-images.githubusercontent.com/6377293/52905655-c8b2df80-3202-11e9-9da7-8433f7d002f7.png">


Notice that the repl buffer is not scrolled. Simply adding a `(goto-char (point-max))` in `cider-insert-in-repl` was not sufficient due. (see stack overflow post from commit message above).

## After

By using `with-selected-window` we can manipulate the view of that buffer. So now we end up with this much more sensical view when using these commands:

<img width="659" alt="after" src="https://user-images.githubusercontent.com/6377293/52905674-09125d80-3203-11e9-822b-024691e1c926.png">
