### PR TITLE
Replace logical sexp in eval-sexp-and-replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Fix broken links to the docs in REPL warnings (the REPL links included the full CIDER version, but the docs URLs are without the patch version).
 * [#2916](https://github.com/clojure-emacs/cider/issues/2916): Fix ordering of dependencies, global-opts and params for Clojure CLI projects when calling `cider-jack-in`.
+* [#2929](https://github.com/clojure-emacs/cider/issues/2929): Fix handling of reader tags or metadata when calling `cider-eval-last-sexp-and-replace`
 
 ### Changes
 

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -802,7 +802,9 @@ buffer."
     ;; we have to be sure the evaluation won't result in an error
     (cider-nrepl-sync-request:eval last-sexp)
     ;; seems like the sexp is valid, so we can safely kill it
-    (backward-kill-sexp)
+    (let ((opoint (point)))
+      (clojure-backward-logical-sexp)
+      (kill-region (point) opoint))
     (cider-interactive-eval last-sexp
                             (cider-eval-print-handler)
                             nil


### PR DESCRIPTION
This function find the sexp to evaluate with `clojure-backward-logical-sexp`,
but replaces it with `backward-kill-sexp`. This leads to incorrect results, e.g.
when eval+replacing `#inst "2020"`, you get `#inst #inst "2020"`.
