### PR TITLE
Add an entry in cider-mode-eval-menu for `insert and eval in REPL`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#2617](https://github.com/clojure-emacs/cider/pull/2617): Add menu bar entry for `Insert last sexp in REPL and eval` under `CIDER Eval`.
+
 ## 0.24.0 (2020-02-15)
 
 ### New features

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -360,6 +360,8 @@ If invoked with a prefix ARG eval the expression after inserting it."
     ["Interrupt evaluation" cider-interrupt]
     "--"
     ["Insert last sexp in REPL" cider-insert-last-sexp-in-repl]
+    ["Insert last sexp in REPL and eval" (cider-insert-last-sexp-in-repl t)
+     :keys "\\[universal-argument] \\[cider-insert-last-sexp-in-repl]"]
     ["Insert top-level sexp in REPL" cider-insert-defun-in-repl]
     ["Insert region in REPL" cider-insert-region-in-repl]
     ["Insert ns form in REPL" cider-insert-ns-form-in-repl]

--- a/doc/modules/ROOT/pages/usage/cider_mode.adoc
+++ b/doc/modules/ROOT/pages/usage/cider_mode.adoc
@@ -61,6 +61,10 @@ kbd:[C-c C-e]
 | kbd:[C-c M-p]
 | Load the form preceding point in the REPL buffer.
 
+| `cider-insert-last-sexp-in-repl`
+| kbd:[C-u C-c M-p]
+| Load the form preceding point in the REPL buffer and eval.
+
 | `cider-pprint-eval-last-sexp`
 | kbd:[C-c C-v C-f e]
 | Evaluate the form preceding point and pretty-print the result in a popup buffer. If invoked with a prefix argument, insert the result into the current buffer as a comment.


### PR DESCRIPTION
This is a solution for issue-2617 on cider github.
https://github.com/clojure-emacs/cider/issues/2617

Added an entry for "Insert last sexp in REPL and eval" in menu bar under CIDER Eval.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [X] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`make test`)
- [X] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [X] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
