### PR TITLE
Fix cider-last-sexp bounds on whitespaces after sexp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@
 
 * [#2941](https://github.com/clojure-emacs/cider/issues/2941): Use main args in alias for clojure cli
 * [#2953](https://github.com/clojure-emacs/cider/issues/2953): Don't font-lock function/macro vars as vars.
+* [#2937](https://github.com/clojure-emacs/cider/issues/2937): Green fringe produced for extra line in rich comment block
 
 ### Changes
 
 * Removed `cider-clojure-cli-parameters` due to clojure-cli jack-in changes
 * Bump the injected `cider-nrepl` to 0.25.6. This should fix a compatibility issue with Java 15 and fetching fresh ClojureDocs data.
+* Changed the behaviour of cider-last-sexp so it returns only the sexp, excluding all whitespace and/or the first newline after.
 
 ## 1.0.0 (2020-28-12)
 

--- a/cider-util.el
+++ b/cider-util.el
@@ -193,8 +193,6 @@ instead."
            (clojure-backward-logical-sexp 1)
            (list (point)
                  (progn (clojure-forward-logical-sexp 1)
-                        (skip-chars-forward "[:blank:]")
-                        (when (looking-at-p "\n") (forward-char 1))
                         (point))))))
 
 (defun cider-start-of-next-sexp (&optional skip)

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -213,6 +213,23 @@ buffer."
         (insert "'")
         (expect (cider-sexp-at-point 'bounds) :to-equal '(5 15))))))
 
+(describe "cider-last-sexp"
+  (describe "when the param 'bounds is not given"
+    (it "returns the last sexp"
+      (with-clojure-buffer "a\n\n(defn ...)|\n\nb"
+        (expect (cider-last-sexp) :to-equal "(defn ...)")))
+    (it "returns the last sexp event when there are whitespaces"
+      (with-clojure-buffer "a\n\n(defn ...) ,\n|\nb"
+        (expect (cider-last-sexp) :to-equal "(defn ...)"))))
+
+  (describe "when the param 'bounds is given"
+    (it "returns the bounds of last sexp"
+      (with-clojure-buffer "a\n\n(defn ...)|\n\nb"
+        (expect (cider-last-sexp 'bounds) :to-equal '(4 14))))
+    (it "returns the bounds of last sexp event when there are whitespaces"
+      (with-clojure-buffer "a\n\n(defn ...) ,\n|\nb"
+        (expect (cider-last-sexp 'bounds) :to-equal '(4 14))))))
+
 (describe "cider-defun-at-point"
   (describe "when the param 'bounds is not given"
     (it "returns the defun at point"


### PR DESCRIPTION
Evaluating cider-last-sexp includes whitespaces and the first newline
after such sexp, which causes some weird behaviours evaluating
code (see https://github.com/clojure-emacs/cider/issues/2937).

Modified cider-last-sexp by removing two forms that included whitespaces and the first newline in the returned value (string
or bounds), so the result is exactly the last sexp as advertised.


-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
