### PR TITLE
Expired elpa key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ commands:
   setup:
     steps:
       - checkout
+      - run: make elpa-key
       - run: make elpa
       - run: emacs --version
   test:

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ elpa-key:
 	  exit 1 ; \
 	)
 	-mkdir -p $(shell $(CASK) package-directory)
-	rsync -azSH $(HOME)/.emacs.d/elpa/gnupg $(shell $(CASK) package-directory)
+	cp -pr $(HOME)/.emacs.d/elpa/gnupg $(shell $(CASK) package-directory)
 
 elpa-$(EMACS):
 	$(CASK) install

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ elpa-key:
 	-mkdir -p $(HOME)/.emacs.d/elpa/gnupg
 	chmod 700 $(HOME)/.emacs.d/elpa/gnupg
 	( for i in 1 2 3 ; do \
-	    gpg --keyserver hkp://pool.sks-keyservers.net --homedir $(HOME)/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40 ; \
+	    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir $(HOME)/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40 ; \
 	    if gpg -q --homedir $(HOME)/.emacs.d/elpa/gnupg -k | grep 81E42C40 ; then \
 	      exit 0 ; \
 	    fi ; \

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,22 @@ all: build
 
 -include .depend
 
+.PHONY: elpa-key
+elpa-key:
+	-mkdir -p $(HOME)/.emacs.d/elpa/gnupg
+	chmod 700 $(HOME)/.emacs.d/elpa/gnupg
+	( for i in 1 2 3 ; do \
+	    gpg --keyserver hkp://pool.sks-keyservers.net --homedir $(HOME)/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40 ; \
+	    if gpg -q --homedir $(HOME)/.emacs.d/elpa/gnupg -k | grep 81E42C40 ; then \
+	      exit 0 ; \
+	    fi ; \
+	    sleep 5 ; \
+	  done ; \
+	  exit 1 ; \
+	)
+	-mkdir -p $(shell $(CASK) package-directory)
+	rsync -azSH $(HOME)/.emacs.d/elpa/gnupg $(shell $(CASK) package-directory)
+
 elpa-$(EMACS):
 	$(CASK) install
 	$(CASK) update


### PR DESCRIPTION
The elpa key expiration has wrought havoc among elisp repos that actually conduct proper testing, proving yet again that no good deed goes unpunished.

The silex images should pre-bake the new key into the various images.  Until then, this.