### PR TITLE
Soften the warning around cider-nrepl version mismatches

### DIFF
--- a/cider-connection.el
+++ b/cider-connection.el
@@ -245,7 +245,7 @@ message in the REPL area."
                                  "CIDER requires cider-nrepl to be fully functional. Some features will not be available without it!"))
      ((not (cider--compatible-middleware-version-p cider-required-middleware-version middleware-version))
       (cider-emit-manual-warning "troubleshooting.html#cider-complains-of-the-cider-nrepl-version"
-                                 "CIDER %s requires cider-nrepl %s, but you're currently using cider-nrepl %s. The version mismatch might break some functionality!"
+                                 "cider.el %s assumes cider-nrepl %s, but you're currently using cider-nrepl %s. That might be fine, however it is recommended that you ensure the versions are consistent, especially before reporting any issue."
                                  cider-version cider-required-middleware-version middleware-version)))))
 
 (declare-function cider-interactive-eval-handler "cider-eval")

--- a/doc/modules/ROOT/pages/troubleshooting.adoc
+++ b/doc/modules/ROOT/pages/troubleshooting.adoc
@@ -207,7 +207,7 @@ effect of changes you have to restart Emacs.
 This is a warning displayed on the REPL buffer when it starts, and usually looks like this:
 
 ____
-*WARNING:* CIDER 0.18.0 requires cider-nrepl x.y.z, but you're currently using cider-nrepl a.b.c. Some functionality may not work properly!
+*WARNING:* cider.el 1.1.1 assumes cider-nrepl x.y.z, but you're currently using cider-nrepl a.b.c. That might be fine, however it is recommended that you ensure the versions are consistent, especially before reporting any issue.
 ____
 
 where `a.b.c` might be an actual version, like `0.17.0`, or it might be `not installed` or `nil`.


### PR DESCRIPTION
Especially given we try to inflict as few breaking changes as possible (https://github.com/clojure-emacs/cider/discussions/2960), a version mismatch might simply mean that one is using a more recent cider-nrepl version (without one having bothered to customize the related `defcustom` to silence this).

This commit proposes a softer wording for the warning, so that people feel less alarmed in face of these.

Else one gives the quite untruthful impression that things are more fragile/coupled than they actually are.
