### PR TITLE
`cider-repl-require-repl-utils` loads cljs repl utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * `spec-list` and `spec-form` requests send the current namespace for alias resolution.
 * `C-c , C-g` and `C-c C-t C-g` cancel the key chord instead of rerunning the last test. The respective command has been moved to `C-c , C-a`, `C-c , a`, `C-c C-t C-a` and `C-c C-t a`.
 * [#2643](https://github.com/clojure-emacs/cider/issues/2643): **(Breaking)** Stop using the `cider.tasks/nrepl-server` custom task for `cider-jack-in` with Boot.
+* [#2647](https://github.com/clojure-emacs/cider/issues/2647) `cider-repl-require-repl-utils` now loads cljs specific repl utils in cljs buffers.
 
 ### Bug fixes
 

--- a/test/cider-repl-tests.el
+++ b/test/cider-repl-tests.el
@@ -202,3 +202,17 @@ PROPERTY should be a symbol of either 'text, 'ansi-context or
     (expect (cider-locref-at-point)
             :to-equal
             '(:type compilation :highlight (2 . 132) :var nil :file "/path/to/a/file.clj" :line 575))))
+
+(describe "cider-repl-require-repl-utils"
+  (before-each
+    (spy-on 'cider-current-repl :and-return-value nil)
+    (spy-on 'nrepl--eval-request)
+    (spy-on 'nrepl-send-sync-request :and-return-value nil))
+  (it "requires clj utils in a clj buffer"
+    (spy-on 'cider-repl-type :and-return-value 'clj)
+    (cider-repl-require-repl-utils)
+    (expect 'nrepl--eval-request :to-have-been-called-with (cdr (assoc 'clj cider-repl-require-repl-utils-code))))
+  (it "requires cljs utils in a cljs buffer"
+    (spy-on 'cider-repl-type :and-return-value 'cljs)
+    (cider-repl-require-repl-utils)
+    (expect 'nrepl--eval-request :to-have-been-called-with (cdr (assoc 'cljs cider-repl-require-repl-utils-code)))))


### PR DESCRIPTION
Part of the solution for #2647, loading cljs repl utils in cljs buffers.

- [X] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [X] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`make test`)
- [X] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
