### PR TITLE
Fix errors on empty stacktraces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bugs fixed
 
+* [#3022](https://github.com/clojure-emacs/cider/issues/3022): Handle empty stacktraces, pointing users to docs about the OmitStackTraceInFastThrow JVM optimization.
 * [#3020](https://github.com/clojure-emacs/cider/issues/3020): Fix session linking on Windows, e.g. when jumping into a library on the classpath.
 * [#3031](https://github.com/clojure-emacs/cider/pull/3031): Fix `cider-eval-defun-up-to-point` failing to match delimiters correctly in some cases, resulting in reader exceptions.
 * [#3039](https://github.com/clojure-emacs/cider/pull/3039): Allow starting the sideloader for the tooling session

--- a/doc/modules/ROOT/pages/troubleshooting.adoc
+++ b/doc/modules/ROOT/pages/troubleshooting.adoc
@@ -281,4 +281,20 @@ to be cached and have no stacktrace.
 You can turn off the optimization by adding the JVM flag `-XX:-OmitStackTraceInFastThrow` to whatever
 command you're using to start nREPL.
 
+In particular, by adding it to a deps.edn file under an alias (eg. `:dev`)
+[source,lisp]
+---
+{:aliases
+ {:dev
+  {:jvm-opts ["-XX:-OmitStackTraceInFastThrow"]
+  ...}}}
+---
+
+Or by customising the jack-in options.
+[source,lisp]
+---
+(setq cider-clojure-cli-global-options "-J-XX:-OmitStackTraceInFastThrow")
+---
+
+
 TIP: You can read more about this problem https://github.com/clojure-emacs/cider/issues/3022[here].

--- a/doc/modules/ROOT/pages/troubleshooting.adoc
+++ b/doc/modules/ROOT/pages/troubleshooting.adoc
@@ -269,16 +269,10 @@ counting from 0 while Clojure starts from 1. Accordingly, the `cider-nrepl`
 middleware uses 1-based indexing and all conversions to 0-based indexing should
 be handled client-side. See https://github.com/clojure-emacs/cider/issues/2852.
 
-=== Empty Java stacktraces resulting in `NullPointerException`
+=== Empty Java stacktraces
 
-Occasionally the JVM might remove some stack frames, which will break
-CIDER's stacktrace display functionality, resulting in error message like these:
-
-[source]
-----
-error in process filter: cider-stacktrace-render-frame: Format specifier doesn’t match argument type
-error in process filter: Format specifier doesn’t match argument type
-----
+Occasionally the JVM might remove some stack frames, resulting in no stacktrace
+information being displayed in CIDER's error buffer.
 
 That's caused by an JVM optimization (`OmitStackTraceInFastThrow`, enabled by
 default), which optimizes "built-in" exceptions that are thrown frequently enough


### PR DESCRIPTION
Fixes #3022, succeeds #3023.

I also edited the docs to reflect that Cider no longer throws an error, and added beginner-friendly instructions for setting the JVM opts. 
Note: only added examples for Clojure CLI, since Leiningen enables the flag by default and I'm not familiar with Boot. 



-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
