### PR TITLE
Fix for 2787 when using nrepl-hide-special-buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#2787](https://github.com/clojure-emacs/cider/issues/2787): Fix nrepl process naming collision when using `nrepl-hide-special-buffers`
 * [#2744](https://github.com/clojure-emacs/cider/pull/2744): Add startup commands to repl banner.
 * [#2499](https://github.com/clojure-emacs/cider/issues/2499): Add `cider-jump-to-pop-to-buffer-actions`.
 * [#2738](https://github.com/clojure-emacs/cider/pull/2738): Add ability to lookup a function symbol when cursor is at the opening paren.

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -203,14 +203,14 @@ PARAMS and DUP-OK are as in `nrepl-make-buffer-name'."
 (defun nrepl-server-buffer-name (params)
   "Return the name of the server buffer.
 PARAMS is as in `nrepl-make-buffer-name'."
-  (nrepl--make-hidden-name
-   (nrepl-make-buffer-name nrepl-server-buffer-name-template params)))
+  (nrepl-make-buffer-name (nrepl--make-hidden-name nrepl-server-buffer-name-template)
+                          params))
 
 (defun nrepl-tunnel-buffer-name (params)
   "Return the name of the tunnel buffer.
 PARAMS is as in `nrepl-make-buffer-name'."
-  (nrepl--make-hidden-name
-   (nrepl-make-buffer-name nrepl-tunnel-buffer-name-template params)))
+  (nrepl-make-buffer-name (nrepl--make-hidden-name nrepl-tunnel-buffer-name-template)
+                          params))
 
 (defun nrepl-messages-buffer-name (params)
   "Return the name for the message buffer given connection PARAMS."

--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -43,7 +43,15 @@
       (setq nrepl-hide-special-buffers t
             nrepl-server-buffer-name-template "*nrepl-server %h:%p*")
       (expect (nrepl-server-buffer-name params)
-              :to-equal " *nrepl-server localhost:1*"))))
+              :to-equal " *nrepl-server localhost:1*"))
+    (it "creates two separate server processes if needed"
+      (setq nrepl-hide-special-buffers t
+            nrepl-server-buffer-name-template "*cider-test-buffer-names*")
+      (let ((first-buffer (nrepl-server-buffer-name params)))
+        (expect first-buffer :to-equal " *cider-test-buffer-names*")
+        (get-buffer-create first-buffer)
+        (expect (nrepl-server-buffer-name params)
+                :not :to-equal first-buffer)))))
 
 
 (describe "nrepl-dbind-response"


### PR DESCRIPTION
nrepl-hide-special-buffers would prepend a leading space to the nrepl
process buffer to hide it from the buffer list. If you created a new
sibling process there was a bug however. In order to uniquely name
buffers, CIDER uses `generate-new-buffer-name` to ensure a buffer is
uniquely named. However, the space was put on _after_ this
call. The sequence is as follows:

- jack in
- use template "*cider-nrepl blah" to see if existing process buffer
is around. Its not. Since we want these hidden, add a leading space so
now " *cider-nrepl blah*" process buffer exists
- watch for "nREPL server started on port \\([0-9]+\\)" and not
already a port saved
- start repl
- jack in again creating sibling process
- check if buffer "*cider-nrepl blah" exists. It doesn't since the
first one has a leading space
- add a leading space to the buffer name to get " *cider-nrepl blah"
which actually now is a collision
- lein/deps/shadow startup output goes in the same buffer as the other
process and therefore no new repl is started up when watching the the
process output since the following code is waiting:

```lisp
(when (and (null nrepl-endpoint)
           (string-match "nREPL server started on port \\([0-9]+\\)" output))
```

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
