### PR TITLE
Fix broken link in page 'contributing'

### DIFF
--- a/doc/modules/ROOT/pages/contributing.adoc
+++ b/doc/modules/ROOT/pages/contributing.adoc
@@ -4,7 +4,7 @@
 
 Report issues and suggest features and improvements on the
 https://github.com/clojure-emacs/cider/issues[GitHub issue tracker]. Don't ask
-questions on the issue tracker - use the xref:support.adoc[support channels] instead.
+questions on the issue tracker - use the xref:about/support.adoc[support channels] instead.
 
 If you want to file a bug, please provide all the necessary info listed in
 our issue reporting template (it's loaded automatically when you create a


### PR DESCRIPTION
Fix broken link to 'support channels' in page 'contributing'

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
