### PR TITLE
Sideloader: handle binary files, support multiple directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,7 @@
 * [#3020](https://github.com/clojure-emacs/cider/issues/3020): Fix session linking on Windows, e.g. when jumping into a library on the classpath.
 * [#3031](https://github.com/clojure-emacs/cider/pull/3031): Fix `cider-eval-defun-up-to-point` failing to match delimiters correctly in some cases, resulting in reader exceptions.
 * [#3039](https://github.com/clojure-emacs/cider/pull/3039): Allow starting the sideloader for the tooling session.
-* [#3039](https://github.com/clojure-emacs/cider/pull/3039): Allow starting the sideloader for the tooling session
-* [#3031](https://github.com/clojure-emacs/cider/pull/3041): Sideloader: handle binary files, support multiple directories
+* [#3041](https://github.com/clojure-emacs/cider/pull/3041): Sideloader: handle binary files, support multiple directories
 
 ## 1.1.1 (2021-05-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 * [#3020](https://github.com/clojure-emacs/cider/issues/3020): Fix session linking on Windows, e.g. when jumping into a library on the classpath.
 * [#3031](https://github.com/clojure-emacs/cider/pull/3031): Fix `cider-eval-defun-up-to-point` failing to match delimiters correctly in some cases, resulting in reader exceptions.
 * [#3039](https://github.com/clojure-emacs/cider/pull/3039): Allow starting the sideloader for the tooling session.
+* [#3039](https://github.com/clojure-emacs/cider/pull/3039): Allow starting the sideloader for the tooling session
+* [#3031](https://github.com/clojure-emacs/cider/pull/3041): Sideloader: handle binary files, support multiple directories
 
 ## 1.1.1 (2021-05-24)
 

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -191,7 +191,7 @@ When invoked with a prefix ARG the command doesn't prompt for confirmation."
 
 (defvar cider-sideloader-dirs
   (list (file-name-directory load-file-name))
-  "Directories where we look for resources requested by the sideloader")
+  "Directories where we look for resources requested by the sideloader.")
 
 ;; based on f-read-bytes
 (defun cider-read-bytes (path)

--- a/test/cider-eval-test.el
+++ b/test/cider-eval-test.el
@@ -37,6 +37,13 @@
           (filename (make-temp-file "abc.clj")))
       (with-temp-file filename
         (dotimes (_ 60) (insert "x")))
-      (expect (cider-provide-file filename) :not :to-match "\n"))))
+      (expect (cider-provide-file filename) :not :to-match "\n")))
+  (it "can handle multibyte characters"
+    (let ((cider-sideloader-dir "/tmp")
+          (default-directory "/tmp")
+          (filename (make-temp-file "abc.clj")))
+      (with-temp-file filename
+        (insert "🍻"))
+      (expect (cider-provide-file filename) :to-equal "8J+Nuw=="))))
 
 (provide 'cider-eval-tests)


### PR DESCRIPTION
Make sure that files are served byte-for-byte as they are on disk, without emacs
doing any coding system conversion. This also prevents base64-encode from
complaining about multibyte characters.

Support multiple directories as sources for the sideloader, e.g.
cider-nrepl/src, cider-nrepl/resources, orchard/src

Part of https://github.com/clojure-emacs/cider/issues/3037

Discovered this because cider.nrepl.middleware.track-state contains a U+2019 RIGHT SINGLE QUOTATION MARK :)

-----------------

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

