### PR TITLE
jack-in: move Clojure-cli parameter global-opts after -Sdeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs fixed
 
 * Fix broken links to the docs in REPL warnings (the REPL links included the full CIDER version, but the docs URLs are without the patch version).
+* Fix ordering of dependencies, global-opts and params for Clojure CLI projects when calling cider-jack-in. Thanks to @iarenaza  Resolves #2916
 
 ### Changes
 

--- a/cider.el
+++ b/cider.el
@@ -564,16 +564,16 @@ removed, LEIN-PLUGINS, and finally PARAMS."
 
 (defun cider-clojure-cli-jack-in-dependencies (global-opts params dependencies)
   "Create Clojure tools.deps jack-in dependencies.
-Does so by concatenating GLOBAL-OPTS, DEPENDENCIES finally PARAMS."
+Does so by concatenating DEPENDENCIES, GLOBAL-OPTS and PARAMS."
   (let ((dependencies (append dependencies cider-jack-in-lein-plugins)))
     (concat
-     global-opts
-     (unless (seq-empty-p global-opts) " ")
      "-Sdeps '{:deps {"
      (mapconcat #'identity
                 (seq-map (lambda (dep) (format "%s {:mvn/version \"%s\"}" (car dep) (cadr dep))) dependencies)
                 " ")
      "}}' "
+     global-opts
+     (unless (seq-empty-p global-opts) " ")
      params)))
 
 (defun cider-shadow-cljs-jack-in-dependencies (global-opts params dependencies)


### PR DESCRIPTION
Move the aliases (global-opts) after the -Sdeps dependencies in cider-jack-in to
match the order of arguments to the clojure command line tool.

This fix has been successfully tested with the new `-M` flag and the classic `-A` flag for defining aliases for the Clojure CLI tools.

Resolves #2916

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md) - confirmed
- [x] You've added tests - no additional tests required
- [x] All tests are passing (`eldev test`) - all tests passed
- [x] All code passes the linter (`eldev lint`) - no warnings on changed file, cider.el (warnings in other files that were not changed)
- [x]  [changelog](../blob/master/CHANGELOG.md) - added fix and referenced issue
- [x] user manual - no visual change

