### PR TITLE
[Fix #2659] Fix tests on Emacs 25

### DIFF
--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -265,11 +265,10 @@
 (defmacro with-temp-shadow-config (contents &rest body)
   "Run BODY with a mocked shadow-cljs.edn project file with the CONTENTS."
   `(let* ((edn-file "shadow-cljs.edn")
-          (temp-dir (temporary-file-directory))
-          (file-path (concat temp-dir edn-file)))
+          (file-path (concat temporary-file-directory edn-file)))
      (with-temp-file file-path
        (insert ,contents))
-     (spy-on 'clojure-project-dir :and-return-value temp-dir)
+     (spy-on 'clojure-project-dir :and-return-value temporary-file-directory)
      ,@body
      (delete-file file-path)))
 


### PR DESCRIPTION
`temporary-file-directory` the function was introduced in Emacs 26 so
the tests failed on Emacs 25. Change to use `temporary-file-directory`
the variable instead as it's present in both versions.

-----------------

- [x] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)