### PR TITLE
Allow lookup of function symbol when cursor is on opening paren

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#2738](https://github.com/clojure-emacs/cider/pull/2738): Add ability to lookup a function symbol when cursor is at the opening paren.
 * [#2735](https://github.com/clojure-emacs/cider/pull/2735): New debugger command `P` to inspect an arbitrary expression, it was previously bound to `p` which now inspects the current value.
 * [#2729](https://github.com/clojure-emacs/cider/pull/2729): New cider inspector command `cider-inspector-def-current-val` lets you define a var with the current inspector value.
 

--- a/cider-util.el
+++ b/cider-util.el
@@ -134,6 +134,8 @@ find a symbol if there isn't one at point."
       (when look-back
         (save-excursion
           (ignore-errors
+            (when (looking-at "(")
+              (forward-char 1))
             (while (not (looking-at "\\sw\\|\\s_\\|\\`"))
               (forward-sexp -1)))
           (cider-symbol-at-point)))))

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -98,6 +98,13 @@
       (spy-on 'thing-at-point :and-return-value nil)
       (expect (cider-symbol-at-point) :not :to-be-truthy)))
 
+  (describe "when on an opening paren"
+    (it "returns the following symbol"
+      (with-temp-buffer
+        (insert "(some function call)")
+        (goto-char (point-min))
+        (expect (cider-symbol-at-point 'look-back) :to-equal "some"))))
+
   (it "can identify symbols in a repl, ignoring the repl prompt"
     ;; ignores repl prompts
     (spy-on 'thing-at-point :and-return-value (propertize "user>" 'field 'cider-repl-prompt))


### PR DESCRIPTION
A simple DWIM addition to allow for calling `cider-doc` and related commands on a symbol when the cursor is at its opening paren. (This is a common state to be in when using structure based navigation)


Eg. with the cursor at `|`, calling M-x cider-doc should bring up documentation for `g`
```clojure
(f |(g x))
```

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)