### PR TITLE
Include ns when requiring repl utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+* [#2730](https://github.com/clojure-emacs/cider/pull/2730) Require repl utilities into current namespace not just user ns
+
 ## 0.23.0 (2019-10-08)
 
 ### New features

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -262,7 +262,7 @@ This cache is stored in the connection buffer.")
          (require-code (cdr (assoc (cider-repl-type current-repl) cider-repl-require-repl-utils-code))))
     (nrepl-send-sync-request
      (lax-plist-put
-      (nrepl--eval-request require-code)
+      (nrepl--eval-request require-code (cider-current-ns))
       "inhibit-cider-middleware" "true")
      current-repl)))
 

--- a/test/cider-repl-tests.el
+++ b/test/cider-repl-tests.el
@@ -211,8 +211,10 @@ PROPERTY should be a symbol of either 'text, 'ansi-context or
   (it "requires clj utils in a clj buffer"
     (spy-on 'cider-repl-type :and-return-value 'clj)
     (cider-repl-require-repl-utils)
-    (expect 'nrepl--eval-request :to-have-been-called-with (cdr (assoc 'clj cider-repl-require-repl-utils-code))))
+    (expect 'nrepl--eval-request :to-have-been-called-with
+            (cdr (assoc 'clj cider-repl-require-repl-utils-code)) "user"))
   (it "requires cljs utils in a cljs buffer"
     (spy-on 'cider-repl-type :and-return-value 'cljs)
     (cider-repl-require-repl-utils)
-    (expect 'nrepl--eval-request :to-have-been-called-with (cdr (assoc 'cljs cider-repl-require-repl-utils-code)))))
+    (expect 'nrepl--eval-request :to-have-been-called-with
+            (cdr (assoc 'cljs cider-repl-require-repl-utils-code)) "user")))


### PR DESCRIPTION
Requiring repl utils did not send the current ns, so they were always required into the user namespace, not into the current ns.

```lisp
(-->
  id                       "55"
  op                       "eval"
  session                  "4ecbc22b-1107-4070-8c15-8659413e1479"
  time-stamp               "2019-10-12 09:26:43.125825653"
  code                     "(clojure.core/apply clojure.core/require clojure.main/repl-r..."
  inhibit-cider-middleware "true"
)
(<--
  id         "55"
  session    "4ecbc22b-1107-4070-8c15-8659413e1479"
  time-stamp "2019-10-12 09:26:43.130607785"
  ns         "user"    ;; note that these were evaled in user since no ns was supplied
  value      "nil"
)
(<--
  id         "55"
  session    "4ecbc22b-1107-4070-8c15-8659413e1479"
  time-stamp "2019-10-12 09:26:43.131230533"
  status     ("done")
)
```

