### PR TITLE
cider-jack-in: Add `-XX:-OmitStackTraceInFastThrow` by default

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -575,7 +575,7 @@ one used."
                       (cider-jack-in-normalized-nrepl-middlewares)
                       ","))
          (main-opts (format "\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[%s]\"" middleware)))
-    (format "%s-Sdeps '{:deps {%s} :aliases {:cider/nrepl {:main-opts [%s]}}}' -M%s:cider/nrepl"
+    (format "%s-Sdeps '{:deps {%s} :aliases {:cider/nrepl {:main-opts [%s] :jvm-opts [\"-XX:-OmitStackTraceInFastThrow\"]}}}' -M%s:cider/nrepl"
             (if global-options (format "%s " global-options) "")
             deps-string
             main-opts

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -371,7 +371,8 @@
       (let ((expected (string-join '("clojure -Sdeps '{:deps {nrepl/nrepl {:mvn/version \"0.8.3\"} "
                                      "cider/cider-nrepl {:mvn/version \"0.25.7\"}} "
                                      ":aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\""
-                                     " \"[cider.nrepl/cider-middleware]\"]}}}' -M:cider/nrepl")
+                                     " \"[cider.nrepl/cider-middleware]\"] :jvm-opts [\"-XX:-OmitStackTraceInFastThrow\"]}}}' "
+                                     "-M:cider/nrepl")
                                    "")))
         (setq-local cider-allow-jack-in-without-project t)
         (setq-local cider-clojure-cli-command "clojure")
@@ -385,7 +386,8 @@
       (let ((expected (string-join '("clojure -Sdeps '{:deps {nrepl/nrepl {:mvn/version \"0.8.3\"} "
                                      "cider/cider-nrepl {:mvn/version \"0.25.7\"}} "
                                      ":aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\""
-                                     " \"[cider.nrepl/cider-middleware]\"]}}}' -M:dev:test:cider/nrepl")
+                                     " \"[cider.nrepl/cider-middleware]\"] :jvm-opts [\"-XX:-OmitStackTraceInFastThrow\"]}}}' "
+                                     "-M:dev:test:cider/nrepl")
                                    "")))
         (setq-local cider-clojure-cli-aliases "-A:dev:test")
         (setq-local cider-allow-jack-in-without-project t)
@@ -399,7 +401,8 @@
       (let ((expected (string-join '("-Sdeps '{:deps {nrepl/nrepl {:mvn/version \"0.8.3\"} "
                                      "cider/cider-nrepl {:mvn/version \"0.25.7\"}} "
                                      ":aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\""
-                                     " \"[cider.nrepl/cider-middleware]\"]}}}' -M:test:cider/nrepl")
+                                     " \"[cider.nrepl/cider-middleware]\"] :jvm-opts [\"-XX:-OmitStackTraceInFastThrow\"]}}}' "
+                                     "-M:test:cider/nrepl")
                                    ""))
             (deps '(("nrepl/nrepl" "0.8.3"))))
         (let ((cider-clojure-cli-aliases "test"))
@@ -416,7 +419,8 @@
       (let ((expected (string-join '("-J-Djdk.attach.allowAttachSelf -Sdeps '{:deps {nrepl/nrepl {:mvn/version \"0.8.3\"} "
                                      "cider/cider-nrepl {:mvn/version \"0.25.7\"}} "
                                      ":aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\""
-                                     " \"[cider.nrepl/cider-middleware]\"]}}}' -M:test:cider/nrepl")
+                                     " \"[cider.nrepl/cider-middleware]\"] :jvm-opts [\"-XX:-OmitStackTraceInFastThrow\"]}}}' "
+                                     "-M:test:cider/nrepl")
                                    ""))
             (deps '(("nrepl/nrepl" "0.8.3"))))
         (let ((cider-clojure-cli-aliases "test"))


### PR DESCRIPTION
Expands `cider-clojure-cli-jack-in-dependencies` to also add `:jvm-opts
["-XX:-OmitStackTraceInFastThrow"]` in the `:cider/nrepl` alias so that
there are less situations where CIDER encounters a stack trace that has no
traceback.

May be worth extending to the other `cider-*-jack-in-dependencies`
functions.

Fixes https://github.com/clojure-emacs/cider/issues/3022