### PR TITLE
Fix two typos in misc_features.adoc

### DIFF
--- a/doc/modules/ROOT/pages/usage/misc_features.adoc
+++ b/doc/modules/ROOT/pages/usage/misc_features.adoc
@@ -47,11 +47,11 @@ Typing kbd:[C-c M-n r] or kbd:[C-c M-n M-r] will invoke
 `cider-ns-refresh` and reload all modified Clojure files on the
 classpath.
 
-Adding a prefix argument, kbd:[C-u C-c M-n n], will reload all
+Adding a prefix argument, kbd:[C-u C-c M-n r], will reload all
 the namespaces on the classpath unconditionally, regardless of their
 modification status.
 
-Adding a double prefix argument, kbd:[C-u C-u M-n n], will first
+Adding a double prefix argument, kbd:[C-u C-u M-n r], will first
 clear the state of the namespace tracker before reloading. This is
 useful for recovering from some classes of error that normal reloads
 would otherwise not recover from. A good example is circular


### PR DESCRIPTION
Typos in the keybindings for the prefix and double-prefix arguments to `cider-ns-refresh`
