### PR TITLE
docs: fix spelling

### DIFF
--- a/doc/modules/ROOT/pages/index.adoc
+++ b/doc/modules/ROOT/pages/index.adoc
@@ -39,7 +39,7 @@ using CIDER - you're constantly interacting with it and changing it.
 You can find more details about the typical CIDER workflow in the
 xref:usage/interactive_programming.adoc[Interactive Programming] section. While we're a bit
 short on video tutorials, you can check out this
-https://www.youtube.com/watch?v=aYA4AAjLfT0[into to CIDER] to get a
+https://www.youtube.com/watch?v=aYA4AAjLfT0[introduction to CIDER] to get a
 feel about what do we mean by an "Interactive Development Environment".
 
 CIDER's built on top of https://github.com/nrepl/nrepl[nREPL], the Clojure networked REPL server.


### PR DESCRIPTION
- [x] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
~~- [ ] You've added tests (if possible) to cover your change(s)~~
~~- [ ] All tests are passing (`make test`)~~
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
~~- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)~~
~~- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)~~
