### PR TITLE
[Fix #2796] Disable debug if CIDER disconnected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ macros, special forms and methods.
 * Show eldoc for `.` and `..`.
 * [#2860](https://github.com/clojure-emacs/cider/issues/2860): Don't send blank strings in `eldoc` requests.
 * [#2718](https://github.com/clojure-emacs/cider/issues/2718): When calling `cider-pprint-eval-last-sexp-to-comment`, avoid printing empty comment if eval throws error.
+* [#2796](https://github.com/clojure-emacs/cider/issues/2796): Closing CIDER connection will disable the debug minor mode on clojure buffers.
 
 ## 0.25.0 (2020-06-04)
 

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -263,11 +263,13 @@ See command `cider-mode'."
     (with-current-buffer buffer
       (cider-mode +1))))
 
+(declare-function cider--debug-mode "cider-debug")
 (defun cider-disable-on-existing-clojure-buffers ()
-  "Disable command `cider-mode' on existing Clojure buffers."
+  "Disable command `cider-mode' and related commands on existing Clojure buffers."
   (interactive)
   (dolist (buffer (cider-util--clojure-buffers))
     (with-current-buffer buffer
+      (cider--debug-mode -1)
       (cider-mode -1))))
 
 (defun cider-possibly-disable-on-existing-clojure-buffers ()


### PR DESCRIPTION
On closing CIDER connection, we currently disable cider-mode across all clojure-mode buffers, however we don't disable debug-mode if active.

Even without this change I noticed that when closing the CIDER connection during a debugging sessoion, a buffer appears for a split second before being deleted, tracing it back I can see it's an unhandled `java.lang.InterruptedException` that gets thrown when the input promise is deref'd in cider-repl. This seems fine as is?