### PR TITLE
require and in-ns ns in separate forms for cider-repl-set-ns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs fixed
 
+* [#2993](https://github.com/clojure-emacs/cider/issues/2993): Fix bug where calling `cider-repl-set-ns` for a cljs ns when `cider-repl-require-ns-on-set` is `t` would fail
 * [#2983](https://github.com/clojure-emacs/cider/issues/2983): update signal description in nrepl server sentinel as a workaround for emacs bug #46284 affecting v27.1 on windows
 * [#2941](https://github.com/clojure-emacs/cider/issues/2941): Use main args in alias for clojure cli
 * [#2953](https://github.com/clojure-emacs/cider/issues/2953): Don't font-lock function/macro vars as vars.

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1183,7 +1183,9 @@ With a prefix argument CLEAR-REPL it will clear the entire REPL buffer instead."
         (cider-repl--clear-region start (1+ end))))))
 
 (defun cider-repl-require-ns-handler (buffer)
-  "Make an nREPL evaluation handler for the REPL BUFFER's ns require."
+  "Make an nREPL evaluation handler for the REPL BUFFER's ns require.
+Ignores a `done' response, so as to avoid a double prompt when called
+alongside `cider-repl-switch-ns-handler'."
   (nrepl-make-response-handler buffer
                                (lambda (_buffer _value))
                                (lambda (buffer out)

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1208,7 +1208,7 @@ command will prompt for the name of the namespace to switch to."
   (cider-map-repls :auto
     (lambda (connection)
       (when cider-repl-require-ns-on-set
-        (cider-nrepl-sync-request:eval (format "(require '%s)" ns)))
+        (cider-nrepl-sync-request:eval (format "(require '%s)" ns) connection))
       (cider-nrepl-request:eval (format "(in-ns '%s)" ns)
                                 (cider-repl-switch-ns-handler connection)))))
 

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1182,18 +1182,6 @@ With a prefix argument CLEAR-REPL it will clear the entire REPL buffer instead."
       (let ((inhibit-read-only t))
         (cider-repl--clear-region start (1+ end))))))
 
-(defun cider-repl-require-ns-handler (buffer)
-  "Make an nREPL evaluation handler for the REPL BUFFER's ns require.
-Ignores a `done' response, so as to avoid a double prompt when called
-alongside `cider-repl-switch-ns-handler'."
-  (nrepl-make-response-handler buffer
-                               (lambda (_buffer _value))
-                               (lambda (buffer out)
-                                 (cider-repl-emit-stdout buffer out))
-                               (lambda (buffer err)
-                                 (cider-repl-emit-stderr buffer err))
-                               (lambda (_buffer))))
-
 (defun cider-repl-switch-ns-handler (buffer)
   "Make an nREPL evaluation handler for the REPL BUFFER's ns switching."
   (nrepl-make-response-handler buffer
@@ -1220,8 +1208,7 @@ command will prompt for the name of the namespace to switch to."
   (cider-map-repls :auto
     (lambda (connection)
       (when cider-repl-require-ns-on-set
-        (cider-nrepl-request:eval (format "(require '%s)" ns)
-                                  (cider-repl-require-ns-handler connection)))
+        (cider-nrepl-sync-request:eval (format "(require '%s)" ns)))
       (cider-nrepl-request:eval (format "(in-ns '%s)" ns)
                                 (cider-repl-switch-ns-handler connection)))))
 


### PR DESCRIPTION
I _think_ I had to create a new nrepl response handler in order to ensure it wouldn't cause _two_ new prompts. Tested in two cljs environments, where it works fine. Feedback very welcome!
