### PR TITLE
Translate paths from CIDER to nREPL and vice-versa

### DIFF
--- a/cider-eval.el
+++ b/cider-eval.el
@@ -710,9 +710,11 @@ This is used by pretty-printing commands."
 
 (defvar cider-to-nrepl-filename-function
   (with-no-warnings
-    (if (eq system-type 'cygwin)
-        #'cygwin-convert-file-name-to-windows
-      #'identity))
+    (lambda (path)
+      (let ((path* (if (eq system-type 'cygwin)
+                       (cygwin-convert-file-name-to-windows path)
+                     path)))
+        (or (cider--translate-path-to-nrepl path*) path*))))
   "Function to translate Emacs filenames to nREPL namestrings.")
 
 (defun cider--prep-interactive-eval (form connection)

--- a/test/cider-interaction-tests.el
+++ b/test/cider-interaction-tests.el
@@ -42,18 +42,26 @@
             :to-equal "a.two-three.b")))
 
 (describe "cider-to-nrepl-filename-function"
-  (let ((windows-file-name "C:/foo/bar")
-        (unix-file-name "/cygdrive/c/foo/bar"))
-    (if (eq system-type 'cygwin)
-        (and (expect (funcall cider-from-nrepl-filename-function windows-file-name)
-                     :to-equal unix-file-name)
-             (expect (funcall cider-to-nrepl-filename-function unix-file-name)
-                     :to-equal windows-file-name))
-
-      (and (expect (funcall cider-from-nrepl-filename-function unix-file-name)
-                   :to-equal unix-file-name)
-           (expect (funcall cider-to-nrepl-filename-function unix-file-name)
-                   :to-equal unix-file-name)))))
+  (it "translates file paths when running on cygwin systems"
+    (let ((windows-file-name "C:/foo/bar")
+          (unix-file-name "/cygdrive/c/foo/bar"))
+      (if (eq system-type 'cygwin)
+          (progn
+            (expect (funcall cider-from-nrepl-filename-function windows-file-name)
+                    :to-equal unix-file-name)
+            (expect (funcall cider-to-nrepl-filename-function unix-file-name)
+                    :to-equal windows-file-name))
+        (progn
+          (expect (funcall cider-from-nrepl-filename-function unix-file-name)
+                  :to-equal unix-file-name)
+          (expect (funcall cider-to-nrepl-filename-function unix-file-name)
+                  :to-equal unix-file-name)))))
+  (it "translates file paths from container/vm location to host location"
+    (let ((cider-path-translations '(("/docker/src" . "/cygdrive/c/project/src"))))
+      (expect (funcall cider-from-nrepl-filename-function "/docker/src/ns.clj")
+              :to-equal "/cygdrive/c/project/src/ns.clj")
+      (expect (funcall cider-to-nrepl-filename-function "/cygdrive/c/project/src/ns.clj")
+              :to-equal "/docker/src/ns.clj"))))
 
 (describe "cider-quit"
   (it "raises a user error if cider is not connected"


### PR DESCRIPTION
When `cider-path-translations` is in use (e.g., when CIDER is running
on the host, but the nREPL is running in a virtual machine or a
container) we need to translate from the host "CIDER-based" paths to
the container "nREPL-based" paths and vice-versa, depending on the
operation.

Translations from "nREPL-based" paths to "CIDER-based" paths were
already implemented, but not the other way around. Some operations in
clj-refactor need the "CIDER-based"to "nREPL-based" path translations
to work correctly (e.g., `cljr-rename-file-or-dir`,
`cljr-rename-symbol`, etc.).

This patch implements the missing path translations, and is a
pre-requisite for the complementary clj-refactor patch that is
proposed separately.



-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [X] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`eldev test`)
- [X] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
