### PR TITLE
[Fix #2659] handle `#shadow/env` tag when getting shadow-cljs builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [#2607](https://github.com/clojure-emacs/cider/pull/2607): Use markers for specifying insertion point for `cider-eval-*-to-comment`commands. This fixes a bug where editing the buffer during a pending evaluation resulted in comments appearing in unintended locations.
 * [#2308](https://github.com/clojure-emacs/cider/issues/2308): Don't rely on the classpath in `cider-library-present-p`. Now it does a `require` instead to check if some library is present or not.
 * [#2541](https://github.com/clojure-emacs/cider/issues/2541): Hook properly CIDER's code completion machinery.
+* [#2659](https://github.com/clojure-emacs/cider/issues/2659): Handle `#shadow/env` reader tags in `cider--shadow-get-builds`.
 
 ## 0.21.0 (2019-02-19)
 

--- a/cider.el
+++ b/cider.el
@@ -725,7 +725,7 @@ The default options of `browser-repl' and `node-repl' are also included."
     (when (file-exists-p shadow-edn)
       (with-temp-buffer
         (insert-file-contents shadow-edn)
-        (let ((hash (car (parseedn-read))))
+        (let ((hash (car (parseedn-read '((shadow/env . identity))))))
           (cider--shadow-parse-builds hash))))))
 
 (defun cider-shadow-select-cljs-init-form ()


### PR DESCRIPTION
Since builds are unlikely to be set from env variables just pass the
`#shadow/env` tag values to `identity`, preventing things from crashing. 
An alternative could be to read the actual env value using `getenv`.
Perhaps that would be better even though setting a build from a env variable seems highly unlikely?

Had some trouble writing tests for this as `cider--shadow-get-builds` seems to be untested and I can't figure out how to mock the edn file.
Perhaps adding a test for this isn't worth the effort and that's the reason it currently is untested?

Let me know if anything needs an improvement.

-----------------
- [X] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`make test`)
- [X] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
