### PR TITLE
Add cider-inspector-def-current-val to cider-inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugs fixed
 * [#2730](https://github.com/clojure-emacs/cider/pull/2730) Require repl utilities into current namespace not just user ns
+* New cider inspector command `cider-inspector-def-current-val` lets you define a var with the current inspector value.
 
 ## 0.23.0 (2019-10-08)
 

--- a/doc/modules/ROOT/pages/debugging/misc.adoc
+++ b/doc/modules/ROOT/pages/debugging/misc.adoc
@@ -59,4 +59,7 @@ internally using `cider-inspector-mode`):
 
 | kbd:[s]
 | Set a new page size in paginated view
+
+| kbd:[d]
+| Defines a var with current inspector value
 |===


### PR DESCRIPTION
Add `cider-inspector-def-current-val` command to cider inspector so you can define a var with the inspector current value.
Also binds `d` in the inspector mode map to this command and adds "Define var" to the inspector menu.

Depends on https://github.com/clojure-emacs/cider-nrepl/pull/653/ 

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`make test`)
- [X] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [X] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)