### PR TITLE
added cache for previous eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * Bump the injected `cider-nrepl` version to `0.25.4`.
 * [#2897](https://github.com/clojure-emacs/cider/pull/2897): Translate paths from CIDER to nREPL and vice-versa.
 * Set `cider-prompt-for-symbol` to `nil` by default.
-* Add cache for previously eval'd sexp to re-run for convenience.
+* Add buffer-local for previously eval'd sexp to re-run for convenience.
 
 ## 0.26.1 (2020-08-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Bump the injected `cider-nrepl` version to `0.25.4`.
 * [#2897](https://github.com/clojure-emacs/cider/pull/2897): Translate paths from CIDER to nREPL and vice-versa.
 * Set `cider-prompt-for-symbol` to `nil` by default.
+* Add cache for previously eval'd sexp to re-run for convenience.
 
 ## 0.26.1 (2020-08-14)
 

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -811,15 +811,6 @@ buffer."
                               (cider--nrepl-pr-request-map))
     (user-error "No sexp has been run in this buffer")))
 
-(defun cider-eval-last-sexp-or-re-eval-previous-sexp (&optional re-run-previous-sexp)
-  "Evaluate the expected preceding the point or a cached sexp.
-If invoked with RE-RUN-PREVIOUS-SEXP `cider-eval-last-sexp` otherwise
-`cider-re-eval-previous-sexp'"
-  (interactive "P")
-  (if re-run-previous-sexp
-      (cider-re-eval-previous-sexp)
-    (cider-eval-last-sexp)))
-
 (defun cider-eval-last-sexp-and-replace ()
   "Evaluate the expression preceding point and replace it with its result."
   (interactive)

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -500,7 +500,7 @@ As it stands Emacs fires these events on <mouse-8> and <mouse-9> on 'x' and
     (define-key map (kbd "C-M-x")   #'cider-eval-defun-at-point)
     (define-key map (kbd "C-c C-c") #'cider-eval-defun-at-point)
     (define-key map (kbd "C-x C-e") #'cider-eval-last-sexp)
-    (define-key map (kbd "C-c C-e") #'cider-eval-last-sexp-or-re-eval-previous-sexp)
+    (define-key map (kbd "C-c C-e") #'cider-eval-last-sexp)
     (define-key map (kbd "C-c C-p") #'cider-pprint-eval-last-sexp)
     (define-key map (kbd "C-c C-f") #'cider-pprint-eval-defun-at-point)
     (define-key map (kbd "C-c C-v") 'cider-eval-commands-map)

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -500,7 +500,7 @@ As it stands Emacs fires these events on <mouse-8> and <mouse-9> on 'x' and
     (define-key map (kbd "C-M-x")   #'cider-eval-defun-at-point)
     (define-key map (kbd "C-c C-c") #'cider-eval-defun-at-point)
     (define-key map (kbd "C-x C-e") #'cider-eval-last-sexp)
-    (define-key map (kbd "C-c C-e") #'cider-eval-last-sexp)
+    (define-key map (kbd "C-c C-e") #'cider-eval-last-sexp-or-re-eval-previous-sexp)
     (define-key map (kbd "C-c C-p") #'cider-pprint-eval-last-sexp)
     (define-key map (kbd "C-c C-f") #'cider-pprint-eval-defun-at-point)
     (define-key map (kbd "C-c C-v") 'cider-eval-commands-map)

--- a/doc/modules/ROOT/pages/usage/code_evaluation.adoc
+++ b/doc/modules/ROOT/pages/usage/code_evaluation.adoc
@@ -173,9 +173,17 @@ Below is a listing of most keybindings for evaluation commands:
 | Command | Keyboard shortcut | Description
 
 | `cider-eval-last-sexp`
-| kbd:[C-x C-e] +
-kbd:[C-c C-e]
+| kbd:[C-x C-e]
 | Evaluate the form preceding point and display the result in the echo area and/or in an buffer overlay (according to `cider-use-overlays`).  If invoked with a prefix argument, insert the result into the current buffer.
+
+| `cider-eval-last-sexp-or-re-eval-previous-sexp`
+| kbd:[C-c C-e]
+| Evaluate the form preceding point like `cider-eval-last-sexp` unless invoked with a prefix argument, in which case it will evaluate the previously evaluated expression. This includes any context stored by commands like `cider-eval-last-sexp-in-context`.
+
+| `cider-eval-last-sexp-in-context`
+| kbd:[C-c C-v C-c] +
+kbd:[C-c C-v c]
+| Eval the form preceding point with a containing lexical scope. The context is defined interactively in the minibuffer and evaluated as if provided in as `let` bindings surrounding the form to be evaluated. Useful for debugging deeply nested forms.
 
 | `cider-eval-last-sexp-and-replace`
 | kbd:[C-c C-v w]

--- a/doc/modules/ROOT/pages/usage/code_evaluation.adoc
+++ b/doc/modules/ROOT/pages/usage/code_evaluation.adoc
@@ -67,20 +67,20 @@ example:
 ----
 (defn long-and-complicated-function [x y]
   (let [r (range x)
-        l (map #(+ % y) r)] ;; <- form we want to eval independently of it's context
+        l (map #(+ % y) r)] ;; <- form we want to eval independently of its context
     (reduce + l)))
 ----
 
 If you position the point after the `map` form and evaluate it with
 kbd:[C-c C-e], you will get an error because you have undefined
 symbols `y` and `r`. You can provide a context in which to evaluate
-this expression by using kbd:[C-c C-v C-c], which is bound to
-`cider-eval-last-sexp-in-context`. This will prompt you at the
-minibuffer for a lexical context to evaluate the form in. This is like
-wrapping the form in a `let` binding before sending it for evaluation.
-In this case you could bind `y` to `1` and `r` to `[0 1 2 3 4]` by
-entering these binding when prompted to produce the result `=> (1 2 3
-4 5)`.
+this expression by using kbd:[C-c C-v C-c] or kbd:[C-c C-v c], which
+is bound to `cider-eval-last-sexp-in-context`. This will prompt you at
+the minibuffer for a lexical context to evaluate the form in. This is
+like wrapping the form in a `let` binding before sending it for
+evaluation. In this case you could bind `y` to `1` and `r` to `[0 1 2
+3 4]` by entering these binding when prompted to produce the result
+`=> (1 2 3 4 5)`.
 
 [source]
 ----
@@ -88,7 +88,7 @@ Evaluation context (let-style) for `(map #(+ % y) r)': y 1 r [0 1 2 3 4]
 ----
 
 After evaluating an expression, you can re-evaluate this expression in
-the same buffer with kbd:[C-c C-v C-a] or kbd:[C-c C-v ], both of
+the same buffer with kbd:[C-c C-v C-a] or kbd:[C-c C-v a], both of
 which are bound to `cider-re-eval-previous-sexp`. This is useful when
 working on a function with some test code nearby in the same buffer.
 For example:

--- a/doc/modules/ROOT/pages/usage/code_evaluation.adoc
+++ b/doc/modules/ROOT/pages/usage/code_evaluation.adoc
@@ -226,7 +226,7 @@ Below is a listing of most keybindings for evaluation commands:
 
 | `cider-eval-last-sexp`
 | kbd:[C-x C-e] +
-[C-c C-e]
+kbd:[C-c C-e]
 | Evaluate the form preceding point and display the result in the echo area and/or in an buffer overlay (according to `cider-use-overlays`).  If invoked with a prefix argument, insert the result into the current buffer.
 
 | `cider-eval-last-sexp-and-replace`

--- a/doc/modules/ROOT/pages/usage/code_evaluation.adoc
+++ b/doc/modules/ROOT/pages/usage/code_evaluation.adoc
@@ -173,17 +173,9 @@ Below is a listing of most keybindings for evaluation commands:
 | Command | Keyboard shortcut | Description
 
 | `cider-eval-last-sexp`
-| kbd:[C-x C-e]
+| kbd:[C-x C-e] +
+[C-c C-e]
 | Evaluate the form preceding point and display the result in the echo area and/or in an buffer overlay (according to `cider-use-overlays`).  If invoked with a prefix argument, insert the result into the current buffer.
-
-| `cider-eval-last-sexp-or-re-eval-previous-sexp`
-| kbd:[C-c C-e]
-| Evaluate the form preceding point like `cider-eval-last-sexp` unless invoked with a prefix argument, in which case it will evaluate the previously evaluated expression. This includes any context stored by commands like `cider-eval-last-sexp-in-context`.
-
-| `cider-eval-last-sexp-in-context`
-| kbd:[C-c C-v C-c] +
-kbd:[C-c C-v c]
-| Eval the form preceding point with a containing lexical scope. The context is defined interactively in the minibuffer and evaluated as if provided in as `let` bindings surrounding the form to be evaluated. Useful for debugging deeply nested forms.
 
 | `cider-eval-last-sexp-and-replace`
 | kbd:[C-c C-v w]
@@ -232,6 +224,16 @@ kbd:[C-u C-c C-c]
 | `cider-eval-region`
 | kbd:[C-c C-v r]
 | Evaluate the region and display the result in the echo area.
+
+| `cider-eval-last-sexp-in-context`
+| kbd:[C-c C-v C-c] +
+kbd:[C-c C-v c]
+| Eval the form preceding point with a containing lexical scope. The context is defined interactively in the minibuffer and evaluated as if provided in as `let` bindings surrounding the form to be evaluated. Useful for debugging deeply nested forms.
+
+| `cider-re-eval-previous-sexp`
+| kbd:[C-c C-v C-a] +
+kbd:[C-c C-v a]
+| Evaluate the form preceding point like `cider-eval-last-sexp` unless invoked with a prefix argument, in which case it will evaluate the previously evaluated expression. This includes any context stored by commands like `cider-eval-last-sexp-in-context`.
 
 | `cider-interrupt`
 | kbd:[C-c C-b]

--- a/doc/modules/ROOT/pages/usage/code_evaluation.adoc
+++ b/doc/modules/ROOT/pages/usage/code_evaluation.adoc
@@ -59,6 +59,58 @@ the source buffer.
 
 NOTE: WIP
 
+Sometimes, when debugging a function, it is useful to provide a
+surrounding lexical context outside of the code you're evaluating. For
+example:
+
+[source,clojure]
+----
+(defn long-and-complicated-function [x y]
+  (let [r (range x)
+        l (map #(+ % y) r)] ;; <- form we want to eval independently of it's context
+    (reduce + l)))
+----
+
+If you position the point after the `map` form and evaluate it with
+kbd:[C-c C-e], you will get an error because you have undefined
+symbols `y` and `r`. You can provide a context in which to evaluate
+this expression by using kbd:[C-c C-v C-c], which is bound to
+`cider-eval-last-sexp-in-context`. This will prompt you at the
+minibuffer for a lexical context to evaluate the form in. This is like
+wrapping the form in a `let` binding before sending it for evaluation.
+In this case you could bind `y` to `1` and `r` to `[0 1 2 3 4]` by
+entering these binding when prompted to produce the result `=> (1 2 3
+4 5)`.
+
+[source]
+----
+Evaluation context (let-style) for `(map #(+ % y) r)': y 1 r [0 1 2 3 4]
+----
+
+After evaluating an expression, you can re-evaluate this expression in
+the same buffer with kbd:[C-c C-v C-a] or kbd:[C-c C-v ], both of
+which are bound to `cider-re-eval-previous-sexp`. This is useful when
+working on a function with some test code nearby in the same buffer.
+For example:
+
+[source,clojure]
+----
+(defn sum-of-squares [n]
+  (->> (range n)
+       (map #(* % %)) ;; <- point in the guts of a complicated function
+       (reduce +)))
+
+(comment
+  (sum-of-squares 10) ;; test code that we want to run
+  )
+----
+
+After you've run the test code once, using kbd:[C-c C-e] for example,
+you can re-run that code while editing the function without having to
+navigate back to find the test expression. This will also remember any
+context stored by `cider-eval-last-sexp-in-context` or
+`cider-eval-sexp-at-point-in-context`.
+
 == Evaluating Clojure Code in the Minibuffer
 
 You can evaluate Clojure code in the minibuffer at almost any time


### PR DESCRIPTION
Added feature to cache the previously eval'd form and a function to eval that cached form (`cider-re-eval-previous-sexp'). Also changed the default keybinding for `C-c C-e` to point to this new function rather than `cider-eval-last-sexp`. The new function will do the same as the old one without a prefix arg. With a prefix arg, it'll re-run the last sexp that was eval'd (instead of changing the `OUTPUT-TO-CURRENT-BUFFER` behaviour). The old behaviour is still available with the keyboard combination `C-x C-e`.

Also added `cider-re-eval-previous-sexp` (with a keybinding of `"a"/"C-a"` in `cider-eval-commands-map`) which re-evals previous sexp to allow access to the `OUTPUT-TO-CURRENT-BUFFER` functionality of `cider-eval-last-sexp`.

Also added a short description of `cider-eval-last-sexp-in-context`, because I referred to it in the documentation I wrote for `cider-eval-last-sexp-or-re-eval-previous-sexp`.

---

Apologies if I've overstepped the mark by changing an existing keyboard binding. I'm quite prepared to put this back if it upsets anyone, I just thought that seeing as there was another keyboard binding for the old function and the new function only differs by a prefix arg, nobody would mind too much. The shortcut `C-u C-c C-e` is pretty convenient for me to type (I'm using a dvorak layout - some of the hany qwerty shortcuts are incovenient to type) so I thought it'd be ok to have access to a cached sexp and a non-cached sexp version of evaluation and that might be useful. Given different keybindings for the same functionality I figured it'd be a small change ... ;)

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
