### PR TITLE
[fix #3017] Annotate company completion kinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugs fixed
 
+* [#3017](https://github.com/clojure-emacs/cider/issues/3017): Annotate company completion kinds.
 * [#3020](https://github.com/clojure-emacs/cider/issues/3020): Fix session linking on Windows, e.g. when jumping into a library on the classpath.
 
 ## 1.1.1 (2021-05-24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## master (unreleased)
 
-### Bugs fixed
+### New features
 
 * [#3017](https://github.com/clojure-emacs/cider/issues/3017): Annotate company completion kinds.
+
+### Bugs fixed
+
 * [#3020](https://github.com/clojure-emacs/cider/issues/3020): Fix session linking on Windows, e.g. when jumping into a library on the classpath.
 
 ## 1.1.1 (2021-05-24)

--- a/cider-completion.el
+++ b/cider-completion.el
@@ -84,6 +84,26 @@ backend, and ABBREVIATION is a short form of that type."
   :group 'cider
   :package-version '(cider . "0.9.0"))
 
+(defconst cider-completion-kind-alist
+  '(("class" class)
+    ("field" field)
+    ("function" function)
+    ("import" class)
+    ("keyword" keyword)
+    ("local" variable)
+    ("macro" macro)
+    ("method" method)
+    ("namespace" module)
+    ("protocol" enum)
+    ("protocol-function" enum-member)
+    ("record" struct)
+    ("special-form" keyword)
+    ("static-field" field)
+    ("static-method" interface)
+    ("type" parameter)
+    ("var" variable))
+  "Icon mapping for company-mode.")
+
 (defcustom cider-completion-annotations-include-ns 'unqualified
   "Controls passing of namespaces to `cider-annotate-completion-function'.
 
@@ -192,6 +212,12 @@ completion functionality."
   (concat (when ns (format " (%s)" ns))
           (when type (format " <%s>" type))))
 
+(defun cider-company-symbol-kind (symbol)
+  "Get SYMBOL kind for company-mode."
+  (let ((type (get-text-property 0 'type symbol)))
+    (or (cadr (assoc type cider-completion-kind-alist))
+        type)))
+
 (defun cider-annotate-symbol (symbol)
   "Return a string suitable for annotating SYMBOL.
 If SYMBOL has a text property `type` whose value is recognised, its
@@ -213,6 +239,7 @@ performed by `cider-annotate-completion-function'."
       (list (car bounds) (cdr bounds)
             (completion-table-dynamic #'cider-complete)
             :annotation-function #'cider-annotate-symbol
+            :company-kind #'cider-company-symbol-kind
             :company-doc-buffer #'cider-create-doc-buffer
             :company-location #'cider-company-location
             :company-docsig #'cider-company-docsig))))


### PR DESCRIPTION
Fix #3017

This adds icon mapping for various completion kinds, allowing company-mode users to enable icons for completion items.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`eldev test`)
- [X] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
