### PR TITLE
Provide ability to customise cljfmt code formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#2930](https://github.com/clojure-emacs/cider/issues/2930): Add new customization variable `cider-test-default-include-selectors` and `cider-test-default-exclude-selectors` for specifying default test selectors when running commands such as `cider-test-run-ns-tests`.
+* [#2907](https://github.com/clojure-emacs/cider/issues/2907): Add new customization variable `cider-format-code-options` to specify options used by `cljfmt' to format code when running commands `cider-format-buffer`, `cider-format-region`  and `cider-format-defun`.
 
 ### Bugs fixed
 

--- a/cider-format.el
+++ b/cider-format.el
@@ -85,7 +85,9 @@ Uses the following heuristic to try to maintain point position:
 START and END represent the region's boundaries."
   (interactive "r")
   (cider-ensure-connected)
-  (cider--format-region start end #'cider-sync-request:format-code))
+  (cider--format-region start end
+                        (lambda (buf)
+                          (cider-sync-request:format-code buf cider-format-code-options))))
 
 
 ;;; Format defun
@@ -114,7 +116,8 @@ of the buffer into a formatted string."
   (interactive)
   (check-parens)
   (cider-ensure-connected)
-  (cider--format-buffer #'cider-sync-request:format-code))
+  (cider--format-buffer (lambda (buf)
+                          (cider-sync-request:format-code buf cider-format-code-options))))
 
 
 ;;; Format EDN


### PR DESCRIPTION
**Describe the solution you'd like**

It should be possible to provide a custom formatting configuration for
cider-nrepl/cljfmt. The cljfmt configuration format is described here:

  https://github.com/weavejester/cljfmt#configuration

The desired solution should have a defcustom variable where the
configuration can be provided.

**Describe alternatives you've considered**

A workaround to this solution is to use an after-save-hook as
described here:

https://github.com/dzer6/cljfmt-graalvm

However, in this case, the two formatters (cider, external cljfmt)
will keep fighting each other causing an awful user experience.

**Additional context**

In https://github.com/clojure-emacs/cider/issues/2907 Bozhidar Batsov
commented:

 > You can just disable dynamic (REPL-powered) indentation if you
 > don't rely on it
 > https://docs.cider.mx/cider/0.26/config/indentation.html
 > Alternative you can completely override the indentation logic of
 > clojure-mode and provide whatever implementation you want. CIDER
 > simply hooks into it and adds new indentation rules there
 > dynamically when connected.

To which Brunno Bonacci responded:

  > However, I still think that this ticket stands. Having the
  > possibility to configure the cljfmt indentation rules is a
  > nice-to-have feature.

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`eldev test`)
- [X] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!
