### PR TITLE
[Fix #2656] Base64 encode command when using PowerShell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#2656](https://github.com/clojure-emacs/cider/issues/2656): Base64 encode clojure command and arguments on jack-in when `cider-clojure-cli-command` is `"powershell"` to avoid escaping issues. If no `clojure` command is found on Windows `cider-clojure-cli-command` defaults to `"powershell"`.
 * Allow editing of jack in command with prefix or when `cider-edit-jack-in-command` is truthy.
 * New defcustom `cider-repl-require-ns-on-set`: Set it to make cider require the namespace before setting it, when calling `cider-repl-set-ns`.
 * [#2611](https://github.com/clojure-emacs/cider/issues/2611): Add `eval`-based classpath lookup fallback. It's used when cider-nrepl is not present.

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -122,6 +122,12 @@ these are passed to the command directly, in first position
 usually task names and their parameters (e.g., `dev` for launching
 boot's dev task instead of the standard `repl -s wait`).
 
+To use `cider-jack-in` with `tools.deps` on Windows set the
+`cider-clojure-cli-command` to `"powershell"`. This happens by default
+if you are on Windows and no `clojure` executable is found. Using
+`"powershell"` will Base64 encode the clojure launch command before
+passing it to PowerShell and avoids shell-escaping issues.
+
 == Connect to a Running nREPL Server
 
 If you have an nREPL server already running, CIDER can connect to


### PR DESCRIPTION
To avoid multiple layers of escaping when using tools.deps with
PowerShell, base64 encode the clojure command and arguments when
calling jack-in with `cider-clojure-cli-command` as `"powershell"`.

If no clojure command is found on a Windows system use "powershell"
for `cider-clojure-cli-command` by default.

Adds `cider--powershell-encode-command` function to `cider.el` which produces a launch command when the project type is `clojure-cli` and the `cider-clojure-cli-command` is `powershell` like the following:

```
[nREPL] Starting server via "c:/WINDOWS/System32/WindowsPowerShell/v1.0/powershell.exe" -encodedCommand YwBsAG8AagB1AHIAZQAgAC0AUwBkAGUAcABzACAAJwB7ADoAZABlAHAAcwAgAHsAbgByAGUAcABsACAAewA6AG0AdgBuAC8AdgBlAHIAcwBpAG8AbgAgACIAIgAwAC4ANgAuADAAIgAiAH0AIAByAGUAZgBhAGMAdABvAHIALQBuAHIAZQBwAGwAIAB7ADoAbQB2AG4ALwB2AGUAcgBzAGkAbwBuACAAIgAiADIALgA0AC4AMAAiACIAfQAgAGMAaQBkAGUAcgAvAGMAaQBkAGUAcgAtAG4AcgBlAHAAbAAgAHsAOgBtAHYAbgAvAHYAZQByAHMAaQBvAG4AIAAiACIAMAAuADIAMgAuADAALQBiAGUAdABhADgAIgAiAH0AfQB9ACcAIAAtAG0AIABuAHIAZQBwAGwALgBjAG0AZABsAGkAbgBlACAALQAtAG0AaQBkAGQAbABlAHcAYQByAGUAIAAnAFsAIgAiAHIAZQBmAGEAYwB0AG8AcgAtAG4AcgBlAHAAbAAuAG0AaQBkAGQAbABlAHcAYQByAGUALwB3AHIAYQBwAC0AcgBlAGYAYQBjAHQAbwByACIAIgAsACAAIgAiAGMAaQBkAGUAcgAuAG4AcgBlAHAAbAAvAGMAaQBkAGUAcgAtAG0AaQBkAGQAbABlAHcAYQByAGUAIgAiAF0AJwA=
```

```elisp
(insert (decode-coding-string (base64-decode-string "YwBsAG8AagB1AHIAZQAgAC0AUwBkAGUAcABzACAAJwB7ADoAZABlAHAAcwAgAHsAbgByAGUAcABsACAAewA6AG0AdgBuAC8AdgBlAHIAcwBpAG8AbgAgACIAIgAwAC4ANgAuADAAIgAiAH0AIAByAGUAZgBhAGMAdABvAHIALQBuAHIAZQBwAGwAIAB7ADoAbQB2AG4ALwB2AGUAcgBzAGkAbwBuACAAIgAiADIALgA0AC4AMAAiACIAfQAgAGMAaQBkAGUAcgAvAGMAaQBkAGUAcgAtAG4AcgBlAHAAbAAgAHsAOgBtAHYAbgAvAHYAZQByAHMAaQBvAG4AIAAiACIAMAAuADIAMgAuADAALQBiAGUAdABhADkAIgAiAH0AfQB9ACcAIAAtAG0AIABuAHIAZQBwAGwALgBjAG0AZABsAGkAbgBlACAALQAtAG0AaQBkAGQAbABlAHcAYQByAGUAIAAnAFsAIgAiAHIAZQBmAGEAYwB0AG8AcgAtAG4AcgBlAHAAbAAuAG0AaQBkAGQAbABlAHcAYQByAGUALwB3AHIAYQBwAC0AcgBlAGYAYQBjAHQAbwByACIAIgAsACAAIgAiAGMAaQBkAGUAcgAuAG4AcgBlAHAAbAAvAGMAaQBkAGUAcgAtAG0AaQBkAGQAbABlAHcAYQByAGUAIgAiAF0AJwA=") 'utf-16le))
clojure -Sdeps '{:deps {nrepl {:mvn/version ""0.6.0""} refactor-nrepl {:mvn/version ""2.4.0""} cider/cider-nrepl {:mvn/version ""0.22.0-beta9""}}}' -m nrepl.cmdline --middleware '[""refactor-nrepl.middleware/wrap-refactor"", ""cider.nrepl/cider-middleware""]'nil
```


-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [X] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`make test`)
- [X] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [X] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
