### PR TITLE
Workaround for Emacs 27.2 MS-Windows precompiled binaries CircleCI issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,12 @@ jobs:
     steps:
       - run:
           name: Install Emacs latest
-          command: choco install emacs
+          command: |
+            choco install emacs
+            # temporary workaround for
+            # https://debbugs.gnu.org/cgi/bugreport.cgi?bug=51038
+            # can be removed in versions newer than 27.2
+            emacs --batch --eval '(progn (require ''nsm) (make-directory (file-name-directory (directory-file-name nsm-settings-file)) t) (when (file-exists-p nsm-settings-file) (nsm-read-settings)) (setq nsm-permanent-host-settings (append nsm-permanent-host-settings ''(   (:id \"sha1:ccfd2cc2a08c89a9b10969be8c1e926954d53e28\" :fingerprints (\"sha1:0c:bd:68:cb:c0:01:e2:ad:93:0d:b9:3b:77:09:2e:47:9c:de:6b:28\") :host \"stable.melpa.org:443\" :conditions (:expired :invalid :verify-cert))   (:id \"sha1:85b31c268009209a8d3c5387033b219264f7e62b\" :fingerprints (\"sha1:0c:bd:68:cb:c0:01:e2:ad:93:0d:b9:3b:77:09:2e:47:9c:de:6b:28\") :host \"melpa.org:443\" :conditions (:expired :invalid :verify-cert))   (:id \"sha1:6d4eb958390599243ba9f5035cb671fa8dd6a93a\" :fingerprints (\"sha1:56:41:11:79:62:b9:85:66:f8:9e:e4:3b:39:2d:5f:a6:a5:c7:e9:2d\") :host \"elpa.gnu.org:443\" :conditions (:expired :invalid :verify-cert)))  )) (nsm-write-settings))'
       - setup-windows
       - test
 
@@ -81,7 +86,12 @@ jobs:
     steps:
       - run:
           name: Install Emacs latest
-          command: choco install emacs
+          command: |
+            choco install emacs
+            # temporary workaround for
+            # https://debbugs.gnu.org/cgi/bugreport.cgi?bug=51038
+            # can be removed in versions newer than 27.2
+            emacs --batch --eval '(progn (require ''nsm) (make-directory (file-name-directory (directory-file-name nsm-settings-file)) t) (when (file-exists-p nsm-settings-file) (nsm-read-settings)) (setq nsm-permanent-host-settings (append nsm-permanent-host-settings ''(   (:id \"sha1:ccfd2cc2a08c89a9b10969be8c1e926954d53e28\" :fingerprints (\"sha1:0c:bd:68:cb:c0:01:e2:ad:93:0d:b9:3b:77:09:2e:47:9c:de:6b:28\") :host \"stable.melpa.org:443\" :conditions (:expired :invalid :verify-cert))   (:id \"sha1:85b31c268009209a8d3c5387033b219264f7e62b\" :fingerprints (\"sha1:0c:bd:68:cb:c0:01:e2:ad:93:0d:b9:3b:77:09:2e:47:9c:de:6b:28\") :host \"melpa.org:443\" :conditions (:expired :invalid :verify-cert))   (:id \"sha1:6d4eb958390599243ba9f5035cb671fa8dd6a93a\" :fingerprints (\"sha1:56:41:11:79:62:b9:85:66:f8:9e:e4:3b:39:2d:5f:a6:a5:c7:e9:2d\") :host \"elpa.gnu.org:443\" :conditions (:expired :invalid :verify-cert)))  )) (nsm-write-settings))'
       - setup-windows
       - lint
 


### PR DESCRIPTION
> Fixes #3081

Hi,

could you please consider fix for the CircleCI failing MS-Windows jobs as raised in #3081.

 CIDER CircleCI MS-Windows test jobs are using the readily available Chocolatey package manager to install the latest version of Emacs on the servers. Chocolatey uses the precomplied version of Emacs for MS-Winodws as found on the official Gnu FTP servers at https://ftp.gnu.org/gnu/emacs/windows/.

The latest available Emacs release at the time of this writing is 27.2.  The precompiled binaries include all necessary dependencies, of which one is GnuTLS 3.16.12. There is a bug in that version that it might flag a certificate as invalid if the issuer's certificate has expired, even though there is a replacement issuer certificate that is valid (see https://gitlab.com/gnutls/gnutls/-/issues/1008). 

Let's Encrypt appears to be one of these issuers whose certificate has expired on the 30th of September but they still have another valid certificate made available (see https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/). As such some sites could be flagged as invalid by GnuTLS in versions before that fix. 

Since the above precompiled 27.2 binaries are affected by this bug, some sites (including ELPA/MELPA) became unavailable and this is what we are seeing in CIDER's CircleCI failure.

This patch permanently configures Emacs [Network Security Manager](https://www.gnu.org/software/emacs/manual/html_node/emacs/Network-Security.html) to bypass issuer certification checks for the known hosts referenced by the tests (It's `Eldev` that contancts melpa.org, stable.melpa.org and elpa.gnu.org to bootstarp itself). It is all done in an one liner `emacs --eval` command suitably escaped for Powershell:

``` ps1
 emacs --batch --eval '(progn (require ''nsm) (make-directory (file-name-directory (directory-file-name nsm-settings-file)) t) (when (file-exists-p nsm-settings-file) (nsm-read-settings)) (setq nsm-permanent-host-settings (append nsm-permanent-host-settings ''(   (:id \"sha1:ccfd2cc2a08c89a9b10969be8c1e926954d53e28\" :fingerprints (\"sha1:0c:bd:68:cb:c0:01:e2:ad:93:0d:b9:3b:77:09:2e:47:9c:de:6b:28\") :host \"stable.melpa.org:443\" :conditions (:expired :invalid :verify-cert))   (:id \"sha1:85b31c268009209a8d3c5387033b219264f7e62b\" :fingerprints (\"sha1:0c:bd:68:cb:c0:01:e2:ad:93:0d:b9:3b:77:09:2e:47:9c:de:6b:28\") :host \"melpa.org:443\" :conditions (:expired :invalid :verify-cert))   (:id \"sha1:6d4eb958390599243ba9f5035cb671fa8dd6a93a\" :fingerprints (\"sha1:56:41:11:79:62:b9:85:66:f8:9e:e4:3b:39:2d:5f:a6:a5:c7:e9:2d\") :host \"elpa.gnu.org:443\" :conditions (:expired :invalid :verify-cert)))  )) (nsm-write-settings))'
```

with the actual script being

``` emacs-lisp
(progn
  (require 'nsm)
  (make-directory (file-name-directory (directory-file-name nsm-settings-file)) t)
  (when (file-exists-p nsm-settings-file) (nsm-read-settings))
  (setq nsm-permanent-host-settings
        (append nsm-permanent-host-settings
                '( (:id "sha1:ccfd2cc2a08c89a9b10969be8c1e926954d53e28" :fingerprints ("sha1:0c:bd:68:cb:c0:01:e2:ad:93:0d:b9:3b:77:09:2e:47:9c:de:6b:28") :host "stable.melpa.org:443" :conditions (:expired :invalid :verify-cert))
                   (:id "sha1:85b31c268009209a8d3c5387033b219264f7e62b" :fingerprints ("sha1:0c:bd:68:cb:c0:01:e2:ad:93:0d:b9:3b:77:09:2e:47:9c:de:6b:28") :host "melpa.org:443" :conditions (:expired :invalid :verify-cert))
                   (:id "sha1:6d4eb958390599243ba9f5035cb671fa8dd6a93a" :fingerprints ("sha1:56:41:11:79:62:b9:85:66:f8:9e:e4:3b:39:2d:5f:a6:a5:c7:e9:2d") :host "elpa.gnu.org:443" :conditions (:expired :invalid :verify-cert)))))
  (nsm-write-settings))
```

The settings are thus stored in `~/.emacs.d/network-security.data`.

The above exception settings for each site were captured by `M-x eww <host>` on an Emacs version that was ffected by this bug, (a)ccepting the certificates and the inspecting `nsm-temporary-host-settings` for the above fingerprints.

Emacs devs are not in favour of updating the binaries upstream (see https://debbugs.gnu.org/cgi/bugreport.cgi?bug=51038), and thus a workaround is required.

All tests now pass. 

Thanks

