### PR TITLE
[Fix #2909] Add option to control auto selection of the inspector buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#2909](https://github.com/clojure-emacs/cider/issues/2909): Add new customization variable `cider-inspector-auto-select-buffer` to control the auto selection of the inspector buffer.
+
 ### Bugs fixed
 
 * Fix broken links to the docs in REPL warnings (the REPL links included the full CIDER version, but the docs URLs are without the patch version).

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -67,6 +67,12 @@ by clicking or navigating to them by other means."
   :group 'cider-inspector
   :package-version '(cider . "0.25.0"))
 
+(defcustom cider-inspector-auto-select-buffer t
+  "Determines if the inspector buffer should be auto selected."
+  :type 'boolean
+  :group 'cider-inspector
+  :package-version '(cider . "0.27.0"))
+
 (defvar cider-inspector-uninteresting-regexp
   (concat "nil"                      ; nils are not interesting
           "\\|:" clojure--sym-regexp ; nor keywords
@@ -307,7 +313,7 @@ Set the page size in paginated view to PAGE-SIZE."
   "Render VALUE."
   (cider-make-popup-buffer cider-inspector-buffer 'cider-inspector-mode 'ancillary)
   (cider-inspector-render cider-inspector-buffer value)
-  (cider-popup-buffer-display cider-inspector-buffer t)
+  (cider-popup-buffer-display cider-inspector-buffer cider-inspector-auto-select-buffer)
   (when cider-inspector-fill-frame (delete-other-windows))
   (with-current-buffer cider-inspector-buffer
     (when (eq cider-inspector-last-command 'cider-inspector-pop)

--- a/doc/modules/ROOT/pages/debugging/inspector.adoc
+++ b/doc/modules/ROOT/pages/debugging/inspector.adoc
@@ -53,10 +53,15 @@ You'll have access to additional keybindings in the inspector buffer
 | Defines a var in the REPL namespace with current inspector value
 |===
 
+== Configuration
 
 By default, navigation skips over values like nils, numbers and
 keywords, which are not interesting to inspect. You can control this
 behavior using the variable `cider-inspector-skip-uninteresting`.
+
+The inspector buffer is automatically selected by default. You
+can disable the auto selection with the variable
+`cider-inspector-auto-select-buffer`.
 
 == Additional Resources
 


### PR DESCRIPTION
This PR adds a a new customization variable `cider-auto-select-inspector-buffer` to control the auto selection of the inspector buffer.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`eldev test`)
- [X] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
