### PR TITLE
Changes to cider-symbol-at-point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ### Changes
 
-* [#2617](https://github.com/clojure-emacs/cider/pull/2617): Add menu bar entry for `Insert last sexp in REPL and eval` under `CIDER Eval`.
+* [#2826](https://github.com/clojure-emacs/cider/pull/2826): Add support for symbols with quotes and resolving of ns-aliased keywords in `cider-symbol-at-point`.
+
+* [#2617](https://github.com/clojure-emacs/cider/pull/2617): Add menu bar entry for `Insert last sexp in REPL 
 
 ### Bugs fixed
 

--- a/cider-util.el
+++ b/cider-util.el
@@ -129,8 +129,8 @@ Ignores the REPL prompt.  If LOOK-BACK is non-nil, move backwards trying to
 find a symbol if there isn't one at point."
   (or (when-let* ((str (thing-at-point 'symbol)))
         (unless (text-property-any 0 (length str) 'field 'cider-repl-prompt str)
-          ;; Remove font-locking and trailing . from constructors like Record.
-          (string-remove-suffix "." (substring-no-properties str))))
+          ;; Remove font-locking, prefix quotes, and trailing . from constructors like Record.
+          (string-remove-prefix "'" (string-remove-suffix "." (substring-no-properties str)))))
       (when look-back
         (save-excursion
           (ignore-errors

--- a/cider-util.el
+++ b/cider-util.el
@@ -42,6 +42,7 @@
 (require 'cider-compat)
 (require 'clojure-mode)
 (require 'nrepl-dict)
+(declare-function cider-sync-request:macroexpand "cider-macroexpansion")
 
 (defalias 'cider-pop-back 'pop-tag-mark)
 
@@ -128,6 +129,9 @@ instead."
 Ignores the REPL prompt.  If LOOK-BACK is non-nil, move backwards trying to
 find a symbol if there isn't one at point."
   (or (when-let* ((str (thing-at-point 'symbol)))
+        ;; resolve ns-aliased keywords
+        (when (string-match-p "^::.+" str)
+          (setq str (or (ignore-errors (cider-sync-request:macroexpand "macroexpand-1" str)) "")))
         (unless (text-property-any 0 (length str) 'field 'cider-repl-prompt str)
           ;; Remove font-locking, prefix quotes, and trailing . from constructors like Record.
           (string-remove-prefix "'" (string-remove-suffix "." (substring-no-properties str)))))


### PR DESCRIPTION
----

Trim leading quotes from symbol, now that clojure-mode treats it as a symbol constituent: 
https://github.com/clojure-emacs/clojure-mode/pull/559

This makes it possible to use cider-doc, eldoc, and various other features on symbols with quotes in them like `foo'`.

Also uses `macroexpand` to resolve ns-aliased keywords, allowing cider-browse-spec to work on aliased keywords at point. 
(Not sure how to write tests for this one)

Would this go under the "changes" or "new features" heading of the changelog? 

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [ ] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
