### PR TITLE
Clearer fringe evaluation indicator - second try

### DIFF
--- a/cider-overlays.el
+++ b/cider-overlays.el
@@ -169,7 +169,7 @@ full list of available bitmaps."
                  (const hollow-square)
                  (const vertical-bar))
   :group 'cider
-  :package-version '(cider . "0.27.0"))
+  :package-version '(cider . "1.0"))
 
 (defun cider--fringe-overlay-good ()
   "Create the before-string property that add a green indicator on the fringe."

--- a/cider-overlays.el
+++ b/cider-overlays.el
@@ -142,10 +142,10 @@ This function also removes itself from `post-command-hook'."
 
     ;; This is the definition we want to use, if possible.
     (((class color) (background light))
-     :foreground (:inherit diff-added)
+     :foreground "green"
      :distant-foreground "DarkGreen")
     (((class color) (background dark))
-     :foreground (:inherit diff-added)
+     :foreground "green"
      :distant-foreground "LimeGreen"))
   "Face used on the fringe indicator for successful evaluation."
   :group 'cider)

--- a/cider-overlays.el
+++ b/cider-overlays.el
@@ -29,7 +29,7 @@
 (require 'subr-x)
 (require 'cider-compat)
 (require 'cl-lib)
-(require 'diff-mode) ;; for fringe bitmap
+(require 'diff-mode) ;; for `define-fringe-bitmap'
 
 
 ;;; Customization


### PR DESCRIPTION
Closes #2748
Closes #2751 

Second try for this stale PR: #2751

> 
> # Overview
> Issue #2748 notes that the evaluation indicator in the fringe is very subtle. This PR makes three changes to address this, split into 3 commits:
> 
> 1. Extract the bitmap displayed in the fringe into a user-configurable `custom`.
> 2. Inherit the indicator's color from the current theme, rather than hard-coding it.
> 3. Change the default bitmap used to `filled-rectangle`.
> 
> This is just an initial stab at changing the indicators, to prove the concept. Happy to rewrite as necessary. I haven't cleared the checklist yet - wanted to hear what you guys thought before formally cleaning things up.
> 
> # Current Look
> The indicator is difficult to see in certain themes. Colors are hard-coded, which can result in an inconsistent palette. The bitmap itself creates a semi-transparent effect. Some examples:
> 
> ![before-spacemacs-dark](https://user-images.githubusercontent.com/40725916/69018048-49079c00-095f-11ea-8d0e-d4ef9df4dd1c.png)
> `spacemacs-dark`
> 
> ![before-spacemacs-light](https://user-images.githubusercontent.com/40725916/69018049-4c9b2300-095f-11ea-92db-21ebbdfb48f5.png)
> `spacemacs-light`
> 
> ![before-nord](https://user-images.githubusercontent.com/40725916/69018053-558bf480-095f-11ea-9476-3f5bcbf825fb.png)
> `doom-nord`
> 
> # Different Bitmap
> Swapping to a different bitmap makes things a little bolder. I had a look through all the built-in bitmaps, in my opinion `filled-rectangle` looks best.
> 
> ![symbol-only-spacemacs-dark](https://user-images.githubusercontent.com/40725916/69018098-8409cf80-095f-11ea-8052-911025cd2cc0.png)
> `spacemacs-dark`
> 
> ![symbol-only-spacemacs-light](https://user-images.githubusercontent.com/40725916/69018100-866c2980-095f-11ea-90e1-ccfdfde3d7c3.png)
> `spacemacs-light`
> 
> ![symbol-only-nord](https://user-images.githubusercontent.com/40725916/69018104-89ffb080-095f-11ea-8c43-d1d5ea061875.png)
> `doom-nord`
> 
> # Dynamic Colors
> Rather than expecting each theme to explicitly override the fringe colors, it would be better if we could dynamically adjust the color to match each theme. `diff-attach` is a built-in face which is almost always green, and should match the palette of the theme.
> 
> Inheriting the foreground from this face works across a wide range of themes:
> 
> ![both-spacemacs-dark](https://user-images.githubusercontent.com/40725916/69018228-2de95c00-0960-11ea-903d-84890f5d19de.png)
> `spacemacs-dark`
> 
> ![both-spacemacs-light](https://user-images.githubusercontent.com/40725916/69018237-36da2d80-0960-11ea-8947-6d23dd995e09.png)
> `spacemacs-light`
> 
> ![both-nord](https://user-images.githubusercontent.com/40725916/69018240-39d51e00-0960-11ea-8807-7e0d596b76a3.png)
> `doom-nord`
> 
> ![both-zenburn](https://user-images.githubusercontent.com/40725916/69018278-69842600-0960-11ea-835e-d41075df7847.png)
> `zenburn`
> 
> ![both-leuven](https://user-images.githubusercontent.com/40725916/69018249-45284980-0960-11ea-8177-6f5ebd71b144.png)
> `leuven`
> 
> ![both-doom-one](https://user-images.githubusercontent.com/40725916/69018254-4a859400-0960-11ea-857f-f8c7dac5dba8.png)
> `doom-one`
> 
> ![both-monokai](https://user-images.githubusercontent.com/40725916/69018259-51aca200-0960-11ea-90d0-e35c7a2697da.png)
> `monokai`
> 
> ![both-solarized-dark](https://user-images.githubusercontent.com/40725916/69018263-58d3b000-0960-11ea-8441-9427cd7d3d40.png)
> `solarized-dark`
> 
> ![both-solarized-light](https://user-images.githubusercontent.com/40725916/69018273-61c48180-0960-11ea-99da-e30d591b2f19.png)
> `solarized-light`
> 
> Many themes also set the background for `diff-attach`. Inheriting just the foreground reduces visual clutter, and seems to work consistently. We can make the operation safer with `:distant-foreground`, to defer to a hard-coded green if the diff foreground is not sufficiently visible.
> 
> ## Scaling
> An issue with `filled-rectangle` is it doesn't scale vertically. It seems the proportions are locked and the fringe is pegged to a specific pixel width. The original bitmap doesn't have this issue. For example:
> 
> ![large-text](https://user-images.githubusercontent.com/40725916/69018497-971d9f00-0961-11ea-9f4a-99cbd10a43e6.png)
> 
> I'm not sure if defining a new bitmap would allow us to adjust this property. Another solution might also be to adjust the background color of the fringe directly, rather than display a bitmap.
> 
> Before submitting the PR make sure the following things have been done (and denote this
> by checking the relevant checkboxes):
> 
> * [x]  The commits are consistent with our [contribution guidelines](../.github/CONTRIBUTING.md)
> * [ ]  You've added tests (if possible) to cover your change(s)
> * [ ]  All tests are passing (`make test`)
> * [ ]  All code passes the linter (`make lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
>   
>   * [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
> * [ ]  You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
> * [ ]  You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
> 
> Thanks!
> 
> _If you're just starting out to hack on CIDER you might find this [section of its manual](https://docs.cider.mx/cider/contributing/hacking.html) extremely useful._

