### PR TITLE
[Fix #2676] widen before cider--file-string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [#2308](https://github.com/clojure-emacs/cider/issues/2308): Don't rely on the classpath in `cider-library-present-p`. Now it does a `require` instead to check if some library is present or not.
 * [#2541](https://github.com/clojure-emacs/cider/issues/2541): Hook properly CIDER's code completion machinery.
 * [#2659](https://github.com/clojure-emacs/cider/issues/2659): Handle `#shadow/env` reader tags in `cider--shadow-get-builds`.
+* [#2676](https://github.com/clojure-emacs/cider/issues/2676): Widen before cider--file-string, to allow cider-load-buffer to work on narrowed buffers
 
 ## 0.21.0 (2019-02-19)
 

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -1068,7 +1068,9 @@ passing arguments."
 (defun cider--file-string (file)
   "Read the contents of a FILE and return as a string."
   (with-current-buffer (find-file-noselect file)
-    (substring-no-properties (buffer-string))))
+    (save-restriction
+      (widen)
+      (substring-no-properties (buffer-string)))))
 
 (defun cider-load-buffer (&optional buffer)
   "Load (eval) BUFFER's file in nREPL.


### PR DESCRIPTION
Wrap the (buffer-string) in cider--file-string in
a (save-restriction (widen)), so that if the current buffer is narrowed
by the user we still get the entire string during calls
to (cider-load-buffer)
-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`make test`)
- [X] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

