### PR TITLE
Use appropriate coding system when unzipping jars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@
 * [#2953](https://github.com/clojure-emacs/cider/issues/2953): Don't font-lock function/macro vars as generic vars.
 * [#2964](https://github.com/clojure-emacs/cider/issues/2964): Fix issue with `cider-company-enable-fuzzy-completion` and Helm.
 * [#2937](https://github.com/clojure-emacs/cider/issues/2937): Green fringe produced for extra line in rich comment block.
-* [#2996]((https://github.com/clojure-emacs/cider/issues/2937)): Fix debugger incorrectly locating `#_` ignored forms.
+* [#2996](https://github.com/clojure-emacs/cider/issues/2937): Fix debugger incorrectly locating `#_` ignored forms.
 * Bump the injected `cider-nrepl` to 0.25.6. This should fix a compatibility issue with Java 15 and fetching fresh ClojureDocs data.
+* [#3004](https://github.com/clojure-emacs/cider/pull/3004): Use appropriate coding system when unzipping jars
 
 ### Changes
 

--- a/cider-common.el
+++ b/cider-common.el
@@ -382,7 +382,18 @@ found."
             (t
              (with-current-buffer (generate-new-buffer
                                    (file-name-nondirectory entry))
-               (archive-zip-extract path entry)
+               ;; Use appropriate coding system for bytes read from unzip cmd to
+               ;; display Emacs native newlines regardless of whether the file
+               ;; uses unix LF or dos CRLF line endings.
+               ;; It's important to avoid spurious CR characters, which may
+               ;; appear as `^M', because they can confuse clojure-mode's symbol
+               ;; detection, e.g. `clojure-find-ns', and break `cider-find-var'.
+               ;; `clojure-find-ns' uses Emacs' (thing-at-point 'symbol) as
+               ;; part of identifying a file's namespace, and when a file
+               ;; isn't decoded properly, namespaces can be reported as
+               ;; `my.lib^M' which `cider-find-var' won't know what to do with.
+               (let ((coding-system-for-read 'prefer-utf-8))
+                 (archive-zip-extract path entry))
                (set-visited-file-name name)
                (setq-local default-directory (file-name-directory path))
                (setq-local buffer-read-only t)


### PR DESCRIPTION
in `cider-find-file`. This prevents CRLF encoded files from appearing with ^M
characters at the end of each line, which, in turn, avoids confusing
`clojure-find-ns` and breaking `cider-find-var`.
`clojure-find-ns` uses Emacs' `(thing-at-point 'symbol)` as part of identifying
a file's namespace, and when a file isn't decoded properly, namespaces can be
reported as `my.lib^M` which `cider-find-var` won't know what to do with.

-----------------

Hey again! I came across https://github.com/clojure-emacs/cider/discussions/2957 today, where @expez mentions `cider-find-var` is broken in jars. I do this all the time and it works fine, so I looked into the repro a little and found that `cider-find-var` was getting confused in `cljfx.api`, as extracted from its jar, because it has windows line endings.

The nrepl message trace:
```
(-->
  id         "14"
  op         "info"
  session    "5cf7e082-fe85-448e-bc8f-9bb99e038211"
  time-stamp "2021-04-15 14:33:35.951811315"

  ns         #("cljfx.api^M" 0 10 (fontified nil))
;;                        ^--- broken!

  sym        "event-handler/dispatch-effect"
)
(<--
  id         "14"
  session    "5cf7e082-fe85-448e-bc8f-9bb99e038211"
  time-stamp "2021-04-15 14:33:35.954095391"
  status     ("done" "no-info")
)
```

The ns value is obtained from `clojure-find-ns` via `(thing-at-point 'symbol)`, which will include the `^M` if it's there.
While we could wrap a `(string-trim-right ...)` around the ns name somewhere, that shouldn't really be necessary, and `clojure-mode` uses `thing-at-point` in several other ways so this might not be the only broken thing. The `^M`s are also a bit of an eyesore, so I think attempting to get rid of them is the way to go. People might still be broken by files with mixed encoding though.

-----------------

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

