### PR TITLE
[Fix #2941] Use main args in :cider/nrepl alias for clojure cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Changes
 
+* Removed `cider-clojure-cli-parameters` due to clojure-cli jack-in changes
 * Bump the injected `cider-nrepl` to 0.25.6. This should fix a compatibility issue with Java 15 and fetching fresh ClojureDocs data.
 
 ## 1.0.0 (2020-28-12)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs fixed
 
+* [#2941](https://github.com/clojure-emacs/cider/issues/2941): Use main args in alias for clojure cli
 * [#2953](https://github.com/clojure-emacs/cider/issues/2953): Don't font-lock function/macro vars as vars.
 
 ### Changes

--- a/cider.el
+++ b/cider.el
@@ -157,13 +157,15 @@ default to \"powershell\"."
   :safe #'stringp
   :package-version '(cider . "0.17.0"))
 
-(defcustom cider-clojure-cli-global-options
+(defcustom cider-clojure-cli-aliases
   nil
   "Command line options used to execute clojure with tools.deps."
   :type 'string
   :group 'cider
   :safe #'stringp
   :package-version '(cider . "0.17.0"))
+
+(make-obsolete-variable 'cider-clojure-cli-global-options 'cider-clojure-cli-aliases "1.1")
 
 (defcustom cider-shadow-cljs-command
   "npx shadow-cljs"
@@ -346,7 +348,7 @@ Throws an error if PROJECT-TYPE is unknown."
   (pcase project-type
     ('lein        cider-lein-global-options)
     ('boot        cider-boot-global-options)
-    ('clojure-cli cider-clojure-cli-global-options)
+    ('clojure-cli cider-clojure-cli-aliases)
     ('shadow-cljs cider-shadow-cljs-global-options)
     ('gradle      cider-gradle-global-options)
     (_            (user-error "Unsupported project type `%S'" project-type))))

--- a/cider.el
+++ b/cider.el
@@ -159,7 +159,8 @@ default to \"powershell\"."
 
 (defcustom cider-clojure-cli-aliases
   nil
-  "Command line options used to execute clojure with tools.deps."
+  "A list of aliases to include when using the clojure cli.
+Should be of the form `-A:foo:bar`."
   :type 'string
   :group 'cider
   :safe #'stringp

--- a/cider.el
+++ b/cider.el
@@ -550,9 +550,12 @@ removed, LEIN-PLUGINS, and finally PARAMS."
    " -- "
    params))
 
-(defun cider-clojure-cli-jack-in-dependencies (global-opts params dependencies)
+(defun cider-clojure-cli-jack-in-dependencies (jack-in-aliases _params dependencies)
   "Create Clojure tools.deps jack-in dependencies.
-Does so by concatenating DEPENDENCIES, GLOBAL-OPTS and PARAMS."
+Does so by concatenating DEPENDENCIES and JACK-IN-ALIASES into a suitable
+`clojure` invocation.  The main is placed in an inline alias :cider/nrepl
+so that if your aliases contain any mains, the cider/nrepl one will be the
+one used."
   (let* ((deps-string (string-join
                        (seq-map (lambda (dep)
                                   (format "%s {:mvn/version \"%s\"}" (car dep) (cadr dep)))
@@ -564,7 +567,7 @@ Does so by concatenating DEPENDENCIES, GLOBAL-OPTS and PARAMS."
                       ","))
          (main-opts (format "\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[%s]\"" middleware)))
     (format "%s-Sdeps '{:deps {%s} :aliases {:cider/nrepl {:main-opts [%s]}}}' -M:cider/nrepl"
-            (if global-opts (format "%s " global-opts) "")
+            (if jack-in-aliases (format "%s " jack-in-aliases) "")
             deps-string
             main-opts)))
 

--- a/cider.el
+++ b/cider.el
@@ -165,16 +165,6 @@ default to \"powershell\"."
   :safe #'stringp
   :package-version '(cider . "0.17.0"))
 
-(defcustom cider-clojure-cli-parameters
-  ""
-  "Params passed to clojure to start an nREPL server via `cider-jack-in'.
-This is evaluated using `format', with the first argument being the Clojure
-vector of middleware variables as a string."
-  :type 'string
-  :group 'cider
-  :safe #'stringp
-  :package-version '(cider . "0.17.0"))
-
 (defcustom cider-shadow-cljs-command
   "npx shadow-cljs"
   "The command used to execute shadow-cljs.
@@ -370,7 +360,7 @@ Throws an error if PROJECT-TYPE is unknown."
   (pcase project-type
     ('lein        cider-lein-parameters)
     ('boot        cider-boot-parameters)
-    ('clojure-cli cider-clojure-cli-parameters)
+    ('clojure-cli nil)
     ('shadow-cljs cider-shadow-cljs-parameters)
     ('gradle      cider-gradle-parameters)
     (_            (user-error "Unsupported project type `%S'" project-type))))

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -126,7 +126,7 @@ You can further customize the command line CIDER uses for `cider-jack-in` by
 modifying the following string options:
 
 * `cider-lein-global-options`, `cider-boot-global-options`,
-`cider-clojure-cli-global-options`, `cider-gradle-global-options`:
+`cider-clojure-cli-aliases`, `cider-gradle-global-options`:
 these are passed to the command directly, in first position
 (e.g., `-o` to `lein` enables offline mode).
 * `cider-lein-parameters`, `cider-boot-parameters`,

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -130,7 +130,7 @@ modifying the following string options:
 these are passed to the command directly, in first position
 (e.g., `-o` to `lein` enables offline mode).
 * `cider-lein-parameters`, `cider-boot-parameters`,
-`cider-clojure-cli-parameters`, `cider-gradle-parameters`: these are
+ `cider-gradle-parameters`: these are
 usually task names and their parameters (e.g., `dev` for launching
 boot's dev task instead of the standard `repl -s wait`).
 

--- a/doc/modules/ROOT/pages/cljs/figwheel.adoc
+++ b/doc/modules/ROOT/pages/cljs/figwheel.adoc
@@ -77,7 +77,7 @@ use `revert-buffer`.)
 +
 [source,lisp]
 ----
-((clojurescript-mode . ((cider-clojure-cli-global-options . "-A:fig"))))
+((clojurescript-mode . ((cider-clojure-cli-aliases . "-A:fig"))))
 ----
 
 TIP: If you didn't setup `.dir-locals.el` you can edit the command-line

--- a/doc/modules/ROOT/pages/config/project_config.adoc
+++ b/doc/modules/ROOT/pages/config/project_config.adoc
@@ -22,7 +22,7 @@ Very simply put, all you need to do is to create in the root of your project a f
 [source,emacs-lisp]
 ----
 ((clojurescript-mode
-  (cider-clojure-cli-global-options . "-A:fig")
+  (cider-clojure-cli-aliases . "-A:fig")
   (eval . (cider-register-cljs-repl-type 'super-cljs "(do (foo) (bar))"))
   (cider-default-cljs-repl . super-cljs)))
 ----

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -306,18 +306,18 @@
         (setq-local cider-allow-jack-in-without-project t)
         (setq-local cider-clojure-cli-command "clojure")
         (setq-local cider-inject-dependencies-at-jack-in t)
-        (setq-local cider-clojure-cli-global-options nil)
+        (setq-local cider-clojure-cli-aliases nil)
         (spy-on 'cider-project-type :and-return-value 'clojure-cli)
         (spy-on 'cider-jack-in-resolve-command :and-return-value "clojure")
         (expect (plist-get (cider--update-jack-in-cmd nil) :jack-in-cmd)
                 :to-equal expected)))
-    (it "allows specifying custom aliases with `cider-clojure-cli-global-options`"
+    (it "allows specifying custom aliases with `cider-clojure-cli-aliases`"
       (let ((expected (string-join '("clojure -A:dev:test -Sdeps '{:deps {nrepl/nrepl {:mvn/version \"0.8.3\"} "
                                      "cider/cider-nrepl {:mvn/version \"0.25.7\"}} "
                                      ":aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\""
                                      " \"[\\\"cider.nrepl/cider-middleware\\\"]\"]}}}' -M:cider/nrepl")
                                    "")))
-        (setq-local cider-clojure-cli-global-options "-A:dev:test")
+        (setq-local cider-clojure-cli-aliases "-A:dev:test")
         (setq-local cider-allow-jack-in-without-project t)
         (setq-local cider-clojure-cli-command "clojure")
         (setq-local cider-inject-dependencies-at-jack-in t)

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -292,7 +292,39 @@
       (expect (plist-get (cider--update-jack-in-cmd nil) :jack-in-cmd)
               :to-equal (concat "resolved-powershell -encodedCommand "
                                 ;; Eval to reproduce reference string below: (base64-encode-string (encode-coding-string "clojure \"\"cmd-params\"\"" 'utf-16le) t)
-                                "YwBsAG8AagB1AHIAZQAgACIAIgBjAG0AZAAtAHAAYQByAGEAbQBzACIAIgA=")))))
+                                "YwBsAG8AagB1AHIAZQAgACIAIgBjAG0AZAAtAHAAYQByAGEAbQBzACIAIgA="))))
+  (describe "when 'clojure-cli project type"
+    (it "uses main opts in an alias to prevent other mains from winning"
+      (setq-local cider-jack-in-dependencies '(("nrepl/nrepl" "0.8.3")))
+      (setq-local cider-jack-in-lein-plugins '(("cider/cider-nrepl" "0.25.7")))
+      (setq-local cider-jack-in-nrepl-middlewares '("cider.nrepl/cider-middleware"))
+      (let ((expected (string-join '("clojure -Sdeps '{:deps {nrepl/nrepl {:mvn/version \"0.8.3\"} "
+                                     "cider/cider-nrepl {:mvn/version \"0.25.7\"}} "
+                                     ":aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\""
+                                     " \"[\\\"cider.nrepl/cider-middleware\\\"]\"]}}}' -M:cider/nrepl")
+                                   "")))
+        (setq-local cider-allow-jack-in-without-project t)
+        (setq-local cider-clojure-cli-command "clojure")
+        (setq-local cider-inject-dependencies-at-jack-in t)
+        (setq-local cider-clojure-cli-global-options nil)
+        (spy-on 'cider-project-type :and-return-value 'clojure-cli)
+        (spy-on 'cider-jack-in-resolve-command :and-return-value "clojure")
+        (expect (plist-get (cider--update-jack-in-cmd nil) :jack-in-cmd)
+                :to-equal expected)))
+    (it "allows specifying custom aliases with `cider-clojure-cli-global-options`"
+      (let ((expected (string-join '("clojure -A:dev:test -Sdeps '{:deps {nrepl/nrepl {:mvn/version \"0.8.3\"} "
+                                     "cider/cider-nrepl {:mvn/version \"0.25.7\"}} "
+                                     ":aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\""
+                                     " \"[\\\"cider.nrepl/cider-middleware\\\"]\"]}}}' -M:cider/nrepl")
+                                   "")))
+        (setq-local cider-clojure-cli-global-options "-A:dev:test")
+        (setq-local cider-allow-jack-in-without-project t)
+        (setq-local cider-clojure-cli-command "clojure")
+        (setq-local cider-inject-dependencies-at-jack-in t)
+        (spy-on 'cider-project-type :and-return-value 'clojure-cli)
+        (spy-on 'cider-jack-in-resolve-command :and-return-value "clojure")
+        (expect (plist-get (cider--update-jack-in-cmd nil) :jack-in-cmd)
+                :to-equal expected)))))
 
 (defmacro with-temp-shadow-config (contents &rest body)
   "Run BODY with a mocked shadow-cljs.edn project file with the CONTENTS."


### PR DESCRIPTION
Addresses #2941.

Hopefully the string building is a bit more clear with the format string 

```emacs-lisp
    (format "%s-Sdeps '{:deps {%s} :aliases {:cider/nrepl {:main-opts [%s]}}}' -M:cider/nrepl"
            (if global-opts (format "%s " global-opts) "")
            deps-string
            main-opts)
```