### PR TITLE
Sideloader: no line breaks in base64 content

### DIFF
--- a/cider-eval.el
+++ b/cider-eval.el
@@ -196,7 +196,7 @@ When invoked with a prefix ARG the command doesn't prompt for confirmation."
   (let ((file (expand-file-name file cider-sideloader-dir)))
     (if (file-exists-p file)
         (with-current-buffer (find-file-noselect file)
-          (base64-encode-string (substring-no-properties (buffer-string))))
+          (base64-encode-string (substring-no-properties (buffer-string)) 'no-line-breaks))
       ;; if we can't find the file we should return an empty string
       (base64-encode-string ""))))
 

--- a/test/cider-eval-test.el
+++ b/test/cider-eval-test.el
@@ -1,0 +1,42 @@
+;;; cider-eval-tests.el
+
+;; Copyright © 2012-2021 Arne Brasseur
+
+;; Author: Arne Brasseur
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; This file is part of CIDER
+
+;;; Code:
+
+(require 'buttercup)
+(require 'cider-eval)
+
+(describe "cider-provide-file"
+  (it "returns an empty string when the file is not found"
+    (expect (cider-provide-file "abc.clj") :to-equal ""))
+  (it "base64 encodes without newlines"
+    (let ((cider-sideloader-dir "/tmp")
+          (default-directory "/tmp")
+          (filename (make-temp-file "abc.clj")))
+      (with-temp-file filename
+        (dotimes (_ 60) (insert "x")))
+      (expect (cider-provide-file filename) :not :to-match "\n"))))
+
+(provide 'cider-eval-tests)


### PR DESCRIPTION
Currently we are sending sideloaded resources as line-wrapped base64. The extra
newlines confuse the nREPL sideloader, turning the result into binary garbage.

I think in this case we should be both more conservative in what we send (this
patch) and more lenient in what we receive (nREPL should sanitize the input and
drop any characters that aren't valid base64).

Part of https://github.com/clojure-emacs/cider/issues/3037

-----------------

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] ~You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)~

