### PR TITLE
correct signal descriptions in nrepl server sentinel as a workaround for emacs bug #46284

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs fixed
 
+* [#2983](https://github.com/clojure-emacs/cider/issues/2983): update signal description in nrepl server sentinel as a workaround for emacs bug #46284 affecting v27.1 on windows
 * [#2941](https://github.com/clojure-emacs/cider/issues/2941): Use main args in alias for clojure cli
 * [#2953](https://github.com/clojure-emacs/cider/issues/2953): Don't font-lock function/macro vars as vars.
 * [#2964](https://github.com/clojure-emacs/cider/issues/2964): Fixes issue with `cider-company-enable-fuzzy-completion` and Helm

--- a/test/nrepl-server-mock.el
+++ b/test/nrepl-server-mock.el
@@ -1,0 +1,105 @@
+;; nrepl-server-mock.el
+
+;; Copyright © 2021 Ioannis Kappas
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; This file is part of CIDER
+;;
+;; A mock nREPL server that sends dummy replies back to clients with just enough
+;; information onboard to accommodate testing requirements.
+;;
+;; Meant to be invoked as the top-level fn of an emacs subprocess.
+
+;;; Code:
+
+(require 'nrepl-client)
+(require 'nrepl-tests-utils)
+(require 'queue)
+
+(defun nrepl-server-mock-filter (proc output)
+  "Handle the nREPL message found in OUTPUT sent by the client
+PROC. Minimal implementation, just enough for fulfilling clients' testing
+requirements."
+  (mock/log! ":mock.filter/output %s :msg %s" proc output)
+
+  (condition-case error-details
+      (let* ((msg (queue-dequeue (cdr (nrepl-bdecode output))))
+             (response (pcase msg
+                         (`(dict "op" "clone" "id" ,id)
+                          `(dict "id" ,id
+                                 "session" "a-session"
+                                 "status" ("done")
+			         "new-session" "a-new-session"))
+
+                         (`(dict "op" "describe" "session" ,session "id" ,id)
+                          `(dict "id" ,id "session" ,session "status"
+			         ("done"))))))
+
+        (mock/log! ":mock.filter/msg :in %s :out %s" msg response)
+        (if (not response)
+            (progn
+              (mock/log! ":mock.filter/unsupported-msg :in %s :msg %s"
+                         output msg)
+              (error ":mock.filter/unsupported-msg %s" output))
+
+          (progn
+            (mock/log! ":mock.filter/response-sending... %s" response)
+            (process-send-string proc (nrepl-bencode response)))))
+
+    (error
+     (mock/log! ":mock.filter/fatal-error %s" error-details)
+     (error error-details))
+
+
+    ))
+
+(defun nrepl-server-mock-start ()
+  "Start a mock nREPL server process. Prints out nREPL welcome message of
+the port and host it is started on. Exits after a 10 secs"
+
+  ;; change first argument to non-nil to enable logging to file
+  (nrepl-tests-log/init! nil mock "./nrepl-server-mock.log" 'new)
+  (mock/log! ":mock/starting...")
+
+  (let* ((server-process (make-network-process
+			  :name "server-mock/process"
+			  :server 't
+			  :host 'local
+                          ;; listen to an unoccupied port
+			  :service 't
+			  :buffer "server-mock/buffer"
+			  :filter 'nrepl-server-mock-filter
+			  :sentinel
+			  (lambda (proc status-change-descr)
+			    (mock/log! ":mock/process-status %s" status-change-descr))))
+	 (contact (process-contact server-process 't))
+         (mock-message (format "nREPL server started on port %d on host %s"
+                               (plist-get contact :service)
+                               (plist-get contact :host))))
+    ;; print welcome message
+    (message "%s%s" mock-message
+             (when  (eq system-type 'windows-nt)
+               ;; emacs bug #46388, emacs --batch's stderr is buffered under
+               ;; windows when not attached directly to the console; feed enough
+               ;; padding chars to flush the message out.
+               ;;
+               ;; https://debbugs.gnu.org/cgi/bugreport.cgi?bug=46388
+               (make-string (- 4096 (length mock-message)) ?*)))
+    (sleep-for 10)
+    (mock/log! ":mock/exiting...")))

--- a/test/utils/nrepl-tests-utils.el
+++ b/test/utils/nrepl-tests-utils.el
@@ -1,0 +1,102 @@
+;;; nrepl-test-utils.el
+
+;; Copyright © 2021 Ioannis Kappas
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; useful utils for nREPL testing
+
+;; This file is part of CIDER
+
+;;; Code:
+
+(defmacro nrepl-tests-log/init! (enable? name log-filename &optional clean?)
+  "When ENABLE? is true, create a NAME/log! elisp function to log messages to LOG-FILENAME,
+taking the same arguments as `message'. Messages are appended to
+LOG-FILENAME, beginning with a :timestamp and followed up with :NAME. When
+CLEAN? is true remove LOG-FILENAME.
+
+If ENABLE? is nil, NAME/log! function is a nil macro discarding all
+arguments unevaluated.
+
+This logger fn is written in mind with multiple processes writing to the
+the same file, each having a unique name, in order to capture the order of
+events (e.g. a nREPL client process and mock server process writing to the
+same file).
+"
+  (let* ((log-file-path (file-truename log-filename))
+         (name-string (symbol-name name))
+         (log-symbol (intern (concat name-string "/log!"))))
+    (if enable? 
+        `(progn
+           (when ,clean?
+             (delete-file ,log-file-path))
+           (defun ,log-symbol (fmt &rest rest)
+             (let ((create-lockfiles nil)) ;; don't create lock files
+               (write-region (apply 'format (concat "%s :%s " fmt "\n")
+                                    (format-time-string "%H:%M:%S.%6N")
+                                    ,name-string
+                                    rest)
+                             nil ,log-file-path 'append))))
+
+      ;; send to the abyss!
+      `(defmacro ,log-symbol (fmt &rest rest)
+         '()))))
+
+(defmacro nrepl-tests-sleep-until (timeout-secs condition)
+  "Sleep for up to TIMEOUT-SECS or until CONDITION becomes true. It wakes
+up every 0.2 seconds to check for CONDITION."
+  (let* ((interval-secs 0.2)
+         (count (truncate (/ timeout-secs interval-secs))))
+    `(cl-loop repeat ,count
+              until ,condition
+              do (sleep-for ,interval-secs))))
+
+(defun nrepl-server-mock-invocation-string ()
+  "Return a shell command that can be used by nrepl-start-srever-process to
+invoke the mock nREPL server. The command will invoke emacs in --batch mode
+using the same load path, version and user package as the parent emacs
+calling process."
+  ;; try to use the same executable and user dirs as eldev
+  (concat "\"" (substring-no-properties (car command-line-args)) "\""
+          " -Q --batch"
+
+          ;; make sure to initialise packages
+          ;; so that the server can reference them.
+          " --eval \""
+          "(progn "
+          " (setf package-user-dir"
+          "       \\\"" package-user-dir "\\\""
+
+          "       load-path "
+          ;; maintain double quotes around paths,
+          ;; and also escape them with \
+          "       '" (replace-regexp-in-string
+                      "\"" (regexp-quote "\\\"") (prin1-to-string load-path))
+
+          "       user-emacs-directory"
+          "       \\\"" user-emacs-directory "\\\""
+          "  )"
+          " (package-initialize))"
+          "\""
+
+          ;; invoke mock server
+          " -l test/nrepl-server-mock.el -f nrepl-server-mock-start"))
+
+
+(provide 'nrepl-tests-utils)


### PR DESCRIPTION
Please consider a potential fix for issue #2983.

Emacs has switched to a new and improved dumper in 27.1 which caused a slight regression issue.  The unix signal descriptions faked under windows, are not carried over in the dump with new pdumper and as thus any attempt to convert a signal to a signal description (such as SIGKILL to "Killed") under windows results to an "uknown signal" being generated. The signal description is passed as the second argument to the process sentinel. Thus whoever uses that description to take decisions in their programs is potentially afffected by it. See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=46284 for more details.

When cider-quit's, it sends the interrupt signals to the process which triggers a call to the nrepl-server-sentinel. The latter, due to this emacs bug, receives an "uknown signal" EVENT instead of "Interrupt", an EVENT it knows nothing about and bails out with an empty problem description resulting to the following error being raised:

_error in process sentinel: Could not start nREPL server:_

The issue has been since fixed in 27.1 and the forthcoming 28 branch.

This fix consists of having nrepl-server-sentinel to correct the EVENT description at reception when necessary (if it is a signal and when it is running under 27.1/windows). The fix can be removed once 27.1 is past the end of its support life.

I have a test in the making  to validate the nrepl client lifecycle process, but it is taking me more time than anticipated due at least one more bug discovered in emacs under windows and some inconsistencies with running eldev tests under windows.

Anyway, I thought it would be good idea to take this patch out for review while putting the final touches to the test (which is much more involved).

thanks