### PR TITLE
[Fix #2495] Add option to require ns before setting it in the repl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * Allow editing of jack in command with prefix or when `cider-edit-jack-in-command` is truthy.
+* New defcustom `cider-repl-require-ns-on-set`: Set it to make cider require the namespace before setting it, when calling `cider-repl-set-ns`.
 
 ### Changes
 

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -143,6 +143,12 @@ will be used."
   :group 'cider-repl
   :package-version '(cider . "0.10.0"))
 
+(defcustom cider-repl-require-ns-on-set nil
+  "Controls wether to require the ns before setting it in the repl."
+  :type 'boolean
+  :group 'cider-repl
+  :package-version '(cider . "0.21.0"))
+
 (defcustom cider-repl-result-prefix ""
   "The prefix displayed in the REPL before a result value.
 By default there's no prefix, but you can specify something
@@ -1083,7 +1089,9 @@ command will prompt for the name of the namespace to switch to."
     (user-error "No namespace selected"))
   (cider-map-repls :auto
     (lambda (connection)
-      (cider-nrepl-request:eval (format "(in-ns '%s)" ns)
+      (cider-nrepl-request:eval (if cider-repl-require-ns-on-set
+                                    (format "(require '%s) (in-ns '%s)" ns ns)
+                                  (format "(in-ns '%s)" ns))
                                 (cider-repl-switch-ns-handler connection)))))
 
 

--- a/doc/repl/configuration.md
+++ b/doc/repl/configuration.md
@@ -230,3 +230,10 @@ and <kbd>C-<Return></kbd> send the form off for evaluation.
 
 Note that CIDER writes the history to the file when you kill the REPL
 buffer, which includes invoking `cider-quit`, or when you quit Emacs.
+
+## Set ns in REPL
+
+By default `cider-repl-set-ns` won't require the the ns, just set it. If you want to change this behaviour (to avoid calling `cider-repl-set-ns` and then `(require 'my-ns)` manually), you can set:
+```el
+(setq cider-repl-require-ns-on-set t)
+```


### PR DESCRIPTION
Allow CIDER to require the namespace when calling `cider-repl-set-ns`.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/en/latest/hacking_on_cider/
