### PR TITLE
Tests/regex tests

### DIFF
--- a/cider-debug.el
+++ b/cider-debug.el
@@ -212,16 +212,13 @@ Can be toggled at any time with `\\[cider-debug-toggle-locals]'."
     (?t "trace" "trace")
     (?q "quit" "quit"))
   "A list of debugger command specs.
-They are in the format (KEY COMMAND-NAME DISPLAY-NAME?), where:
+Specs are in the format (KEY COMMAND-NAME DISPLAY-NAME?)
+where KEY is a character which is mapped to the command
+COMMAND-NAME is a valid debug command to be passed to the cider-nrepl middleware
+DISPLAY-NAME is the string displayed in the debugger overlay
 
-* KEY is a character which is mapped to the command
-* COMMAND-NAME is a valid debug command to be passed to the cider-nrepl
-middleware
-* DISPLAY-NAME is the string displayed in the debugger overlay
-
-If DISPLAY-NAME is nil, that command is hidden from the overlay but still
-callable.  The rest of the commands are displayed in their order of appearance
-on this list."
+If DISPLAY-NAME is nil, that command is hidden from the overlay but still callable.
+The rest of the commands are displayed in the same order as this list."
   :type '(alist :key-type character
                 :value-type (list
                              (string :tag "command name")
@@ -244,9 +241,9 @@ Each element of LOCALS should be a list of at least two elements."
     ""))
 
 (defun cider--debug-propertize-prompt-commands ()
-  "In-place formatting of the command display names for the cider-debug-prompt overlay."
+  "In-place formatting of the command display names for the `cider-debug-prompt' overlay."
   (mapc (lambda (spec)
-          (cl-destructuring-bind (char cmd disp-name) spec
+          (cl-destructuring-bind (char _cmd disp-name) spec
             (when-let* ((pos (cl-position char disp-name)))
               (put-text-property pos (1+ pos) 'face 'cider-debug-prompt-face disp-name))))
         cider-debug-prompt-commands))
@@ -258,7 +255,7 @@ Each element of LOCALS should be a list of at least two elements."
   (format (propertize "%s\n" 'face 'default)
           (cl-reduce
            (lambda (prompt spec)
-             (cl-destructuring-bind (char cmd disp) spec
+             (cl-destructuring-bind (_char cmd disp) spec
                (if (and disp (cl-find cmd commands :test 'string=))
                    (concat prompt " " disp)
                  prompt)))
@@ -353,7 +350,7 @@ In order to work properly, this mode must be activated by
             ;; Map over the key->command alist and set the keymap
             (mapc
              (lambda (p)
-               (let ((char (car p)) (cmd (cdr p)))
+               (let ((char (car p)))
                  (unless (= char ?h)   ; `here' needs a special command.
                    (define-key cider--debug-mode-map (string char) #'cider-debug-mode-send-reply))
                  (when (= char ?o)

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -311,8 +311,7 @@ It delegates the actual error content to the eval or op handler."
                                      (group-n 2 (minimal-match (zero-or-more anything)))
                                      ":"
                                      (group-n 3 (one-or-more digit))
-                                     ":"
-                                     (group-n 4 (one-or-more digit))
+                                     (optional ":" (group-n 4 (one-or-more digit)))
                                      ")."))
 
 (defconst cider-clojure-1.9-error `(sequence
@@ -321,8 +320,7 @@ It delegates the actual error content to the eval or op handler."
                                     (group-n 2 (minimal-match (zero-or-more anything)))
                                     ":"
                                     (group-n 3 (one-or-more digit))
-                                    ":"
-                                    (group-n 4 (one-or-more digit))
+                                    (optional ":" (group-n 4 (one-or-more digit)))
                                     ")"))
 
 (defconst cider-clojure-warning `(sequence
@@ -332,8 +330,7 @@ It delegates the actual error content to the eval or op handler."
                                   (group-n 2 (minimal-match (zero-or-more anything)))
                                   ":"
                                   (group-n 3 (one-or-more digit))
-                                  ":"
-                                  (group-n 4 (one-or-more digit))
+                                  (optional ":" (group-n 4 (one-or-more digit)))
                                   " - "))
 
 (defconst cider-clojure-compilation-regexp (rx bol (or (eval cider-clojure-1.9-error)
@@ -370,7 +367,7 @@ See `compilation-error-regexp-alist' for help on their format.")
        (when line (string-to-number (match-string-no-properties line message)))
        (when col
          (let ((val (match-string-no-properties col message)))
-           (when val (string-to-number val))))
+           (when (and val (not (string-blank-p val))) (string-to-number val))))
        (aref [cider-warning-highlight-face
               cider-warning-highlight-face
               cider-error-highlight-face]

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -220,7 +220,8 @@ Current page will be reset to zero."
 (defun cider-inspector-def-current-val (var-name ns)
   "Defines a var with VAR-NAME in current namespace.
 
-Doesn't modify current page."
+Doesn't modify current page.  When called interactively NS defaults to
+current-namespace."
   (interactive (list (cider-read-from-minibuffer "Var name: ")
                      (cider-current-ns)))
   (setq cider-inspector--current-repl (cider-current-repl))

--- a/cider-overlays.el
+++ b/cider-overlays.el
@@ -177,7 +177,7 @@ Return the overlay if it was placed successfully, and nil if it failed.
 This function takes some optional keyword arguments:
 
   If WHERE is a number or a marker, apply the overlay as determined by
-  `cider-result-overlay-position'. If it is a cons cell, the car and cdr
+  `cider-result-overlay-position'.  If it is a cons cell, the car and cdr
   determine the start and end of the overlay.
   DURATION takes the same possible values as the
   `cider-eval-result-duration' variable.


### PR DESCRIPTION
1. Fix tests for error message parsing: columns weren't treated as optional in the regex despite tests showing they were optional.
2. various doc fixups, punctuation, aligning to left of buffer, and marking bindings as unused.

One thing to note: in emacs 27 the linting is getting more strict when i run it locally. Its asking for doc strings on the generic functions from sesman and also a warning relating to seq functions:

> nrepl-client.el:1251:42:Error: ‘seq-contains’ is an obsolete function (as of 27.1); use ‘seq-contains-p’ instead.

- [x] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
