### PR TITLE
Enable eldoc-mode in existing clojure buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@
 * [#2937](https://github.com/clojure-emacs/cider/issues/2937): Green fringe produced for extra line in rich comment block.
 * [#2996](https://github.com/clojure-emacs/cider/issues/2937): Fix debugger incorrectly locating `#_` ignored forms.
 * Bump the injected `cider-nrepl` to 0.25.6. This should fix a compatibility issue with Java 15 and fetching fresh ClojureDocs data.
-* [#3004](https://github.com/clojure-emacs/cider/pull/3004): Use appropriate coding system when unzipping jars
+* [#3004](https://github.com/clojure-emacs/cider/pull/3004): Use appropriate coding system when unzipping jars.
+* [#2934](https://github.com/clojure-emacs/cider/issues/2934): Enable eldoc-mode in existing clojure buffers.
 
 ### Changes
 

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -261,7 +261,18 @@ See command `cider-mode'."
   (add-hook 'clojure-mode-hook #'cider-mode)
   (dolist (buffer (cider-util--clojure-buffers))
     (with-current-buffer buffer
-      (cider-mode +1))))
+      (cider-mode +1)
+      ;; In global-eldoc-mode, a new file-visiting buffer calls
+      ;; `turn-on-eldoc-mode' which enables eldoc-mode if it's supported in that
+      ;; buffer as determined by `eldoc--supported-p'.  Cider's eldoc support
+      ;; allows new buffers in cider-mode to enable eldoc-mode.  As of 2021-04,
+      ;; however, clojure-mode itself has no eldoc support, so old clojure
+      ;; buffers opened before cider started aren't necessarily in eldoc-mode.
+      ;; Here, we've enabled cider-mode for this old clojure buffer, and now, if
+      ;; global-eldoc-mode is enabled, try to enable eldoc-mode as if the buffer
+      ;; had just been created with cider-mode.
+      (when global-eldoc-mode
+        (turn-on-eldoc-mode)))))
 
 (declare-function cider--debug-mode "cider-debug")
 (defun cider-disable-on-existing-clojure-buffers ()


### PR DESCRIPTION
Fixes https://github.com/clojure-emacs/cider/issues/2934

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
