### PR TITLE
Run lint tests in emacs 26

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,8 @@ jobs:
 
   test-lint:
     docker:
-      - image: silex/emacs:25-dev
+      - image: silex/emacs:26-dev
+      - entrypoint: bash
     steps:
       - setup
       - lint


### PR DESCRIPTION
I _think_ this clears up the lint tests. Perhaps indent-region got better with the emacs upgrade. Now to tackle the tests running on emacs master.