### PR TITLE
[Documentation] Tip to evaluate namespace before lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Bump the injected Piggieback version to 0.5.2. See [this issue](https://github.com/nrepl/piggieback/issues/118) for details.
 * [#2897](https://github.com/clojure-emacs/cider/pull/2897): Translate paths from CIDER to nREPL and vice-versa.
 * Set `cider-prompt-for-symbol` to `nil` by default.
+* Doc: add tip to evaluate namespace before documentation lookup.
 
 ## 0.26.1 (2020-08-14)
 

--- a/doc/modules/ROOT/pages/usage/working_with_documentation.adoc
+++ b/doc/modules/ROOT/pages/usage/working_with_documentation.adoc
@@ -11,6 +11,8 @@ press kbd:[C-c C-d C-d] then. This open a documentation buffer
 containing all the relevant information about the thing referenced
 by the symbol (special form, var, Java method, etc).
 
+TIP: Ensure the namespace of a var is evaluated before looking up the documentation. Cider relies on the runtime state to lookup documentation.
+
 == JavaDoc
 
 CIDER provides a quick access to the online Javadoc documentation


### PR DESCRIPTION
Add Tip to "Working with Documentation" page that a namespace should be
evaluated before lookup of documentation.

Resolves: #2913

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests - documentation only pr
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) - no lint errors on specific change
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
