### PR TITLE
Unix domain socket connection

### DIFF
--- a/cider-connection.el
+++ b/cider-connection.el
@@ -85,7 +85,8 @@ PARAMS is a plist containing :host, :port, :server and other parameters for
     (plist-get params :port)
     (plist-get params :server)
     (lambda (_)
-      (cider-repl-create params)))))
+      (cider-repl-create params))
+    (plist-get params :socket-file))))
 
 (defun cider-sessions ()
   "Return a list of all active CIDER sessions."

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -83,10 +83,10 @@ PARAMS is a plist containing :host, :port, :server and other parameters for
    (nrepl-start-client-process
     (plist-get params :host)
     (plist-get params :port)
+    (plist-get params :socket-file)
     (plist-get params :server)
     (lambda (_)
-      (cider-repl-create params))
-    (plist-get params :socket-file))))
+      (cider-repl-create params)))))
 
 (defun cider-sessions ()
   "Return a list of all active CIDER sessions."

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -83,10 +83,10 @@ PARAMS is a plist containing :host, :port, :server and other parameters for
    (nrepl-start-client-process
     (plist-get params :host)
     (plist-get params :port)
-    (plist-get params :socket-file)
     (plist-get params :server)
     (lambda (_)
-      (cider-repl-create params)))))
+      (cider-repl-create params))
+    (plist-get params :socket-file))))
 
 (defun cider-sessions ()
   "Return a list of all active CIDER sessions."

--- a/cider.el
+++ b/cider.el
@@ -1216,7 +1216,7 @@ server buffer, in which case a new session for that server is created."
        (cider--update-cljs-init-function)
        (plist-put :session-name ses-name)
        (plist-put :repl-type 'pending-cljs)))))
- 
+
 ;;;###autoload
 (defun cider-connect-clj (&optional params)
   "Initialize a Clojure connection to an nREPL server.
@@ -1572,13 +1572,13 @@ of remote SSH hosts."
   "Interactively select unix domain socket file name."
   (read-file-name "Socket File: " nil nil t nil
                   (lambda (filename)
-                    (let ((file-type
-                           (string-to-char
-                            (file-attribute-modes
-                             (file-attributes
-                              filename)))))
-                      (or (eq ?s file-type)
-                          (eq ?d file-type))))))
+                    "Predicate: auto-complete only socket-files and directories"
+                    (let ((filetype (string-to-char
+                                     (file-attribute-modes
+                                      (file-attributes
+                                       filename)))))
+                      (or (eq ?s filetype)
+                          (eq ?d filetype))))))
 
 (defun cider-locate-running-nrepl-ports (&optional dir)
   "Locate ports of running nREPL servers.

--- a/cider.el
+++ b/cider.el
@@ -1216,6 +1216,20 @@ server buffer, in which case a new session for that server is created."
        (cider--update-cljs-init-function)
        (plist-put :session-name ses-name)
        (plist-put :repl-type 'pending-cljs)))))
+ 
+;;;###autoload
+(defun cider-connect-unix (&optional params)
+  "Initialize a Clojure connection to an nREPL server.
+PARAMS is a plist optionally containing :socket-file and :project-dir.  On
+prefix argument, prompt for all the parameters."
+  (interactive "P")
+  (cider-nrepl-connect
+   (thread-first params
+     (cider--update-project-dir)
+     (cider--check-existing-session)
+     (plist-put :repl-init-function nil)
+     (plist-put :session-name nil)
+     (plist-put :repl-type 'clj))))
 
 ;;;###autoload
 (defun cider-connect-clj (&optional params)

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -269,6 +269,26 @@ cause problems with complex or nonstandard ssh configs.
 You can safely run `cider-jack-in-*` while working with remote files over TRAMP. CIDER
 will handle this use-case transparently for you.
 
+== Connecting via unix domain file socket
+
+When locally running nREPL servers, there is the option to listen on a
+socket file instead of opening a network port. This can have
+advantages in some use cases, e.g. when working with virtual networks
+(containers) where sharing a file socket can be vastly simpler than
+managing bridge networks and firewall setups.
+
+After having started an nREPL server on a file socket, e.g. with the
+`clj` command (see https://nrepl.org/nrepl/usage/server.html for other
+examples),
+
+[source,sh]
+----
+$ clj -R:nREPL -m nrepl.cmdline --socket nrepl.sock
+----
+
+you can then connect CIDER by using the `local-unix-domain-socket`
+special hostname with `cider-connect`: kbd:[M-x] `cider-connect` kbd:[RET] `local-unix-domain-socket` kbd:[RET] `nrepl.sock` kbd:[RET]
+
 == What's Next?
 
 So, what to do next now that CIDER's ready for action? Here are a few ideas:

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -647,7 +647,7 @@ Do not kill the server if there is a REPL connected to that server."
                            (buffer-list)))
         (nrepl-kill-server-buffer server-buf)))))
 
-(defun nrepl-start-client-process (&optional host port server-proc buffer-builder socket-file)
+(defun nrepl-start-client-process (&optional host port socket-file server-proc buffer-builder)
   "Create new client process identified by HOST and PORT.
 In remote buffers, HOST and PORT are taken from the current tramp
 connection.  SERVER-PROC must be a running nREPL server process within

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -649,7 +649,7 @@ Do not kill the server if there is a REPL connected to that server."
                            (buffer-list)))
         (nrepl-kill-server-buffer server-buf)))))
 
-(defun nrepl-start-client-process (&optional host port socket-file server-proc buffer-builder)
+(defun nrepl-start-client-process (&optional host port server-proc buffer-builder socket-file)
   "Create new client process identified by either HOST and PORT or SOCKET-FILE.
 If SOCKET-FILE is non-nil, it takes precedence.  In remote buffers, HOST
 and PORT are taken from the current tramp connection.  SERVER-PROC must be

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -655,7 +655,7 @@ Emacs.  BUFFER-BUILDER is a function of one argument (endpoint returned by
 `nrepl-connect') which returns a client buffer.  Return the newly created
 client process."
   (let* ((endpoint (if socket-file
-                       (nrepl--unix-connect socket-file)
+                       (nrepl--unix-connect (expand-file-name socket-file))
                      (nrepl-connect host port)))
          (client-proc (plist-get endpoint :proc))
          (builder (or buffer-builder (error "`buffer-builder' must be provided")))

--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -166,10 +166,10 @@
                    (process-client (nrepl-start-client-process
                                     (plist-get server-endpoint :host)
                                     (plist-get server-endpoint :port)
-                                    (plist-get params :socket-file)
                                     server-process
                                     (lambda (client-endpoint)
-                                      client-buffer))))
+                                      client-buffer)
+                                    (plist-get params :socket-file))))
 
               ;; client connection is open
               (expect (process-status process-client)

--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -166,6 +166,7 @@
                    (process-client (nrepl-start-client-process
                                     (plist-get server-endpoint :host)
                                     (plist-get server-endpoint :port)
+                                    (plist-get params :socket-file)
                                     server-process
                                     (lambda (client-endpoint)
                                       client-buffer))))


### PR DESCRIPTION
Preview for https://github.com/clojure-emacs/cider/issues/3032

- [x] nrepl-client adaptions to connect via socket file
- [x] rudimentary menu integration, by overloading on a special hostname
- [x] select socket file with auto completion
- [ ] update menu structure to not overload host, instead take explicit protocol with `C-u` prefix arg

Please note that as per https://github.com/clojure-emacs/cider/issues/3032#issuecomment-958133135, this is not yet considered ready.

-----------------

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

