### PR TITLE
Remove lein from circle images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ commands:
   setup:
     steps:
       - checkout
-      - run: apt-get update && apt-get install make
       - run: make elpa
       - run: emacs --version
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ commands:
   setup:
     steps:
       - checkout
-      - run: apt-get update && apt-get install make leiningen=2.8.1-6 -y
+      - run: apt-get update && apt-get install make
       - run: make elpa
       - run: emacs --version
   test:

--- a/test/cider-connection-tests.el
+++ b/test/cider-connection-tests.el
@@ -348,6 +348,7 @@
           cider-default-cljs-repl 'node)
     (spy-on 'cider--gather-session-params
             :and-return-value '(:project-dir "/some/project" :host "localhost" :port 1234))
+    (spy-on 'cider-jack-in-resolve-command :and-return-value "lein")
     (spy-on 'nrepl-start-server-process
             :and-return-value nil)
     (spy-on 'sesman-current-sessions


### PR DESCRIPTION
part of jack in is to determine which build tool and to resolve the
command. when not present it signals an error. Lein is not actually
used in the test other than just being present on the path

