### PR TITLE
Fix #3010 - middleware error on invalid keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Bugs fixed
 
 * [#3012](https://github.com/clojure-emacs/cider/issues/3012): Allow connecting sibling repls from any buffer.
-
+* [#3010](https://github.com/clojure-emacs/cider/issues/3010): Remove :: auto-resolved keyword expansion logic from cider-symbol-at-point, moving it to cider-browse-spec.
 
 ## 1.1.0 (2021-04-22)
 

--- a/cider-browse-spec.el
+++ b/cider-browse-spec.el
@@ -277,6 +277,10 @@ a more user friendly representation of SPEC-FORM."
   "Browse SPEC."
   (cider-ensure-connected)
   (cider-ensure-op-supported "spec-form")
+  ;; Expand auto-resolved keywords
+  (when-let* ((val (and (string-match-p "^::.+" spec)
+                        (nrepl-dict-get (cider-sync-tooling-eval spec (cider-current-ns)) "value"))))
+    (setq spec val))
   (with-current-buffer (cider-popup-buffer cider-browse-spec-buffer 'select #'cider-browse-spec-view-mode 'ancillary)
     (setq-local cider-browse-spec--current-spec spec)
     (cider-browse-spec--draw-spec-buffer (current-buffer)

--- a/cider-util.el
+++ b/cider-util.el
@@ -42,8 +42,6 @@
 (require 'cider-compat)
 (require 'clojure-mode)
 
-(declare-function cider-sync-request:macroexpand "cider-macroexpansion")
-
 (defalias 'cider-pop-back 'pop-tag-mark)
 
 (defcustom cider-font-lock-max-length 10000
@@ -127,11 +125,10 @@ instead."
 (defun cider-symbol-at-point (&optional look-back)
   "Return the name of the symbol at point, otherwise nil.
 Ignores the REPL prompt.  If LOOK-BACK is non-nil, move backwards trying to
-find a symbol if there isn't one at point."
+find a symbol if there isn't one at point.
+Does not strip the : from keywords, nor attempt to expand :: auto-resolved
+keywords."
   (or (when-let* ((str (thing-at-point 'symbol)))
-        ;; resolve ns-aliased keywords
-        (when (string-match-p "^::.+" str)
-          (setq str (or (ignore-errors (cider-sync-request:macroexpand "macroexpand-1" str)) "")))
         (unless (text-property-any 0 (length str) 'field 'cider-repl-prompt str)
           ;; remove font-locking
           (setq str (substring-no-properties str))

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -129,13 +129,11 @@ buffer."
       (with-clojure-buffer ":abc/foo"
         (expect (cider-symbol-at-point) :to-equal ":abc/foo")))
 
-    (it "attempts to resolve namespaced keywords"
-      (spy-on 'cider-sync-request:macroexpand :and-return-value ":foo.bar/abc")
+    (it "does not attempt to resolve auto-resolved keywords"
       (with-clojure-buffer "(ns foo.bar) ::abc"
-        (expect (cider-symbol-at-point) :to-equal ":foo.bar/abc"))
-      (spy-on 'cider-sync-request:macroexpand :and-return-value ":clojure.string/abc")
+        (expect (cider-symbol-at-point) :to-equal "::abc"))
       (with-clojure-buffer "(ns foo.bar (:require [clojure.string :as str])) ::str/abc"
-        (expect (cider-symbol-at-point) :to-equal ":clojure.string/abc"))))
+        (expect (cider-symbol-at-point) :to-equal "::str/abc"))))
 
   (describe "when there's nothing at point"
     (it "returns nil"


### PR DESCRIPTION
Fixes #3010 - `cider-tooling-eval` does not throw middleware errors if the keyword is invalid.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
