### PR TITLE
[completion] Protect get-context function from errors

### DIFF
--- a/cider-completion.el
+++ b/cider-completion.el
@@ -132,7 +132,11 @@ form, with symbol at point replaced by __prefix__."
                           ;; `ending-of-defun' work incorrectly in the REPL
                           ;; buffer, so context extraction fails there.
                           (derived-mode-p 'clojure-mode))
-                     (or (cider-completion-get-context-at-point)
+                     ;; We use ignore-errors here since grabbing the context
+                     ;; might fail because of unbalanced parens, or other
+                     ;; technical reasons, yet we don't want to lose all
+                     ;; completions and throw error to user because of that.
+                     (or (ignore-errors (cider-completion-get-context-at-point))
                          "nil")
                    "nil")))
     (if (string= cider-completion-last-context context)


### PR DESCRIPTION
Mostly because of #2682, is also related to #2375.

This is useful in any case since it's better to provide fewer completions (because we couldn't obtain the context) than returning an error to the user and not showing any completions at all. Even if #2682 is somehow fixed, there could be other errors that we don't want to break on.