### PR TITLE
Fix debugger incorrectly locating #_ ignored forms

### DIFF
--- a/cider-debug.el
+++ b/cider-debug.el
@@ -414,6 +414,7 @@ In order to work properly, this mode must be activated by
     ["Continue non-stop" (cider-debug-mode-send-reply ":continue-all") :keys "C"]
     ["Move out of sexp" (cider-debug-mode-send-reply ":out") :keys "o"]
     ["Forced move out of sexp" (cider-debug-mode-send-reply ":out" nil true) :keys "O"]
+    ["Move to current position" (cider-debug-mode-send-reply ":here") :keys "h"]
     ["Quit" (cider-debug-mode-send-reply ":quit") :keys "q"]
     "--"
     ["Evaluate in current scope" (cider-debug-mode-send-reply ":eval") :keys "e"]

--- a/cider-debug.el
+++ b/cider-debug.el
@@ -505,6 +505,17 @@ REASON is a keyword describing why this buffer was necessary."
     (search-forward-regexp (concat "\\_<" (regexp-quote key) "\\_>")
                            limit 'noerror)))
 
+(defun cider--debug-skip-ignored-forms ()
+  "Skip past all forms ignored with #_ reader macro."
+  ;; Logic taken from `clojure--search-comment-macro-internal'
+  (while (looking-at (concat "[ ,\r\t\n]*" clojure--comment-macro-regexp))
+    (let ((md (match-data))
+          (start (match-beginning 1)))
+      (goto-char start)
+      ;; Count how many #_ we got and step by that many sexps
+      (clojure-forward-logical-sexp
+       (count-matches (rx "#_") (elt md 0) (elt md 1))))))
+
 (defun cider--debug-move-point (coordinates)
   "Place point on after the sexp specified by COORDINATES.
 COORDINATES is a list of integers that specify how to navigate into the
@@ -579,7 +590,9 @@ key of a map, and it means \"go to the value associated with this key\"."
                           (pop coordinates))))))
               ;; If that extra pop was the last coordinate, this represents the
               ;; entire #(...), so we should move back out.
-              (backward-up-list))))
+              (backward-up-list)))
+          ;; Finally skip past all #_ forms
+          (cider--debug-skip-ignored-forms))
         ;; Place point at the end of instrumented sexp.
         (clojure-forward-logical-sexp 1))
     ;; Avoid throwing actual errors, since this happens on every breakpoint.


### PR DESCRIPTION
This was a quick fix I made over a year ago which closes #2996, putting it up here without any tests for now.

Also includes a menubar commit I forgot to include in a previous PR #2735

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
