### PR TITLE
support figwheel-connected sibling cljs repl

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -763,6 +763,8 @@ The supplied string will be wrapped in a do form if needed."
     (figwheel "(do (require 'figwheel-sidecar.repl-api) (figwheel-sidecar.repl-api/start-figwheel!) (figwheel-sidecar.repl-api/cljs-repl))"
               cider-check-figwheel-requirements)
     (figwheel-main cider-figwheel-main-init-form cider-check-figwheel-main-requirements)
+    (figwheel-sidecar "(figwheel-sidecar.repl-api/cljs-repl)"
+                      cider-check-figwheel-requirements)
     (node "(do (require 'cljs.repl.node) (cider.piggieback/cljs-repl (cljs.repl.node/repl-env)))"
           cider-check-node-requirements)
     (weasel "(do (require 'weasel.repl.websocket) (cider.piggieback/cljs-repl (weasel.repl.websocket/repl-env :ip \"127.0.0.1\" :port 9001)))"

--- a/cider.el
+++ b/cider.el
@@ -763,7 +763,7 @@ The supplied string will be wrapped in a do form if needed."
     (figwheel "(do (require 'figwheel-sidecar.repl-api) (figwheel-sidecar.repl-api/start-figwheel!) (figwheel-sidecar.repl-api/cljs-repl))"
               cider-check-figwheel-requirements)
     (figwheel-main cider-figwheel-main-init-form cider-check-figwheel-main-requirements)
-    (figwheel-sidecar "(figwheel-sidecar.repl-api/cljs-repl)"
+    (figwheel-running "(figwheel-sidecar.repl-api/cljs-repl)"
                       cider-check-figwheel-requirements)
     (node "(do (require 'cljs.repl.node) (cider.piggieback/cljs-repl (cljs.repl.node/repl-env)))"
           cider-check-node-requirements)

--- a/cider.el
+++ b/cider.el
@@ -763,8 +763,8 @@ The supplied string will be wrapped in a do form if needed."
     (figwheel "(do (require 'figwheel-sidecar.repl-api) (figwheel-sidecar.repl-api/start-figwheel!) (figwheel-sidecar.repl-api/cljs-repl))"
               cider-check-figwheel-requirements)
     (figwheel-main cider-figwheel-main-init-form cider-check-figwheel-main-requirements)
-    (figwheel-running "(figwheel-sidecar.repl-api/cljs-repl)"
-                      cider-check-figwheel-requirements)
+    (figwheel-connected "(figwheel-sidecar.repl-api/cljs-repl)"
+                        cider-check-figwheel-requirements)
     (node "(do (require 'cljs.repl.node) (cider.piggieback/cljs-repl (cljs.repl.node/repl-env)))"
           cider-check-node-requirements)
     (weasel "(do (require 'weasel.repl.websocket) (cider.piggieback/cljs-repl (weasel.repl.websocket/repl-env :ip \"127.0.0.1\" :port 9001)))"


### PR DESCRIPTION
## Use Case
- Start figwheel via `lein figwheel` and have it configured to start an nrepl
- Connect to nrepl via `C-c M-c`
- Start a sibling cljs repl of `figwheel-running` type, to get into a figwheel-connected browser

Right now, this has to be done with a custom init form, which is annoying

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/en/latest/hacking_on_cider/
