### PR TITLE
fix deprecated positional arguments warning in emacs 28

### DIFF
--- a/cider-debug.el
+++ b/cider-debug.el
@@ -340,7 +340,7 @@ of `cider-interactive-eval' in debug sessions."
   "Mode active during debug sessions.
 In order to work properly, this mode must be activated by
 `cider--turn-on-debug-mode'."
-  nil " DEBUG" '()
+  :init-value nil :lighter " DEBUG" :keymap '()
   (if cider--debug-mode
       (if cider--debug-mode-response
           (nrepl-dbind-response cider--debug-mode-response (input-type)

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -1048,9 +1048,9 @@ property."
   "Minor mode for REPL interaction from a Clojure buffer.
 
 \\{cider-mode-map}"
-  nil
-  cider-mode-line
-  cider-mode-map
+  :init-value nil
+  :lighter cider-mode-line
+  :keymap cider-mode-map
   (if cider-mode
       (progn
         (setq-local sesman-system 'CIDER)

--- a/cider-test.el
+++ b/cider-test.el
@@ -828,7 +828,7 @@ the results are received."
 When enabled this reruns tests every time a Clojure file is loaded.
 Only runs tests corresponding to the loaded file's namespace and does
 nothing if no tests are defined or if the file failed to load."
-  nil (cider-mode " Test") nil
+  :init-value nil :lighter (cider-mode " Test") :keymap nil
   :global t
   (if cider-auto-test-mode
       (add-hook 'cider-file-loaded-hook #'cider--test-silently)


### PR DESCRIPTION
in emacs 28, there are some warning messages:
```
.emacs.d/straight/build/cider/cider-test.el: Warning: Use keywords rather than deprecated positional arguments to `define-minor-mode'
.emacs.d/straight/build/cider/cider-mode.el: Warning: Use keywords rather than deprecated positional arguments to `define-minor-mode'
.emacs.d/straight/build/cider/cider-debug.el: Warning: Use keywords rather than deprecated positional arguments to `define-minor-mode'
```
use keywords could fix these warning.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
