### PR TITLE
Add svg rendering support to cider-repl

### DIFF
--- a/cider-repl.el
+++ b/cider-repl.el
@@ -910,6 +910,13 @@ Part of the default `cider-repl-content-type-handler-alist'."
                              (cider-repl--image image 'png t)
                              show-prefix bol))
 
+(defun cider-repl-handle-svg (_type buffer image &optional show-prefix bol)
+  "A handler for inserting an svg IMAGE into a repl BUFFER.
+Part of the default `cider-repl-content-type-handler-alist'."
+  (cider-repl--display-image buffer
+                             (cider-repl--image image 'svg t)
+                             show-prefix bol))
+
 (defun cider-repl-handle-external-body (type buffer _ &optional _show-prefix _bol)
   "Handler for slurping external content into BUFFER.
 Handles an external-body TYPE by issuing a slurp request to fetch the content."
@@ -924,7 +931,8 @@ Handles an external-body TYPE by issuing a slurp request to fetch the content."
 (defvar cider-repl-content-type-handler-alist
   `(("message/external-body" . ,#'cider-repl-handle-external-body)
     ("image/jpeg" . ,#'cider-repl-handle-jpeg)
-    ("image/png" . ,#'cider-repl-handle-png))
+    ("image/png" . ,#'cider-repl-handle-png)
+    ("image/svg+xml" . ,#'cider-repl-handle-svg))
   "Association list from content-types to handlers.
 Handlers must be functions of two required and two optional arguments - the
 REPL buffer to insert into, the value of the given content type as a raw


### PR DESCRIPTION
This PR gives Cider the ability to render SVG images at the REPL.

This came up while I was implementing https://github.com/applied-science/emacs-vega-view/pull/11 ;  I realized that with this small change, we could get both Vega(-lite) charts AND generated LaTeX rendering at the REPL.

Here are the results of this change, on a Vega-generated svg file:

![image](https://user-images.githubusercontent.com/69635/109361812-f649af00-7846-11eb-8c7d-8d9cd7ac806f.png)

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
