### PR TITLE
Display evaluation result overlays at end of sexp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+### New features
+* New configuration variable `cider-result-overlay-position` determining where debugger and inline eval result overlays should be displayed. Current options are 'at-eol and 'at-point.
+
 ### Changes
 
 * `cider-selector` has more robust handling for edge cases.

--- a/doc/modules/ROOT/pages/config/misc.adoc
+++ b/doc/modules/ROOT/pages/config/misc.adoc
@@ -21,6 +21,17 @@ bottom) with the `cider-use-overlays` variable.
 (setq cider-use-overlays nil)
 ----
 
+By default, result overlays are displayed at the end of the line. You can set
+the variable `cider-result-overlay-position` to display results at the end of
+their respective forms instead.
+Note that this also affects the position of debugger overlays.
+
+[source,lisp]
+----
+(setq cider-result-overlay-position 'at-point)
+----
+
+
 == Minibuffer completion
 
 Out-of-the box CIDER uses the standard `completing-read` Emacs mechanism. While


### PR DESCRIPTION
Rename argument from point -> where to match cider--make-result-overlay and
update docstring
-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
