### PR TITLE
Make `cider-describe-connection` be aware of babashka

### DIFF
--- a/cider-connection.el
+++ b/cider-connection.el
@@ -382,17 +382,27 @@ process buffer."
 (defun cider--connection-info (connection-buffer &optional genericp)
   "Return info about CONNECTION-BUFFER.
 Info contains project name, current REPL namespace, host:port endpoint and
-Clojure version.  When GENERICP is non-nil, don't provide specific info
+runtime details.  When GENERICP is non-nil, don't provide specific info
 about this buffer (like variable `cider-repl-type')."
   (with-current-buffer connection-buffer
-    (format "%s%s@%s:%s (Java %s, Clojure %s, nREPL %s)"
-            (if genericp "" (upcase (concat (symbol-name cider-repl-type) " ")))
-            (or (cider--project-name nrepl-project-dir) "<no project>")
-            (plist-get nrepl-endpoint :host)
-            (plist-get nrepl-endpoint :port)
-            (cider--java-version)
-            (cider--clojure-version)
-            (cider--nrepl-version))))
+    (cond
+     ((cider--clojure-version)
+      (format "%s%s@%s:%s (Java %s, Clojure %s, nREPL %s)"
+              (if genericp "" (upcase (concat (symbol-name cider-repl-type) " ")))
+              (or (cider--project-name nrepl-project-dir) "<no project>")
+              (plist-get nrepl-endpoint :host)
+              (plist-get nrepl-endpoint :port)
+              (cider--java-version)
+              (cider--clojure-version)
+              (cider--nrepl-version)))
+     ((cider--babashka-version)
+      (format "%s%s@%s:%s (Babashka %s, babashka.nrepl %s)"
+              (if genericp "" (upcase (concat (symbol-name cider-repl-type) " ")))
+              (or (cider--project-name nrepl-project-dir) "<no project>")
+              (plist-get nrepl-endpoint :host)
+              (plist-get nrepl-endpoint :port)
+              (cider--babashka-version)
+              (cider--babashka-nrepl-version))))))
 
 
 ;;; Cider's Connection Management UI


### PR DESCRIPTION
`cider-describe-connection` assumes one is using `cider-nrepl`, and shows `nil` for Clojure, Java and nREPL versions when using other things.

---

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

What do you think about this @bbatsov  ?
