### PR TITLE
[Fix #2527] Enable configuring REPL auto-clear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+* [#2527](https://github.com/clojure-emacs/cider/issues/2527): Enable auto-clear of REPL buffer by setting a limit to the max buffer size.
 * [#2852](https://github.com/clojure-emacs/cider/issues/2852): Convert 1-based column numbers in response map to Emacs' 0-based system.
 
 ## 0.25.0 (2020-06-04)

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -670,7 +670,7 @@ Each functions takes a string and must return a modified string.  Also see
   "The max size of the REPL buffer.
 Setting this to nil removes the limit."
   :group 'cider
-  :type 'boolean
+  :type 'integer
   :package-version '(cider . "0.26.0"))
 
 (defun cider-start-of-next-prompt (point)

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -680,20 +680,22 @@ Setting this to nil removes the limit."
         next-prompt-or-input
       (next-single-char-property-change next-prompt-or-input 'field))))
 
-(defun cider-repl-trim-buffer-to-below-limit (buffer)
-  "Trims REPL output from beginning of BUFFER.
+(defun cider-repl-trim-top-of-buffer (buffer)
+  "Trims REPL output from beginning of BUFFER by one fifth of `cider-repl-buffer-size-limit'.
 Also clears remaining partial input or results."
-  (with-current-buffer buffer
+  (if cider-repl-buffer-size-limit
+      (with-current-buffer buffer
     (let* ((to-trim (ceiling (* cider-repl-buffer-size-limit 0.2)))
            (start-of-next-prompt (cider-start-of-next-prompt to-trim))
            (inhibit-read-only t))
-      (cider-repl--clear-region (point-min) start-of-next-prompt))))
+      (cider-repl--clear-region (point-min) start-of-next-prompt)))
+    (message "cider-repl-buffer-size-limit is not set.")))
 
 (defun cider-repl-trim-buffer ()
   "Trim the currently visited REPL buffer partially from the top.
 See also `cider-repl-clear-buffer'."
   (interactive)
-  (cider-repl-trim-buffer-to-below-limit (current-buffer)))
+  (cider-repl-trim-top-of-buffer (current-buffer)))
 
 (defun cider-repl-trim-buffer-if-limit-exceeded (buffer)
   "Clears portion of printed output in BUFFER when `cider-repl-buffer-size-limit' is exceeded."
@@ -1528,6 +1530,7 @@ constructs."
 (cider-repl-add-shortcut "clear" #'cider-repl-clear-buffer)
 (cider-repl-add-shortcut "clear-banners" #'cider-repl-clear-banners)
 (cider-repl-add-shortcut "clear-help-banner" #'cider-repl-clear-help-banner)
+(cider-repl-add-shortcut "trim" #'cider-repl-trim-buffer)
 (cider-repl-add-shortcut "ns" #'cider-repl-set-ns)
 (cider-repl-add-shortcut "toggle-pprint" #'cider-repl-toggle-pretty-printing)
 (cider-repl-add-shortcut "toggle-font-lock" #'cider-repl-toggle-clojure-font-lock)
@@ -1716,6 +1719,7 @@ constructs."
         ["Previous prompt" cider-repl-previous-prompt]
         ["Clear output" cider-repl-clear-output]
         ["Clear buffer" cider-repl-clear-buffer]
+        ["Trim buffer" cider-repl-trim-buffer]
         ["Clear banners" cider-repl-clear-banners]
         ["Clear help banner" cider-repl-clear-help-banner]
         ["Kill input" cider-repl-kill-input]

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -671,12 +671,11 @@ Each functions takes a string and must return a modified string.  Also see
 Setting this to nil removes the limit."
   :group 'cider
   :type 'boolean
-  :package-version '(cider . "0.25.0"))
+  :package-version '(cider . "0.26.0"))
 
 (defun cider-clear-old-repl-output-if-limit-exceeded ()
   "Clears printed output to meet `cider-repl-buffer-size-limit'.
-If limit exceeded, clears any partial input or results until under the limit.
-Clears partial input or results that remain."
+Also clears remaining partial input or results."
   (let ((size (buffer-size)))
     (when (> size cider-repl-buffer-size-limit)
       (let* ((over-limit (- size cider-repl-buffer-size-limit))

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -681,14 +681,15 @@ Setting this to nil removes the limit."
       (next-single-char-property-change next-prompt-or-input 'field))))
 
 (defun cider-repl-trim-top-of-buffer (buffer)
-  "Trims REPL output from beginning of BUFFER by one fifth of `cider-repl-buffer-size-limit'.
+  "Trims REPL output from beginning of BUFFER.
+Trims by one fifth of `cider-repl-buffer-size-limit'.
 Also clears remaining partial input or results."
   (if cider-repl-buffer-size-limit
       (with-current-buffer buffer
-    (let* ((to-trim (ceiling (* cider-repl-buffer-size-limit 0.2)))
-           (start-of-next-prompt (cider-start-of-next-prompt to-trim))
-           (inhibit-read-only t))
-      (cider-repl--clear-region (point-min) start-of-next-prompt)))
+        (let* ((to-trim (ceiling (* cider-repl-buffer-size-limit 0.2)))
+               (start-of-next-prompt (cider-start-of-next-prompt to-trim))
+               (inhibit-read-only t))
+          (cider-repl--clear-region (point-min) start-of-next-prompt)))
     (message "cider-repl-buffer-size-limit is not set.")))
 
 (defun cider-repl-trim-buffer ()
@@ -700,7 +701,7 @@ See also `cider-repl-clear-buffer'."
 (defun cider-repl-trim-buffer-if-limit-exceeded (buffer)
   "Clears portion of printed output in BUFFER when `cider-repl-buffer-size-limit' is exceeded."
   (when (> (buffer-size) cider-repl-buffer-size-limit)
-    (cider-repl-trim-buffer-to-below-limit buffer)))
+    (cider-repl-trim-top-of-buffer buffer)))
 
 (defun cider-repl--emit-output (buffer string face)
   "Using BUFFER, emit STRING as output font-locked using FACE.

--- a/doc/modules/ROOT/pages/repl/basic_usage.adoc
+++ b/doc/modules/ROOT/pages/repl/basic_usage.adoc
@@ -56,7 +56,9 @@ Performance can degrade when the REPL buffer grows very large. This is
 especially true if either `cider-repl-use-clojure-font-lock` or
 `nrepl-log-messages` are enabled. You can use `cider-repl-clear-output` to
 either clear the result of the previous evaluation, or with a prefix argument
-clear the entire REPL buffer.
+clear the entire REPL buffer. You can also set `cider-repl-buffer-size-limit`
+which will enable trimming the buffer automatically after each evaluation. This
+trimming can also be invoked manually with `cider-repl-trim-buffer`.
 
 Very long lines are guaranteed to bring Emacs to a crawl, so using a value of
 `cider-print-fn` that wraps lines beyond a certain width (i.e. any of the

--- a/doc/modules/ROOT/pages/repl/configuration.adoc
+++ b/doc/modules/ROOT/pages/repl/configuration.adoc
@@ -118,6 +118,13 @@ built-in option `scroll-conservatively`, for example:
 (add-hook 'cider-repl-mode-hook '(lambda () (setq scroll-conservatively 101)))
 ----
 
+== Auto-trimming the buffer
+Disabled by default (`nil`).
+
+This can be enabled by setting `cider-repl-buffer-size-limit` to an integer. By setting
+a limit to the number of characters in the buffer, the buffer can be trimmed after
+each evaluation if the set limit has been exceeded.
+
 == Result Prefix
 
 You can change the string used to prefix REPL results:


### PR DESCRIPTION
Enables setting a limit to the buffer size of the REPL buffer (off by default), which when exceeded after printing out a result or other output, will clear old repl output from the beginning to ensure it stays within the limit. When clearing it also ensures partial input or output is erased.

Tested it with logging smaller/larger outputs every millisecond via [tools.logging](https://github.com/clojure/tools.logging), haven't come across any performance issues so far. 

Currently it's calling clear after new output is printed. May make more sense for that call to come before printing new output?