### PR TITLE
Allow starting the sideloader for the tooling session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * [#3020](https://github.com/clojure-emacs/cider/issues/3020): Fix session linking on Windows, e.g. when jumping into a library on the classpath.
 * [#3031](https://github.com/clojure-emacs/cider/pull/3031): Fix `cider-eval-defun-up-to-point` failing to match delimiters correctly in some cases, resulting in reader exceptions.
+* [#3039](https://github.com/clojure-emacs/cider/pull/3039): Allow starting the sideloader for the tooling session
 
 ## 1.1.1 (2021-05-24)
 

--- a/cider-client.el
+++ b/cider-client.el
@@ -162,13 +162,14 @@ Signal an error if it is not supported."
   (unless (cider-nrepl-op-supported-p op)
     (user-error "`%s' requires the nREPL op \"%s\" (provided by cider-nrepl)" this-command op)))
 
-(defun cider-nrepl-send-request (request callback &optional connection)
+(defun cider-nrepl-send-request (request callback &optional connection tooling)
   "Send REQUEST and register response handler CALLBACK.
 REQUEST is a pair list of the form (\"op\" \"operation\" \"par1-name\"
                                     \"par1\" ... ).
 If CONNECTION is provided dispatch to that connection instead of
-the current connection.  Return the id of the sent message."
-  (nrepl-send-request request callback (or connection (cider-current-repl 'any 'ensure))))
+the current connection.  Return the id of the sent message.
+If TOOLING is truthy then the tooling session is used."
+  (nrepl-send-request request callback (or connection (cider-current-repl 'any 'ensure)) tooling))
 
 (defun cider-nrepl-send-sync-request (request &optional connection abort-on-input)
   "Send REQUEST to the nREPL server synchronously using CONNECTION.

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -208,13 +208,16 @@ When invoked with a prefix ARG the command doesn't prompt for confirmation."
           (when (member "sideloader-lookup" status)
             (cider-request:sideloader-provide id type name))))))
 
-(defun cider-request:sideloader-start (&optional connection)
+(defun cider-request:sideloader-start (&optional connection tooling)
   "Perform the nREPL \"sideloader-start\" op.
-If CONNECTION is nil, use `cider-current-repl'."
+If CONNECTION is nil, use `cider-current-repl'.
+If TOOLING is truthy then the operation is perfomed over the tooling
+session, rather than the regular session."
   (cider-ensure-op-supported "sideloader-start")
   (cider-nrepl-send-request `("op" "sideloader-start")
                             (cider-sideloader-lookup-handler)
-                            connection))
+                            connection
+                            tooling))
 
 (defun cider-request:sideloader-provide (id type file &optional connection)
   "Perform the nREPL \"sideloader-provide\" op for ID, TYPE and FILE.


### PR DESCRIPTION
CIDER's deferred loading of middleware means that requires can happen during all
kinds of nREPL ops, many of which are performed over the tooling session. To
make this work via the sideloader we need it to be active both on the regular
session and on the tooling session, so provide a flag for starting it in either
session.

-----------------


- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
