### PR TITLE
[DOCS] Fix autocompletion for `map-indexed`

### DIFF
--- a/doc/code_completion.md
+++ b/doc/code_completion.md
@@ -74,7 +74,7 @@ CIDER-specific "fuzzy completion" by adding:
 ```
 
 Now, `company-mode` will accept certain fuzziness when matching
-candidates against the prefix. For example, typing `mp` will show you
+candidates against the prefix. For example, typing `mi` will show you
 `map-indexed` as one of the possible completion candidates and `cji`
 will complete to `clojure.java.io`. Different completion examples are
 shown


### PR DESCRIPTION
Fix autocompletion for `map-indexed` at docs, I'm testing with `compliment` and it accepts, for this case, only `mi`, not `mp`.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/en/latest/hacking_on_cider/
