### PR TITLE
Add enrich-classpath integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### New features
 
+* Integrate [enrich-classpath](https://github.com/clojure-emacs/enrich-classpath) by default for Leiningen projects.
+  * This enables functionality related to Java sources, javadocs or parsing thereof.
+  * This can slightly slow down jack-in for the _first_ time for a given project; later on the related work will be cached.
 * [#2831](https://github.com/clojure-emacs/cider/issues/2831): Add xref integration, configured with customizable variables cider-use-xref and cider-xref-fn-depth.
 * [#3017](https://github.com/clojure-emacs/cider/issues/3017): Annotate company completion kinds.
 * [#3040](https://github.com/clojure-emacs/cider/pull/3040): Support invoking `cider-clojuredocs` within the `*clojuredocs*` buffer.
@@ -11,6 +14,7 @@
 * Make it possible to specify the version of nREPL to use with `cider-jack-in`. See `cider-injected-nrepl-version`.
 * Upgrade `cider-nrepl`, `Orchard` and `clj-suitable` for pulling their latest bugfixes.
 * Add support for babaska projects to `cider-jack-in`.
+* Introduce `cider-jack-in-lein-middlewares` defcustom.
 
 ### Bugs fixed
 

--- a/cider.el
+++ b/cider.el
@@ -455,7 +455,7 @@ Should be newer than the required version for optimal results."
   :package-version '(cider . "1.2.0")
   :safe #'stringp)
 
-(defcustom cider-enrich-classpath-p t
+(defcustom cider-enrich-classpath t
   "Whether to use git.io/JiJVX for adding sources and javadocs to the classpath.
 
 This is done in a clean manner, without interfering with classloaders.
@@ -515,7 +515,7 @@ returned by this function does not include keyword arguments.
 
 PROJECT-TYPE will be observed, for avoiding injecting plugins
 where it doesn't make sense."
-  (let* ((corpus (if (and cider-enrich-classpath-p
+  (let* ((corpus (if (and cider-enrich-classpath
                           (eq project-type 'lein))
                      (append cider-jack-in-lein-plugins
                              '(("mx.cider/enrich-classpath" "1.4.1")))
@@ -708,7 +708,7 @@ dependencies."
              cider-jack-in-dependencies)
             cider-jack-in-dependencies-exclusions
             (cider-jack-in-normalized-lein-plugins project-type)
-            (if cider-enrich-classpath-p
+            (if cider-enrich-classpath
                 (append cider-jack-in-lein-middlewares
                         '("cider.enrich-classpath/middleware"))
               cider-jack-in-lein-middlewares)))

--- a/cider.el
+++ b/cider.el
@@ -455,6 +455,16 @@ Should be newer than the required version for optimal results."
   :package-version '(cider . "1.2.0")
   :safe #'stringp)
 
+(defcustom cider-enrich-classpath-p t
+  "Whether to use git.io/JiJVX for adding sources and javadocs to the classpath.
+
+This is done in a clean manner, without interfering with classloaders.
+
+Only available for Leiningen projects at the moment."
+  :type 'boolean
+  :group 'cider
+  :safe #'booleanp)
+
 (defcustom cider-jack-in-auto-inject-clojure nil
   "Version of clojure to auto-inject into REPL.
 If nil, do not inject Clojure into the REPL.  If `latest', inject
@@ -484,25 +494,41 @@ want to inject some middleware only when within a project context.)")
 (cider-add-to-alist 'cider-jack-in-lein-plugins
                     "cider/cider-nrepl" cider-injected-middleware-version)
 
+(defvar cider-jack-in-lein-middlewares nil
+  "List of Leiningen :middleware values to be injected at jack-in.
+
+Necessary for plugins which require an explicit middleware name to be specified.
+
+Can also facilitate using middleware in a specific order.")
+(put 'cider-jack-in-lein-middlewares 'risky-local-variable t)
+
 (defvar cider-jack-in-cljs-lein-plugins nil
   "List of Leiningen plugins to be injected at jack-in.
 Added to `cider-jack-in-lein-plugins' (which see) when doing
 `cider-jack-in-cljs'.")
 (put 'cider-jack-in-cljs-lein-plugins 'risky-local-variable t)
 
-(defun cider-jack-in-normalized-lein-plugins ()
+(defun cider-jack-in-normalized-lein-plugins (&optional project-type)
   "Return a normalized list of Leiningen plugins to be injected.
 See `cider-jack-in-lein-plugins' for the format, except that the list
-returned by this function does not include keyword arguments."
-  (thread-last cider-jack-in-lein-plugins
-    (seq-filter
-     (lambda (spec)
-       (if-let* ((pred (plist-get (seq-drop spec 2) :predicate)))
-           (funcall pred spec)
-         t)))
-    (mapcar
-     (lambda (spec)
-       (seq-take spec 2)))))
+returned by this function does not include keyword arguments.
+
+PROJECT-TYPE will be observed, for avoiding injecting plugins
+where it doesn't make sense."
+  (let* ((corpus (if (and cider-enrich-classpath-p
+                          (eq project-type 'lein))
+                     (append cider-jack-in-lein-plugins
+                             '(("mx.cider/enrich-classpath" "1.4.1")))
+                   cider-jack-in-lein-plugins)))
+    (thread-last corpus
+      (seq-filter
+       (lambda (spec)
+         (if-let* ((pred (plist-get (seq-drop spec 2) :predicate)))
+             (funcall pred spec)
+           t)))
+      (mapcar
+       (lambda (spec)
+         (seq-take spec 2))))))
 
 (defvar cider-jack-in-nrepl-middlewares nil
   "List of Clojure variable names.
@@ -584,10 +610,10 @@ of EXCLUSIONS can be provided as well.  The returned
 string is quoted for passing as argument to an inferior shell."
   (shell-quote-argument (format "[%s %S%s]" (car list) (cadr list) (cider--lein-artifact-exclusions exclusions))))
 
-(defun cider-lein-jack-in-dependencies (global-opts params dependencies dependencies-exclusions lein-plugins)
+(defun cider-lein-jack-in-dependencies (global-opts params dependencies dependencies-exclusions lein-plugins &optional lein-middlewares)
   "Create lein jack-in dependencies.
 Does so by concatenating GLOBAL-OPTS, DEPENDENCIES, with DEPENDENCIES-EXCLUSIONS
-removed, LEIN-PLUGINS, and finally PARAMS."
+removed, LEIN-PLUGINS, LEIN-MIDDLEWARES and finally PARAMS."
   (concat
    global-opts
    (unless (seq-empty-p global-opts) " ")
@@ -600,7 +626,11 @@ removed, LEIN-PLUGINS, and finally PARAMS."
                       (seq-map (lambda (plugin)
                                  (concat "update-in :plugins conj "
                                          (cider--list-as-lein-artifact plugin)))
-                               lein-plugins))
+                               lein-plugins)
+                      (seq-map (lambda (middleware)
+                                 (concat "update-in :middlewares conj "
+                                         middleware))
+                               lein-middlewares))
               " -- ")
    " -- "
    params))
@@ -614,6 +644,8 @@ one used."
   (let* ((deps-string (string-join
                        (seq-map (lambda (dep)
                                   (format "%s {:mvn/version \"%s\"}" (car dep) (cadr dep)))
+                                ;; NOTE: injecting Lein plugins for deps.edn projects
+                                ;; seems a bit dubious, worth revisiting at some point.
                                 (append dependencies cider-jack-in-lein-plugins))
                        " "))
          (middleware (mapconcat
@@ -675,13 +707,17 @@ dependencies."
             (cider-add-clojure-dependencies-maybe
              cider-jack-in-dependencies)
             cider-jack-in-dependencies-exclusions
-            (cider-jack-in-normalized-lein-plugins)))
+            (cider-jack-in-normalized-lein-plugins project-type)
+            (if cider-enrich-classpath-p
+                (append cider-jack-in-lein-middlewares
+                        '("cider.enrich-classpath/middleware"))
+              cider-jack-in-lein-middlewares)))
     ('boot (cider-boot-jack-in-dependencies
             global-opts
             params
             (cider-add-clojure-dependencies-maybe
              cider-jack-in-dependencies)
-            (cider-jack-in-normalized-lein-plugins)
+            (cider-jack-in-normalized-lein-plugins project-type)
             (cider-jack-in-normalized-nrepl-middlewares)))
     ('clojure-cli (cider-clojure-cli-jack-in-dependencies
                    global-opts

--- a/doc/modules/ROOT/pages/basics/middleware_setup.adoc
+++ b/doc/modules/ROOT/pages/basics/middleware_setup.adoc
@@ -31,14 +31,16 @@ Use the convenient plugin for defaults, either in your project's
 
 [source,clojure]
 ----
-:plugins [[cider/cider-nrepl "x.y.z"]]
+:plugins [[cider/cider-nrepl "x.y.z"]
+          [mx.cider/enrich-classpath "x.y.z"]]
 ----
 
 A minimal `profiles.clj` for CIDER would be:
 
 [source,clojure]
 ----
-{:repl {:plugins [[cider/cider-nrepl "0.25.2"]]}}
+{:repl {:plugins [[cider/cider-nrepl "0.27.2"]
+                  [mx.cider/enrich-classpath "1.4.1"]]}}
 ----
 
 WARNING: Be careful not to place this in the `:user` profile, as this way CIDER's

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -122,6 +122,9 @@
                                 (shell-quote-argument "[nrepl/nrepl \"0.5.3\"]")
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[cider/cider-nrepl \"0.10.0-SNAPSHOT\"]")
+                                " -- update-in :plugins conj "
+                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.4.1\"]")
+                                " -- update-in :middlewares conj cider.enrich-classpath/middleware"
                                 " -- repl :headless")))
 
     (it "can inject dependencies in a lein project with an exclusion"
@@ -132,6 +135,9 @@
                          (shell-quote-argument "[nrepl/nrepl \"0.5.3\" :exclusions [org.clojure/clojure]]")
                          " -- update-in :plugins conj "
                          (shell-quote-argument "[cider/cider-nrepl \"0.10.0-SNAPSHOT\"]")
+                         " -- update-in :plugins conj "
+                         (shell-quote-argument "[mx.cider/enrich-classpath \"1.4.1\"]")
+                         " -- update-in :middlewares conj cider.enrich-classpath/middleware"
                          " -- repl :headless")))
 
     (it "can inject dependencies in a lein project with multiple exclusions"
@@ -141,6 +147,9 @@
                                 (shell-quote-argument "[nrepl/nrepl \"0.5.3\" :exclusions [org.clojure/clojure foo.bar/baz]]")
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[cider/cider-nrepl \"0.10.0-SNAPSHOT\"]")
+                                " -- update-in :plugins conj "
+                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.4.1\"]")
+                                " -- update-in :middlewares conj cider.enrich-classpath/middleware"
                                 " -- repl :headless")))
 
     (it "can inject dependencies in a boot project"
@@ -173,6 +182,9 @@
                                 (shell-quote-argument "[refactor-nrepl \"2.0.0\"]")
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[cider/cider-nrepl \"0.11.0\"]")
+                                " -- update-in :plugins conj "
+                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.4.1\"]")
+                                " -- update-in :middlewares conj cider.enrich-classpath/middleware"
                                 " -- repl :headless")))
 
     (it "can inject dependencies in a boot project"
@@ -203,6 +215,9 @@
                                 (shell-quote-argument "[nrepl/nrepl \"0.5.3\"]")
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[cider/cider-nrepl \"0.11.0\"]")
+                                " -- update-in :plugins conj "
+                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.4.1\"]")
+                                " -- update-in :middlewares conj cider.enrich-classpath/middleware"
                                 " -- repl :headless")))
     (it "can concat in a boot project"
       (expect (cider-inject-jack-in-dependencies "-C -o" "repl -s wait" 'boot)
@@ -259,12 +274,14 @@
       (cider-jack-in-normalized-nrepl-middlewares)
       (expect 'middlewares-predicate :to-have-been-called-times 1)))
 
-  (describe "when the middleware and plugin lists have been normalized"
+  (describe "when the middleware and plugin lists have been normalized (Lein)"
     (before-each
       (spy-on 'cider-jack-in-normalized-nrepl-middlewares
               :and-return-value '("refactor-nrepl.middleware/wrap-refactor" "cider.nrepl/cider-middleware"))
       (spy-on 'cider-jack-in-normalized-lein-plugins
-              :and-return-value '(("refactor-nrepl" "2.0.0") ("cider/cider-nrepl" "0.11.0")))
+              :and-return-value '(("refactor-nrepl" "2.0.0")
+                                  ("cider/cider-nrepl" "0.11.0")
+                                  ("mx.cider/enrich-classpath" "1.4.1")))
       (setq-local cider-jack-in-dependencies-exclusions '()))
     (it "uses them in a lein project"
       (expect (cider-inject-jack-in-dependencies "" "repl :headless" 'lein)
@@ -274,7 +291,19 @@
                                 (shell-quote-argument "[refactor-nrepl \"2.0.0\"]")
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[cider/cider-nrepl \"0.11.0\"]")
-                                " -- repl :headless")))
+                                " -- update-in :plugins conj "
+                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.4.1\"]")
+                                " -- update-in :middlewares conj cider.enrich-classpath/middleware"
+                                " -- repl :headless"))))
+
+  (describe "when the middleware and plugin lists have been normalized (Boot)"
+    (before-each
+      (spy-on 'cider-jack-in-normalized-nrepl-middlewares
+              :and-return-value '("refactor-nrepl.middleware/wrap-refactor" "cider.nrepl/cider-middleware"))
+      (spy-on 'cider-jack-in-normalized-lein-plugins
+              :and-return-value '(("refactor-nrepl" "2.0.0")
+                                  ("cider/cider-nrepl" "0.11.0")))
+      (setq-local cider-jack-in-dependencies-exclusions '()))
     (it "uses them in a boot project"
       (expect (cider-inject-jack-in-dependencies "" "repl -s wait" 'boot)
               :to-equal (concat "-i \"(require 'cider.tasks)\""


### PR DESCRIPTION
⚠️ not for merging, as I cannot directly try out the cider.el integration atm (I use a fork).

There are details to polish in Orchard and enrich-classpath anyway.

Would greatly appreciate if someone could QA this locally!

Specifically, the middleware should be injected and it should make a difference in the classpath you perceive (especially in a real-world project with at least a few Java deps) + the features you get from CIDER.