### PR TITLE
Fix example in pretty_printing.adoc

### DIFF
--- a/doc/modules/ROOT/pages/usage/pretty_printing.adoc
+++ b/doc/modules/ROOT/pages/usage/pretty_printing.adoc
@@ -67,7 +67,7 @@ You can pass an options map to the print function by setting `cider-print-option
 
 [source,lisp]
 ----
-(setq cider-print-options '(dict "length" 50 "right-margin" 70))
+(setq cider-print-options '(("length" 50) ("right-margin" 70)))
 ----
 
 NOTE: Each print engine has its own configuration options, so you'll have to be sure to set `cider-print-options` accordingly.


### PR DESCRIPTION
The example setting for `cider-print-options` does not work for me. I think the issue is with `dict`. 

Using the example in the `defcustom` documentation works: https://github.com/clojure-emacs/cider/blob/4cc4280677e6eeb16cd55d9865c0ea9f9d141af3/cider-client.el#L248-L252

