### PR TITLE
Eliminate various byte-compilation warnings

### DIFF
--- a/cider-browse-spec.el
+++ b/cider-browse-spec.el
@@ -36,6 +36,7 @@
 
 (require 'cider-client)
 (require 'cider-compat)
+(require 'cider-popup)
 (require 'cider-util)
 (require 'cl-lib)
 (require 'nrepl-dict)

--- a/cider-compat.el
+++ b/cider-compat.el
@@ -26,6 +26,8 @@
 
 ;;; Code:
 
+(require 'subr-x)
+
 (eval-and-compile
 
   (unless (fboundp 'if-let*)

--- a/cider-completion.el
+++ b/cider-completion.el
@@ -31,6 +31,7 @@
 
 (require 'cider-client)
 (require 'cider-common)
+(require 'cider-doc)
 (require 'cider-eldoc)
 (require 'nrepl-dict)
 

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -34,6 +34,9 @@
 (require 'format-spec)
 (require 'sesman)
 (require 'sesman-browser)
+(require 'spinner)
+(require 'cider-popup)
+(require 'cider-util)
 
 (defcustom cider-session-name-template "%J:%h:%p"
   "Format string to use for session names.
@@ -243,6 +246,7 @@ message in the REPL area."
                                  cider-version cider-required-middleware-version middleware-version)))))
 
 (declare-function cider-interactive-eval-handler "cider-eval")
+(declare-function cider-nrepl-send-request "cider-client")
 ;; TODO: Use some null handler here
 (defun cider--subscribe-repl-to-server-out ()
   "Subscribe to the nREPL server's *out*."
@@ -273,6 +277,7 @@ See command `cider-mode'."
 
 (declare-function cider--debug-init-connection "cider-debug")
 (declare-function cider-repl-init "cider-repl")
+(declare-function cider-nrepl-op-supported-p "cider-client")
 (defun cider--connected-handler ()
   "Handle CIDER initialization after nREPL connection has been established.
 This function is appended to `nrepl-connected-hook' in the client process
@@ -438,6 +443,8 @@ REPL defaults to the current REPL."
 
 (defconst cider-nrepl-session-buffer "*cider-nrepl-session*")
 
+(declare-function cider-nrepl-eval-session "cider-client")
+(declare-function cider-nrepl-tooling-session "cider-client")
 (defun cider-describe-nrepl-session ()
   "Describe an nREPL session."
   (interactive)
@@ -469,6 +476,7 @@ REPL defaults to the current REPL."
 (cl-defmethod sesman-more-relevant-p ((_system (eql CIDER)) session1 session2)
   (sesman-more-recent-p (cdr session1) (cdr session2)))
 
+(declare-function cider-classpath-entries "cider-client")
 (cl-defmethod sesman-friendly-session-p ((_system (eql CIDER)) session)
   (setcdr session (seq-filter #'buffer-live-p (cdr session)))
   (when-let* ((repl (cadr session))

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -563,6 +563,7 @@ REPL buffer.  This is controlled via
             (cider--make-fringe-overlay (point)))
         (scan-error nil)))))
 
+(declare-function cider-inspect-last-result "cider-inspector")
 (defun cider-interactive-eval-handler (&optional buffer place)
   "Make an interactive eval handler for BUFFER.
 PLACE is used to display the evaluation result.

--- a/cider-find.el
+++ b/cider-find.el
@@ -28,6 +28,7 @@
 
 (require 'cider-client)
 (require 'cider-common)
+(require 'cider-resolve)
 
 (require 'thingatpt)
 

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -39,6 +39,7 @@
 (require 'cider-doc) ; required only for the menu
 (require 'cider-profile) ; required only for the menu
 (require 'cider-completion)
+(require 'cider-inspector)
 (require 'subr-x)
 (require 'cider-compat)
 

--- a/cider-ns.el
+++ b/cider-ns.el
@@ -62,6 +62,7 @@
 (require 'subr-x)
 
 (require 'cider-client)
+(require 'cider-eval)
 (require 'cider-popup)
 (require 'cider-stacktrace)
 

--- a/cider-repl-history.el
+++ b/cider-repl-history.el
@@ -35,6 +35,7 @@
 (require 'clojure-mode)
 (require 'derived)
 (require 'pulse)
+(require 'sesman)
 
 (defconst cider-repl-history-buffer "*cider-repl-history*")
 

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -52,6 +52,8 @@
 (require 'cider-util)
 (require 'cider-resolve)
 
+(declare-function cider-inspect "cider-inspector")
+
 (eval-when-compile
   (defvar paredit-version)
   (defvar paredit-space-for-delimiter-predicates))

--- a/cider-util.el
+++ b/cider-util.el
@@ -41,7 +41,7 @@
 ;; clojure-mode and CIDER
 (require 'cider-compat)
 (require 'clojure-mode)
-(require 'nrepl-dict)
+
 (declare-function cider-sync-request:macroexpand "cider-macroexpansion")
 
 (defalias 'cider-pop-back 'pop-tag-mark)

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -75,6 +75,7 @@
 (require 'cl-lib)
 (require 'nrepl-dict)
 (require 'queue)
+(require 'sesman)
 (require 'tramp)
 
 
@@ -181,6 +182,7 @@ To be used for tooling calls (i.e. completion, eldoc, etc)")
 (defconst nrepl-server-buffer-name-template "*nrepl-server %s*")
 (defconst nrepl-tunnel-buffer-name-template "*nrepl-tunnel %s*")
 
+(declare-function cider-format-connection-params "cider-connection")
 (defun nrepl-make-buffer-name (template params &optional dup-ok)
   "Generate a buffer name using TEMPLATE and PARAMS.
 TEMPLATE and PARAMS are as in `cider-format-connection-params'.  If
@@ -729,6 +731,7 @@ to the REPL."
     (message msg)))
 
 (defvar cider-buffer-ns)
+(defvar cider-print-quota)
 (defvar cider-special-mode-truncate-lines)
 (declare-function cider-need-input "cider-client")
 (declare-function cider-set-buffer-ns "cider-mode")
@@ -1298,6 +1301,7 @@ it into the buffer."
         (pp object (current-buffer))
         (insert "\n")))))
 
+(declare-function cider--gather-connect-params "cider-connection")
 (defun nrepl-messages-buffer (conn)
   "Return or create the buffer for CONN.
 The default buffer name is *nrepl-messages connection*."


### PR DESCRIPTION
As decided in #2865. This cleans up byte-compilation in preparation for switch to Eldev. As a side-effect, Flycheck is also happier and doesn't report the warnings anymore.