### PR TITLE
Align krell repl initialization to latest version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugs fixed
 
+* [#3014](https://github.com/clojure-emacs/cider/pull/3014): Update Krell repl initialization code to follow latest guidelines as found in Krell wiki.
 * [#3012](https://github.com/clojure-emacs/cider/issues/3012): Allow connecting sibling repls from any buffer.
 
 

--- a/cider.el
+++ b/cider.el
@@ -865,7 +865,6 @@ The supplied string will be wrapped in a do form if needed."
          '[krell.api :as krell]
          '[krell.repl])
 (def config (edn/read-string (slurp (io/file \"build.edn\"))))
-(krell/build config)
 (apply cider.piggieback/cljs-repl (krell.repl/repl-env) (mapcat identity config))"
            cider-check-krell-requirements)
     (custom cider-custom-cljs-repl-init-form nil))


### PR DESCRIPTION
As found in https://github.com/vouch-opensource/krell/wiki/Tooling-Integration---Emacs%2C-Cursive%2C-VSCode-etc.

The current initialization code causes an exception to be raised when
jacking-in:
```   
ReferenceError: Can't find variable: cljs
```

Relevant issue in krell: https://github.com/vouch-opensource/krell/issues/136
