### PR TITLE
Doc fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 
 ### Changes
 
-* [#2731](https://github.com/clojure-emacs/cider/pull/2781): Extend `cider-doc-xref-regexp` to recognize `[[var]]` syntax  and fully qualified symbols as xref links in cider-doc buffers. [#2731](https://github.com/clojure-emacs/cider/pull/2731): Make the in-buffer debugging menu customizable via `cider-debug-prompt-commands`.
+* [#2781](https://github.com/clojure-emacs/cider/pull/2781): Extend `cider-doc-xref-regexp` to recognize `[[var]]` syntax  and fully qualified symbols as xref links in cider-doc buffers.
+* [#2731](https://github.com/clojure-emacs/cider/pull/2731): Make the in-buffer debugging menu customizable via `cider-debug-prompt-commands`.
 
 ### Bugs fixed
 

--- a/cider.el
+++ b/cider.el
@@ -833,7 +833,7 @@ The supplied string will be wrapped in a do form if needed."
   "A list of supported ClojureScript REPLs.
 
 For each one we have its name, the form we need to evaluate in a Clojure
-REPL to start the ClojureScript REPL and functions to very their requirements.
+REPL to start the ClojureScript REPL and functions to verify their requirements.
 
 The form should be either a string or a function producing a string.")
 

--- a/doc/modules/ROOT/pages/indent_spec.adoc
+++ b/doc/modules/ROOT/pages/indent_spec.adoc
@@ -82,11 +82,11 @@ only the arglist is indented specially and the rest is the body).
     "My very own thing!!"))
 ----
 
-For something even more complicated: `letfn` is `[1 [[:defn]] :form]`. This means
+For something even more complicated: `letfn` is `+[1 [[:defn]] :form]+`. This means
 
 * `letfn` has one special argument (the bindings list).
-* The first arg has an indent spec of `[[:defn]]`, which means all forms
-_inside_ the first arg have an indent spec of `[:defn]`.
+* The first arg has an indent spec of `+[[:defn]]+`, which means all forms
+_inside_ the first arg have an indent spec of `+[:defn]+`.
 * The second argument, and all other arguments, are regular forms.
 
 [source,clojure]


### PR DESCRIPTION
Just realised I made a typo in Changelog.md in my last PR, oops.
Also closes #2763 by using literal syntax for the indentation spec example

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
