### PR TITLE
Fix cider-completion-flush-caches

### DIFF
--- a/cider-client.el
+++ b/cider-client.el
@@ -570,6 +570,7 @@ CONTEXT represents a completion context for compliment."
   "Send \"complete-flush-caches\" op to flush Compliment's caches."
   (cider-nrepl-send-sync-request (list "op" "complete-flush-caches"
                                        "session" (cider-nrepl-eval-session))
+                                 nil
                                  'abort-on-input))
 
 (defun cider-sync-request:info (symbol &optional class member)


### PR DESCRIPTION
Fixes #2914 

In `cider-sync-request:complete-flush-caches` the call to `cider-nrepl-send-sync-request` was passing `'abort-on-input` in place of the connection parameter, which was causing problems down the line. 

Adding a nil should fix it, as `cider-nrepl-send-sync-request` will provide a connection if nil is passed in, and was consistent with the usage in `cider-sync-request:eldoc-datomic-query`.

Checked the other calls to `cider-nrepl-send-sync-request` but it looked like the others were okay. 
