### PR TITLE
Show startup commands in repl buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#2744](https://github.com/clojure-emacs/cider/pull/2744): Add startup commands to repl banner.
 * [#2499](https://github.com/clojure-emacs/cider/issues/2499): Add `cider-jump-to-pop-to-buffer-actions`.
 * [#2738](https://github.com/clojure-emacs/cider/pull/2738): Add ability to lookup a function symbol when cursor is at the opening paren.
 * [#2735](https://github.com/clojure-emacs/cider/pull/2735): New debugger command `P` to inspect an arbitrary expression, it was previously bound to `p` which now inspects the current value.

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -699,6 +699,7 @@ PARAMS is a plist as received by `cider-repl-create'."
 (declare-function cider-repl-reset-markers "cider-repl")
 (defvar-local cider-session-name nil)
 (defvar-local cider-repl-init-function nil)
+(defvar-local cider-launch-params nil)
 (defun cider-repl-create (params)
   "Create new repl buffer.
 PARAMS is a plist which contains :repl-type, :host, :port, :project-dir,
@@ -727,7 +728,8 @@ function with the repl buffer set as current."
             ;; REPLs start with clj and then "upgrade" to a different type
             cider-repl-type (plist-get params :repl-type)
             ;; ran at the end of cider--connected-handler
-            cider-repl-init-function (plist-get params :repl-init-function))
+            cider-repl-init-function (plist-get params :repl-init-function)
+            cider-launch-params params)
       (cider-repl-reset-markers)
       (add-hook 'nrepl-response-handler-functions #'cider-repl--state-handler nil 'local)
       (add-hook 'nrepl-connected-hook #'cider--connected-handler nil 'local)

--- a/test/cider-repl-tests.el
+++ b/test/cider-repl-tests.el
@@ -30,6 +30,38 @@
 (require 'buttercup)
 (require 'cider-repl)
 
+(describe "cider-repl--insert-param-values"
+  (it "doesn't output anything when the params aren't present"
+    (let ((output "")
+          (cider-launch-params '()))
+      (spy-on 'insert-before-markers
+              :and-call-fake (lambda (arg)
+                               (setq output (format "%s%s" output (substring-no-properties arg)))))
+      (cider-repl--insert-startup-commands)
+      (expect output :to-be "")))
+  (it "puts jack-in-command in same style as banner"
+    (let ((output "")
+          (cider-launch-params '(:jack-in-cmd "lein command")))
+      (spy-on 'insert-before-markers
+              :and-call-fake (lambda (arg)
+                               (setq output (format "%s%s" output (substring-no-properties arg)))))
+      (cider-repl--insert-startup-commands)
+      (expect output :to-equal
+              ";;  Startup: lein command\n")))
+  (it "formats output if present"
+    (let ((output "")
+          (cider-launch-params '(:cljs-repl-type shadow :repl-init-form "(do)")))
+      (spy-on 'insert-before-markers
+              :and-call-fake (lambda (arg)
+                               (setq output (format "%s%s" output (substring-no-properties arg)))))
+      (cider-repl--insert-startup-commands)
+      (expect output :to-equal
+              ";;
+;; ClojureScript REPL type: shadow
+;; ClojureScript REPL init form: (do)
+;;
+"))))
+
 (describe "cider-repl--banner"
   :var (cider-version cider-codename)
   (before-all


### PR DESCRIPTION
Simple change to show the commands CIDER uses to get everything running to the user in the repl buffer.

![image](https://user-images.githubusercontent.com/6377293/68450719-9773a880-01b1-11ea-91cf-1de8dfbef30e.png)

There are a few good reasons to do this:
- we show the jack in command but its as a message and can quickly go away
- we never show the cljs command so people might forget how they are actually starting the cljs repl when CIDER doesn't display it
- it removes the "magic" of what CIDER does for beginners and trouble shooters.
- it gives someone access to the commands if they prefer to `cider-connect` instead of having clojure running as a subprocess to emacs.


- [x] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
