### PR TITLE
Add extend to stacktrace and test results faces

### DIFF
--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -822,7 +822,7 @@ the NAME.  The whole group is prefixed by string INDENT."
           (cider-propertize-region '(detail 2)
             (insert "\n")
             (let ((beg (point))
-                  (bg `(:background ,cider-stacktrace-frames-background-color)))
+                  (bg `(:background ,cider-stacktrace-frames-background-color :extend t)))
               (dolist (frame stacktrace)
                 (cider-stacktrace-render-frame buffer frame))
               (overlay-put (make-overlay beg (point)) 'font-lock-face bg)))

--- a/cider-test.el
+++ b/cider-test.el
@@ -412,7 +412,7 @@ With the actual value, the outermost '(not ...)' s-expression is removed."
         (cider-propertize-region (cider-intern-keys (cdr test))
           (let ((beg (point))
                 (type-face (cider-test-type-simple-face type))
-                (bg `(:background ,cider-test-items-background-color)))
+                (bg `(:background ,cider-test-items-background-color :extend t)))
             (cider-insert (capitalize type) type-face nil " in ")
             (cider-insert var 'font-lock-function-name-face t)
             (when context  (cider-insert context 'font-lock-doc-face t))


### PR DESCRIPTION
It will fix broken rendering for emacs-27

Stacktrace before:
![cider-stacktrace-before](https://user-images.githubusercontent.com/6093590/73341855-c6b02800-427d-11ea-9f82-1185f0a44f47.png)
Test results before:
![cider-test-before](https://user-images.githubusercontent.com/6093590/73341878-d0d22680-427d-11ea-8d7d-2dd29f3212d6.png)
Stacktrace after:
![cider-stacktrace-after](https://user-images.githubusercontent.com/6093590/73341888-d7609e00-427d-11ea-8dd3-5a809a00931f.png)
Test results after:
![cider-test-after](https://user-images.githubusercontent.com/6093590/73341899-dfb8d900-427d-11ea-91a1-af5284ff5843.png)

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
