### PR TITLE
Update *print-meta* bug comment in usage/pretty_printing

### DIFF
--- a/doc/modules/ROOT/pages/usage/pretty_printing.adoc
+++ b/doc/modules/ROOT/pages/usage/pretty_printing.adoc
@@ -49,9 +49,10 @@ Here's one example:
   (apply pp/write value (mapcat identity (assoc options :stream writer))))
 ----
 
-IMPORTANT: Due to a https://clojure.atlassian.net/browse/CLJ-1445[bug] in `clojure.pprint`
-it doesn't work properly with `+*print-meta*+`. If you need to print the metadata you'll
-have to change the print function or disable pretty-printing.
+IMPORTANT: Before Clojure 1.10.2, a
+https://clojure.atlassian.net/browse/CLJ-1445[bug] in `clojure.pprint` caused it
+to not work properly with `+*print-meta*+`. If you need to print the metadata
+you'll have to change the print function or disable pretty-printing.
 
 == Limiting printed output
 


### PR DESCRIPTION
https://clojure.atlassian.net/browse/CLJ-1445 is fixed as of Clojure 1.10.2, so this is no longer an active bug for the latest versions of Clojure. I added a note about versioning here, but we can also choose to remove this note entirely.

Verification:
```clj
user> (set! *print-meta* true)
;; => true
user> 
user> (with-meta [1 2 3] {:foo "bar"})
;; => ^{:foo "bar"} [1 2 3]
user> (def xs (with-meta [1 2 3] {:foo "bar"}))
;; => ^{:line 36, :column 7, :file "*cider-repl ml/tool-server:localhost:51070(clj)*", :name xs, :ns #namespace[user]} #'user/xs
user> xs
;; => ^{:foo "bar"} [1 2 3] ;; notice that meta is printed
```