### PR TITLE
Fix tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,33 +1,51 @@
 version: 2.1
 
 # Default actions to perform on each Emacs version
-default: &default-steps
-  steps:
-    - checkout
-    - run: apt-get update && apt-get install make leiningen=2.8.1-6 -y
-    - run: make elpa
-    - run: emacs --version
-    - run: make test
-    - run: make lint
+commands:
+  setup:
+    steps:
+      - checkout
+      - run: apt-get update && apt-get install make leiningen=2.8.1-6 -y
+      - run: make elpa
+      - run: emacs --version
+  test:
+    steps:
+      - run: make test
+  lint:
+    steps:
+      - run: make lint
 
 jobs:
   test-emacs-25:
     docker:
       - image: silex/emacs:25-dev
         entrypoint: bash
-    <<: *default-steps
+    steps:
+      - setup
+      - test
 
   test-emacs-26:
     docker:
       - image: silex/emacs:26-dev
         entrypoint: bash
-    <<: *default-steps
+    steps:
+      - setup
+      - test
 
   test-emacs-master:
     docker:
       - image: silex/emacs:master-dev
         entrypoint: bash
-    <<: *default-steps
+    steps:
+      - setup
+      - test
+
+  test-lint:
+    docker:
+      - image: silex/emacs:25-dev
+    steps:
+      - setup
+      - lint
 
 workflows:
   version: 2
@@ -36,3 +54,4 @@ workflows:
       - test-emacs-25
       - test-emacs-26
       - test-emacs-master
+      - test-lint

--- a/cider.el
+++ b/cider.el
@@ -711,7 +711,7 @@ Generally you should not disable this unless you run into some faulty check."
   :package-version '(cider . "0.18.0"))
 
 (defun cider--shadow-parse-builds (hash)
-  "Parses the build names of a shadow-cljs.edn hash map.
+  "Parses the build names of a shadow-cljs.edn HASH map.
 The default options of `browser-repl' and `node-repl' are also included."
   (let* ((builds (when (hash-table-p hash)
                    (gethash :builds hash)))

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -255,7 +255,7 @@
   (it "parses valid input"
     (expect (cider--shadow-parse-builds
              (parseedn-read-str "{:builds {:app {} :release {}}}"))
-            :to-equal '(:release :app browser-repl node-repl)))
+            :to-have-same-items-as '(:release :app browser-repl node-repl)))
   (it "returns default options on empty / invalid input"
     (expect (cider--shadow-parse-builds (parseedn-read-str "{}"))
             :to-equal '(browser-repl node-repl))


### PR DESCRIPTION
Fix some silly things. `HASH` wasn't capitalized in a doc string. Also had an issue with comparing hashkeys with buttercup. There's a predicate to compare as sets as when I ran the test locally it failed.

The bigger thing is the change to `.circleci/config.yml`. Changing this has two benefits
1) Linting is independent of testing. If there's a lint failure now, we have 3 failed builds. In the future, there will be a failing lint test and 3 passing (hopefully) test runs
2) We can run the tests locally as they would in circle.

I ran `circleci local execute --job test-lint` to see that the linting was resolved. I'm having an issue on linux where running the tests no longer finishes and eats quite a bit of ram so being able to run the tests locally in docker _exactly_ as how the CI runner will is quite nice.