### PR TITLE
Translate docker paths when `cider-docker-translations` alist is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 * New configuration variable `cider-result-overlay-position` determining where debugger and inline eval result overlays should be displayed. Current options are 'at-eol and 'at-point.
+* [#2606](https://github.com/clojure-emacs/cider/pull/2606): Defcustom `cider-path-translations` for translating paths from nrepl messages
 
 ### Changes
 

--- a/doc/modules/ROOT/pages/config/basic_config.adoc
+++ b/doc/modules/ROOT/pages/config/basic_config.adoc
@@ -83,6 +83,32 @@ To prefer local resources to remote resources (tramp) when both are available:
 (setq cider-prefer-local-resources t)
 ----
 
+== Translate paths
+
+If you wish to translate paths from your running instance you may use
+the `cider-path-translations` defcustom to do so. For instance,
+suppose your app is running in a docker container with your source
+directories mounted. The navigation paths will be relative to the
+source in the docker container rather than the correct path on your
+host machine. You can add translations easily by setting the
+following, most likely in dir locals:
+
+[source,lisp]
+----
+((nil
+  (cider-path-translations . (("/root" . "/Users/foo")
+                              ("/src/" . "/Users/foo/projects")))))
+---
+
+Each entry will be interpreted as a directory entry so trailing slash
+is optional. Navigation will attempt to translate these locations, and
+if they exist, navigate there rather than report the file does not
+exist. In the example above, the m2 directory is mounted at /root/.m2
+and the source at /src. These translations would map these locations
+back to the users computer so that navigation would work.
+
+
+
 == Auto-Save Clojure Buffers on Load
 
 Normally, CIDER prompts you to save a modified Clojure buffer when you


### PR DESCRIPTION
If you connect to a running docker image, often the source is mounted
in the docker image. This breaks navigation as rather than navigating
to "/home/me/projects/foo/src/ns.clj" it believes the file is
"/src/ns.clj". This allows rewriting of these prefixes so the
locations can map back to the local filesystem.

- [x] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
