### PR TITLE
Detect host and port number from babashka nREPL conn msg

### DIFF
--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -1062,10 +1062,13 @@ been determined."
               (set-window-point win (point)))))
         ;; detect the port the server is listening on from its output
         (when (and (null nrepl-endpoint)
-                   (string-match "nREPL server started on port \\([0-9]+\\)" output))
-          (let ((port (string-to-number (match-string 1 output))))
-            (setq nrepl-endpoint (list :host (or (file-remote-p default-directory 'host)
-                                                 "localhost")
+                   (string-match "\\(?:nREPL server started on port \\(?1:[0-9]+\\)\\|Started nREPL server at \\(?2:.*?\\):\\(?1:[0-9]+\\)\\)"
+                                 output))
+          (let ((host (or (match-string 2 output)
+                          (file-remote-p default-directory 'host)
+                          "localhost"))
+                (port (string-to-number (match-string 1 output))))
+            (setq nrepl-endpoint (list :host host
                                        :port port))
             (message "[nREPL] server started on %s" port)
             (when nrepl-on-port-callback

--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -111,6 +111,32 @@
         (expect (nrepl-make-buffer-name "*buff-name %r:%S*" params)
                 :to-equal "*buff-name cljs*")))))
 
+(describe "nrepl-parse-port"
+  (it "standard"
+      (let ((msg "nREPL server started on port 58882 on host kubernetes.docker.internal - nrepl://kubernetes.docker.internal:58882"))
+        (expect (string-match nrepl-listening-address-regexp msg)
+                :not :to-be nil)
+        (expect (match-string 1 msg)
+                :to-equal "58882")
+        (expect (match-string 2 msg)
+                :to-be nil)))
+  (it "babashka"
+      (let ((msg "Started nREPL server at 127.0.0.1:1667"))
+        (expect (string-match nrepl-listening-address-regexp msg)
+                :not :to-be nil)
+        (expect (match-string 1 msg)
+                :to-equal "1667")
+        (expect (match-string 2 msg)
+                :to-equal "127.0.0.1")))
+    (it "shadow"
+      (let ((msg "shadow-cljs - nREPL server started on port 50999"))
+        (expect (string-match nrepl-listening-address-regexp msg)
+                :not :to-be nil)
+        (expect (match-string 1 msg)
+                :to-equal "50999")
+        (expect (match-string 2 msg)
+                :to-be nil))))
+
 (describe "nrepl-client-lifecycle"
   (it "start and stop nrepl client process"
 


### PR DESCRIPTION
Hi,

could you please consider fix for jacking-in into the babashka prompt. 

There appears to be an issue with the current code, that the nrepl client can't parse the port of host number from the babashka nREPL opening message ([as defined in babashka nrepl code](https://github.com/babashka/babashka.nrepl/blob/fa3a55ae58f7bcbcfcfaf10fab98b412220f733f/src/babashka/nrepl/server.clj#L34)) , example:

```
Started nREPL server at 127.0.0.1:1667
For more info visit: https://book.babashka.org/#_nrepl
```

which is a differnet format from the standard clojure nREPL opening message, example:

```
nREPL server started on port 57721 on host localhost - nrepl://localhost:57721
```

The patch combines the two into a single regexp using a shy group:
```emacs-lisp
"\\(?:nREPL server started on port \\(?1:[0-9]+\\)\\|Started nREPL server at \\(?2:.*?\\):\\(?1:[0-9]+\\)\\)"
```

I can further refactor it if required.

Fixes #3086.

Thanks,