### PR TITLE
Correct typo, fudge -> fudje

### DIFF
--- a/doc/modules/ROOT/pages/testing/supported_libraries.adoc
+++ b/doc/modules/ROOT/pages/testing/supported_libraries.adoc
@@ -22,7 +22,7 @@ https://github.com/clojure/test.check/blob/24f74b83f1c7a032f98efdcc1db9d74b3a6a7
 * [test-check]
 * https://github.com/clojure-expectations/expectations[clojure-expectations] added
 support for `clojure.test` in version 2.2 and should also work with CIDER.
-* https://github.com/jimpil/fudje[fudge]
+* https://github.com/jimpil/fudje[fudje]
 
 == Midje Support
 


### PR DESCRIPTION
The link for jimpil's fudje is shown as `fudge`. This change fixes that. The typo also appears in the legacy documentation, but I left it as is.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [X] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)