### PR TITLE
Use require rather than use in cljs require repl-utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#2807](https://github.com/clojure-emacs/cider/pull/2807): Fix require-repl-utils for shadow-cljs repls
+
 ## 0.24.0 (2020-02-15)
 
 ### New features

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -170,7 +170,7 @@ you'd like to use the default Emacs behavior use
 
 (defvar cider-repl-require-repl-utils-code
   '((clj . "(clojure.core/apply clojure.core/require clojure.main/repl-requires)")
-    (cljs . "(use '[cljs.repl :only [apropos dir doc find-doc print-doc pst source]])")))
+    (cljs . "(require '[cljs.repl :refer [apropos dir doc find-doc print-doc pst source]])")))
 
 (defcustom cider-repl-init-code (list (cdr (assoc 'clj cider-repl-require-repl-utils-code)))
   "Clojure code to evaluate when starting a REPL.


### PR DESCRIPTION
Shadow doesn't allow `use` and this require statement gets the same result

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
