### PR TITLE
Add force-out support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#2800](https://github.com/clojure-emacs/cider/pull/2800): Add support for force-out debugger command.
+
+### Changes
+
+### Bugs fixed
+
 ## 0.24.0 (2020-02-15)
 
 ### New features

--- a/cider-debug.el
+++ b/cider-debug.el
@@ -202,7 +202,7 @@ Can be toggled at any time with `\\[cider-debug-toggle-locals]'."
     (?n "next" "next")
     (?i "in" "in")
     (?o "out" "out")
-    (?O "out" nil)
+    (?O "force-out" nil)
     (?h "here" "here")
     (?e "eval" "eval")
     (?p "inspect" "inspect")

--- a/cider-debug.el
+++ b/cider-debug.el
@@ -173,9 +173,9 @@ configure `cider-debug-prompt' instead."
     (ignore-errors
       ;; Result
       (cider--make-result-overlay (cider-font-lock-as-clojure value)
-        :where (point-marker)
-        :type 'debug-result
-        'before-string cider--fringe-arrow-string)
+                                  :where (point-marker)
+                                  :type 'debug-result
+                                  'before-string cider--fringe-arrow-string)
       ;; Code
       (cider--make-overlay (save-excursion (clojure-backward-logical-sexp 1) (point))
                            (point) 'debug-code
@@ -202,6 +202,7 @@ Can be toggled at any time with `\\[cider-debug-toggle-locals]'."
     (?n "next" "next")
     (?i "in" "in")
     (?o "out" "out")
+    (?O "out" nil)
     (?h "here" "here")
     (?e "eval" "eval")
     (?p "inspect" "inspect")
@@ -409,6 +410,7 @@ In order to work properly, this mode must be activated by
     ["Continue" (cider-debug-mode-send-reply ":continue") :keys "c"]
     ["Continue non-stop" (cider-debug-mode-send-reply ":continue-all") :keys "C"]
     ["Move out of sexp" (cider-debug-mode-send-reply ":out") :keys "o"]
+    ["Forced move out of sexp" (cider-debug-mode-send-reply ":out" nil true) :keys "O"]
     ["Quit" (cider-debug-mode-send-reply ":quit") :keys "q"]
     "--"
     ["Evaluate in current scope" (cider-debug-mode-send-reply ":eval") :keys "e"]

--- a/cider-debug.el
+++ b/cider-debug.el
@@ -173,9 +173,9 @@ configure `cider-debug-prompt' instead."
     (ignore-errors
       ;; Result
       (cider--make-result-overlay (cider-font-lock-as-clojure value)
-                                  :where (point-marker)
-                                  :type 'debug-result
-                                  'before-string cider--fringe-arrow-string)
+        :where (point-marker)
+        :type 'debug-result
+        'before-string cider--fringe-arrow-string)
       ;; Code
       (cider--make-overlay (save-excursion (clojure-backward-logical-sexp 1) (point))
                            (point) 'debug-code


### PR DESCRIPTION
Adding the option to force out of a debugging operation. Also skips
instrumented functions lower in the call stack. Already implemented
at cider-nrepl level.

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
