### PR TITLE
WORK PROBABLY STILL NEEDED — Evaluate forms in multiple REPLs when appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#2744](https://github.com/clojure-emacs/cider/pull/2744): Add startup commands to repl banner.
+* [#2756](https://github.com/clojure-emacs/cider/issues/2756): Evaluate forms in multiple REPLS.
 * [#2499](https://github.com/clojure-emacs/cider/issues/2499): Add `cider-jump-to-pop-to-buffer-actions`.
 * [#2738](https://github.com/clojure-emacs/cider/pull/2738): Add ability to lookup a function symbol when cursor is at the opening paren.
 * [#2735](https://github.com/clojure-emacs/cider/pull/2735): New debugger command `P` to inspect an arbitrary expression, it was previously bound to `p` which now inspects the current value.

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1120,12 +1120,12 @@ command will prompt for the name of the namespace to switch to."
                        (cider-current-ns))))
   (when (or (not ns) (equal ns ""))
     (user-error "No namespace selected"))
-  (cider-map-repls :auto
-    (lambda (connection)
-      (cider-nrepl-request:eval (if cider-repl-require-ns-on-set
-                                    (format "(do (require '%s) (in-ns '%s))" ns ns)
-                                  (format "(in-ns '%s)" ns))
-                                (cider-repl-switch-ns-handler connection)))))
+  (let ((fun (lambda (connection)
+               (cider-nrepl-request:eval (if cider-repl-require-ns-on-set
+                                             (format "(do (require '%s) (in-ns '%s))" ns ns)
+                                           (format "(in-ns '%s)" ns))
+                                         (cider-repl-switch-ns-handler connection)))))
+    (cider-map-repls :auto fun cider-eval-forms-in-all-sessions)))
 
 
 ;;; Location References


### PR DESCRIPTION
This addresses the issue of evaluating forms from .cljc files in both CLJ and CLJS REPLs — see https://github.com/clojure-emacs/cider/issues/2756

There was already high-level code to handle multiple REPLs, but the low-level code (around Sesman sessions) didn't handle multiple REPLs.

I've made changes to `cider-repls` and `cider-map-repls`, adding some more optional parameters. I don't much like the way things have turned out, but I've tried to make sure that things are backward-compatible. Perhaps things should be done differently.

WORK IS PROBABLY STILL NEEDED TO COMPLETE THIS, but I'd appreciate comments before going further.

These are the outstanding issues that I'm aware of:

- There are multiple evaluation results, from multiple REPLs. The result that happens second overwrites the result that happens first. I'm not sure what to do about this.
- The manual needs updating. The new variable `cider-eval-forms-in-all-sessions` needs to be documented, and I think there may be some documentation that talks about evaluation happening in the most recent REPL, which will need to be fixed.
- Perhaps new tests are needed. (I'm not sure I have the knowledge to do that — but I am happy to take a look if I get positive feedback on what I've done so far.)

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
