### PR TITLE
Handle var-quotes on symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Bugs fixed
 
+* [#2839](https://github.com/clojure-emacs/cider/pull/2839): Fix symbol-at-point on var-quoted symbols
 * [#2807](https://github.com/clojure-emacs/cider/pull/2807): Fix require-repl-utils for shadow-cljs repls.
 
 ## 0.24.0 (2020-02-15)

--- a/cider-util.el
+++ b/cider-util.el
@@ -134,7 +134,12 @@ find a symbol if there isn't one at point."
           (setq str (or (ignore-errors (cider-sync-request:macroexpand "macroexpand-1" str)) "")))
         (unless (text-property-any 0 (length str) 'field 'cider-repl-prompt str)
           ;; Remove font-locking, prefix quotes, and trailing . from constructors like Record.
-          (string-remove-prefix "'" (string-remove-suffix "." (substring-no-properties str)))))
+          (thread-last (substring-no-properties str)
+            ;; constructurs (Foo.)
+            (string-remove-suffix ".")
+            (string-remove-prefix "'")
+            ;; var references (#'inc 2)
+            (string-remove-prefix "#'"))))
       (when look-back
         (save-excursion
           (ignore-errors

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -107,6 +107,11 @@ buffer."
       (with-clojure-buffer "'foo'bar"
         (expect (cider-symbol-at-point) :to-equal "foo'bar"))))
 
+  (describe "when the symbol at point is var-quoted"
+    (it "returns the symbol without the preceding #'"
+      (with-clojure-buffer "#'inc"
+        (expect (cider-symbol-at-point) :to-equal "inc"))))
+
   (describe "when point is on a keyword"
     (it "returns the keyword along with beginning : character"
       (with-clojure-buffer ":abc"


### PR DESCRIPTION
- [ ] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

