### PR TITLE
Fix regression in cider-info-form arglists-str

### DIFF
--- a/cider-client.el
+++ b/cider-client.el
@@ -434,7 +434,7 @@ contain a `candidates' key, it is returned as is."
           (cond-> (:special-form info) (update :special-form str))
           (cond-> (:protocol info) (update :protocol str))
           (cond-> (:arglists info) (update :arglists str))
-          (assoc :arglists-str (:arglists info))
+          (assoc :arglists-str (str (:arglists info)))
           (clojure.walk/stringify-keys)))))
 ")
 


### PR DESCRIPTION
Fix a regression in commit 1be3b8 where arglists-str is not a string anymore.
I didn't update Changelog as the issue was introduced after the latest release version.

The current code produces an error on emacs when trying to use `cider-doc`:

```
Debugger entered--Lisp error: (wrong-type-argument stringp ([f] [f coll] [f c1 c2] [f c1 c2 c3] [f c1 c2 c3 & colls]))
  string-match("\n" ([f] [f coll] [f c1 c2] [f c1 c2 c3] [f c1 c2 c3 & colls]) 0)
  split-string(([f] [f coll] [f c1 c2] [f c1 c2 c3] [f c1 c2 c3 & colls]) "\n")
  cider-docview-render-info(#<buffer *cider-doc*> (dict "ns" "clojure.core" "name" "map" "built-in" t "arglists" "([f] [f coll] [f c1 c2] [f c1 c2 c3] [f c1 c2 c3 &..." "doc" "Returns a lazy sequence consisting of the result o..." "file" "" "arglists-str" ([f] [f coll] [f c1 c2] [f c1 c2 c3] [f c1 c2 c3 & colls])))
  cider-docview-render(#<buffer *cider-doc*> "map" (dict "ns" "clojure.core" "name" "map" "built-in" t "arglists" "([f] [f coll] [f c1 c2] [f c1 c2 c3] [f c1 c2 c3 &..." "doc" "Returns a lazy sequence consisting of the result o..." "file" "" "arglists-str" ([f] [f coll] [f c1 c2] [f c1 c2 c3] [f c1 c2 c3 & colls])))
  cider-create-doc-buffer("map")
  cider-doc-lookup("map")
  cider-try-symbol-at-point("Doc for" cider-doc-lookup)
  cider-doc(nil)
  funcall-interactively(cider-doc nil)
  call-interactively(cider-doc nil nil)
  command-execute(cider-doc)
```

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
