### PR TITLE
Add command `cider-toggle-ignore-next-form`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#2930](https://github.com/clojure-emacs/cider/issues/2930): Add new customization variable `cider-test-default-include-selectors` and `cider-test-default-exclude-selectors` for specifying default test selectors when running commands such as `cider-test-run-ns-tests`.
+* New command `cider-toggle-ignore-next-form` for toggling Clojure "ignore next form" reader macro `#_`.
 
 ### Bugs fixed
 

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -523,6 +523,7 @@ As it stands Emacs fires these events on <mouse-8> and <mouse-9> on 'x' and
     (define-key map (kbd "C-c C-? C-d") #'cider-xref-fn-deps-select)
     (define-key map (kbd "C-c C-q") #'cider-quit)
     (define-key map (kbd "C-c M-r") #'cider-restart)
+    (define-key map (kbd "C-c C-#") #'cider-toggle-ignore-next-form)
     (dolist (variable '(cider-mode-interactions-menu
                         cider-mode-eval-menu
                         cider-mode-menu))

--- a/cider-util.el
+++ b/cider-util.el
@@ -836,6 +836,27 @@ file path otherwise."
                 (t (error "Unexpected archive: %s" d))))
         cider-jdk-src-paths)))))
 
+(defun cider-toggle-ignore-next-form ()
+  "Toggle \"Ignore next form\" reader macro.
+When on whitespace toggle on the next form. Otherwise toggle on the current form."
+  (interactive)
+  (cl-flet ((cursor-is-on-ignore-form ()
+                                      (equal "#_"
+                                             (buffer-substring-no-properties
+                                              (point) (+ (point) 2)))))
+    (save-excursion
+      (if (cursor-is-on-ignore-form)
+          (delete-char 2)
+        (progn
+          (if (string-match "[\s\n]" (char-to-string (char-after)))
+              (skip-chars-forward "[\s\n]")
+            (progn
+              (forward-char 1)
+              (thing-at-point--beginning-of-sexp)))
+          (if (cursor-is-on-ignore-form)
+              (delete-char 2)
+            (insert "#_")))))))
+
 (provide 'cider-util)
 
 ;;; cider-util.el ends here

--- a/doc/modules/ROOT/pages/usage/cider_mode.adoc
+++ b/doc/modules/ROOT/pages/usage/cider_mode.adoc
@@ -295,6 +295,10 @@ kbd:[C-c C-t C-b]
 | kbd:[M-TAB]
 | Complete the symbol at point.
 
+| `cider-toggle-ignore-next-form`
+| kbd:[C-c C-#]
+| Toggling Clojure "ignore next form" reader macro `#_`.
+
 | `cider-quit`
 | kbd:[C-c C-q]
 | Quit the current nREPL connection.


### PR DESCRIPTION
New command `cider-toggle-ignore-next-form` for toggling Clojure "ignore next form" reader macro `#_`.

When the cursor is on whitespace toggle on the next form. Otherwise toggle on the current form.

I use this a lot for debugging purposes. Especially to disable and enable the last item in a threading macro form like 
```clojure
(-> [:a :b nil :d]
    (remove nil?)
    #_(sort))
```
where a `;;` comment on the last line would break the S-Expression.

-----------------

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
