### PR TITLE
Remove CircleCI MS-Windows-linter job, fix doc formatting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,20 +81,6 @@ jobs:
       - setup
       - lint
 
-  test-windows-lint:
-    executor: win/default
-    steps:
-      - run:
-          name: Install Emacs latest
-          command: |
-            choco install emacs
-            # temporary workaround for
-            # https://debbugs.gnu.org/cgi/bugreport.cgi?bug=51038
-            # can be removed in versions newer than 27.2
-            emacs --batch --eval '(progn (require ''nsm) (make-directory (file-name-directory (directory-file-name nsm-settings-file)) t) (when (file-exists-p nsm-settings-file) (nsm-read-settings)) (setq nsm-permanent-host-settings (append nsm-permanent-host-settings ''(   (:id \"sha1:ccfd2cc2a08c89a9b10969be8c1e926954d53e28\" :fingerprints (\"sha1:0c:bd:68:cb:c0:01:e2:ad:93:0d:b9:3b:77:09:2e:47:9c:de:6b:28\") :host \"stable.melpa.org:443\" :conditions (:expired :invalid :verify-cert))   (:id \"sha1:85b31c268009209a8d3c5387033b219264f7e62b\" :fingerprints (\"sha1:0c:bd:68:cb:c0:01:e2:ad:93:0d:b9:3b:77:09:2e:47:9c:de:6b:28\") :host \"melpa.org:443\" :conditions (:expired :invalid :verify-cert))   (:id \"sha1:6d4eb958390599243ba9f5035cb671fa8dd6a93a\" :fingerprints (\"sha1:56:41:11:79:62:b9:85:66:f8:9e:e4:3b:39:2d:5f:a6:a5:c7:e9:2d\") :host \"elpa.gnu.org:443\" :conditions (:expired :invalid :verify-cert)))  )) (nsm-write-settings))'
-      - setup-windows
-      - lint
-
 workflows:
   version: 2
   ci-test-matrix:
@@ -104,4 +90,3 @@ workflows:
       - test-emacs-master
       - test-lint
       - test-windows-emacs-latest
-      - test-windows-lint

--- a/doc/modules/ROOT/pages/contributing/hacking.adoc
+++ b/doc/modules/ROOT/pages/contributing/hacking.adoc
@@ -179,13 +179,14 @@ such as `/tmp/a-dir` or `/docker/src, in tests,` as test inputs. These
 are not valid absolute paths on Windows though, since they are missing
 the initial driver letter (e.g.`c:/tmp/a-dir`), but we can wrap them
 around with `expand-file-name` to make them so e.g. in tests
-
----
++
+[source,emacs-lisp]
+----
 (let ((a-dir (expand-file-name "/tmp/a-dir"))
       (docker-src (expand-file-name "/docker/src")))
   ;; ...
   )
----
+----
 
 . Command-line arguments. When calling external programs, it might be
 necessary to quote some long command line arguments, though quoting


### PR DESCRIPTION
Hi,

could you please consider the following changes.

The CircleCI MS-Windows linter check is not necessary, since there already exists a job to lint the codebase. It was blindly added when introducing the corresponding MS-Windows test job back at the time.

Also fixed a formatting issue with the doc hacking section.

All CircleCI tests are passing.

Thanks.