### PR TITLE
[Documentation] Configure Test report even on successful tests

### DIFF
--- a/doc/modules/ROOT/pages/testing/test_reports.adoc
+++ b/doc/modules/ROOT/pages/testing/test_reports.adoc
@@ -8,8 +8,7 @@ and jump directly to the definition of failing tests.
 
 Calling test commands again will update the test report.
 
-Customise the `cider-test-show-report-on-success` and set to true 
-and a test report is also shown when tests pass.
+link:running_tests.html#display-test-report-on-success[Configure test reports on success]
 
 |===
 | Keyboard shortcut | Description

--- a/doc/modules/ROOT/pages/testing/test_reports.adoc
+++ b/doc/modules/ROOT/pages/testing/test_reports.adoc
@@ -1,10 +1,15 @@
 = Interacting with Test Result Reports
 :experimental:
 
-After running your tests, CIDER displays a test result report in the
+Shoud tests fail then CIDER displays a test result report in the
 `+*cider-test-report*+` buffer. This buffer uses `cider-test-report-mode`,
 which makes it easy to review any failures that might have occurred
 and jump directly to the definition of failing tests.
+
+Calling test commands again will update the test report.
+
+Customise the `cider-test-show-report-on-success` and set to true 
+and a test report is also shown when tests pass.
 
 |===
 | Keyboard shortcut | Description


### PR DESCRIPTION
A test report is never created when all tests run are successful.  Add information on how to configure CIDER to create a test report when tests are successful.

Small documentation only PR, no tests required?
