### PR TITLE
Handle multiple REPL types for single project

### DIFF
--- a/cider-connection.el
+++ b/cider-connection.el
@@ -699,7 +699,8 @@ For the REPL type use the function `cider-repl-type'."
   (with-current-buffer (or buffer (current-buffer))
     (cond
      ((derived-mode-p 'clojurescript-mode) 'cljs)
-     ((derived-mode-p 'clojurec-mode) 'multi)
+     ((derived-mode-p 'clojurec-mode) (or (cider-repl-type (or buffer (current-buffer)))
+                                          'multi))
      ((derived-mode-p 'clojure-mode) 'clj)
      (cider-repl-type))))
 
@@ -858,9 +859,9 @@ throw an error if no linked session exists."
                ((listp type)
                 (mapcar #'cider-maybe-intern type))
                ((cider-maybe-intern type))))
-        (repls (cdr (if ensure
-                        (sesman-ensure-session 'CIDER)
-                      (sesman-current-session 'CIDER)))))
+        (repls (mapcar #'cadr (sesman-current-sessions 'CIDER))))
+    (when (and ensure (null repls))
+      (user-error "No linked CIDER sessions"))
     (or (seq-filter (lambda (b)
                       (cider--match-repl-type type b))
                     repls)


### PR DESCRIPTION
## Handle multiple REPL types for single project

Goal of this PR is to handle the issue:

1. Create and open project with `lein` and `shadow-cljs` working in one directory tree:
```
src
├── clj  (lein source-paths)
├── cljc (lein & shadow-cljs source-paths)
└── cljs (shadow-cljs source-paths)
```
2. Open `.clj` file, jack-in `cider-jack-in-clj`
3. Switch to CLJ REPL buffer with `(cider-switch-to-repl-buffer)` - works fine
4. Open `.cljs` file, jack-in `cider-jack-in-cljs`, accept creation of sibling REPL.
5. Switch to CLJS REPL buffer with `(cider-switch-to-repl-buffer)` - fails with message `user-error: No clj REPLs in current session "project/project:localhost:63409"`

### Root cause
* There are two `sesman` sessions created linked to the same project: 
```
 CIDER Sessions:

  1: project/project:localhost:63409
      linked-to: proj(~/project/)  
        objects: *cider-repl %s(clj)*  

  2: project/project:localhost:63420
      linked-to: proj(~/project/)  
        objects: *cider-repl %s(cljs:shadow)*  
```
* `(cider-repls)` uses `(sesman-current-session)` to get only one matching session for project (even though there might be more than one) without taking type into consideration. Then it matches type against the single result.

### Proposed solution
* Look for specified type within all matching sesman sessions
* When deciding on buffer type, on `cljc` file detection, consult `(cider-repl-type)` function. This enables easy change of REPL type for CLJC buffer (which might be simultaneously used by both REPLs) with snippet like (in spacemacs):
```
  ;; Shortcut for easily changing REPL type in ClojureC mode
  (add-hook 'cider-mode-hook (lambda ()
                               (spacemacs/set-leader-keys-for-major-mode 'clojurec-mode "st" 'cider-set-repl-type)))
```