### PR TITLE
Add P for inspect-prompt debugger command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#2735](https://github.com/clojure-emacs/cider/pull/2735): New debugger command `P` to inspect an arbitrary expression, it was previously bound to `p` which now inspects the current value.
 * [#2729](https://github.com/clojure-emacs/cider/pull/2729): New cider inspector command `cider-inspector-def-current-val` lets you define a var with the current inspector value.
 
 ### Bugs fixed

--- a/cider-debug.el
+++ b/cider-debug.el
@@ -205,6 +205,7 @@ Can be toggled at any time with `\\[cider-debug-toggle-locals]'."
     (?h "here" "here")
     (?e "eval" "eval")
     (?p "inspect" "inspect")
+    (?P "inspect-prompt" nil)
     (?l "locals" "locals")
     (?j "inject" "inject")
     (?s "stacktrace" "stacktrace")
@@ -405,13 +406,14 @@ In order to work properly, this mode must be activated by
   `("CIDER Debugger"
     ["Next step" (cider-debug-mode-send-reply ":next") :keys "n"]
     ["Continue" (cider-debug-mode-send-reply ":continue") :keys "c"]
-    ["Continue non-stop" (cider-debug-mode-send-reply ":Continue") :keys "C"]
+    ["Continue non-stop" (cider-debug-mode-send-reply ":continue-all") :keys "C"]
     ["Move out of sexp" (cider-debug-mode-send-reply ":out") :keys "o"]
     ["Quit" (cider-debug-mode-send-reply ":quit") :keys "q"]
     "--"
     ["Evaluate in current scope" (cider-debug-mode-send-reply ":eval") :keys "e"]
     ["Inject value" (cider-debug-mode-send-reply ":inject") :keys "i"]
-    ["Inspect value" (cider-debug-mode-send-reply ":inspect")]
+    ["Inspect current value" (cider-debug-mode-send-reply ":inspect") :keys "p"]
+    ["Inspect expression" (cider-debug-mode-send-reply ":inspect-prompt") :keys "P"]
     ["Inspect local variables" (cider-debug-mode-send-reply ":locals") :keys "l"]
     "--"
     ("Configure keys prompt"

--- a/doc/modules/ROOT/pages/debugging/debugger.adoc
+++ b/doc/modules/ROOT/pages/debugging/debugger.adoc
@@ -95,13 +95,19 @@ keys, although there are some differences.
 | Force-step to "`here`"
 
 | kbd:[c]
-| Continue without stopping
+| Continue without stopping in current breakpoint
+
+| kbd:[C]
+| Continue without stopping for all breakpoints
 
 | kbd:[e]
 | Eval code in current context
 
 | kbd:[p]
-| Inspect a value
+| Inspect the current value
+
+| kbd:[P]
+| Inspect an arbitrary expression
 
 | kbd:[l]
 | Inspect local variables
@@ -143,14 +149,16 @@ you step out with `O`.
 at the point where you want to stop next. Then press `h`, and the debugger
 will skip all breakpoints up until that spot.
 * *Here*: Same as `h`, but skips breakpoints in other functions, as with `O`.
-* *continue*: Continues without stopping, skipping all breakpoints.
+* *continue*: Continues without stopping for the current breakpoint.
+* *continue-all*: Continues without stopping, skipping all breakpoints.
 
 == Other Command Details
 
 * *eval*: Prompts for a clojure expression, which can reference local
 variables that are in scope where the debugger is stopped. Displays the result
 in an overlay.
-* *inspect*: Like eval, but displays the value in a `cider-inspector` buffer.
+* *inspect*: Inspects the currently evaluated value in a `cider-inspector` buffer.
+* *inspect-prompt*: Like eval, but displays the value in a `cider-inspector` buffer.
 * *locals*: Opens a `cider-inspector` buffer displaying all local variables
 defined in the context where the debugger is stopped.
 * *inject*: Replaces the currently-displayed value with the value of an


### PR DESCRIPTION
See https://github.com/clojure-emacs/cider-nrepl/pull/655

Also fixes a few references to :continue-all that were missed in the last PR.


Tests appear to fail locally in unrelated parts of Cider, it looks like a recent change introduced a dependency on `s.el` without explicitly requiring it in the Caskfile:

```
========================================
cider-extract-error-info extracts correct information from the error message

Traceback (most recent call last):
  (buttercup-expect (lambda nil (quote (file-name info)) (file-name info)) :...
  (buttercup-fail "%s" "Expected `(file-name info)' to be `equal' to `\"/som...
  (signal buttercup-failed "Expected `(file-name info)' to be `equal' to `\"...
FAILED: Expected `(file-name info)' to be `equal' to `"/some/test/file/core.clj"', but instead it was `nil' which does not match because: (different-types nil "/some/test/file/core.clj").

========================================
The cider compilation regex Recognizes a clojure warning message

Traceback (most recent call last):
  (buttercup-expect (lambda nil (quote (s-matches-p cider-clojure-compilatio...
  (buttercup--apply-matcher :to-equal ((lambda nil (quote (s-matches-p cider...
  (apply #[514 "\300\301D\"\211G\302U\203\211A\262\242\202\303\304\3...
  (#[514 "\300\301D\"\211G\302U\203\211A\262\242\202\303\304\305GD\...
  (mapcar buttercup--expr-and-value ((lambda nil (quote (s-matches-p cider-c...
  (buttercup--expr-and-value (lambda nil (quote (s-matches-p cider-clojure-c...
  ((lambda nil (quote (s-matches-p cider-clojure-compilation-regexp clojure-...
  (s-matches-p cider-clojure-compilation-regexp clojure-compiler-warning)
error: (void-function s-matches-p)


========================================
The cider compilation regex Recognizes a clojure-1.9 error message

Traceback (most recent call last):
  (buttercup-expect (lambda nil (quote (s-matches-p cider-clojure-compilatio...
  (buttercup--apply-matcher :to-equal ((lambda nil (quote (s-matches-p cider...
  (apply #[514 "\300\301D\"\211G\302U\203\211A\262\242\202\303\304\3...
  (#[514 "\300\301D\"\211G\302U\203\211A\262\242\202\303\304\305GD\...
  (mapcar buttercup--expr-and-value ((lambda nil (quote (s-matches-p cider-c...
  (buttercup--expr-and-value (lambda nil (quote (s-matches-p cider-clojure-c...
  ((lambda nil (quote (s-matches-p cider-clojure-compilation-regexp clojure-...
  (s-matches-p cider-clojure-compilation-regexp clojure-1\.9-compiler-error)
error: (void-function s-matches-p)


========================================
The cider compilation regex Recognizes a clojure-1.10 error message

Traceback (most recent call last):
  (buttercup-expect (lambda nil (quote (s-matches-p cider-clojure-compilatio...
  (buttercup--apply-matcher :to-equal ((lambda nil (quote (s-matches-p cider...
  (apply #[514 "\300\301D\"\211G\302U\203\211A\262\242\202\303\304\3...
  (#[514 "\300\301D\"\211G\302U\203\211A\262\242\202\303\304\305GD\...
  (mapcar buttercup--expr-and-value ((lambda nil (quote (s-matches-p cider-c...
  (buttercup--expr-and-value (lambda nil (quote (s-matches-p cider-clojure-c...
  ((lambda nil (quote (s-matches-p cider-clojure-compilation-regexp clojure-...
  (s-matches-p cider-clojure-compilation-regexp clojure-1\.10-compiler-error)
error: (void-function s-matches-p)


Ran 293 specs, 4 failed, in 2.4 seconds.
```

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
