### PR TITLE
Make it possible to `cider-find-var` in another window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#2759](https://github.com/clojure-emacs/cider/pull/2759): Fix `cider-find-var` prefix behaviour when `var` is passed.
 * [#2744](https://github.com/clojure-emacs/cider/pull/2744): Add startup commands to repl banner.
 * [#2499](https://github.com/clojure-emacs/cider/issues/2499): Add `cider-jump-to-pop-to-buffer-actions`.
 * [#2738](https://github.com/clojure-emacs/cider/pull/2738): Add ability to lookup a function symbol when cursor is at the opening paren.

--- a/cider-find.el
+++ b/cider-find.el
@@ -41,12 +41,12 @@ Display the results in a different window."
         (cider--jump-to-loc-from-info info t))
     (user-error "Symbol `%s' not resolved" var)))
 
-(defun cider--find-var (var &optional line)
-  "Find the definition of VAR, optionally at a specific LINE."
+(defun cider--find-var (var &optional line other-window)
+  "Find the definition of VAR, optionally at a specific LINE and in OTHER-WINDOW."
   (if-let* ((info (cider-var-info var)))
       (progn
         (if line (setq info (nrepl-dict-put info "line" line)))
-        (cider--jump-to-loc-from-info info))
+        (cider--jump-to-loc-from-info info other-window))
     (user-error "Symbol `%s' not resolved" var)))
 
 ;;;###autoload
@@ -59,7 +59,7 @@ the results to be displayed in a different window.  The default value is
 thing at point."
   (interactive "P")
   (if var
-      (cider--find-var var line)
+      (cider--find-var var line (cider--open-other-window-p arg))
     (funcall (cider-prompt-for-symbol-function arg)
              "Symbol"
              (if (cider--open-other-window-p arg)


### PR DESCRIPTION
This fix makes it possible to use `-` prefix (`M-- t`) to jump to test definition in another window. Before this fix, pressing enter (or `t`) in the CIDER test report buffer always opened the definition of the failing test function in the same window as the test report.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [ ] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
