### PR TITLE
Observe `cider-use-tooltips` so it can prevent filling the echo area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Changes
 
+* `cider-use-tooltips` now also controls whether `help-echo` is used.
 * `cider-print-options` is now supported by the `pr` option for `cider-print-fn`. The options will now be also used by interactive eval commands that do not use pretty-printing.
 * `spec-list` and `spec-form` requests send the current namespace for alias resolution.
 * `C-c , C-g` and `C-c C-t C-g` cancel the key chord instead of rerunning the last test. The respective command has been moved to `C-c , C-a`, `C-c , a`, `C-c C-t C-a` and `C-c C-t a`.

--- a/cider-apropos.el
+++ b/cider-apropos.el
@@ -29,6 +29,7 @@
 (require 'cider-util)
 (require 'subr-x)
 (require 'cider-compat)
+(require 'cider-mode)
 
 (require 'cider-client)
 (require 'cider-popup)
@@ -96,10 +97,13 @@ and be case-sensitive (based on CASE-SENSITIVE-P)."
   "Emit a RESULT matching QUERY into current buffer, formatted for DOCS-P."
   (nrepl-dbind-response result (name type doc)
     (let* ((label (capitalize (if (string= type "variable") "var" type)))
-           (help (concat "Display doc for this " (downcase label))))
-      (cider-propertize-region (list 'apropos-symbol name
-                                     'action 'cider-apropos-doc
-                                     'help-echo help)
+           (help (concat "Display doc for this " (downcase label)))
+           (props (list 'apropos-symbol name
+                        'action 'cider-apropos-doc))
+           (props (if cider-use-tooltips
+                      (append props (list 'help-echo help))
+                    props)))
+      (cider-propertize-region props
         (insert-text-button name 'type 'apropos-symbol)
         (insert "\n  ")
         (insert-text-button label 'type (intern (concat "apropos-" type)))

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -969,7 +969,7 @@ SYM and INFO is passed to `cider-docview-render'"
      (buffer-substring-no-properties (point-min) (1- (point))))))
 
 (defcustom cider-use-tooltips t
-  "If non-nil, CIDER displays mouse-over tooltips."
+  "If non-nil, CIDER displays mouse-over tooltips, as well as the `help-echo' mechanism."
   :group 'cider
   :type 'boolean
   :package-version '(cider "0.12.0"))
@@ -1011,7 +1011,8 @@ property."
   (lambda (beg end &rest rest)
     (with-silent-modifications
       (remove-text-properties beg end '(cider-locals nil cider-block-dynamic-font-lock nil))
-      (add-text-properties beg end '(help-echo cider--help-echo))
+      (when cider-use-tooltips
+        (add-text-properties beg end '(help-echo cider--help-echo)))
       (when cider-font-lock-dynamically
         (cider--update-locals-for-region beg end)))
     (apply func beg end rest)))


### PR DESCRIPTION
Fixes clojure-emacs/cider#2472 using the agreed strategy.

I have tested out the changes in my day-to-day Emacs usage, and they work fine.

- [x] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
