### PR TITLE
Fix cider-inspector error at beginning of buffer

### DIFF
--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -408,7 +408,7 @@ If ARG is negative, move forwards."
                      when value
                      return (list property value)))))
     (or (funcall find-property (point))
-        (funcall find-property (1- (point))))))
+        (funcall find-property (max (point-min) (1- (point)))))))
 
 (defun cider-inspector-operate-on-point ()
   "Invoke the command for the text at point.


### PR DESCRIPTION
A tiny fix for `cider-inspector-operate-on-point` at the beginning of buffer, where it would attempt to operate on `(1- (point))` and throw an `Args out of range (0 . 0)` error. 
(I don't think this warrants a mention in the changelog?)


-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
