### PR TITLE
Add before and after eval hooks

### DIFF
--- a/cider-client.el
+++ b/cider-client.el
@@ -70,6 +70,18 @@ resulting value are used to compute completions."
   :group 'cider
   :package-version '(cider . "0.23.0"))
 
+(defcustom cider-before-eval-hook nil
+  "List of functions to call before eval request is sent to nrepl."
+  :type 'hook
+  :group 'cider
+  :package-version '(cider . "1.2.0"))
+
+(defcustom cider-after-eval-done-hook nil
+  "List of functions to call after eval was responded by nrepl with done status."
+  :type 'hook
+  :group 'cider
+  :package-version '(cider . "1.2.0"))
+
 (defun cider-spinner-start (buffer)
   "Start the evaluation spinner in BUFFER.
 Do nothing if `cider-show-eval-spinner' is nil."
@@ -78,21 +90,19 @@ Do nothing if `cider-show-eval-spinner' is nil."
       (spinner-start cider-eval-spinner-type nil
                      cider-eval-spinner-delay))))
 
-(defun cider-eval-spinner-handler (eval-buffer original-callback)
-  "Return a response handler to stop the spinner and call ORIGINAL-CALLBACK.
+(defun cider-eval-spinner (eval-buffer response)
+  "Handle RESPONSE stopping the spinner.
 EVAL-BUFFER is the buffer where the spinner was started."
-  (lambda (response)
-    ;; buffer still exists and
-    ;; we've got status "done" from nrepl
-    ;; stop the spinner
-    (when (and (buffer-live-p eval-buffer)
-               (let ((status (nrepl-dict-get response "status")))
-                 (or (member "done" status)
-                     (member "eval-error" status)
-                     (member "error" status))))
-      (with-current-buffer eval-buffer
-        (when spinner-current (spinner-stop))))
-    (funcall original-callback response)))
+  ;; buffer still exists and
+  ;; we've got status "done" from nrepl
+  ;; stop the spinner
+  (when (and (buffer-live-p eval-buffer)
+             (let ((status (nrepl-dict-get response "status")))
+               (or (member "done" status)
+                   (member "eval-error" status)
+                   (member "error" status))))
+    (with-current-buffer eval-buffer
+      (when spinner-current (spinner-stop)))))
 
 
 ;;; Evaluation helpers
@@ -198,10 +208,14 @@ define the position of INPUT in its buffer.  ADDITIONAL-PARAMS is a plist
 to be appended to the request message.  CONNECTION is the connection
 buffer, defaults to (cider-current-repl)."
   (let ((connection (or connection (cider-current-repl nil 'ensure))))
+    (run-hooks 'cider-before-eval-hook)
     (nrepl-request:eval input
-                        (if cider-show-eval-spinner
-                            (cider-eval-spinner-handler connection callback)
-                          callback)
+                        (lambda (response)
+                          (when cider-show-eval-spinner
+                            (cider-eval-spinner connection response))
+                          (when (member "done" (nrepl-dict-get response "status"))
+                            (run-hooks 'cider-after-eval-done-hook))
+                          (funcall callback response))
                         connection
                         ns line column additional-params)
     (cider-spinner-start connection)))

--- a/doc/modules/ROOT/pages/usage/code_evaluation.adoc
+++ b/doc/modules/ROOT/pages/usage/code_evaluation.adoc
@@ -123,6 +123,12 @@ file has been evaluated.
 TIP: `cider-auto-test-mode` is implemented in terms of this hook -
 tests are re-run every time you evaluate a file.
 
+You can use `cider-before-eval-hook` to trigger some action before eval
+request is sent to nrepl server.
+
+You can use `cider-after-eval-done-hook` to trigger some action after the
+eval response was received from nrepl server with status "done".
+
 == Synchronous vs Asynchronous Evaluation
 
 nREPL has an asynchronous evaluation model, where eval requests


### PR DESCRIPTION
This PR adds 2 new hooks:
- `cider-before-eval-hook` which runs **before** the request is sent to nrepl
- `cider-after-eval-done-hook` which runs **after** the nrepl response handle with status "done".

This is useful so users can listen to eval hooks and do customizations on UI, for example doom-modeline which show the REPL icon:
![image](https://user-images.githubusercontent.com/7820865/139609262-a7b7c95d-32fb-4dc6-bd77-9a770e7e5cde.png)


-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
