### PR TITLE
Update parseedn/parseclj to the latest version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,14 +36,6 @@ commands:
           command: eldev -dtT compile --warnings-as-errors
 
 jobs:
-  test-emacs-25:
-    docker:
-      - image: silex/emacs:25-dev
-        entrypoint: bash
-    steps:
-      - setup
-      - test
-
   test-emacs-26:
     docker:
       - image: silex/emacs:26-dev
@@ -97,7 +89,6 @@ workflows:
   version: 2
   ci-test-matrix:
     jobs:
-      - test-emacs-25
       - test-emacs-26
       - test-emacs-27
       - test-emacs-master

--- a/cider.el
+++ b/cider.el
@@ -12,7 +12,7 @@
 ;; Maintainer: Bozhidar Batsov <bozhidar@batsov.dev>
 ;; URL: http://www.github.com/clojure-emacs/cider
 ;; Version: 1.2.0-snapshot
-;; Package-Requires: ((emacs "25") (clojure-mode "5.12") (parseedn "1.0.3") (pkg-info "0.4") (queue "0.2") (spinner "1.7") (seq "2.22") (sesman "0.3.2"))
+;; Package-Requires: ((emacs "25") (clojure-mode "5.12") (parseedn "1.0.4") (pkg-info "0.4") (queue "0.2") (spinner "1.7") (seq "2.22") (sesman "0.3.2"))
 ;; Keywords: languages, clojure, cider
 
 ;; This program is free software: you can redistribute it and/or modify

--- a/cider.el
+++ b/cider.el
@@ -12,7 +12,7 @@
 ;; Maintainer: Bozhidar Batsov <bozhidar@batsov.dev>
 ;; URL: http://www.github.com/clojure-emacs/cider
 ;; Version: 1.2.0-snapshot
-;; Package-Requires: ((emacs "25") (clojure-mode "5.12") (parseedn "1") (pkg-info "0.4") (queue "0.2") (spinner "1.7") (seq "2.22") (sesman "0.3.2"))
+;; Package-Requires: ((emacs "25") (clojure-mode "5.12") (parseedn "1.0.3") (pkg-info "0.4") (queue "0.2") (spinner "1.7") (seq "2.22") (sesman "0.3.2"))
 ;; Keywords: languages, clojure, cider
 
 ;; This program is free software: you can redistribute it and/or modify

--- a/test/cider-eval-test.el
+++ b/test/cider-eval-test.el
@@ -41,7 +41,8 @@
   (it "can handle multibyte characters"
     (let ((cider-sideloader-path (list "/tmp"))
           (default-directory "/tmp")
-          (filename (make-temp-file "abc.clj")))
+          (filename (make-temp-file "abc.clj"))
+          (coding-system-for-write 'utf-8-unix))
       (with-temp-file filename
         (insert "🍻"))
       (expect (cider-provide-file filename) :to-equal "8J+Nuw=="))))


### PR DESCRIPTION
This is a bugfix release, it is important we pull in this one and not 1.0.0 or
1.0.1.

Closes #3059 