### PR TITLE
Improve handling of carriage return ("\r")

### DIFF
--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -323,7 +323,7 @@ object is a root list or dict."
         (goto-char end)
         ;; normalise any platform-specific newlines
         (let* ((original (buffer-substring-no-properties beg end))
-               (result (replace-regexp-in-string "\r\n\\|\n\r\\|\r" "\n" original)))
+               (result (replace-regexp-in-string "\r\n\\|\n\r" "\n" original)))
           (cons nil (nrepl--push result stack))))))
    ;; integer
    ((looking-at "i\\(-?[0-9]+\\)e")


### PR DESCRIPTION
A CARRIAGE RETURN character moves the head of the teletype printer (the
carriage) to the beginning of the line, without scrolling the paper (this is
done by the LINE FEED "\n")

In a contemporary terminal emulator this translates to moving the cursor to the
beginning of the current line. Any subsequent output then overwrites what was
already on that line. This is how terminal progress bars are implemented.

The existing implementation incorrectly treated "\r" as "\n", thus inserting a
newline, instead of moving to the beginning of the current line.

Instead iterate over the output and deal with "\r" and "\n" the way terminals
do, "\r" (ASCII 13) moves to the beginning of the line, "\n" (ASCII 10) moves to
the beginning of the next line. Any output overwrites output on the same line
after the cursor position.

Sample code:

```
(println "aaaa\rbb\ncccc\rdd")
;; Outputs:
;; bbaa
;; ddcc

(dotimes [i 20]
  (print "\r[" (inc i) "]")
  (flush)
  (Thread/sleep 500))
;; prints a counter in place
```

Feedback welcome as I'm not sure of the performance impact of dealing with each
character individually. Also not sure what the effect is of propertizing and
running cider-repl-preoutput-hook per character.

Fixes #1677 (which was closed but not actually implemented, only worked around)


-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

```
➜ make test
make: Nothing to be done for 'test'.

➜ make lint
make: *** No rule to make target 'lint'.  Stop.
```