### PR TITLE
Dynamically upgrade nrepl connection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,10 @@ commands:
       - run:
           name: Install Eldev
           command: curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/circle-eldev > x.sh && source ./x.sh
+      - run:
+          name: Install unzip
+          command: apt-get update && apt-get install unzip
+
   setup-windows:
     steps:
       - checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#3031](https://github.com/clojure-emacs/cider/pull/3031): Fix `cider-eval-defun-up-to-point` failing to match delimiters correctly in some cases, resulting in reader exceptions.
 * [#3039](https://github.com/clojure-emacs/cider/pull/3039): Allow starting the sideloader for the tooling session.
 * [#3041](https://github.com/clojure-emacs/cider/pull/3041): Sideloader: handle binary files, support multiple directories
+* [#3044](https://github.com/clojure-emacs/cider/pull/3044): Dynamically upgrade nREPL connection
 
 ## 1.1.1 (2021-05-24)
 

--- a/cider-jar.el
+++ b/cider-jar.el
@@ -1,0 +1,117 @@
+;;; cider-jar.el --- Jar functionality for Clojure -*- lexical-binding: t -*-
+
+;; Copyright © 2021 Arne Brasseur
+;;
+;; Author: Arne Brasseur <arne@arnebrasseur.net>
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+
+;; Dealing with JAR (Java archive) files, which are really just zip files in
+;; disguise.  In particular downloading and retrieving the cider-nrepl jar.
+
+;;; Code:
+
+(require 'url)
+(require 'arc-mode)
+(require 'map)
+
+
+(defvar cider-jar-cache-dir (expand-file-name "cider-cache" user-emacs-directory)
+  "Location where we store dowloaded files for later use.")
+
+(defvar cider-jar-content-cache (make-hash-table :test #'equal)
+  "Nested hash table of jar-path -> file-path -> bool.
+This provides an efficient check to see if a file exists in a jar or not.")
+
+(defun cider-jar-clojars-url (group artifact version)
+  "URL to download a specific jar from Clojars.
+GROUP, ARTIFACT, and VERSION are the components of the Maven coordinates."
+  (concat "https://repo.clojars.org/" group "/" artifact "/"
+          version
+          "/cider-nrepl-"
+          version
+          ".jar"))
+
+(defun cider-jar-find-or-fetch (group artifact version)
+  "Download the given jar off clojars and cache it.
+
+GROUP, ARTIFACT, and VERSION are the components of the Maven coordinates.
+Returns the path to the jar."
+  (let* ((m2-path (expand-file-name (concat "~/.m2/repository/" group "/" artifact "/" version "/" artifact "-" version ".jar")))
+         (clojars-url (cider-jar-clojars-url group artifact version))
+         (cache-path (expand-file-name (replace-regexp-in-string "https://" "" clojars-url) cider-jar-cache-dir)))
+    (cond
+     ((file-exists-p m2-path) m2-path)
+     ((file-exists-p cache-path) cache-path)
+     (t
+      (make-directory (file-name-directory cache-path) t)
+      (url-copy-file clojars-url cache-path)
+      cache-path))))
+
+(defun cider-jar-contents (jarfile)
+  "Get the list of filenames in a jar (or zip) file.
+JARFILE is the location of the archive."
+  (with-temp-buffer
+    (set-buffer-multibyte nil)
+    (setq buffer-file-coding-system 'binary)
+    (insert-file-contents-literally jarfile nil)
+    (seq-map
+     (lambda (v)
+       (if (vectorp v)
+           ;; Earlier emacsen, result is a vector, first slot is the name
+           (elt v 0)
+         ;; Emacs 28, result is a recordp / cl-defstruct. First slot contains the
+         ;; name.
+         ;; This should really be a (funcall #'archive--file-desc-ext-file-name v)
+         ;; but because of linting we can't have nice things.
+         (aref v 1)))
+     (archive-zip-summarize))))
+
+(defun cider-jar-contents-cached (jarfile)
+  "Like cider-jar-contents, but cached.
+
+Instead of returning a list of strings this returns a hash table of string
+keys and values `t`, for quick lookup.  JARFILE is the location of the
+archive."
+  (let ((m (map-elt cider-jar-content-cache jarfile)))
+    (if m
+        m
+      (let ((m (make-hash-table :test #'equal)))
+        (seq-do (lambda (path)
+                  (puthash path t m))
+                (cider-jar-contents jarfile))
+        (puthash jarfile m cider-jar-content-cache)
+        m))))
+
+(defun cider-jar-contains-p (jarfile name)
+  "Does the JARFILE contain a file with the given NAME?"
+  (map-elt (cider-jar-contents-cached jarfile) name))
+
+(defun cider-jar-retrieve-resource (jarfile name)
+  "Extract a file NAME from a JARFILE as a string."
+  (make-directory archive-tmpdir :make-parents)
+  (when (cider-jar-contains-p jarfile name)
+    (let ((default-directory archive-tmpdir))
+      (with-temp-buffer
+        (set-buffer-multibyte nil)
+        (setq buffer-file-coding-system 'binary)
+        (archive-zip-extract jarfile name)
+        (buffer-substring-no-properties (point-min) (point-max))))))
+
+(provide 'cider-jar)
+;;; cider-jar.el ends here

--- a/test/cider-eval-test.el
+++ b/test/cider-eval-test.el
@@ -32,14 +32,14 @@
   (it "returns an empty string when the file is not found"
     (expect (cider-provide-file "abc.clj") :to-equal ""))
   (it "base64 encodes without newlines"
-    (let ((cider-sideloader-dir "/tmp")
+    (let ((cider-sideloader-path (list "/tmp"))
           (default-directory "/tmp")
           (filename (make-temp-file "abc.clj")))
       (with-temp-file filename
         (dotimes (_ 60) (insert "x")))
       (expect (cider-provide-file filename) :not :to-match "\n")))
   (it "can handle multibyte characters"
-    (let ((cider-sideloader-dir "/tmp")
+    (let ((cider-sideloader-path (list "/tmp"))
           (default-directory "/tmp")
           (filename (make-temp-file "abc.clj")))
       (with-temp-file filename

--- a/test/cider-jar-test.el
+++ b/test/cider-jar-test.el
@@ -1,0 +1,74 @@
+;;; cider-jar-tests.el
+
+;; Copyright © 2012-2021 Arne Brasseur
+
+;; Author: Arne Brasseur <arne@arnebrasseur.net>
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; This file is part of CIDER
+
+;;; Code:
+
+(require 'buttercup)
+(require 'cider-jar)
+(require 'map)
+
+(describe "cider-jar--cider-nrepl-clojars-url"
+  (expect (cider-jar-clojars-url "cider" "cider-nrepl" "0.1.2")
+          :to-equal
+          "https://repo.clojars.org/cider/cider-nrepl/0.1.2/cider-nrepl-0.1.2.jar"))
+
+(describe "cider-jar-ensure-cider-nrepl-jar"
+  (expect (cider-jar-find-or-fetch "cider" "cider-nrepl" "0.20.0")
+          :to-match
+          (rx "cider-cache/repo.clojars.org/cider/cider-nrepl/0.20.0/cider-nrepl-0.20.0.jar")))
+
+(describe "cider-jar-contents"
+  (expect
+   (cider-jar-contents (cider-jar-find-or-fetch "cider" "cider-nrepl" "0.20.0"))
+   :to-contain
+   "cider/nrepl.clj"))
+
+(describe "cider-jar-contents-cached"
+  (expect
+   (map-elt (cider-jar-contents-cached (cider-jar-find-or-fetch "cider" "cider-nrepl" "0.20.0"))
+            "cider/nrepl.clj")
+   :to-be t))
+
+(describe "cider-jar-contains"
+  (expect
+   (cider-jar-contains-p (cider-jar-find-or-fetch "cider" "cider-nrepl" "0.20.0")
+                         "cider/nrepl.clj")
+   :to-be t)
+  (expect
+   (cider-jar-contains-p (cider-jar-find-or-fetch "cider" "cider-nrepl" "0.20.0")
+                         "foo/bar.clj")
+   :to-be nil))
+
+(describe "cider-jar-retrieve-resource"
+  (expect
+   (cider-jar-retrieve-resource (cider-jar-find-or-fetch "cider" "cider-nrepl" "0.20.0")
+                                "data_readers.clj")
+   :to-equal
+   "{dbg cider.nrepl.middleware.debug/debug-reader
+ break cider.nrepl.middleware.debug/breakpoint-reader
+ light cider.nrepl.middleware.enlighten/light-reader}
+"))
+
+(provide 'cider-jar-test)


### PR DESCRIPTION
Piece together the final pieces to make dynamic loading + sideloading of
middleware work.

This introduces `M-x cider-upgrade-nrepl-connection`, which combines the different steps needed
- fetch the cider-nrepl jar
- start the sideloader
- insert the middleware
- reload the nREPL capabilities

This introduces a cider-jar mini library for looking up jars and files in jars fairly efficiently and in a cross-platform manner.

Part of https://github.com/clojure-emacs/cider/issues/3037

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [-] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
