### PR TITLE
Updated Krell startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#3015](https://github.com/clojure-emacs/cider/pull/3015): Updated the Krell invocation, to match the latest stable.
+
 ### Bugs fixed
 
 * [#3012](https://github.com/clojure-emacs/cider/issues/3012): Allow connecting sibling repls from any buffer.

--- a/cider.el
+++ b/cider.el
@@ -865,7 +865,6 @@ The supplied string will be wrapped in a do form if needed."
          '[krell.api :as krell]
          '[krell.repl])
 (def config (edn/read-string (slurp (io/file \"build.edn\"))))
-(krell/build config)
 (apply cider.piggieback/cljs-repl (krell.repl/repl-env) (mapcat identity config))"
            cider-check-krell-requirements)
     (custom cider-custom-cljs-repl-init-form nil))


### PR DESCRIPTION
Krell has been updated to not need the excluded function.

Ensuring that CIDER stays upto date and functionaly with it.

See:
https://github.com/vouch-opensource/krell/wiki/Tooling-Integration---Emacs,-Cursive,-VSCode-etc./_compare/d90af2b3a1a49b30a25ed0cdf8d9c9b3becd2e6a...7ca191102fa0b8506010cbefa18632ae6953262c


- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
~- [ ] You've added tests (if possible) to cover your change(s)~
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
~- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)~

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
