### PR TITLE
[Fix #3045] Add customizable variable cider-xref-fn-depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#3044](https://github.com/clojure-emacs/cider/pull/3044): Dynamically upgrade nREPL connection
 * [#3047](https://github.com/clojure-emacs/cider/pull/3047): Fix info/lookup fallback: response has an extra level
 * [#2746](https://github.com/clojure-emacs/cider/issues/2746): Handle gracefully Clojure versions with non-standard qualifiers (e.g. `1.11.0-master-SNAPSHOT`).
+* [#3045] (https://github.com/clojure-emacs/cider/issues/3045): Add customizable variable cider-xref-fn-depth for specifying depth when adding to xref-backend-functions.
 
 ## 1.1.1 (2021-05-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New features
 
-* [#2831](https://github.com/clojure-emacs/cider/issues/2831): Add xref integration.
+* [#2831](https://github.com/clojure-emacs/cider/issues/2831): Add xref integration, configured with customizable variables cider-use-xref and cider-xref-fn-depth.
 * [#3017](https://github.com/clojure-emacs/cider/issues/3017): Annotate company completion kinds.
 * [#3040](https://github.com/clojure-emacs/cider/pull/3040): Support invoking `cider-clojuredocs` within the `*clojuredocs*` buffer.
 
@@ -18,7 +18,6 @@
 * [#3044](https://github.com/clojure-emacs/cider/pull/3044): Dynamically upgrade nREPL connection
 * [#3047](https://github.com/clojure-emacs/cider/pull/3047): Fix info/lookup fallback: response has an extra level
 * [#2746](https://github.com/clojure-emacs/cider/issues/2746): Handle gracefully Clojure versions with non-standard qualifiers (e.g. `1.11.0-master-SNAPSHOT`).
-* [#3045] (https://github.com/clojure-emacs/cider/issues/3045): Add customizable variable cider-xref-fn-depth for specifying depth when adding to xref-backend-functions.
 
 ## 1.1.1 (2021-05-24)
 

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -483,6 +483,14 @@ As it stands Emacs fires these events on <mouse-8> and <mouse-9> on 'x' and
   :group 'cider
   :version '(cider . "1.2.0"))
 
+(defcustom cider-xref-fn-depth nil
+  "The depth to use when adding the CIDER xref function to the relevant hook.
+By convention this is a number between -100 and 100, lower numbers indicating a
+higher precedence."
+  :type 'integer
+  :group 'cider
+  :version '(cider . "1.2.0"))
+
 (defconst cider-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c C-d") 'cider-doc-map)
@@ -1063,7 +1071,7 @@ property."
           (setq-local clojure-get-indent-function #'cider--get-symbol-indent))
         (setq-local clojure-expected-ns-function #'cider-expected-ns)
         (when cider-use-xref
-          (add-hook 'xref-backend-functions #'cider--xref-backend nil 'local))
+          (add-hook 'xref-backend-functions #'cider--xref-backend cider-xref-fn-depth 'local))
         (setq next-error-function #'cider-jump-to-compilation-error))
     ;; Mode cleanup
     (mapc #'kill-local-variable '(completion-at-point-functions

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -483,7 +483,7 @@ As it stands Emacs fires these events on <mouse-8> and <mouse-9> on 'x' and
   :group 'cider
   :version '(cider . "1.2.0"))
 
-(defcustom cider-xref-fn-depth nil
+(defcustom cider-xref-fn-depth -90
   "The depth to use when adding the CIDER xref function to the relevant hook.
 By convention this is a number between -100 and 100, lower numbers indicating a
 higher precedence."

--- a/doc/modules/ROOT/pages/usage/misc_features.adoc
+++ b/doc/modules/ROOT/pages/usage/misc_features.adoc
@@ -352,3 +352,12 @@ Beginning with version 1.2.0, cider support Emacs built-in xref, which means `M-
 ----
 (setq cider-use-xref nil)
 ----
+
+If you use other minor modes (e.g. lsp-mode) that also integrate with xref, you may with to customize the precedence of CIDER, e.g. to use CIDER rather than LSP (when available), you can set the following:
+
+[source,lisp]
+----
+(setq cider-xref-fn-depth -90)
+----
+
+See the documentation for `add-hook` for more information about depth.

--- a/doc/modules/ROOT/pages/usage/misc_features.adoc
+++ b/doc/modules/ROOT/pages/usage/misc_features.adoc
@@ -353,11 +353,13 @@ Beginning with version 1.2.0, cider support Emacs built-in xref, which means `M-
 (setq cider-use-xref nil)
 ----
 
-If you use other packags (e.g. lsp-mode) that also integrate with xref, you may with to customize the precedence of CIDER, e.g. to use CIDER rather than LSP (when available), you can set the following:
+If you use other packages (e.g. lsp-mode) that also integrate with xref, you may wish to customize the precedence of CIDER. The precedence is controlled by the
+order in which functions appear in the `xref-backend-functions` hook. By default, the CIDER xref function will be added with a depth of -90, so will come first.
+If you would prefer it to have a lower precedence, you can change cider-xref-fn-depth:
 
 [source,lisp]
 ----
-(setq cider-xref-fn-depth -90)
+(setq cider-xref-fn-depth 90)
 ----
 
 See https://www.gnu.org/software/emacs/manual/html_node/elisp/Setting-Hooks.html[Setting Hooks] for more information about depth.

--- a/doc/modules/ROOT/pages/usage/misc_features.adoc
+++ b/doc/modules/ROOT/pages/usage/misc_features.adoc
@@ -353,11 +353,11 @@ Beginning with version 1.2.0, cider support Emacs built-in xref, which means `M-
 (setq cider-use-xref nil)
 ----
 
-If you use other minor modes (e.g. lsp-mode) that also integrate with xref, you may with to customize the precedence of CIDER, e.g. to use CIDER rather than LSP (when available), you can set the following:
+If you use other packags (e.g. lsp-mode) that also integrate with xref, you may with to customize the precedence of CIDER, e.g. to use CIDER rather than LSP (when available), you can set the following:
 
 [source,lisp]
 ----
 (setq cider-xref-fn-depth -90)
 ----
 
-See the documentation for `add-hook` for more information about depth.
+See https://www.gnu.org/software/emacs/manual/html_node/elisp/Setting-Hooks.html[Setting Hooks] for more information about depth.


### PR DESCRIPTION
This allows the depth to be specified when adding to
xref-backend-functions, giving control over whether
cider--xref-backend is added before or after other functions. This will
determine which function in the hook is tried first (i.e. which will
provide the xref functionality, e.g. to ensure is used instead of
lsp-mode).

This fixes https://github.com/clojure-emacs/cider/issues/3045 

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
