### PR TITLE
[debugger] Fix inspector behavior when multiple REPLs are connected

### DIFF
--- a/cider-debug.el
+++ b/cider-debug.el
@@ -630,6 +630,7 @@ needed.  It is expected to contain at least \"key\", \"input-type\", and
              (setq cider--debug-mode-response response)
              (cider--debug-mode 1)))
           (when inspect
+            (setq cider-inspector--current-repl (cider-current-repl))
             (cider-inspector--render-value inspect)))
       ;; If something goes wrong, we send a "quit" or the session hangs.
       (error (cider-debug-mode-send-reply ":quit" key)


### PR DESCRIPTION
Identical to #2454, this ensures that the inspector in the debugger mode works with the correct REPL and doesn't jump around.