### PR TITLE
[Fix #3020] Session linking on Windows 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#3020](https://github.com/clojure-emacs/cider/issues/3020): Fix session linking on Windows, e.g. when jumping into a library on the classpath.
+
 ## 1.1.1 (2021-05-24)
 
 ### Bugs fixed

--- a/cider-client.el
+++ b/cider-client.el
@@ -582,9 +582,10 @@ resolve those to absolute paths."
 
 (defun cider-classpath-entries ()
   "Return a list of classpath entries."
-  (if (cider-nrepl-op-supported-p "classpath")
-      (cider-sync-request:classpath)
-    (cider-fallback-eval:classpath)))
+  (seq-map #'expand-file-name ; normalize filenames for e.g. Windows
+           (if (cider-nrepl-op-supported-p "classpath")
+               (cider-sync-request:classpath)
+             (cider-fallback-eval:classpath))))
 
 (defun cider-sync-request:completion (prefix)
   "Return a list of completions for PREFIX using nREPL's \"completion\" op."

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -542,7 +542,8 @@ REPL defaults to the current REPL."
                                   (let ((cp (thread-last classpath
                                               (seq-filter (lambda (path) (not (string-match-p "\\.jar$" path))))
                                               (mapcar #'file-name-directory)
-                                              (seq-remove  #'null))))
+                                              (seq-remove  #'null)
+                                              (seq-uniq))))
                                     (process-put proc :cached-classpath-roots cp)
                                     cp))))
         (or (seq-find (lambda (path) (string-prefix-p path file))


### PR DESCRIPTION
When jumping into a file on the classpath it isn't properly linked with
the current buffer at present.  This commit fixes that, by normalizing
the file paths returned by `cider-classpath-entries`.

Without this normalization step the comparison in
`sesman-friendly-session-p` returns the wrong results when comparing the
current buffer with entries on the class path.

The normalized path will look like this `c:/myFile` whereas the raw one,
on Windows, will look like this: `c:\\myFile`.