### PR TITLE
Fix `cider-eval-defun-up-to-point` incorrectly matching brackets

### DIFF
--- a/cider-eval.el
+++ b/cider-eval.el
@@ -1038,35 +1038,6 @@ command `cider-debug-defun-at-point'."
                             (cider-defun-at-point 'bounds)
                             (cider--nrepl-pr-request-map))))
 
-(defun cider--calculate-opening-delimiters ()
-  "Walks up the list of expressions to collect all sexp opening delimiters.
-The result is a list of the delimiters.
-
-That function is used in `cider-eval-defun-up-to-point' so it can make an
-incomplete expression complete."
-  (interactive)
-  (let ((result nil))
-    (save-excursion
-      (condition-case nil
-          (while t
-            (backward-up-list)
-            (push (char-after) result))
-        (error result)))))
-
-(defun cider--matching-delimiter (delimiter)
-  "Get the matching (opening/closing) delimiter for DELIMITER."
-  (pcase delimiter
-    (?\( ?\))
-    (?\[ ?\])
-    (?\{ ?\})
-    (?\) ?\()
-    (?\] ?\[)
-    (?\} ?\{)))
-
-(defun cider--calculate-closing-delimiters ()
-  "Compute the list of closing delimiters to make the defun before point valid."
-  (mapcar #'cider--matching-delimiter (cider--calculate-opening-delimiters)))
-
 (defun cider--insert-closing-delimiters ()
   "Closes all open parenthesized or bracketed expressions."
   (interactive)
@@ -1099,6 +1070,16 @@ buffer.  It constructs an expression to eval in the following manner:
                               (cider-eval-print-handler))
                             nil
                             (cider--nrepl-pr-request-map))))
+
+(defun cider--matching-delimiter (delimiter)
+  "Get the matching (opening/closing) delimiter for DELIMITER."
+  (pcase delimiter
+    (?\( ?\))
+    (?\[ ?\])
+    (?\{ ?\})
+    (?\) ?\()
+    (?\] ?\[)
+    (?\} ?\{)))
 
 (defun cider-eval-sexp-up-to-point (&optional  output-to-current-buffer)
   "Evaluate the current sexp form up to point.

--- a/test/cider-interaction-tests.el
+++ b/test/cider-interaction-tests.el
@@ -121,3 +121,11 @@
     (expect (cider--matching-delimiter ?\)) :to-equal ?\()
     (expect (cider--matching-delimiter ?\}) :to-equal ?\{)
     (expect (cider--matching-delimiter ?\]) :to-equal ?\[)))
+
+(describe "cider--insert-closing-delimiters"
+          (it "appends any matching closing delimiters"
+              (with-temp-buffer
+                (clojure-mode)
+                (insert "(let [a 1] (prn 1 [2 {3 4")
+                (cider--insert-closing-delimiters)
+                (expect (buffer-string) :to-equal "(let [a 1] (prn 1 [2 {3 4}]))"))))

--- a/test/cider-interaction-tests.el
+++ b/test/cider-interaction-tests.el
@@ -104,14 +104,6 @@
           (clojure-mode)
           (expect (cider-interactive-eval "(+ 1)") :not :to-throw))))))
 
-(describe "cider--calculate-opening-delimiters"
-  (it "returns the right opening delimiters"
-    (with-temp-buffer
-      (clojure-mode)
-      (insert "(let [a 1] (let [b 2] (+ a b)))")
-      (backward-char 2)
-      (expect (cider--calculate-opening-delimiters) :to-equal '(40 40)))))
-
 (describe "cider--matching-delimiter"
   (it "returns the right closing delimiter"
     (expect (cider--matching-delimiter ?\() :to-equal ?\))


### PR DESCRIPTION
Consider:
```clojure
(prn 1 [2 {3 4|} 5] 6)
```
If `|` represents the cursor, and then I run `cider-eval-defun-up-to-point`, CIDER attempts to evaluate `(prn 1 [2 {3 4|)]}` resulting in an exception.

I also get the issue in a comment block:
```clojure
(comment
  (prn 5|)
)
```
...which results in the evaluation of `(prn 5))` — there is an extra closing delimiter as `cider--calculate-closing-delimiters` looks beyond the `prn` form and matches the `(` of the comment form. I would expect the evaluation of `(prn 5)`.

In this patch I have integrated modified functions that appear to have solved this problem for me.

The code for the new `cider--insert-closing-delimiters` is an adaptation of the [`cider-repl-closing-return`](https://github.com/clojure-emacs/cider/blob/dd4669b454f887350bbad7c3066621a270d21b13/cider-repl.el#L1068-L1081) function. Perhaps `cider-repl-closing-return` should depend on the more general `cider--insert-closing-delimiters`?

In one commit I have removed functions that seem to have been made redundant.

-----------------

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] ~~You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)~~