### PR TITLE
Fixes #2964 -- exception when cider-complete is called without a repl…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bugs fixed
 
 * [#2953](https://github.com/clojure-emacs/cider/issues/2953): Don't font-lock function/macro vars as vars.
+* [#2964](https://github.com/clojure-emacs/cider/issues/2964): Fixes issue with `cider-company-enable-fuzzy-completion` and Helm
 
 ### Changes
 

--- a/cider-completion.el
+++ b/cider-completion.el
@@ -162,7 +162,9 @@ we check if cider-nrepl's complete op is available
 and afterward we fallback on nREPL's built-in
 completion functionality."
   (cond
-   ;; First we try if cider-nrepl's completion is available
+   ;; if we don't have a connection, end early
+   ((not (cider-current-repl nil)) nil)
+   ;; next we try if cider-nrepl's completion is available
    ((cider-nrepl-op-supported-p "complete")
     (let* ((context (cider-completion-get-context))
            (candidates (cider-sync-request:complete prefix context)))

--- a/cider-completion.el
+++ b/cider-completion.el
@@ -163,7 +163,7 @@ and afterward we fallback on nREPL's built-in
 completion functionality."
   (cond
    ;; if we don't have a connection, end early
-   ((not (cider-current-repl nil)) nil)
+   ((not (cider-connected-p)) nil)
    ;; next we try if cider-nrepl's completion is available
    ((cider-nrepl-op-supported-p "complete")
     (let* ((context (cider-completion-get-context))


### PR DESCRIPTION
Helm was causing errors when `cider-company-enable-fuzzy-completion` was enabled and a REPL was not active.

The issue here was that `cider-complete` called `cider-nrepl-op-supported-p`, which requires an active connection, and will signal otherwise -- but in the event of a completion failure it is better to just continue. 

The fix is just to return nil from `cider-complete` in the event there is not an active REPL. 

Example stack trace: 

```
  sesman-ensure-session(CIDER)
  cider-repls(nil ensure)
  cider-current-repl(nil ensure)
  cider-nrepl-op-supported-p("complete")
  cider-complete("as")
  cider-company-unfiltered-candidates("as" ("debug-on-entry") #f(compiled-function (str) #<bytecode 0x1ffd982b1305>) 0)
  #f(compiled-function (style) #<bytecode 0x1ffd9830d4d9>)(cider)
```

# Reproducing

Use `emacs -Q -l startup.el` with the following file, and then M-x to get the error.

```
(setq user-emacs-directory "/tmp/.emacs.d/")
(setq package-archives '(("melpa-stable" . "http://stable.melpa.org/packages/")
                         ("gnu" . "http://elpa.gnu.org/packages/")))

(package-initialize)
(package-refresh-contents)
(package-install 'helm)
(package-install 'cider)
(package-install 'company)

(require 'helm)
(require 'helm-config)
(define-key global-map [remap execute-extended-command] 'helm-M-x)
(helm-mode 1)
(require 'cider)
(require 'company)

(global-company-mode)
(cider-company-enable-fuzzy-completion)
```