### PR TITLE
Don't call `fundamental-mode` if we already are in `fundamental-mode`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#3044](https://github.com/clojure-emacs/cider/pull/3044): Dynamically upgrade nREPL connection
 * [#3047](https://github.com/clojure-emacs/cider/pull/3047): Fix info/lookup fallback: response has an extra level
 * [#2746](https://github.com/clojure-emacs/cider/issues/2746): Handle gracefully Clojure versions with non-standard qualifiers (e.g. `1.11.0-master-SNAPSHOT`).
+* [#3069](https://github.com/clojure-emacs/cider/pull/3069): Fix cursor color changing when it shouldn't in evil-mode
 
 ## 1.1.1 (2021-05-24)
 

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -362,6 +362,11 @@ STACK is as in `nrepl--bdecode-1'.  Return a cons (INFO . STACK)."
             stack (cdr istack)))
     istack))
 
+(defun nrepl--ensure-fundamental-mode ()
+  "Enable `fundamental-mode' if it is not enabled already."
+  (when (not (eq 'fundamental-mode major-mode))
+    (fundamental-mode)))
+
 (defun nrepl-bdecode (string-q &optional response-q)
   "Decode STRING-Q and place the results into RESPONSE-Q.
 STRING-Q is either a queue of strings or a string.  RESPONSE-Q is a queue of
@@ -374,7 +379,10 @@ decoded.  RESPONSE-Q is the original queue with successfully decoded messages
 enqueued and with slot STUB containing a nested stack of an incompletely
 decoded message or nil if the strings were completely decoded."
   (with-current-buffer (get-buffer-create " *nrepl-decoding*")
-    (fundamental-mode)
+    ;; Don't needlessly call `fundamental-mode', to prevent needlessly firing
+    ;; hooks. This fixes an issue with evil-mode where the cursor loses its
+    ;; correct color.
+    (nrepl--ensure-fundamental-mode)
     (erase-buffer)
     (if (queue-p string-q)
         (while (queue-head string-q)
@@ -1352,7 +1360,7 @@ The default buffer name is *nrepl-error*."
       (let ((buffer (get-buffer-create nrepl-error-buffer-name)))
         (with-current-buffer buffer
           (buffer-disable-undo)
-          (fundamental-mode)
+          (nrepl--ensure-fundamental-mode)
           buffer))))
 
 (defun nrepl-log-error (msg)


### PR DESCRIPTION
If the `" *nrepl-decoding*"` buffer already exists then it is likely already in
the right mode. Not re-initializing the mode means we don't re-trigger hooks,
which in this case in particular prevents an unfortunate interaction with
evil-mode, where the cursor color gets updated even though it shouldn't.

Fixes #3068 

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
