### PR TITLE
Avoid requiring org on load

### DIFF
--- a/cider-doc.el
+++ b/cider-doc.el
@@ -37,6 +37,11 @@
 (require 'easymenu)
 (require 'cider-browse-spec)
 
+(declare-function org-table-map-tables 'org-table)
+(declare-function org-table-align 'org-table)
+(declare-function org-table-begin 'org-table)
+(declare-function org-table-end 'org-table)
+
 
 ;;; Variables
 

--- a/cider-doc.el
+++ b/cider-doc.el
@@ -33,7 +33,6 @@
 (require 'cider-client)
 (require 'cider-clojuredocs)
 (require 'nrepl-dict)
-(require 'org-table)
 (require 'button)
 (require 'easymenu)
 (require 'cider-browse-spec)
@@ -346,6 +345,7 @@ Preformatted code text blocks are ignored."
   "Align BUFFER tables and dim borders.
 This processes the GFM table markdown extension using `org-table'.
 Tables are marked to be ignored by line wrap."
+  (require 'org-table)
   (with-current-buffer buffer
     (save-excursion
       (let ((border 'cider-docview-table-border-face))


### PR DESCRIPTION
Currently requiring Cider causes the entire org-mode library to be loaded transitively via `org-table`, which is only required by one function in cider-doc. This can add several seconds to startup the first time one opens a Clojure buffer.

This change simply defers the require statement until the function `cider-docview-format-tables`
needs it.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

