### PR TITLE
Optionally specify callback to cider load buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 * `C-c , C-g` and `C-c C-t C-g` cancel the key chord instead of rerunning the last test. The respective command has been moved to `C-c , C-a`, `C-c , a`, `C-c C-t C-a` and `C-c C-t a`.
 * [#2643](https://github.com/clojure-emacs/cider/issues/2643): **(Breaking)** Stop using the `cider.tasks/nrepl-server` custom task for `cider-jack-in` with Boot.
 * [#2647](https://github.com/clojure-emacs/cider/issues/2647) `cider-repl-require-repl-utils` now loads cljs specific repl utils in cljs buffers.
+* [#2689](https://github.com/clojure-emacs/cider/issues/2689) `cider-load-buffer` now takes an optional `callback` that will override the default `cider-load-file-handler`.
+* [#2689](https://github.com/clojure-emacs/cider/issues/2689) `cider-load-file-handler` now takes an optional `done-handler` lambda that is run once load is complete.
 
 ### Bug fixes
 

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -1079,7 +1079,7 @@ passing arguments."
       (widen)
       (substring-no-properties (buffer-string)))))
 
-(defun cider-load-buffer (&optional buffer)
+(defun cider-load-buffer (&optional buffer callback)
   "Load (eval) BUFFER's file in nREPL.
 If no buffer is provided the command acts on the current buffer.  If the
 buffer is for a cljc file, and both a Clojure and ClojureScript REPL exists
@@ -1114,7 +1114,8 @@ for the project, it is evaluated in both REPLs."
                                        (funcall cider-to-nrepl-filename-function
                                                 (cider--server-filename filename))
                                        (file-name-nondirectory filename)
-                                       repl)))
+                                       repl
+                                       callback)))
           (message "Loading %s..." filename))))))
 
 (defun cider-load-file (filename)

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -491,7 +491,7 @@ or it can be a list with (START END) of the evaluated region."
                                    (cider-handle-compilation-errors err eval-buffer))
                                  '())))
 
-(defun cider-load-file-handler (&optional buffer)
+(defun cider-load-file-handler (&optional buffer done-handler)
   "Make a load file handler for BUFFER."
   (let ((eval-buffer (current-buffer)))
     (nrepl-make-response-handler (or buffer eval-buffer)
@@ -506,7 +506,7 @@ or it can be a list with (START END) of the evaluated region."
                                  (lambda (_buffer err)
                                    (cider-emit-interactive-eval-err-output err)
                                    (cider-handle-compilation-errors err eval-buffer))
-                                 '()
+                                 (or done-handler '())
                                  (lambda ()
                                    (funcall nrepl-err-handler)))))
 

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -492,7 +492,8 @@ or it can be a list with (START END) of the evaluated region."
                                  '())))
 
 (defun cider-load-file-handler (&optional buffer done-handler)
-  "Make a load file handler for BUFFER."
+  "Make a load file handler for BUFFER.
+Optional argument DONE-HANDLER lambda will be run once load is complete."
   (let ((eval-buffer (current-buffer)))
     (nrepl-make-response-handler (or buffer eval-buffer)
                                  (lambda (buffer value)
@@ -1083,7 +1084,8 @@ passing arguments."
   "Load (eval) BUFFER's file in nREPL.
 If no buffer is provided the command acts on the current buffer.  If the
 buffer is for a cljc file, and both a Clojure and ClojureScript REPL exists
-for the project, it is evaluated in both REPLs."
+for the project, it is evaluated in both REPLs.
+Optional argument CALLBACK will override the default ‘cider-load-file-handler’."
   (interactive)
   (setq buffer (or buffer (current-buffer)))
   ;; When cider-load-buffer or cider-load-file are called in programs the


### PR DESCRIPTION
- `cider-load-buffer` (normally bound to C-c C-k) does not pass a callback to `cider-request:load-file`. With this change, a user can now optionally specify this callback. 

- when no callback is passed to `cider-request:load-file`, it will fall back on `cider-load-file-handler`, which does not specify a done-handler. With this change, a user can now optionally specify a done-handler.

These two changes together would allow users to perform some task after loading the current buffer, by doing something like this:

```elisp
(cider-load-buffer nil (cider-load-file-handler nil (lambda (&rest _) (message "I'm done!"))))
```

In my case that would be running tests.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [-] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [-] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [-] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/en/latest/hacking_on_cider/
