### PR TITLE
Stop cursor moving when initialising the CIDER REPL

### DIFF
--- a/cider-repl.el
+++ b/cider-repl.el
@@ -304,7 +304,8 @@ client process connection."
   (with-current-buffer buffer
     (cider-repl--insert-banner)
     (cider-repl--insert-prompt cider-buffer-ns)
-    (set-window-point (get-buffer-window) (point-max)))
+    (when (eql cider-repl-pop-to-buffer-on-connect 'display-only)
+      (set-window-point (get-buffer-window) (point-max))))
   buffer)
 
 (defun cider-repl--insert-banner ()


### PR DESCRIPTION
SORRY — I'm trying to work out how to put this into DRAFT status. I haven't been through the checklist.

Fixes this bug: When cider-repl-pop-to-buffer-on-connect is nil the cursor jumps
when initialising the CIDER REPL. The cursor jumps in whatever buffer is
current.

This commit fixes commit e0aca78b, whose commit message says:

    Make sure REPL window point is at point-max at startup
    Needed when cider-repl-pop-to-buffer-on-connect is 'display-only

This commit applies the new functionality only when
cider-repl-pop-to-buffer-on-connect is display-only.


- [ ] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/en/latest/hacking_on_cider/
