### PR TITLE
Remove 'ensure in initial REPL when switching to other

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 * `cider-print-options` is now supported by the `pr` option for `cider-print-fn`. The options will now be also used by interactive eval commands that do not use pretty-printing.
 * `spec-list` and `spec-form` requests send the current namespace for alias resolution.
+* `cider-repl-switch-to-other` can now switch to other REPL in the absence of a REPL of its own type.
 
 ### Bug fixes
 

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -987,7 +987,7 @@ text property `cider-old-input'."
   "Switch between the Clojure and ClojureScript REPLs for the current project."
   (interactive)
   ;; FIXME: implement cycling as session can hold more than two REPLs
-  (let* ((this-repl (cider-current-repl nil 'ensure))
+  (let* ((this-repl (cider-current-repl))
          (other-repl (car (seq-remove (lambda (r) (eq r this-repl)) (cider-repls nil t)))))
     (if other-repl
         (switch-to-buffer other-repl)


### PR DESCRIPTION
Reason of this PR (very common if you are working with both `cljs` and `clj`):

1. I'm in `cljs` file, just connected to my `clj` REPL
2. Now I'd like to go to my `clj` REPL buffer, maybe convert it to `cljs` REPL (e.g. with `cljs-repl`) - which is common
3. Oops, you can't do that - use `SPC b b` to find either your `clj` REPL or `clj` file

-> Now you can cycle freely

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our contribution guidelines
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (make test)
- [x] All code passes the linter (make lint) which is based on elisp-lint and includes byte-compilation, checkdoc, check-declare, packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the user manual (if adding/changing user-visible functionality)