### PR TITLE
Fix info lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#3039](https://github.com/clojure-emacs/cider/pull/3039): Allow starting the sideloader for the tooling session.
 * [#3041](https://github.com/clojure-emacs/cider/pull/3041): Sideloader: handle binary files, support multiple directories
 * [#3044](https://github.com/clojure-emacs/cider/pull/3044): Dynamically upgrade nREPL connection
+* [#3047](https://github.com/clojure-emacs/cider/pull/3047): Fix info/lookup fallback: response has an extra level
 
 ## 1.1.1 (2021-05-24)
 

--- a/cider-client.el
+++ b/cider-client.el
@@ -637,7 +637,7 @@ CONTEXT represents a completion context for compliment."
                     (cider-nrepl-send-sync-request (cider-current-repl)))))
     (if (member "lookup-error" (nrepl-dict-get var-info "status"))
         nil
-      var-info)))
+      (nrepl-dict-get var-info "info"))))
 
 (defun cider-sync-request:eldoc (symbol &optional class member)
   "Send \"eldoc\" op with parameters SYMBOL or CLASS and MEMBER."

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -699,7 +699,7 @@ Session name can be customized with `cider-session-name-template'."
 ;;; REPL Buffer Init
 
 (defvar-local cider-cljs-repl-type nil
-  "The type of the ClojureScript runtime (Browser, Node, Figwheel, etc.)")
+  "The type of the ClojureScript runtime (Browser, Node, Figwheel, etc.).")
 
 (defvar-local cider-repl-type nil
   "The type of this REPL buffer, usually either clj or cljs.")

--- a/cider-debug.el
+++ b/cider-debug.el
@@ -407,7 +407,7 @@ In order to work properly, this mode must be activated by
   (cider--debug-mode-redisplay))
 
 (easy-menu-define cider-debug-mode-menu cider--debug-mode-map
-  "Menu for CIDER debug mode"
+  "Menu for CIDER debug mode."
   `("CIDER Debugger"
     ["Next step" (cider-debug-mode-send-reply ":next") :keys "n"]
     ["Continue" (cider-debug-mode-send-reply ":continue") :keys "c"]

--- a/cider-doc.el
+++ b/cider-doc.el
@@ -120,25 +120,25 @@
 
 (defface cider-docview-emphasis-face
   '((t (:inherit default :underline t)))
-  "Face for emphasized text"
+  "Face for emphasized text."
   :group 'cider-docview-mode
   :package-version '(cider . "0.7.0"))
 
 (defface cider-docview-strong-face
   '((t (:inherit default :underline t :weight bold)))
-  "Face for strongly emphasized text"
+  "Face for strongly emphasized text."
   :group 'cider-docview-mode
   :package-version '(cider . "0.7.0"))
 
 (defface cider-docview-literal-face
   '((t (:inherit font-lock-string-face)))
-  "Face for literal text"
+  "Face for literal text."
   :group 'cider-docview-mode
   :package-version '(cider . "0.7.0"))
 
 (defface cider-docview-table-border-face
   '((t (:inherit shadow)))
-  "Face for table borders"
+  "Face for table borders."
   :group 'cider-docview-mode
   :package-version '(cider . "0.7.0"))
 
@@ -188,7 +188,7 @@
 (defvar cider-docview-line)
 
 (define-derived-mode cider-docview-mode help-mode "Doc"
-  "Major mode for displaying CIDER documentation
+  "Major mode for displaying CIDER documentation.
 
 \\{cider-docview-mode-map}"
   (setq buffer-read-only t)

--- a/cider-popup.el
+++ b/cider-popup.el
@@ -27,7 +27,7 @@
 (require 'cider-compat)
 
 (define-minor-mode cider-popup-buffer-mode
-  "Mode for CIDER popup buffers"
+  "Mode for CIDER popup buffers."
   nil
   (" cider-tmp")
   '(("q" .  cider-popup-buffer-quit-function)))

--- a/cider-scratch.el
+++ b/cider-scratch.el
@@ -71,7 +71,7 @@
 
 (define-derived-mode cider-clojure-interaction-mode clojure-mode "Clojure Interaction"
   "Major mode for typing and evaluating Clojure forms.
-Like clojure-mode except that \\[cider-eval-print-last-sexp] evals the Lisp expression
+Like `clojure-mode' except that \\[cider-eval-print-last-sexp] evals the Lisp expression
 before point, and prints its value into the buffer, advancing point.
 
 \\{cider-clojure-interaction-mode-map}"

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -86,43 +86,43 @@ The error types are represented as strings."
 
 (defface cider-stacktrace-error-class-face
   '((t (:inherit font-lock-warning-face)))
-  "Face for exception class names"
+  "Face for exception class names."
   :group 'cider-stacktrace
   :package-version '(cider . "0.6.0"))
 
 (defface cider-stacktrace-error-message-face
   '((t (:inherit font-lock-doc-face)))
-  "Face for exception messages"
+  "Face for exception messages."
   :group 'cider-stacktrace
   :package-version '(cider . "0.7.0"))
 
 (defface cider-stacktrace-filter-active-face
   '((t (:inherit button :underline t :weight normal)))
-  "Face for filter buttons representing frames currently visible"
+  "Face for filter buttons representing frames currently visible."
   :group 'cider-stacktrace
   :package-version '(cider . "0.6.0"))
 
 (defface cider-stacktrace-filter-inactive-face
   '((t (:inherit button :underline nil :weight normal)))
-  "Face for filter buttons representing frames currently filtered out"
+  "Face for filter buttons representing frames currently filtered out."
   :group 'cider-stacktrace
   :package-version '(cider . "0.6.0"))
 
 (defface cider-stacktrace-face
   '((t (:inherit default)))
-  "Face for stack frame text"
+  "Face for stack frame text."
   :group 'cider-stacktrace
   :package-version '(cider . "0.6.0"))
 
 (defface cider-stacktrace-ns-face
   '((t (:inherit font-lock-comment-face)))
-  "Face for stack frame namespace name"
+  "Face for stack frame namespace name."
   :group 'cider-stacktrace
   :package-version '(cider . "0.6.0"))
 
 (defface cider-stacktrace-fn-face
   '((t (:inherit default :weight bold)))
-  "Face for stack frame function name"
+  "Face for stack frame function name."
   :group 'cider-stacktrace
   :package-version '(cider . "0.6.0"))
 


### PR DESCRIPTION
When doing a var-info lookup we potentially try three different strategies:
info, lookup, and eval. The second currently always fails, because the "info"
dict is not at the top level in the response message, but nested under an "info"
key.

Compare and contrast:

```emacs-lisp
 (cider-sync-request:info "clojure.core/str")
 (cider-sync-request:lookup "clojure.core/str")
 (cider-fallback-eval:info "clojure.core/str")
```

Running tests locally I get a failure, but it seems unrelated.

```
cider-repls when multiple sessions exist always returns the most recently used connection

Traceback (most recent call last):
  buttercup-fail("%s" "Expected `(cider-repls)' to be `equal' to `(#<buffer *b-session:b2:cljs*(8228)> #<buffer *b-session:b1:clj*(7432)>)', but instead it was `(#<buffer *a-session:bb2:cljs*(8909)> #<buffer *a-session:bb1:clj*(4337)>)' which does not match because: (list-elt 0 (different-atoms #<buffer *a-session:bb2:cljs*(8909)> #<buffer *b-session:b2:cljs*(8228)>)).")
  signal(buttercup-failed "Expected `(cider-repls)' to be `equal' to `(#<buffer *b-session:b2:cljs*(8228)> #<buffer *b-session:b1:clj*(7432)>)', but instead it was `(#<buffer *a-session:bb2:cljs*(8909)> #<buffer *a-session:bb1:clj*(4337)>)' which does not match because: (list-elt 0 (different-atoms #<buffer *a-session:bb2:cljs*(8909)> #<buffer *b-session:b2:cljs*(8228)>)).")
FAILED: Expected `(cider-repls)' to be `equal' to `(#<buffer *b-session:b2:cljs*(8228)> #<buffer *b-session:b1:clj*(7432)>)', but instead it was `(#<buffer *a-session:bb2:cljs*(8909)> #<buffer *a-session:bb1:clj*(4337)>)' which does not match because: (list-elt 0 (different-atoms #<buffer *a-session:bb2:cljs*(8909)> #<buffer *b-session:b2:cljs*(8228)>)).
```

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
