### PR TITLE
Use markers for evaluating to comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Stop cursor moving when initialising the CIDER REPL, when `cider-repl-pop-to-buffer-on-connect` is nil. This fixes a bug introduced by [commit e0aca78b](https://github.com/clojure-emacs/cider/commit/e0aca78ba56425e50ea895c5adc7c0331cee0b19).
 * [#2577](https://github.com/clojure-emacs/cider/issues/2577): Ensure user friendly error messages if a repl connection is expected but none was found in certain situations. 
 * [#2593](https://github.com/clojure-emacs/cider/issues/2593): The REPL's initial namespace is now set correctly if configured in another tool (e.g. Leiningen's `:init-ns`).
+* [#2607](https://github.com/clojure-emacs/cider/pull/2607): Use markers for specifying insertion point for `cider-eval-*-to-comment`commands. This fixes a bug where editing the buffer during a pending evaluation resulted in comments appearing in unintended locations.
 
 ## 0.21.0 (2019-02-19)
 

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -522,13 +522,13 @@ or it can be a list with (START END) of the evaluated region."
 
 (defun cider-eval-print-with-comment-handler (buffer location comment-prefix)
   "Make a handler for evaluating and printing commented results in BUFFER.
-LOCATION is the location at which to insert.  COMMENT-PREFIX is the comment
-prefix to use."
+LOCATION is the location marker at which to insert.  COMMENT-PREFIX is the
+comment prefix to use."
   (nrepl-make-response-handler buffer
                                (lambda (buffer value)
                                  (with-current-buffer buffer
                                    (save-excursion
-                                     (goto-char location)
+                                     (goto-char (marker-position location))
                                      (insert (concat comment-prefix
                                                      value "\n")))))
                                (lambda (_buffer out)
@@ -540,7 +540,7 @@ prefix to use."
 (defun cider-eval-pprint-with-multiline-comment-handler (buffer location comment-prefix continued-prefix comment-postfix)
   "Make a handler for evaluating and inserting results in BUFFER.
 The inserted text is pretty-printed and region will be commented.
-LOCATION is the location at which to insert.
+LOCATION is the location marker at which to insert.
 COMMENT-PREFIX is the comment prefix for the first line of output.
 CONTINUED-PREFIX is the comment prefix to use for the remaining lines.
 COMMENT-POSTFIX is the text to output after the last line."
@@ -554,7 +554,7 @@ COMMENT-POSTFIX is the text to output after the last line."
      (lambda (buffer)
        (with-current-buffer buffer
          (save-excursion
-           (goto-char location)
+           (goto-char (marker-position location))
            (let ((lines (split-string res "[\n]+" t)))
              ;; only the first line gets the normal comment-prefix
              (insert (concat comment-prefix (pop lines)))
@@ -738,7 +738,7 @@ With the prefix arg INSERT-BEFORE, insert before the form, otherwise afterwards.
     (cider-interactive-eval nil
                             (cider-eval-print-with-comment-handler
                              (current-buffer)
-                             insertion-point
+                             (set-marker (make-marker) insertion-point)
                              cider-comment-prefix)
                             bounds
                             (cider--nrepl-pr-request-map))))
@@ -766,7 +766,7 @@ If INSERT-BEFORE is non-nil, insert before the form, otherwise afterwards."
     (cider-interactive-eval nil
                             (cider-eval-pprint-with-multiline-comment-handler
                              (current-buffer)
-                             insertion-point
+                             (set-marker (make-marker) insertion-point)
                              cider-comment-prefix
                              cider-comment-continued-prefix
                              comment-postfix)


### PR DESCRIPTION
Fixes a slightly annoying bug with comments appearing in unintended locations
when calling (expensive) async `cider-eval-***-to-comment` commands on a form,
then making subsequent edits while the evaluation is pending.

--------------------------
Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/en/latest/hacking_on_cider/
