### PR TITLE
fix definition for cider-eval-pprint-commands-map and cider-eval-commands-map

### DIFF
--- a/cider-eval.el
+++ b/cider-eval.el
@@ -1033,7 +1033,8 @@ passing arguments."
     (define-key map (kbd "C-c e") #'cider-pprint-eval-last-sexp-to-comment)
     (define-key map (kbd "C-c C-e") #'cider-pprint-eval-last-sexp-to-comment)
     (define-key map (kbd "C-c d") #'cider-pprint-eval-defun-to-comment)
-    (define-key map (kbd "C-c C-d") #'cider-pprint-eval-defun-to-comment)))
+    (define-key map (kbd "C-c C-d") #'cider-pprint-eval-defun-to-comment)
+    map))
 
 (defvar cider-eval-commands-map
   (let ((map (define-prefix-command 'cider-eval-commands-map)))
@@ -1063,7 +1064,8 @@ passing arguments."
     (define-key map (kbd "C-z") #'cider-eval-defun-up-to-point)
     (define-key map (kbd "C-c") #'cider-eval-last-sexp-in-context)
     (define-key map (kbd "C-b") #'cider-eval-sexp-at-point-in-context)
-    (define-key map (kbd "C-f") 'cider-eval-pprint-commands-map)))
+    (define-key map (kbd "C-f") 'cider-eval-pprint-commands-map)
+    map))
 
 (defun cider--file-string (file)
   "Read the contents of a FILE and return as a string."


### PR DESCRIPTION
The variables ` cider-eval-pprint-commands-map` and `cider-eval-commands-map` where not assigned a key map but the value of the last `define-key`expression.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/en/latest/hacking_on_cider/
