### PR TITLE
Save command history for jack-in with universal arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#2833](https://github.com/clojure-emacs/cider/pull/2833): Save command history for jack-in with universal arg.
 * [#2828](https://github.com/clojure-emacs/cider/pull/2828): Bind "L" to toggle display of locals during a debug session.
 * [#2800](https://github.com/clojure-emacs/cider/pull/2800): Add support for force-out debugger command.
 

--- a/cider.el
+++ b/cider.el
@@ -1221,6 +1221,12 @@ non-nil, don't start if ClojureScript requirements are not met."
   :safe #'booleanp
   :version '(cider . "0.22.0"))
 
+(defvar cider--jack-in-nrepl-params-history nil
+  "History list for user-specified jack-in nrepl command params.")
+
+(defvar cider--jack-in-cmd-history nil
+  "History list for user-specified jack-in commands.")
+
 (defun cider--powershell-encode-command (cmd-params)
   "Base64 encode the powershell command and jack-in CMD-PARAMS for clojure-cli."
   (let* ((quoted-params (replace-regexp-in-string "\"" "\"\"" cmd-params))
@@ -1241,8 +1247,9 @@ non-nil, don't start if ClojureScript requirements are not met."
         (with-current-buffer (or (plist-get params :--context-buffer)
                                  (current-buffer))
           (let* ((command-params (if (plist-get params :do-prompt)
-                                     (read-string (format "nREPL server command: %s " command-params)
-                                                  command-params)
+                                     (read-string "nREPL server command: "
+                                                  command-params
+                                                  'cider--jack-in-nrepl-params-history)
                                    command-params))
                  (cmd-params (if cider-inject-dependencies-at-jack-in
                                  (cider-inject-jack-in-dependencies command-global-opts command-params project-type)
@@ -1258,7 +1265,7 @@ non-nil, don't start if ClojureScript requirements are not met."
                                                                 cmd-params))))
                     (plist-put params :jack-in-cmd (if (or cider-edit-jack-in-command
                                                            (plist-get params :edit-jack-in-command))
-                                                       (read-string "jack-in command: " cmd t)
+                                                       (read-string "jack-in command: " cmd 'cider--jack-in-cmd-history)
                                                      cmd))))
               (user-error "`cider-jack-in' is not allowed without a Clojure project"))))
       (user-error "The %s executable isn't on your `exec-path'" command))))


### PR DESCRIPTION
I recently had to `C-u cider-jack-in` to a project with a custom set of command line params that took a few tries to get right, and found that I had to re-edit the command from scratch each time which was quite frustrating. This should solve the issue, I don't think tests are needed.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
