### PR TITLE
Fix the nrepl endpoint details in the mode line

### DIFF
--- a/cider-mode.el
+++ b/cider-mode.el
@@ -58,10 +58,10 @@ Info contains the connection type, project name and host:port endpoint."
          (when cider-mode-line-show-connection
            (format ":%s@%s:%s"
                    (or (cider--project-name nrepl-project-dir) "<no project>")
-                   (pcase (car nrepl-endpoint)
+                   (pcase (plist-get nrepl-endpoint :host)
                      ("localhost" "")
                      (x x))
-                   (cadr nrepl-endpoint)))))
+                   (plist-get nrepl-endpoint :port)))))
     "not connected"))
 
 ;;;###autoload


### PR DESCRIPTION
This fixes the display of the nrepl connection in the mode line.

It looks like `nrepl-endpoint` was historically a list, but is now a plist. This results in the mode line displaying as: `clj:my-project@:proc:nrepl-connection` with this fix it will now display as: `clj:my-project@:34969`.