### PR TITLE
Ignore patch coordinates during middleware check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 * [#2659](https://github.com/clojure-emacs/cider/issues/2659): Handle `#shadow/env` reader tags in `cider--shadow-get-builds`.
 * [#2676](https://github.com/clojure-emacs/cider/issues/2676): Widen before `cider--file-string`, to allow `cider-load-buffer` to work on narrowed buffers.
 * Don't disable `cider-mode` until all CIDER sessions have been closed.
-* [#2705](https://github.com/clojure-emacs/cider/issues/2705): Only major and minor version coordinates are compared for middleware check.
+* [#2705](https://github.com/clojure-emacs/cider/issues/2705): Only major and minor version coordinates are compared for middleware check. Except in the case when the required-middleware-version is a pre-release. In that case strict version checking is enabled.
 
 ## 0.21.0 (2019-02-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Add a command to find runtime function dependencies (`cider-xref-fn-deps`).
 * Add a menu to the inspector.
 * Add completion of shadow-cljs build names in the minibuffer when connecting or jacking in.
+* [#2705](https://github.com/clojure-emacs/cider/issues/2705): Only major and minor version coordinates are compared for middleware check.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 * [#2659](https://github.com/clojure-emacs/cider/issues/2659): Handle `#shadow/env` reader tags in `cider--shadow-get-builds`.
 * [#2676](https://github.com/clojure-emacs/cider/issues/2676): Widen before `cider--file-string`, to allow `cider-load-buffer` to work on narrowed buffers.
 * Don't disable `cider-mode` until all CIDER sessions have been closed.
-* [#2705](https://github.com/clojure-emacs/cider/issues/2705): Only major and minor version coordinates are compared for middleware check. Except in the case when the required-middleware-version is a pre-release. In that case strict version checking is enabled.
+* [#2705](https://github.com/clojure-emacs/cider/issues/2705): Middleware version check looks at only at the minor version for comparison (when the major version is 0) and ensures a matching major and a minor >= required otherwise.
 
 ## 0.21.0 (2019-02-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@
 * Add a command to find runtime function dependencies (`cider-xref-fn-deps`).
 * Add a menu to the inspector.
 * Add completion of shadow-cljs build names in the minibuffer when connecting or jacking in.
-* [#2705](https://github.com/clojure-emacs/cider/issues/2705): Only major and minor version coordinates are compared for middleware check.
 
 ### Changes
 
@@ -40,6 +39,7 @@
 * [#2659](https://github.com/clojure-emacs/cider/issues/2659): Handle `#shadow/env` reader tags in `cider--shadow-get-builds`.
 * [#2676](https://github.com/clojure-emacs/cider/issues/2676): Widen before `cider--file-string`, to allow `cider-load-buffer` to work on narrowed buffers.
 * Don't disable `cider-mode` until all CIDER sessions have been closed.
+* [#2705](https://github.com/clojure-emacs/cider/issues/2705): Only major and minor version coordinates are compared for middleware check.
 
 ## 0.21.0 (2019-02-19)
 

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -210,6 +210,10 @@ FORMAT is a format string to compile with ARGS and display on the REPL."
                                "Can't determine Clojure's version. CIDER requires Clojure %s (or newer)."
                                cider-minimum-clojure-version)))
 
+(defun cider--strip-version-patch (v)
+  "Strips everything but major.minor from the version, returning a version list."
+  (seq-take (version-to-list v) 2))
+
 (defvar cider-required-middleware-version)
 (defun cider--check-middleware-compatibility ()
   "CIDER frontend/backend compatibility check.
@@ -222,7 +226,8 @@ message in the REPL area."
      ((null middleware-version)
       (cider-emit-manual-warning "troubleshooting.html#_cider_complains_of_the_cider_nrepl_version"
                                  "CIDER requires cider-nrepl to be fully functional. Some features will not be available without it!"))
-     ((not (string= middleware-version cider-required-middleware-version))
+     ((not (version-list-= (cider--strip-version-patch middleware-version)
+                          (cider--strip-version-patch cider-required-middleware-version)))
       (cider-emit-manual-warning "troubleshooting.html#_cider_complains_of_the_cider_nrepl_version"
                                  "CIDER %s requires cider-nrepl %s, but you're currently using cider-nrepl %s. The version mismatch might break some functionality!"
                                  cider-version cider-required-middleware-version middleware-version)))))

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -215,7 +215,7 @@ FORMAT is a format string to compile with ARGS and display on the REPL."
 V is the version string to strip the patch from."
   (seq-take (version-to-list v) 2))
 
-(defun cider--acceptable-middleware-version-p (required-ver ver)
+(defun cider--compatible-middleware-version-p (required-ver ver)
   "Checks that the available middleware version is compatible with the required.
 We look only at the major and minor components.  When the major
 version is 0, only check that the minor versions match.  When the major version
@@ -243,7 +243,7 @@ message in the REPL area."
      ((null middleware-version)
       (cider-emit-manual-warning "troubleshooting.html#_cider_complains_of_the_cider_nrepl_version"
                                  "CIDER requires cider-nrepl to be fully functional. Some features will not be available without it!"))
-     ((not (cider--acceptable-middleware-version-p cider-required-middleware-version middleware-version))
+     ((not (cider--compatible-middleware-version-p cider-required-middleware-version middleware-version))
       (cider-emit-manual-warning "troubleshooting.html#_cider_complains_of_the_cider_nrepl_version"
                                  "CIDER %s requires cider-nrepl %s, but you're currently using cider-nrepl %s. The version mismatch might break some functionality!"
                                  cider-version cider-required-middleware-version middleware-version)))))

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -215,6 +215,11 @@ FORMAT is a format string to compile with ARGS and display on the REPL."
 V is the version string to strip the patch from."
   (seq-take (version-to-list v) 2))
 
+(defun cider--version-pre-release-p (v)
+  "Checks to see if the passed in version has a pre-release component.
+V the version string to check."
+  (seq-filter (lambda (x) (< x 0)) (version-to-list v)))
+
 (defvar cider-required-middleware-version)
 (defun cider--check-middleware-compatibility ()
   "CIDER frontend/backend compatibility check.
@@ -227,6 +232,11 @@ message in the REPL area."
      ((null middleware-version)
       (cider-emit-manual-warning "troubleshooting.html#_cider_complains_of_the_cider_nrepl_version"
                                  "CIDER requires cider-nrepl to be fully functional. Some features will not be available without it!"))
+     ((cider--version-pre-release-p cider-required-middleware-version)
+      (when (not (version= middleware-version cider-required-middleware-version))
+        (cider-emit-manual-warning "troubleshooting.html#_cider_complains_of_the_cider_nrepl_version"
+                                   "CIDER %s requires cider-nrepl %s, but you're currently using cider-nrepl %s. The version mismatch will likely break some functionality!"
+                                 cider-version cider-required-middleware-version middleware-version)))
      ((not (version-list-= (cider--strip-version-patch middleware-version)
                            (cider--strip-version-patch cider-required-middleware-version)))
       (cider-emit-manual-warning "troubleshooting.html#_cider_complains_of_the_cider_nrepl_version"

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -215,10 +215,21 @@ FORMAT is a format string to compile with ARGS and display on the REPL."
 V is the version string to strip the patch from."
   (seq-take (version-to-list v) 2))
 
-(defun cider--version-pre-release-p (v)
-  "Checks to see if the passed in version has a pre-release component.
-V the version string to check."
-  (seq-filter (lambda (x) (< x 0)) (version-to-list v)))
+(defun cider--acceptable-middleware-version-p (required-ver ver)
+  "Checks that the available middleware version is compatible with the required.
+We look only at the major and minor components.  When the major
+version is 0, only check that the minor versions match.  When the major version
+is > 0, first check that the major version matches, then that the minor
+version is >= the required minor version.
+VER the 'installed' version,
+REQUIRED-VER the version required by cider."
+  (let ((ver* (cider--strip-version-patch ver))
+        (required-ver* (cider--strip-version-patch required-ver)))
+    (cond ((= 0 (car required-ver*))  (= (cadr required-ver*)
+                                         (cadr ver*)))
+          (t (and (= (car required-ver*)
+                     (car ver*))
+                  (version-list-<= required-ver* ver*))))))
 
 (defvar cider-required-middleware-version)
 (defun cider--check-middleware-compatibility ()
@@ -232,13 +243,7 @@ message in the REPL area."
      ((null middleware-version)
       (cider-emit-manual-warning "troubleshooting.html#_cider_complains_of_the_cider_nrepl_version"
                                  "CIDER requires cider-nrepl to be fully functional. Some features will not be available without it!"))
-     ((cider--version-pre-release-p cider-required-middleware-version)
-      (when (not (version= middleware-version cider-required-middleware-version))
-        (cider-emit-manual-warning "troubleshooting.html#_cider_complains_of_the_cider_nrepl_version"
-                                   "CIDER %s requires cider-nrepl %s, but you're currently using cider-nrepl %s. The version mismatch will likely break some functionality!"
-                                 cider-version cider-required-middleware-version middleware-version)))
-     ((not (version-list-= (cider--strip-version-patch middleware-version)
-                           (cider--strip-version-patch cider-required-middleware-version)))
+     ((not (cider--acceptable-middleware-version-p cider-required-middleware-version middleware-version))
       (cider-emit-manual-warning "troubleshooting.html#_cider_complains_of_the_cider_nrepl_version"
                                  "CIDER %s requires cider-nrepl %s, but you're currently using cider-nrepl %s. The version mismatch might break some functionality!"
                                  cider-version cider-required-middleware-version middleware-version)))))

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -211,7 +211,8 @@ FORMAT is a format string to compile with ARGS and display on the REPL."
                                cider-minimum-clojure-version)))
 
 (defun cider--strip-version-patch (v)
-  "Strips everything but major.minor from the version, returning a version list."
+  "Strips everything but major.minor from the version, returning a version list.
+V is the version string to strip the patch from."
   (seq-take (version-to-list v) 2))
 
 (defvar cider-required-middleware-version)
@@ -227,7 +228,7 @@ message in the REPL area."
       (cider-emit-manual-warning "troubleshooting.html#_cider_complains_of_the_cider_nrepl_version"
                                  "CIDER requires cider-nrepl to be fully functional. Some features will not be available without it!"))
      ((not (version-list-= (cider--strip-version-patch middleware-version)
-                          (cider--strip-version-patch cider-required-middleware-version)))
+                           (cider--strip-version-patch cider-required-middleware-version)))
       (cider-emit-manual-warning "troubleshooting.html#_cider_complains_of_the_cider_nrepl_version"
                                  "CIDER %s requires cider-nrepl %s, but you're currently using cider-nrepl %s. The version mismatch might break some functionality!"
                                  cider-version cider-required-middleware-version middleware-version)))))

--- a/test/cider-connection-tests.el
+++ b/test/cider-connection-tests.el
@@ -363,19 +363,19 @@
   (it "detects existing project"
     (expect 'y-or-n-p :to-have-been-called-times 3)))
 
-(describe "cider-acceptable-middleware-version-p"
+(describe "cider-compatible-middleware-version-p"
   (describe "correctly check compatible required and middleware versions"
-    (expect (cider--acceptable-middleware-version-p "0.24" "0.24")
+    (expect (cider--compatible-middleware-version-p "0.24.0" "0.24.1")
             :to-be t)
-    (expect (cider--acceptable-middleware-version-p "0.24" "0.23")
+    (expect (cider--compatible-middleware-version-p "0.24.1" "0.23.2")
             :to-be nil)
-    (expect (cider--acceptable-middleware-version-p "0.24" "0.24-alpha2")
+    (expect (cider--compatible-middleware-version-p "0.24.1" "0.24.1-alpha2")
             :to-be t)
-    (expect (cider--acceptable-middleware-version-p "1.24" "0.24-alpha2")
+    (expect (cider--compatible-middleware-version-p "1.24.1" "0.24.1-alpha2")
             :to-be nil)
-    (expect (cider--acceptable-middleware-version-p "1.24" "1.24-alpha2")
+    (expect (cider--compatible-middleware-version-p "1.24.1" "1.24.1-alpha2")
             :to-be t)
-    (expect (cider--acceptable-middleware-version-p "1.24.3" "1.25.2-alpha2")
+    (expect (cider--compatible-middleware-version-p "1.24.3" "1.25.2-alpha2")
             :to-be t)
-    (expect (cider--acceptable-middleware-version-p "1.25.3" "1.25.2-alpha2")
+    (expect (cider--compatible-middleware-version-p "1.25.3" "1.25.2-alpha2")
             :to-be t)))

--- a/test/cider-connection-tests.el
+++ b/test/cider-connection-tests.el
@@ -362,3 +362,20 @@
     (cider-jack-in-clj&cljs '(:project-dir "/some/other/project")))
   (it "detects existing project"
     (expect 'y-or-n-p :to-have-been-called-times 3)))
+
+(describe "cider-acceptable-middleware-version-p"
+  (describe "correctly check compatible required and middleware versions"
+    (expect (cider--acceptable-middleware-version-p "0.24" "0.24")
+            :to-be t)
+    (expect (cider--acceptable-middleware-version-p "0.24" "0.23")
+            :to-be nil)
+    (expect (cider--acceptable-middleware-version-p "0.24" "0.24-alpha2")
+            :to-be t)
+    (expect (cider--acceptable-middleware-version-p "1.24" "0.24-alpha2")
+            :to-be nil)
+    (expect (cider--acceptable-middleware-version-p "1.24" "1.24-alpha2")
+            :to-be t)
+    (expect (cider--acceptable-middleware-version-p "1.24.3" "1.25.2-alpha2")
+            :to-be t)
+    (expect (cider--acceptable-middleware-version-p "1.25.3" "1.25.2-alpha2")
+            :to-be t)))


### PR DESCRIPTION
Only compare major and minor version numbers during the required middleware version check.
Fixes: https://github.com/clojure-emacs/cider/issues/2705
-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s) (didn't seem necessary as there are no existing tests around the version check
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
