### PR TITLE
Fix tests for figwheel-main init form

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -764,9 +764,10 @@ Figwheel for details."
 
 (defun cider--figwheel-main-get-builds ()
   "Extract build names from the <build-id>.cljs.edn config files in the project root."
-  (let ((builds (directory-files (clojure-project-dir) nil ".*\\.cljs\\.edn")))
-    (mapcar (lambda (f) (string-match "^\\(.*\\)\\.cljs\\.edn" f)
-              (match-string 1 f)) builds)))
+  (when-let ((project-dir (clojure-project-dir)))
+    (let ((builds (directory-files project-dir nil ".*\\.cljs\\.edn")))
+      (mapcar (lambda (f) (string-match "^\\(.*\\)\\.cljs\\.edn" f)
+                (match-string 1 f)) builds))))
 
 (defun cider-figwheel-main-init-form ()
   "Produce the figwheel-main ClojureScript init form."

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -38,13 +38,13 @@
   ;; whitespace checks sprinkled amongst other tests
   (describe "from options"
     (it "leaves keywords alone"
-      (let ((cider-figwheel-main-default-options ":dev "))
+      (let ((cider-figwheel-main-default-options ":dev"))
         (expect (cider-figwheel-main-init-form) :to-equal "(do (require 'figwheel.main) (figwheel.main/start :dev))")))
     (it "leaves maps alone"
-      (let ((cider-figwheel-main-default-options " {:a 1 :b 2}"))
+      (let ((cider-figwheel-main-default-options "{:a 1 :b 2}"))
         (expect (cider-figwheel-main-init-form) :to-equal "(do (require 'figwheel.main) (figwheel.main/start {:a 1 :b 2}))")))
     (it "leaves s-exprs alone"
-      (let ((cider-figwheel-main-default-options " (hashmap :a 1 :b 2)"))
+      (let ((cider-figwheel-main-default-options "(hashmap :a 1 :b 2)"))
         (expect (cider-figwheel-main-init-form) :to-equal "(do (require 'figwheel.main) (figwheel.main/start (hashmap :a 1 :b 2)))")))
     (it "prepends colon to plain names"
       (let ((cider-figwheel-main-default-options " dev"))
@@ -55,16 +55,20 @@
       ;; not necessary as of this writing, but it can't hurt
       (setq-local cider-figwheel-main-default-options nil))
     (it "leaves keywords alone"
-      (spy-on 'completing-read :and-return-value " :prod ")
+      (spy-on 'completing-read :and-return-value ":prod")
+      (spy-on 'cider--figwheel-main-get-builds :and-return-value '("dev" "prod"))
       (expect (cider-figwheel-main-init-form) :to-equal "(do (require 'figwheel.main) (figwheel.main/start :prod))"))
     (it "leaves maps alone"
-      (spy-on 'completing-read :and-return-value " {:c 3 :d 4}")
+      (spy-on 'completing-read :and-return-value "{:c 3 :d 4}")
+      (spy-on 'cider--figwheel-main-get-builds :and-return-value '("dev" "prod"))
       (expect (cider-figwheel-main-init-form) :to-equal "(do (require 'figwheel.main) (figwheel.main/start {:c 3 :d 4}))"))
     (it "leaves s-exprs alone"
-      (spy-on 'completing-read :and-return-value "(keyword \"dev\") ")
+      (spy-on 'completing-read :and-return-value "(keyword \"dev\")")
+      (spy-on 'cider--figwheel-main-get-builds :and-return-value '("dev" "prod"))
       (expect (cider-figwheel-main-init-form) :to-equal "(do (require 'figwheel.main) (figwheel.main/start (keyword \"dev\")))"))
     (it "prepends colon to plain names"
-      (spy-on 'completing-read :and-return-value "prod ")
+      (spy-on 'completing-read :and-return-value "prod")
+      (spy-on 'cider--figwheel-main-get-builds :and-return-value '("dev" "prod"))
       (expect (cider-figwheel-main-init-form) :to-equal "(do (require 'figwheel.main) (figwheel.main/start :prod))"))))
 
 (describe "cider-project-type"


### PR DESCRIPTION
fixing tests for figwheel main init form.

I want to point out one thing that I don't like in the solution for this though: it will error if CIDER can't detect figwheel builds. This happens after jvm startup so it doesn't save any time it just adds a point where we could falsely fail a valid figwheel startup. If there isn't a valid build figwheel will provide a nice error message almost instantaneously after this code is run. I don't see a reason to error here.