### PR TITLE
Resolve relative paths in classpath

### DIFF
--- a/cider-client.el
+++ b/cider-client.el
@@ -503,9 +503,23 @@ Optional arguments include SEARCH-NS, DOCS-P, PRIVATES-P, CASE-SENSITIVE-P."
     (cider-nrepl-send-sync-request)
     (nrepl-dict-get "classpath")))
 
+(defun cider-sync-tooling-eval-get-value (expr)
+  (thread-first expr
+    cider-sync-tooling-eval
+    (nrepl-dict-get "value")
+    read))
+
+(defun cider-get-abs-path (path project)
+  (if (not (string= (substring path 0 1) "/"))
+      (format "%s/%s" project path)
+    path))
+
 (defun cider-fallback-eval:classpath ()
   "Return a list of classpath entries using eval."
-  (read (nrepl-dict-get (cider-sync-tooling-eval "(seq (.split (System/getProperty \"java.class.path\") \":\"))") "value")))
+  (lexical-let ((classpath (cider-sync-tooling-eval-get-value "(seq (.split (System/getProperty \"java.class.path\") \":\"))"))
+                ;; Sometimes the classpath contains entries like "src/main" and we need to resolve those to absolute paths.
+                (project (cider-sync-tooling-eval-get-value "(-> (java.io.File. \"\") (.getAbsolutePath))")))
+    (seq-map (lambda (path) (cider-get-abs-path path project)) classpath)))
 
 (defun cider-classpath-entries ()
   "Return a list of classpath entries."

--- a/cider-client.el
+++ b/cider-client.el
@@ -503,23 +503,27 @@ Optional arguments include SEARCH-NS, DOCS-P, PRIVATES-P, CASE-SENSITIVE-P."
     (cider-nrepl-send-sync-request)
     (nrepl-dict-get "classpath")))
 
-(defun cider-sync-tooling-eval-get-value (expr)
-  (thread-first expr
+(defun cider-sync-tooling-eval-get-value (expression)
+  "Send the EXPRESSION to the repl and get the returned value."
+  (thread-first expression
     cider-sync-tooling-eval
     (nrepl-dict-get "value")
     read))
 
-(defun cider-get-abs-path (path project)
+(defun cider--get-abs-path (path project)
+  "Resolve PATH to an absolute path relative to PROJECT.
+Do nothing if PATH is already absolute."
   (if (not (string= (substring path 0 1) "/"))
       (format "%s/%s" project path)
     path))
 
 (defun cider-fallback-eval:classpath ()
-  "Return a list of classpath entries using eval. Sometimes the
-  classpath contains entries like src/main and we need to resolve
-  those to absolute paths."
+  "Return a list of classpath entries using eval.
+
+Sometimes the classpath contains entries like src/main and we need to
+resolve those to absolute paths."
   (let ((classpath (cider-sync-tooling-eval-get-value "(seq (.split (System/getProperty \"java.class.path\") \":\"))")))
-    (mapcar (lambda (path) (cider-get-abs-path path default-directory)) classpath)))
+    (mapcar (lambda (path) (cider--get-abs-path path default-directory)) classpath)))
 
 (defun cider-classpath-entries ()
   "Return a list of classpath entries."

--- a/cider-client.el
+++ b/cider-client.el
@@ -515,11 +515,11 @@ Optional arguments include SEARCH-NS, DOCS-P, PRIVATES-P, CASE-SENSITIVE-P."
     path))
 
 (defun cider-fallback-eval:classpath ()
-  "Return a list of classpath entries using eval."
-  (lexical-let ((classpath (cider-sync-tooling-eval-get-value "(seq (.split (System/getProperty \"java.class.path\") \":\"))"))
-                ;; Sometimes the classpath contains entries like "src/main" and we need to resolve those to absolute paths.
-                (project (cider-sync-tooling-eval-get-value "(-> (java.io.File. \"\") (.getAbsolutePath))")))
-    (seq-map (lambda (path) (cider-get-abs-path path project)) classpath)))
+  "Return a list of classpath entries using eval. Sometimes the
+  classpath contains entries like src/main and we need to resolve
+  those to absolute paths."
+  (let ((classpath (cider-sync-tooling-eval-get-value "(seq (.split (System/getProperty \"java.class.path\") \":\"))")))
+    (mapcar (lambda (path) (cider-get-abs-path path default-directory)) classpath)))
 
 (defun cider-classpath-entries ()
   "Return a list of classpath entries."


### PR DESCRIPTION
Sometimes the classpath returned by `(cider-fallback-eval:classpath)` contains relative entries like `src/main` and we need to resolve those to absolute paths. Otherwise `sesman-friendly-session-p` would throw error because there would be `nil` in `classpath-roots`

https://github.com/clojure-emacs/cider/blob/fa7ffd45/cider-connection.el#L462-L465