### PR TITLE
Put user supplied aliases in `-M[users]:cider/nrepl`

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -160,7 +160,9 @@ default to \"powershell\"."
 (defcustom cider-clojure-cli-aliases
   nil
   "A list of aliases to include when using the clojure cli.
-Should be of the form `-A:foo:bar`."
+Should be of the form `foo:bar`.  Any leading \"-A\" or \"-M\" will be
+stripped as these are concatenated into the \"-M[your-deps]:cider/nrepl\"
+form."
   :type 'string
   :group 'cider
   :safe #'stringp
@@ -567,10 +569,14 @@ one used."
                       (cider-jack-in-normalized-nrepl-middlewares)
                       ","))
          (main-opts (format "\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[%s]\"" middleware)))
-    (format "%s-Sdeps '{:deps {%s} :aliases {:cider/nrepl {:main-opts [%s]}}}' -M:cider/nrepl"
-            (if jack-in-aliases (format "%s " jack-in-aliases) "")
+    (format "-Sdeps '{:deps {%s} :aliases {:cider/nrepl {:main-opts [%s]}}}' -M%s:cider/nrepl"
             deps-string
-            main-opts)))
+            main-opts
+            (if jack-in-aliases
+                ;; replace -A or -M in the jack-in-aliases to be concatenated
+                ;; with cider/nrepl to ensure cider/nrepl comes last
+                (format ":%s" (replace-regexp-in-string "^-\\(A\\\|M\\):" "" jack-in-aliases))
+              ""))))
 
 (defun cider-shadow-cljs-jack-in-dependencies (global-opts params dependencies)
   "Create shadow-cljs jack-in deps.


### PR DESCRIPTION
`clojure -Sdeps {...} -M:[optional user aliases]:cider/nrepl` is the correct template string.

Do some string manipulation to strip off the leading `-A:` or `-M:` from user supplied deps.

The change relied on the main args of the last alias would win, but apparently aliases from `-A` always go last, defeating the purpose. So just throw them into the `-M` form and ensure `cider/nrepl` is last achieves this aim.

Long term we can go back to the `clojure [optional -A: user profiles] -Sdeps {...} -M:cider/nrepl` as indicated by the output of `clj --help`:

```
exec-opts:
 -Aaliases      Use concatenated aliases to modify classpath
 -X[aliases]    Use concatenated aliases to modify classpath or supply exec fn/args
 -M[aliases]    Use concatenated aliases to modify classpath or supply main opts
 -P             Prepare deps - download libs, cache classpath, but don't exec
```

Since it seems the real difference between -A and -M (will ultimately) be the "supply main opts". But that change isn't in effect yet so the `-M` stacking will work for now.