### PR TITLE
[Fix #3074] Makes cider recognize 'pwsh' as powershell.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [#2746](https://github.com/clojure-emacs/cider/issues/2746): Handle gracefully Clojure versions with non-standard qualifiers (e.g. `1.11.0-master-SNAPSHOT`).
 * [#3069](https://github.com/clojure-emacs/cider/pull/3069): Fix cursor color changing when it shouldn't in evil-mode
 * [#3071](https://github.com/clojure-emacs/cider/issues/3071): Use xref instead of etags to push point to marker stack
+* [#3074](https://github.com/clojure-emacs/cider/issues/3074): Recognize pwsh as a powershell executable
 
 ## 1.1.1 (2021-05-24)
 

--- a/cider.el
+++ b/cider.el
@@ -1315,7 +1315,8 @@ non-nil, don't start if ClojureScript requirements are not met."
                           (and (null project-dir)
                                (eq cider-allow-jack-in-without-project 'warn)
                                (y-or-n-p "Are you sure you want to run `cider-jack-in' without a Clojure project? ")))
-                  (let ((cmd (format "%s %s" command-resolved (if (string-equal command "powershell")
+                  (let ((cmd (format "%s %s" command-resolved (if (or (string-equal command "powershell")
+                                                                      (string-equal command "pwsh"))
                                                                   (cider--powershell-encode-command cmd-params)
                                                                 cmd-params))))
                     (plist-put params :jack-in-cmd (if (or cider-edit-jack-in-command


### PR DESCRIPTION
The recent powershell executables (in the .NET Core era) are named pwsh, and should be treated the same as powershell for the purposes of cider-jack-in.
