### PR TITLE
Fringe evaluation indicators colours more visible

### DIFF
--- a/cider-overlays.el
+++ b/cider-overlays.el
@@ -130,8 +130,8 @@ This function also removes itself from `post-command-hook'."
   (add-hook 'post-command-hook #'cider--remove-result-overlay nil 'local))
 
 (defface cider-fringe-good-face
-  '((((class color) (background light)) :foreground "lightgreen")
-    (((class color) (background dark)) :foreground "darkgreen"))
+  '((((class color) (background light)) :foreground "DarkGreen")
+    (((class color) (background dark)) :foreground "LimeGreen"))
   "Face used on the fringe indicator for successful evaluation."
   :group 'cider)
 


### PR DESCRIPTION
Using dark green for a light theme and lime green for a dark theme increases the visibility of the evaluation indicators in the fringe.

https://github.com/clojure-emacs/cider/issues/2748

Tested on the following themes with positive results
spacemacs-dark, spacemacs-light, adwaita, dichromancy, leuven, whiteboard.

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
