### PR TITLE
[Fix #2718] Avoid printing comment if empty result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ macros, special forms and methods.
 * Handle properly missing file metadata in `cider-doc` buffers, when you eval fallback to obtain var metadata.
 * Show eldoc for `.` and `..`.
 * [#2860](https://github.com/clojure-emacs/cider/issues/2860): Don't send blank strings in `eldoc` requests.
+* [#2718](https://github.com/clojure-emacs/cider/issues/2718): When calling `cider-pprint-eval-last-sexp-to-comment`, avoid printing empty comment if eval throws error.
 
 ## 0.25.0 (2020-06-04)
 

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -650,6 +650,20 @@ comment prefix to use."
                                  (cider-emit-interactive-eval-err-output err))
                                '()))
 
+(defun cider-maybe-insert-multiline-comment (result comment-prefix continued-prefix comment-postfix)
+  "Insert eval RESULT at current location if RESULT is not empty.
+RESULT will be preceded by COMMENT-PREFIX.
+CONTINUED-PREFIX is inserted for each additional line of output.
+COMMENT-POSTFIX is inserted after final text output."
+  (unless (string= result "")
+    (let ((lines (split-string result "[\n]+" t)))
+      ;; only the first line gets the normal comment-prefix
+      (insert (concat comment-prefix (pop lines)))
+      (dolist (elem lines)
+        (insert (concat "\n" continued-prefix elem)))
+      (unless (string= comment-postfix "")
+        (insert comment-postfix)))))
+
 (defun cider-eval-pprint-with-multiline-comment-handler (buffer location comment-prefix continued-prefix comment-postfix)
   "Make a handler for evaluating and inserting results in BUFFER.
 The inserted text is pretty-printed and region will be commented.
@@ -668,13 +682,7 @@ COMMENT-POSTFIX is the text to output after the last line."
        (with-current-buffer buffer
          (save-excursion
            (goto-char (marker-position location))
-           (let ((lines (split-string res "[\n]+" t)))
-             ;; only the first line gets the normal comment-prefix
-             (insert (concat comment-prefix (pop lines)))
-             (dolist (elem lines)
-               (insert (concat "\n" continued-prefix elem)))
-             (unless (string= comment-postfix "")
-               (insert comment-postfix))))))
+           (cider-maybe-insert-multiline-comment res comment-prefix continued-prefix comment-postfix))))
      nil
      nil
      (lambda (_buffer warning)


### PR DESCRIPTION
Small fix for https://github.com/clojure-emacs/cider/issues/2718

If an error is returned when `pprint-eval-last-sexp-to-comment` is called, the result string will be empty. While it may occasionally make sense to print out the exception, typically people will only want the successful evaluation, without having to clean up the empty comment string.
