### PR TITLE
Add variables for default test selectors (include/exclude)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 * [#2909](https://github.com/clojure-emacs/cider/issues/2909): Add new customization variable `cider-inspector-auto-select-buffer` to control the auto selection of the inspector buffer.
 * [#2940](https://github.com/clojure-emacs/cider/pull/2940): Add a new customization variable cider-shadow-watched-builds to allow watching several shadow-cljs builds at the same time.
+* [#2930](https://github.com/clojure-emacs/cider/issues/2930): Add new customization variable `cider-test-default-include-selectors` and `cider-test-default-exclude-selectors` for specifying default test selectors when running commands such as `cider-test-run-ns-tests`.
 
 ### Bugs fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New features
 
+* [#2930](https://github.com/clojure-emacs/cider/issues/2930): Add new customization variable `cider-test-default-include-selectors` and `cider-test-default-exclude-selectors` for specifying default test selectors when running commands such as `cider-test-run-ns-tests`.
+
 ### Bugs fixed
 
 * [#2953](https://github.com/clojure-emacs/cider/issues/2953): Don't font-lock function/macro vars as vars.
@@ -16,7 +18,6 @@
 
 * [#2909](https://github.com/clojure-emacs/cider/issues/2909): Add new customization variable `cider-inspector-auto-select-buffer` to control the auto selection of the inspector buffer.
 * [#2940](https://github.com/clojure-emacs/cider/pull/2940): Add a new customization variable cider-shadow-watched-builds to allow watching several shadow-cljs builds at the same time.
-* [#2930](https://github.com/clojure-emacs/cider/issues/2930): Add new customization variable `cider-test-default-include-selectors` and `cider-test-default-exclude-selectors` for specifying default test selectors when running commands such as `cider-test-run-ns-tests`.
 
 ### Bugs fixed
 

--- a/cider-test.el
+++ b/cider-test.el
@@ -621,7 +621,7 @@ This uses the Leiningen convention of appending '-test' to the namespace name."
   "List of include selector strings to use when executing tests if none provided."
   :type '(repeat string)
   :group 'cider-test
-  :package-version '(cider . "0.26.1"))
+  :package-version '(cider . "1.1.0"))
 
 (defcustom cider-test-default-exclude-selectors '()
   "List of exclude selector strings to use when executing tests if none provided."
@@ -648,28 +648,20 @@ namespace is specified.  Upon test completion, results are echoed and a test
 report is optionally displayed.  When test failures/errors occur, their sources
 are highlighted.
 If SILENT is non-nil, suppress all messages other then test results.
-If PROMPT-FOR-FILTERS is the keyword `:selector-vars' then use the variables
-`cider-test-default-include-selectors' and
-`cider-test-default-exclude-selectors'
-for determining selectors otherwise if PROMPT-FOR-FILTERS is non-nil, prompt
-the user for a test selector filters.
+If PROMPT-FOR-FILTERS is non-nil, prompt the user for a test selector filters.
 The include/exclude selectors will be used to filter the tests before
 running them."
   (cider-test-clear-highlights)
   (let ((include-selectors
-         (cond
-          ((eq prompt-for-filters :selector-vars)
-           cider-test-default-include-selectors)
-          (prompt-for-filters (cider-test--prompt-for-selectors
-                               "Test selectors to include (space separated): "))
-          (t nil)))
+         (if prompt-for-filters
+             (cider-test--prompt-for-selectors
+              "Test selectors to include (space separated): ")
+           cider-test-default-include-selectors))
         (exclude-selectors
-         (cond
-          ((eq prompt-for-filters :selector-vars)
-           cider-test-default-exclude-selectors)
-          (prompt-for-filters (cider-test--prompt-for-selectors
-                               "Test selectors to exclude (space separated): "))
-          (t nil))))
+         (if prompt-for-filters
+             (cider-test--prompt-for-selectors
+              "Test selectors to exclude (space separated): ")
+           cider-test-default-exclude-selectors)))
     (cider-map-repls :clj-strict
       (lambda (conn)
         (unless silent
@@ -739,14 +731,14 @@ running them."
 
 If PROMPT-FOR-FILTERS is non-nil, prompt the user for a test selectors to filter the tests with."
   (interactive "P")
-  (cider-test-execute :loaded nil nil (or prompt-for-filters :selector-vars)))
+  (cider-test-execute :loaded nil nil prompt-for-filters))
 
 (defun cider-test-run-project-tests (prompt-for-filters)
   "Run all tests defined in all project namespaces, loading these as needed.
 
 If PROMPT-FOR-FILTERS is non-nil, prompt the user for a test selectors to filter the tests with."
   (interactive "P")
-  (cider-test-execute :project nil nil (or prompt-for-filters :selector-vars)))
+  (cider-test-execute :project nil nil prompt-for-filters))
 
 (defun cider-test-run-ns-tests-with-filters (suppress-inference)
   "Run tests filtered by selectors for the current Clojure namespace context.
@@ -767,7 +759,7 @@ test selectors to filter the tests with."
   (if-let* ((ns (if suppress-inference
                     (cider-current-ns t)
                   (funcall cider-test-infer-test-ns (cider-current-ns t)))))
-      (cider-test-execute ns nil silent (or prompt-for-filters :selector-vars))
+      (cider-test-execute ns nil silent prompt-for-filters)
     (if (eq major-mode 'cider-test-report-mode)
         (when (y-or-n-p (concat "Test report does not define a namespace. "
                                 "Rerun failed/erring tests?"))

--- a/cider-test.el
+++ b/cider-test.el
@@ -627,7 +627,7 @@ This uses the Leiningen convention of appending '-test' to the namespace name."
   "List of exclude selector strings to use when executing tests if none provided."
   :type '(repeat string)
   :group 'cider-test
-  :package-version '(cider . "0.26.1"))
+  :package-version '(cider . "1.1.0"))
 
 (declare-function cider-emit-interactive-eval-output "cider-eval")
 (declare-function cider-emit-interactive-eval-err-output "cider-eval")

--- a/cider-test.el
+++ b/cider-test.el
@@ -617,6 +617,18 @@ This uses the Leiningen convention of appending '-test' to the namespace name."
 
 ;;; Test execution
 
+(defcustom cider-test-default-include-selectors '()
+  "List of include selector strings to use when executing tests if none provided."
+  :type '(repeat string)
+  :group 'cider-test
+  :package-version '(cider . "0.26.1"))
+
+(defcustom cider-test-default-exclude-selectors '()
+  "List of exclude selector strings to use when executing tests if none provided."
+  :type '(repeat string)
+  :group 'cider-test
+  :package-version '(cider . "0.26.1"))
+
 (declare-function cider-emit-interactive-eval-output "cider-eval")
 (declare-function cider-emit-interactive-eval-err-output "cider-eval")
 
@@ -636,16 +648,28 @@ namespace is specified.  Upon test completion, results are echoed and a test
 report is optionally displayed.  When test failures/errors occur, their sources
 are highlighted.
 If SILENT is non-nil, suppress all messages other then test results.
-If PROMPT-FOR-FILTERS is non-nil, prompt the user for a test selector filters.
+If PROMPT-FOR-FILTERS is the keyword `:selector-vars' then use the variables
+`cider-test-default-include-selectors' and
+`cider-test-default-exclude-selectors'
+for determining selectors otherwise if PROMPT-FOR-FILTERS is non-nil, prompt
+the user for a test selector filters.
 The include/exclude selectors will be used to filter the tests before
- running them."
+running them."
   (cider-test-clear-highlights)
   (let ((include-selectors
-         (when prompt-for-filters
-           (cider-test--prompt-for-selectors "Test selectors to include (space separated): ")))
+         (cond
+          ((eq prompt-for-filters :selector-vars)
+           cider-test-default-include-selectors)
+          (prompt-for-filters (cider-test--prompt-for-selectors
+                               "Test selectors to include (space separated): "))
+          (t nil)))
         (exclude-selectors
-         (when prompt-for-filters
-           (cider-test--prompt-for-selectors "Test selectors to exclude (space separated): "))))
+         (cond
+          ((eq prompt-for-filters :selector-vars)
+           cider-test-default-exclude-selectors)
+          (prompt-for-filters (cider-test--prompt-for-selectors
+                               "Test selectors to exclude (space separated): "))
+          (t nil))))
     (cider-map-repls :clj-strict
       (lambda (conn)
         (unless silent
@@ -715,14 +739,14 @@ The include/exclude selectors will be used to filter the tests before
 
 If PROMPT-FOR-FILTERS is non-nil, prompt the user for a test selectors to filter the tests with."
   (interactive "P")
-  (cider-test-execute :loaded nil nil prompt-for-filters))
+  (cider-test-execute :loaded nil nil (or prompt-for-filters :selector-vars)))
 
 (defun cider-test-run-project-tests (prompt-for-filters)
   "Run all tests defined in all project namespaces, loading these as needed.
 
 If PROMPT-FOR-FILTERS is non-nil, prompt the user for a test selectors to filter the tests with."
   (interactive "P")
-  (cider-test-execute :project nil nil prompt-for-filters))
+  (cider-test-execute :project nil nil (or prompt-for-filters :selector-vars)))
 
 (defun cider-test-run-ns-tests-with-filters (suppress-inference)
   "Run tests filtered by selectors for the current Clojure namespace context.
@@ -743,7 +767,7 @@ test selectors to filter the tests with."
   (if-let* ((ns (if suppress-inference
                     (cider-current-ns t)
                   (funcall cider-test-infer-test-ns (cider-current-ns t)))))
-      (cider-test-execute ns nil silent prompt-for-filters)
+      (cider-test-execute ns nil silent (or prompt-for-filters :selector-vars))
     (if (eq major-mode 'cider-test-report-mode)
         (when (y-or-n-p (concat "Test report does not define a namespace. "
                                 "Rerun failed/erring tests?"))

--- a/doc/modules/ROOT/pages/testing/running_tests.adoc
+++ b/doc/modules/ROOT/pages/testing/running_tests.adoc
@@ -40,8 +40,13 @@ prompt for test selector filters and only run those tests that match
 the selector inclusions/exclusions. If you have selectors you want
 automatically applied, you can set the variables
 `cider-test-default-include-selectors` and `cider-test-default-exclude-selectors`
-to a list of stings to use. Note that selectors will ignored when running
-individual tests.
+to a list of stings to use. The following is an example of setting the default exclude
+selectors so that tests tagged as "integration" or "flakey" don't run.
+
+[source,lisp]
+----
+(setq cider-test-default-exclude-selectors '("integration" "flakey"))
+----
 
 Test developers use selectors to define subsets of the total test
 suite that are run together for different testing tasks. For example

--- a/doc/modules/ROOT/pages/testing/running_tests.adoc
+++ b/doc/modules/ROOT/pages/testing/running_tests.adoc
@@ -37,7 +37,11 @@ kbd:[C-c C-t C-l].
 
 If you invoke either of these commands with a prefix, CIDER will
 prompt for test selector filters and only run those tests that match
-the selector inclusions/exclusions.
+the selector inclusions/exclusions. If you have selectors you want
+automatically applied, you can set the variables
+`cider-test-default-include-selectors` and `cider-test-default-exclude-selectors`
+to a list of stings to use. Note that selectors will ignored when running
+individual tests.
 
 Test developers use selectors to define subsets of the total test
 suite that are run together for different testing tasks. For example


### PR DESCRIPTION
This PR addresses issue  #2930 by adding two variables (`cider-test-default-include-selectors` and `cider-test-default-exclude-selectors`) which provide default selectors in contexts where selectors are applicable (ex. ns, project ) and the selector prompt was not indicated (ie by prefix key).

-----------------

PR Checklist:

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change
  - Note: This doesn't include unit tests but let me know if you think I should add some.
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
