### PR TITLE
Bind "L" to toggle locals during debugging 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#2828](https://github.com/clojure-emacs/cider/pull/2828): Bind "L" to toggle display of locals during a debug session.
 * [#2800](https://github.com/clojure-emacs/cider/pull/2800): Add support for force-out debugger command.
 
 ### Changes

--- a/cider-debug.el
+++ b/cider-debug.el
@@ -332,6 +332,7 @@ of `cider-interactive-eval' in debug sessions."
     ;; if invoked with an uppercase letter.
     (define-key map "h" #'cider-debug-move-here)
     (define-key map "H" #'cider-debug-move-here)
+    (define-key map "L" #'cider-debug-toggle-locals)
     map)
   "The active keymap during a debugging session.")
 

--- a/cider-debug.el
+++ b/cider-debug.el
@@ -326,7 +326,14 @@ of `cider-interactive-eval' in debug sessions."
     (tool-bar-add-item "exit" #'cider-debug-mode-send-reply :quit :label "Quit")
     tool-bar-map))
 
-(defvar cider--debug-mode-map)
+(defvar cider--debug-mode-map
+  (let ((map (make-sparse-keymap)))
+    ;; Bind the `:here` command to both h and H, because it behaves differently
+    ;; if invoked with an uppercase letter.
+    (define-key map "h" #'cider-debug-move-here)
+    (define-key map "H" #'cider-debug-move-here)
+    map)
+  "The active keymap during a debugging session.")
 
 (define-minor-mode cider--debug-mode
   "Mode active during debug sessions.
@@ -381,11 +388,6 @@ In order to work properly, this mode must be activated by
       (cider--debug-remove-overlays (current-buffer)))
     (when nrepl-ongoing-sync-request
       (ignore-errors (exit-recursive-edit)))))
-
-;;; Bind the `:here` command to both h and H, because it behaves differently if
-;;; invoked with an uppercase letter.
-(define-key cider--debug-mode-map "h" #'cider-debug-move-here)
-(define-key cider--debug-mode-map "H" #'cider-debug-move-here)
 
 (defun cider--debug-remove-overlays (&optional buffer)
   "Remove CIDER debug overlays from BUFFER if variable `cider--debug-mode' is nil."

--- a/doc/modules/ROOT/pages/debugging/debugger.adoc
+++ b/doc/modules/ROOT/pages/debugging/debugger.adoc
@@ -112,6 +112,9 @@ keys, although there are some differences.
 | kbd:[l]
 | Inspect local variables
 
+| kbd:[L]
+| Toggle display of local variables
+
 | kbd:[j]
 | Inject a value into running code
 


### PR DESCRIPTION
The command `cider-debug-toggle-locals` already exists but does not have a default keybinding, I use it fairly often when locals become too unwieldy to display in the minibuffer.


-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
