### PR TITLE
Fix docstring for cider-mode-menu

### DIFF
--- a/cider-mode.el
+++ b/cider-mode.el
@@ -330,8 +330,8 @@ If invoked with a prefix ARG eval the expression after inserting it."
      :active (seq-remove #'null cider-ancillary-buffers)]
     ("nREPL" :active (cider-connected-p)
      ["Describe nrepl session" cider-describe-nrepl-session]
-     ["Toggle message logging" nrepl-toggle-message-logging])
-    "Menu for CIDER mode."))
+     ["Toggle message logging" nrepl-toggle-message-logging]))
+  "Menu for CIDER mode.")
 
 (defconst cider-mode-eval-menu
   '("CIDER Eval" :visible (cider-connected-p)


### PR DESCRIPTION
Currently, at least on macOS, the text "Menu for CIDER mode." appears as the final item under the "CIDER" menu, with no effect when clicked.  I believe this string was meant to be the docstring for `cider-mode-menu`, and this commit makes it so.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)