### PR TITLE
Start `node-repl` and `browser-repl` shadow builds correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Bugs fixed
 
+* [#2739](https://github.com/clojure-emacs/cider/pull/2739): Start built-in shadow-cljs build profiles correctly (node-repl, browser-repl)
 * [#2730](https://github.com/clojure-emacs/cider/pull/2730): Require repl utilities into current namespace not just `user` ns.
 * [#2614](https://github.com/clojure-emacs/cider/issues/2614): Fix error highlighting in source buffers for Clojure 1.10.
 * [#2733](https://github.com/clojure-emacs/cider/issues/2733): Restore compatibility with Emacs 25.3.

--- a/cider.el
+++ b/cider.el
@@ -746,12 +746,16 @@ not just a string."
   "Generate the init form for a shadow-cljs REPL.
 We have to prompt the user to select a build, that's why
 this is a command, not just a string."
-  (let* ((form "(do (require '[shadow.cljs.devtools.api :as shadow]) (shadow/watch %s) (shadow/nrepl-select %s))")
+  (let* ((shadow-require "(require '[shadow.cljs.devtools.api :as shadow])")
+         (build-form "(do %s (shadow/watch %s) (shadow/nrepl-select %s))")
+         (default-form "(do %s (shadow/%s))")
          (options (or cider-shadow-default-options
                       (completing-read "Select shadow-cljs build: "
                                        (cider--shadow-get-builds))))
          (build (cider-normalize-cljs-init-options options)))
-    (format form build build)))
+    (if (member build '(":browser-repl" ":node-repl"))
+        (format default-form shadow-require (string-remove-prefix ":" build))
+      (format build-form shadow-require build build))))
 
 (defcustom cider-figwheel-main-default-options nil
   "Defines the `figwheel.main/start' options.

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -322,6 +322,24 @@
      (expect (cider--shadow-get-builds)
              :to-have-same-items-as '(browser-repl node-repl)))))
 
+(describe "cider-shadow-cljs-init-form"
+  (it "watches and selects user-defined builds"
+    (spy-on 'completing-read :and-return-value ":client-build")
+    (expect (cider-shadow-cljs-init-form)
+            :to-equal
+            "(do (require '[shadow.cljs.devtools.api :as shadow]) (shadow/watch :client-build) (shadow/nrepl-select :client-build))"))
+  (describe "starts the built-in build profiles correctly"
+    (it "starts a node-repl"
+      (spy-on 'completing-read :and-return-value ":node-repl")
+      (expect (cider-shadow-cljs-init-form)
+              :to-equal
+              "(do (require '[shadow.cljs.devtools.api :as shadow]) (shadow/node-repl))"))
+    (it "starts a browser-repl"
+      (spy-on 'completing-read :and-return-value ":browser-repl")
+      (expect (cider-shadow-cljs-init-form)
+              :to-equal
+              "(do (require '[shadow.cljs.devtools.api :as shadow]) (shadow/browser-repl))"))))
+
 (provide 'cider-tests)
 
 ;;; cider-tests.el ends here


### PR DESCRIPTION
Shadow can start your build with (shadow/watch
build) (shadow/nrepl-select build). But it provides two conveient
default builds on its own which are called in a different
manner: (shadow/node-repl) or (shadow/browser-repl). Need to invoke
correctly as right now we just get an error that there is no build
with id :browser-repl

- [x] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

tests are failing from unrelated changes :(