### PR TITLE
Fixup tests

### DIFF
--- a/test/cider-connection-tests.el
+++ b/test/cider-connection-tests.el
@@ -288,9 +288,10 @@
            (sesman-unregister 'CIDER session)))))))
 
 (describe "cider--connection-info"
-  (spy-on 'cider--java-version :and-return-value "1.7")
-  (spy-on 'cider--clojure-version :and-return-value "1.7.0")
-  (spy-on 'cider--nrepl-version :and-return-value "0.2.1")
+  (before-each
+    (spy-on 'cider--java-version :and-return-value "1.7")
+    (spy-on 'cider--clojure-version :and-return-value "1.7.0")
+    (spy-on 'cider--nrepl-version :and-return-value "0.2.1"))
 
   (describe "when current project is known"
     (it "returns information about the given connection buffer"

--- a/test/cider-eldoc-tests.el
+++ b/test/cider-eldoc-tests.el
@@ -39,7 +39,7 @@
 
 (describe "cider--eldoc-format-class-names"
   :var (class-names)
-  (before-all
+  (before-each
     (setq class-names '("java.lang.String" "java.lang.StringBuffer" "java.lang.CharSequence" "java.lang.StringBuilder")))
 
   (it "returns a formatted class names prefix string"
@@ -71,7 +71,7 @@
 
 (describe "cider-eldoc-format-thing"
   :var (class-names)
-  (before-all
+  (before-each
     (setq class-names '("java.lang.String" "java.lang.StringBuffer" "java.lang.CharSequence" "java.lang.StringBuilder")))
 
   (describe "when ns is given and it exists"
@@ -159,7 +159,7 @@
             :to-equal "map")))
 
 (describe "cider-eldoc-info-in-current-sexp"
-  (before-all
+  (before-each
     (spy-on 'cider-connected-p :and-return-value t)
     (spy-on 'cider-eldoc-info :and-call-fake
             (lambda (thing)
@@ -209,7 +209,7 @@
                 '("eldoc-info" ("clojure.core" "map" (("f") ("f" "coll"))) "thing" "map" "pos" 2)))))
 
   (describe "interop forms"
-    (before-all
+    (before-each
       (spy-on 'cider-connected-p :and-return-value t)
       (spy-on 'cider-eldoc-info :and-call-fake
               (lambda (thing)
@@ -237,7 +237,7 @@
 
 (describe "cider-eldoc-format-sym-doc"
   :var (eldoc-echo-area-use-multiline-p)
-  (before-all
+  (before-each
     (spy-on 'window-width :and-return-value 177))
 
   (it "returns the formated eldoc string"

--- a/test/cider-repl-tests.el
+++ b/test/cider-repl-tests.el
@@ -64,7 +64,7 @@
 
 (describe "cider-repl--banner"
   :var (cider-version cider-codename)
-  (before-all
+  (before-each
     (spy-on 'cider--java-version :and-return-value "1.8.0_31")
     (spy-on 'cider--clojure-version :and-return-value "1.8.0")
     (spy-on 'cider--nrepl-version :and-return-value "0.5.3")

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -79,7 +79,7 @@
       (expect (cider-project-type) :to-equal 'lein)))
 
   (describe "when there are multiple possible project types"
-    (before-all
+    (before-each
       (spy-on 'cider--identify-buildtools-present
               :and-return-value '(build-tool1 build-tool2))
       ;; user choice build-tool2


### PR DESCRIPTION
Fixup tests

buttercup pushes the spy information onto a context which is only available during `before-each` or `it` macros. I'm not sure what `before-all` does now but it doesn't allow for the spies.

I was looking for where the manual the following too helpful bits could go:

1. A filewatcher to rerun tests

```
while inotifywait -e modify -r .
  make test
end
```

2. supplying a pattern to the buttercup runner:

update the makefile with `--pattern` or `-p`:

```
test: version build
	$(CASK) exec buttercup -L . -L ./test/utils/ --pattern cider-eldoc
```

These two bits helped me track down these problem in just a few minutes.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
