### PR TITLE
Add current ns to `spec-list` and `spec-form` requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changes
 
 * `cider-print-options` is now supported by the `pr` option for `cider-print-fn`. The options will now be also used by interactive eval commands that do not use pretty-printing.
+* `spec-list` and `spec-form` requests send the current namespace for alias resolution
 
 ### Bug fixes
 

--- a/cider-client.el
+++ b/cider-client.el
@@ -542,14 +542,16 @@ Optional argument FILTER-REGEX filters specs.  By default, all specs are
 returned."
   (setq filter-regex (or filter-regex ""))
   (thread-first `("op" "spec-list"
-                  "filter-regex" ,filter-regex)
+                  "filter-regex" ,filter-regex
+                  "ns" ,(cider-current-ns))
     (cider-nrepl-send-sync-request)
     (nrepl-dict-get "spec-list")))
 
 (defun cider-sync-request:spec-form (spec)
   "Get SPEC's form from registry."
   (thread-first `("op" "spec-form"
-                  "spec-name" ,spec)
+                  "spec-name" ,spec
+                  "ns" ,(cider-current-ns))
     (cider-nrepl-send-sync-request)
     (nrepl-dict-get "spec-form")))
 


### PR DESCRIPTION
Add current ns to `spec-list` and `spec-form` requests so the server can use that information to resolve namespace aliases when providing completions and spec information.

See: https://github.com/clojure-emacs/orchard/pull/42

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

