### PR TITLE
Remove C-g binding in test map to make C-g work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * `cider-print-options` is now supported by the `pr` option for `cider-print-fn`. The options will now be also used by interactive eval commands that do not use pretty-printing.
 * `spec-list` and `spec-form` requests send the current namespace for alias resolution.
+* `C-c , C-g` and `C-c C-t C-g` cancel the key chord instead of rerunning the last test. The respective command has been moved to `C-c , C-a`, `C-c , a`, `C-c C-t C-a` and `C-c C-t a`.
 
 ### Bug fixes
 

--- a/cider-test.el
+++ b/cider-test.el
@@ -138,7 +138,7 @@ Add to this list to have CIDER recognize additional test defining macros."
     ;; Duplicates of keys below with C- for convenience
     (define-key map (kbd "C-r") #'cider-test-rerun-failed-tests)
     (define-key map (kbd "C-t") #'cider-test-run-test)
-    (define-key map (kbd "C-g") #'cider-test-rerun-test)
+    (define-key map (kbd "C-a") #'cider-test-rerun-test)
     (define-key map (kbd "C-n") #'cider-test-run-ns-tests)
     (define-key map (kbd "C-s") #'cider-test-run-ns-tests-with-filters)
     (define-key map (kbd "C-l") #'cider-test-run-loaded-tests)
@@ -147,7 +147,7 @@ Add to this list to have CIDER recognize additional test defining macros."
     ;; Single-key bindings defined last for display in menu
     (define-key map (kbd "r")   #'cider-test-rerun-failed-tests)
     (define-key map (kbd "t")   #'cider-test-run-test)
-    (define-key map (kbd "g")   #'cider-test-rerun-test)
+    (define-key map (kbd "a")   #'cider-test-rerun-test)
     (define-key map (kbd "n")   #'cider-test-run-ns-tests)
     (define-key map (kbd "s")   #'cider-test-run-ns-tests-with-filters)
     (define-key map (kbd "l")   #'cider-test-run-loaded-tests)

--- a/doc/interactive_programming.md
+++ b/doc/interactive_programming.md
@@ -79,7 +79,7 @@ Here's a list of `cider-mode`'s keybindings:
 `cider-toggle-trace-ns`                       |<kbd>C-c M-t n</kbd>                 | Toggle namespace tracing.
 `cider-undef`                                 |<kbd>C-c C-u</kbd>                   | Undefine a symbol. If invoked with a prefix argument, or no symbol is found at point, prompt for a symbol.
 `cider-test-run-test`                         |<kbd>C-c C-t t</kbd> <br/> <kbd>C-c C-t C-t</kbd> | Run test at point.
-`cider-test-rerun-test`                       |<kbd>C-c C-t g</kbd> <br/> <kbd>C-c C-t C-g</kbd> | Re-run the last test you ran.
+`cider-test-rerun-test`                       |<kbd>C-c C-t a</kbd> <br/> <kbd>C-c C-t C-a</kbd> | Re-run the last test you ran.
 `cider-test-run-ns-tests`                     |<kbd>C-c C-t n</kbd> <br/> <kbd>C-c C-t C-n</kbd> | Run tests for current namespace.
 `cider-test-run-loaded-tests`                 |<kbd>C-c C-t l</kbd> <br/> <kbd>C-c C-t C-l</kbd> | Run tests for all loaded namespaces.
 `cider-test-run-project-tests`                |<kbd>C-c C-t p</kbd> <br/> <kbd>C-c C-t C-p</kbd> | Run tests for all project namespaces. This loads the additional namespaces.

--- a/doc/repl/keybindings.md
+++ b/doc/repl/keybindings.md
@@ -28,7 +28,7 @@ Keyboard shortcut                    | Description
 <kbd>C-c M-t v</kbd> | Toggle var tracing.
 <kbd>C-c M-t n</kbd> | Toggle namespace tracing.
 <kbd>C-c C-t t</kbd> <br/> <kbd>C-c C-t C-t</kbd> | Run test at point.
-<kbd>C-c C-t g</kbd> <br/> <kbd>C-c C-t C-g</kbd> | Re-run the last test you ran.
+<kbd>C-c C-t a</kbd> <br/> <kbd>C-c C-t C-a</kbd> | Re-run the last test you ran.
 <kbd>C-c C-t n</kbd> <br/> <kbd>C-c C-t C-n</kbd> | Run tests for current namespace.
 <kbd>C-c C-t l</kbd> <br/> <kbd>C-c C-t C-l</kbd> | Run tests for all loaded namespaces.
 <kbd>C-c C-t p</kbd> <br/> <kbd>C-c C-t C-p</kbd> | Run tests for all project namespaces. This loads the additional namespaces.


### PR DESCRIPTION
To quote (info "(elisp) Key Binding Conventions"):

    • Similarly, don’t bind a key sequence ending in ‘C-g’, since that is
      commonly used to cancel a key sequence.

-----------------

- [x] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

No tests added because, well, this was a convenience shortcut. I'd like to update the user manual, but it doesn't even cover the `C-c ,` map and instead documents the obsolete `C-c C-t` map.