### PR TITLE
Refcard url parsing

### DIFF
--- a/cider-util.el
+++ b/cider-util.el
@@ -439,7 +439,7 @@ to."
                                    section-id))))
     (buffer-string)))
 
-(defconst cider-refcard-url "https://github.com/clojure-emacs/cider/raw/%s/doc/cider-refcard.pdf"
+(defconst cider-refcard-url "https://github.com/clojure-emacs/cider/raw/%s/refcard/cider-refcard.pdf"
   "The URL to CIDER's refcard.")
 
 (defun cider--github-version ()

--- a/cider-util.el
+++ b/cider-util.el
@@ -439,7 +439,7 @@ to."
                                    section-id))))
     (buffer-string)))
 
-(defconst cider-refcard-url "https://github.com/clojure-emacs/cider/raw/%s/%s/cider-refcard.pdf"
+(defconst cider-refcard-url "https://github.com/clojure-emacs/cider/raw/%s/refcard/cider-refcard.pdf"
   "The URL to CIDER's refcard.")
 
 (defun cider--github-version ()
@@ -448,15 +448,9 @@ to."
       "master"
     (concat "v" cider-version)))
 
-(defun cider--refcard-path ()
-  "The path to the refcard file."
-  (if (> (string-to-number cider-version) 0.22)
-      "refcard"
-    "doc"))
-
 (defun cider-refcard-url ()
   "The CIDER manual's url."
-  (format cider-refcard-url (cider--github-version) (cider--refcard-path)))
+  (format cider-refcard-url (cider--github-version)))
 
 (defun cider-view-refcard ()
   "View the refcard in your default browser."

--- a/cider-util.el
+++ b/cider-util.el
@@ -439,7 +439,7 @@ to."
                                    section-id))))
     (buffer-string)))
 
-(defconst cider-refcard-url "https://github.com/clojure-emacs/cider/raw/%s/refcard/cider-refcard.pdf"
+(defconst cider-refcard-url "https://github.com/clojure-emacs/cider/raw/%s/%s/cider-refcard.pdf"
   "The URL to CIDER's refcard.")
 
 (defun cider--github-version ()
@@ -448,9 +448,15 @@ to."
       "master"
     (concat "v" cider-version)))
 
+(defun cider--refcard-path ()
+  "The path to the refcard file."
+  (if (> (string-to-number cider-version) 0.22)
+      "refcard"
+    "doc"))
+
 (defun cider-refcard-url ()
   "The CIDER manual's url."
-  (format cider-refcard-url (cider--github-version)))
+  (format cider-refcard-url (cider--github-version) (cider--refcard-path)))
 
 (defun cider-view-refcard ()
   "View the refcard in your default browser."

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -208,7 +208,11 @@ buffer."
 
   (it "returns the refcard correct url for snapshot cider versions"
     (setq cider-version "0.11.0-snapshot")
-    (expect (cider-refcard-url) :to-equal "https://github.com/clojure-emacs/cider/raw/master/doc/cider-refcard.pdf")))
+    (expect (cider-refcard-url) :to-equal "https://github.com/clojure-emacs/cider/raw/master/doc/cider-refcard.pdf"))
+
+  (it "returns the refcard correct url for versions later than 0.22"
+    (setq cider-version "0.24.0")
+    (expect (cider-refcard-url) :to-equal "https://github.com/clojure-emacs/cider/raw/v0.24.0/refcard/cider-refcard.pdf")))
 
 (describe "cider-second-sexp-in-list"
   (it "returns the second sexp in the list"

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -203,16 +203,12 @@ buffer."
 (describe "cider-refcard-url"
   :var (cider-version)
   (it "returns the refcard correct url for stable cider versions"
-    (setq cider-version "0.11.0")
-    (expect (cider-refcard-url) :to-equal "https://github.com/clojure-emacs/cider/raw/v0.11.0/doc/cider-refcard.pdf"))
+    (setq cider-version "0.24.0")
+    (expect (cider-refcard-url) :to-equal "https://github.com/clojure-emacs/cider/raw/v0.24.0/refcard/cider-refcard.pdf"))
 
   (it "returns the refcard correct url for snapshot cider versions"
-    (setq cider-version "0.11.0-snapshot")
-    (expect (cider-refcard-url) :to-equal "https://github.com/clojure-emacs/cider/raw/master/doc/cider-refcard.pdf"))
-
-  (it "returns the refcard correct url for versions later than 0.22"
-    (setq cider-version "0.24.0")
-    (expect (cider-refcard-url) :to-equal "https://github.com/clojure-emacs/cider/raw/v0.24.0/refcard/cider-refcard.pdf")))
+    (setq cider-version "0.24.0-snapshot")
+    (expect (cider-refcard-url) :to-equal "https://github.com/clojure-emacs/cider/raw/master/refcard/cider-refcard.pdf")))
 
 (describe "cider-second-sexp-in-list"
   (it "returns the second sexp in the list"


### PR DESCRIPTION
It seems that the refcard document was moved from the path `./doc/` to `./refcard/` in Cider 0.23. However, the `cider-view-refcard` function still uses a URL that points to the old path. For example, in Cider 0.25.0-snapshot, the refcard is opened to https://github.com/clojure-emacs/cider/raw/master/doc/cider-refcard.pdf, which doesn't exist.