### PR TITLE
Add minibuffer completion for shadow-cljs builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#1840](https://github.com/clojure-emacs/cider/issues/1840): Add a command to find runtime function references (`cider-xref-fn-refs`).
 * Add a command to find runtime function dependencies (`cider-xref-fn-deps`).
 * Add a menu to the inspector.
+* Add completion of shadow-cljs build names in the minibuffer when connecting or jacking in.
 
 ### Changes
 

--- a/cider.el
+++ b/cider.el
@@ -709,13 +709,27 @@ Generally you should not disable this unless you run into some faulty check."
   :safe (lambda (s) (or (null s) (stringp s)))
   :package-version '(cider . "0.18.0"))
 
+(defun cider--shadow-parse-builds ()
+  "Extract build names from the shadow-cljs.edn config file in the project root.
+The default options of `browser-repl' and `node-repl' are also included."
+  (let* ((shadow-edn
+          (concat (clojure-project-dir (cider-current-dir)) "shadow-cljs.edn"))
+         (edn-hash (when (file-exists-p shadow-edn)
+                     (with-temp-buffer
+                       (insert-file-contents shadow-edn)
+                       (car (parseedn-read)))))
+         (builds-hash (when edn-hash (gethash :builds edn-hash)))
+         (builds (when builds-hash (hash-table-keys builds-hash))))
+    (append builds '(browser-repl node-repl))))
+
 (defun cider-shadow-select-cljs-init-form ()
   "Generate the init form for a shadow-cljs select-only REPL.
 We have to prompt the user to select a build, that's why this is a command,
 not just a string."
   (let ((form "(do (require '[shadow.cljs.devtools.api :as shadow]) (shadow/nrepl-select %s))")
         (options (or cider-shadow-default-options
-                     (read-from-minibuffer "Select shadow-cljs build (e.g. dev): "))))
+                     (completing-read "Select shadow-cljs build: "
+                                      (cider--shadow-parse-builds)))))
     (format form (cider-normalize-cljs-init-options options))))
 
 (defun cider-shadow-cljs-init-form ()
@@ -724,7 +738,8 @@ We have to prompt the user to select a build, that's why
 this is a command, not just a string."
   (let* ((form "(do (require '[shadow.cljs.devtools.api :as shadow]) (shadow/watch %s) (shadow/nrepl-select %s))")
          (options (or cider-shadow-default-options
-                      (read-from-minibuffer "Select shadow-cljs build (e.g. dev): ")))
+                      (completing-read "Select shadow-cljs build: "
+                                       (cider--shadow-parse-builds))))
          (build (cider-normalize-cljs-init-options options)))
     (format form build build)))
 

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -251,6 +251,17 @@
     (it "prepends colon to plain names"
       (expect (cider-normalize-cljs-init-options "dev") :to-equal ":dev"))))
 
+(describe "cider--shadow-parse-builds"
+  (it "parses valid input"
+    (expect (cider--shadow-parse-builds
+             (parseedn-read-str "{:builds {:app {} :release {}}}"))
+            :to-equal '(:release :app browser-repl node-repl)))
+  (it "returns default options on empty / invalid input"
+    (expect (cider--shadow-parse-builds (parseedn-read-str "{}"))
+            :to-equal '(browser-repl node-repl))
+    (expect (cider--shadow-parse-builds (parseedn-read-str "[oops]"))
+            :to-equal '(browser-repl node-repl))))
+
 (provide 'cider-tests)
 
 ;;; cider-tests.el ends here


### PR DESCRIPTION
This PR adds `completing-read` minibuffer completions for shadow-cljs builds, by looking for and parsing a `shadow-cljs.edn` file in the project root. Default build options of `node-repl` and `browser-repl` are also included.

Inspired by the equivalent functionality in Calva: https://github.com/BetterThanTomorrow/calva/blob/2571d802c0be7c82230db8583caf1443a3c93244/calva/shadow.ts

(Is it necessary to add tests or update the docs for this?)

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)