### PR TITLE
Extend the default doc xref regexp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Changes
 
-* [#2731](https://github.com/clojure-emacs/cider/pull/2731): Make the in-buffer debugging menu customizable via `cider-debug-prompt-commands`.
+* [#2731](https://github.com/clojure-emacs/cider/pull/2781): Extend `cider-doc-xref-regexp` to recognize `[[var]]` syntax  and fully qualified symbols as xref links in cider-doc buffers. [#2731](https://github.com/clojure-emacs/cider/pull/2731): Make the in-buffer debugging menu customizable via `cider-debug-prompt-commands`.
 
 ### Bugs fixed
 

--- a/cider-util.el
+++ b/cider-util.el
@@ -511,9 +511,11 @@ restore it properly when going back."
     (setq help-xref-stack-item item)))
 
 (defcustom cider-doc-xref-regexp
-  (rx (or (: "`" (group-n 1 (+ (not space))) "`")   ; `var`
+  (eval-and-compile
+    (rx-to-string
+     `(or (: "`" (group-n 1 (+ (not space))) "`")  ; `var`
           (: "[[" (group-n 1 (+ (not space))) "]]") ; [[var]]
-          (group-n 1 (+ (not space)) "/" (+ (not space))))) ; Fully qualified
+          (group-n 1 (regexp ,clojure--sym-regexp) "/" (regexp ,clojure--sym-regexp))))) ;; Fully qualified
   "The regexp used to search Clojure vars in doc buffers."
   :type 'regexp
   :safe #'stringp

--- a/cider-util.el
+++ b/cider-util.el
@@ -510,7 +510,10 @@ restore it properly when going back."
         (if tail (setcdr tail nil))))
     (setq help-xref-stack-item item)))
 
-(defcustom cider-doc-xref-regexp "`\\(.*?\\)`"
+(defcustom cider-doc-xref-regexp
+  (rx (or (: "`" (group-n 1 (+ (not space))) "`")   ; `var`
+          (: "[[" (group-n 1 (+ (not space))) "]]") ; [[var]]
+          (group-n 1 (+ (not space)) "/" (+ (not space))))) ; Fully qualified
   "The regexp used to search Clojure vars in doc buffers."
   :type 'regexp
   :safe #'stringp

--- a/doc/modules/ROOT/pages/usage/misc_features.adoc
+++ b/doc/modules/ROOT/pages/usage/misc_features.adoc
@@ -281,9 +281,10 @@ image::spec_browser_gen_example.png[Spec Browser Example]
 
 Sometimes in your documentation strings, you'd like to be able to
 point other programmers at different definitions. If you specify the
-name of a definition in backticks (```), CIDER will convert these
-references into live links when it displays the documentation string
-in the documentation buffer.
+name of a definition as a fully qualified symbol, or surround it in
+backticks (`++`...`++`) or Codox-style delimiters (`+[[...]]+`), CIDER
+will convert these references into live links when it displays the
+documentation string in the documentation buffer.
 
 If the name is in another namespace, then you'll have to include the
 fully qualified name in the docstring.
@@ -293,23 +294,22 @@ Example function with a docstring containing references:
 ----
 (defn test-fn
   "Test function.
-  Also see: `clojure.core/map`, `clojure.core/reduce`, `defn`.
-  You can reference variables like `thor`, `kubaru.data.zookeeper/yoda`.
+  Also see: clojure.core/map, clojure.core/reduce, `defn`.
+  You can reference variables like `thor`, [[kubaru.data.zookeeper/yoda]].
   Also works with references to java interop forms, `java.lang.String/.length`."
   []
   (+ 1 1))
 ----
 
 You can change the delimiters that CIDER uses to find references if
-you don't like using backticks.  Simply update the regexp in
+you want to support other reference formats.  Simply update the regexp in
 `cider-doc-xref-regexp` to match your preferred format. The first
 group of the regexp should always match the cross-reference name. For
-example, if you want to want to use
-https://github.com/weavejester/codox[Codox's] delimiter style
-(`+[[...]]+`) instead of backticks, the regexp would be:
+example, if you want to want to use Latex-style references
+(`+\ref{...}+`) instead, the regexp would be:
 
 ----
-(setq cider-doc-xref-regexp "\\[\\[\\(.*?\\)\\]\\]")
+(setq cider-doc-xref-regexp "\\\\ref{\\(?1:[^}]+\\)}")
 ----
 
 image::cider_see_also.gif[CIDER See Also]

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -254,6 +254,20 @@ buffer."
   (describe "works in buffers"
     (it "fontifies with correct face"
       (with-clojure-buffer "|aaa bbb\n cccc\n ddddd"
-        (cider-add-face "c+" 'font-lock-comment-face)
-        (expect (get-pos-property 11 'face)
-                :to-be 'font-lock-comment-face)))))
+                           (cider-add-face "c+" 'font-lock-comment-face)
+                           (expect (get-pos-property 11 'face)
+                                   :to-be 'font-lock-comment-face)))))
+
+(describe "cider--find-symbol-xref"
+  (it "identifies all types of xref syntax"
+    (with-temp-buffer
+      (insert "(defn temp-fn []
+  \"This is a docstring with `cross` [[references]] to clojure.core/map,
+and some other vars (like clojure.core/filter).
+  [])")
+      (goto-char (point-min))
+      (expect (cider--find-symbol-xref) :to-equal "cross")
+      (expect (cider--find-symbol-xref) :to-equal "references")
+      (expect (cider--find-symbol-xref) :to-equal "clojure.core/map")
+      (expect (cider--find-symbol-xref) :to-equal "clojure.core/filter")
+      (expect (cider--find-symbol-xref) :to-equal nil))))


### PR DESCRIPTION
This allows cider-doc buffers to recognize `[[var]]` syntax and fully qualified symbols as xref links.

Both are fairly common in docstrings in core and 3rd-party libraries that I've personally encountered, and it's otherwise somewhat annoying to navigate to a referenced var or function.  (E.g. executing `M-x cider-doc`in a `*cider-doc*` buffer doesn't pick up the symbol at point).

If this is acceptable I'll go ahead with adding tests and changelogs :)

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

