### PR TITLE
Docs - page not found on bottom link

### DIFF
--- a/doc/modules/ROOT/pages/caveats.adoc
+++ b/doc/modules/ROOT/pages/caveats.adoc
@@ -80,6 +80,6 @@ is set. There are several ways to address this:
 * Remove the `:pedantic? :abort` setting.
 * Switch off injecting the dependencies with setting `cider-inject-dependencies-at-jack-in` to `nil` and
 provide the dependencies by editing your `~/.lein/profiles.clj` as described in
-the link:basics/installation.adoc#setting-up-a-standalone-repl[standalone REPL] section.
+the link:basics/middleware_setup.adoc#setting-up-a-standalone-repl[standalone REPL] section.
 * Adjust the value of `cider-jack-in-dependencies`, so it includes the same nREPL value as the
 one that's bundled with Leiningen.


### PR DESCRIPTION
`basics/installation.adoc#setting-up-a-standalone-repl` does not exists, therefore it caused 404 page on https://docs.cider.mx/cider/basics/installation.adoc#setting-up-a-standalone-repl. I'd assume the correct link should be `basics/middleware_setup.adoc#setting-up-a-standalone-repl` so it goes to https://docs.cider.mx/cider/basics/middleware_setup.html#_setting_up_a_standalone_repl.

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
