### PR TITLE
Stop cursor moving when initialising the CIDER REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug fixes
 
+* Stop cursor moving when initialising the CIDER REPL, when `cider-repl-pop-to-buffer-on-connect` is nil. This fixes a bug introduced by [commit e0aca78b](https://github.com/clojure-emacs/cider/commit/e0aca78ba56425e50ea895c5adc7c0331cee0b19).
+
 * [#2593](https://github.com/clojure-emacs/cider/issues/2593): The REPL's initial namespace is now set correctly if configured in another tool (e.g. Leiningen's `:init-ns`).
 
 ## 0.21.0 (2019-02-19)

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -304,7 +304,8 @@ client process connection."
   (with-current-buffer buffer
     (cider-repl--insert-banner)
     (cider-repl--insert-prompt cider-buffer-ns)
-    (set-window-point (get-buffer-window) (point-max)))
+    (when-let ((window (get-buffer-window)))
+      (set-window-point window (point-max))))
   buffer)
 
 (defun cider-repl--insert-banner ()


### PR DESCRIPTION
Fixes this bug: When cider-repl-pop-to-buffer-on-connect is nil the cursor jumps
when initialising the CIDER REPL. The cursor jumps in whatever buffer is
current.

This commit fixes [commit e0aca78b](https://github.com/clojure-emacs/cider/commit/e0aca78ba56425e50ea895c5adc7c0331cee0b19), whose commit message says:

    Make sure REPL window point is at point-max at startup
    Needed when cider-repl-pop-to-buffer-on-connect is 'display-only

This commit applies the new functionality only when
cider-repl-pop-to-buffer-on-connect is display-only.

- [x] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)

The following are not done, but I think they're not applicable.
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
