### PR TITLE
[Fix #2656] Base64 encode command when using PowerShell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#2656](https://github.com/clojure-emacs/cider/issues/2656): Base64 encode clojure command and arguments on jack-in when `cider-clojure-cli-command` is `"powershell"` to avoid escaping issues. If no `clojure` command is found on windows `cider-clojure-cli-command` defaults to `"powershell"`.
 * Allow editing of jack in command with prefix or when `cider-edit-jack-in-command` is truthy.
 * New defcustom `cider-repl-require-ns-on-set`: Set it to make cider require the namespace before setting it, when calling `cider-repl-set-ns`.
 * [#2611](https://github.com/clojure-emacs/cider/issues/2611): Add `eval`-based classpath lookup fallback. It's used when cider-nrepl is not present.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New features
 
-* [#2656](https://github.com/clojure-emacs/cider/issues/2656): Base64 encode clojure command and arguments on jack-in when `cider-clojure-cli-command` is `"powershell"` to avoid escaping issues. If no `clojure` command is found on windows `cider-clojure-cli-command` defaults to `"powershell"`.
+* [#2656](https://github.com/clojure-emacs/cider/issues/2656): Base64 encode clojure command and arguments on jack-in when `cider-clojure-cli-command` is `"powershell"` to avoid escaping issues. If no `clojure` command is found on Windows `cider-clojure-cli-command` defaults to `"powershell"`.
 * Allow editing of jack in command with prefix or when `cider-edit-jack-in-command` is truthy.
 * New defcustom `cider-repl-require-ns-on-set`: Set it to make cider require the namespace before setting it, when calling `cider-repl-set-ns`.
 * [#2611](https://github.com/clojure-emacs/cider/issues/2611): Add `eval`-based classpath lookup fallback. It's used when cider-nrepl is not present.

--- a/cider.el
+++ b/cider.el
@@ -139,7 +139,7 @@ version from the CIDER package or library.")
   :package-version '(cider . "0.9.0"))
 
 (defcustom cider-clojure-cli-command
-  (if (and (= system-type 'windows-nt)
+  (if (and (eq system-type 'windows-nt)
            (null (executable-find "clojure")))
       "powershell"
     "clojure")

--- a/cider.el
+++ b/cider.el
@@ -139,10 +139,14 @@ version from the CIDER package or library.")
   :package-version '(cider . "0.9.0"))
 
 (defcustom cider-clojure-cli-command
-  "clojure"
+  (if (and (= system-type 'windows-nt)
+           (null (executable-find "clojure")))
+      "powershell"
+    "clojure")
   "The command used to execute clojure with tools.deps (requires Clojure 1.9+).
-Don't use clj here, as it doesn't work when spawned from Emacs due to
-it using rlwrap."
+Don't use clj here, as it doesn't work when spawned from Emacs due to it
+using rlwrap.  If on Windows and no \"clojure\" executable is found we
+default to \"powershell\"."
   :type 'string
   :group 'cider
   :safe #'stringp
@@ -1184,6 +1188,13 @@ non-nil, don't start if ClojureScript requirements are not met."
   :safe #'booleanp
   :version '(cider . "0.22.0"))
 
+(defun cider--powershell-encode-command (cmd-params)
+  "Base64 encode the powershell command and jack-in CMD-PARAMS for clojure-cli."
+  (let* ((quoted-params (replace-regexp-in-string "\"" "\"\"" cmd-params))
+         (command (format "clojure %s" quoted-params))
+         (utf-16le-command (encode-coding-string command 'utf-16le)))
+    (format "-encodedCommand %s" (base64-encode-string utf-16le-command t))))
+
 (defun cider--update-jack-in-cmd (params)
   "Update :jack-in-cmd key in PARAMS."
   (let* ((params (cider--update-do-prompt params))
@@ -1209,7 +1220,9 @@ non-nil, don't start if ClojureScript requirements are not met."
                           (and (null project-dir)
                                (eq cider-allow-jack-in-without-project 'warn)
                                (y-or-n-p "Are you sure you want to run `cider-jack-in' without a Clojure project? ")))
-                  (let ((cmd (format "%s %s" command-resolved cmd-params)))
+                  (let ((cmd (format "%s %s" command-resolved (if (string-equal command "powershell")
+                                                                  (cider--powershell-encode-command cmd-params)
+                                                                cmd-params))))
                     (plist-put params :jack-in-cmd (if (or cider-edit-jack-in-command
                                                            (plist-get params :edit-jack-in-command))
                                                        (read-string "jack-in command: " cmd t)

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -122,6 +122,12 @@ these are passed to the command directly, in first position
 usually task names and their parameters (e.g., `dev` for launching
 boot's dev task instead of the standard `repl -s wait`).
 
+To use `cider-jack-in` with `tools.deps` on Windows set the
+`cider-clojure-cli-command` to `"powershell"`. This happens by default
+if you are on Windows and no `clojure` executable is found. Using
+`"powershell"` will Base64 encode the clojure launch command before
+passing it to PowerShell and avoids shell-escaping issues.
+
 == Connect to a Running nREPL Server
 
 If you have an nREPL server already running, CIDER can connect to


### PR DESCRIPTION
To avoid multiple layers of escaping when using tools.deps with
PowerShell, base64 encode the clojure command and arguments when
calling jack-in with `cider-clojure-cli-command` as `"powershell"`.

Initial stab at using PowerShell's encodedCommand to use tools.deps. On the plus side it works and you can connect using just PowerShell and tools.deps, downside is the launch command is ugly. eg:

```
[nREPL] Starting server via "c:/WINDOWS/System32/WindowsPowerShell/v1.0/powershell.exe" -encodedCommand YwBsAG8AagB1AHIAZQAgAC0AUwBkAGUAcABzACAAJwB7ADoAZABlAHAAcwAgAHsAbgByAGUAcABsACAAewA6AG0AdgBuAC8AdgBlAHIAcwBpAG8AbgAgACIAIgAwAC4ANgAuADAAIgAiAH0AIAByAGUAZgBhAGMAdABvAHIALQBuAHIAZQBwAGwAIAB7ADoAbQB2AG4ALwB2AGUAcgBzAGkAbwBuACAAIgAiADIALgA0AC4AMAAiACIAfQAgAGMAaQBkAGUAcgAvAGMAaQBkAGUAcgAtAG4AcgBlAHAAbAAgAHsAOgBtAHYAbgAvAHYAZQByAHMAaQBvAG4AIAAiACIAMAAuADIAMgAuADAALQBiAGUAdABhADgAIgAiAH0AfQB9ACcAIAAtAG0AIABuAHIAZQBwAGwALgBjAG0AZABsAGkAbgBlACAALQAtAG0AaQBkAGQAbABlAHcAYQByAGUAIAAnAFsAIgAiAHIAZQBmAGEAYwB0AG8AcgAtAG4AcgBlAHAAbAAuAG0AaQBkAGQAbABlAHcAYQByAGUALwB3AHIAYQBwAC0AcgBlAGYAYQBjAHQAbwByACIAIgAsACAAIgAiAGMAaQBkAGUAcgAuAG4AcgBlAHAAbAAvAGMAaQBkAGUAcgAtAG0AaQBkAGQAbABlAHcAYQByAGUAIgAiAF0AJwA=
```
``` elisp
(insert (decode-coding-string (base64-decode-string "YwBsAG8AagB1AHIAZQAgAC0AUwBkAGUAcABzACAAJwB7ADoAZABlAHAAcwAgAHsAbgByAGUAcABsACAAewA6AG0AdgBuAC8AdgBlAHIAcwBpAG8AbgAgACIAIgAwAC4ANgAuADAAIgAiAH0AIAByAGUAZgBhAGMAdABvAHIALQBuAHIAZQBwAGwAIAB7ADoAbQB2AG4ALwB2AGUAcgBzAGkAbwBuACAAIgAiADIALgA0AC4AMAAiACIAfQAgAGMAaQBkAGUAcgAvAGMAaQBkAGUAcgAtAG4AcgBlAHAAbAAgAHsAOgBtAHYAbgAvAHYAZQByAHMAaQBvAG4AIAAiACIAMAAuADIAMgAuADAALQBiAGUAdABhADgAIgAiAH0AfQB9ACcAIAAtAG0AIABuAHIAZQBwAGwALgBjAG0AZABsAGkAbgBlACAALQAtAG0AaQBkAGQAbABlAHcAYQByAGUAIAAnAFsAIgAiAHIAZQBmAGEAYwB0AG8AcgAtAG4AcgBlAHAAbAAuAG0AaQBkAGQAbABlAHcAYQByAGUALwB3AHIAYQBwAC0AcgBlAGYAYQBjAHQAbwByACIAIgAsACAAIgAiAGMAaQBkAGUAcgAuAG4AcgBlAHAAbAAvAGMAaQBkAGUAcgAtAG0AaQBkAGQAbABlAHcAYQByAGUAIgAiAF0AJwA=") 'utf-16le))
clojure -Sdeps '{:deps {nrepl {:mvn/version ""0.6.0""} refactor-nrepl {:mvn/version ""2.4.0""} cider/cider-nrepl {:mvn/version ""0.22.0-beta8""}}}' -m nrepl.cmdline --middleware '[""refactor-nrepl.middleware/wrap-refactor"", ""cider.nrepl/cider-middleware""]'nil
```

I can add tests and manual updates if it is decided this is the correct approach and they are necessary.