### PR TITLE
Bump enrich-classpath

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -519,7 +519,7 @@ where it doesn't make sense."
   (let* ((corpus (if (and cider-enrich-classpath
                           (eq project-type 'lein))
                      (append cider-jack-in-lein-plugins
-                             '(("mx.cider/enrich-classpath" "1.5.0")))
+                             '(("mx.cider/enrich-classpath" "1.5.1")))
                    cider-jack-in-lein-plugins)))
     (thread-last corpus
       (seq-filter

--- a/doc/modules/ROOT/pages/basics/middleware_setup.adoc
+++ b/doc/modules/ROOT/pages/basics/middleware_setup.adoc
@@ -40,7 +40,7 @@ A minimal `profiles.clj` for CIDER would be:
 [source,clojure]
 ----
 {:repl {:plugins [[cider/cider-nrepl "0.27.2"]
-                  [mx.cider/enrich-classpath "1.5.0"]]}}
+                  [mx.cider/enrich-classpath "1.5.1"]]}}
 ----
 
 WARNING: Be careful not to place this in the `:user` profile, as this way CIDER's

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -123,7 +123,7 @@
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[cider/cider-nrepl \"0.10.0-SNAPSHOT\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.5.0\"]")
+                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.5.1\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath/middleware"
                                 " -- repl :headless")))
 
@@ -136,7 +136,7 @@
                          " -- update-in :plugins conj "
                          (shell-quote-argument "[cider/cider-nrepl \"0.10.0-SNAPSHOT\"]")
                          " -- update-in :plugins conj "
-                         (shell-quote-argument "[mx.cider/enrich-classpath \"1.5.0\"]")
+                         (shell-quote-argument "[mx.cider/enrich-classpath \"1.5.1\"]")
                          " -- update-in :middleware conj cider.enrich-classpath/middleware"
                          " -- repl :headless")))
 
@@ -148,7 +148,7 @@
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[cider/cider-nrepl \"0.10.0-SNAPSHOT\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.5.0\"]")
+                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.5.1\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath/middleware"
                                 " -- repl :headless")))
 
@@ -183,7 +183,7 @@
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[cider/cider-nrepl \"0.11.0\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.5.0\"]")
+                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.5.1\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath/middleware"
                                 " -- repl :headless")))
 
@@ -216,7 +216,7 @@
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[cider/cider-nrepl \"0.11.0\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.5.0\"]")
+                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.5.1\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath/middleware"
                                 " -- repl :headless")))
     (it "can concat in a boot project"
@@ -281,7 +281,7 @@
       (spy-on 'cider-jack-in-normalized-lein-plugins
               :and-return-value '(("refactor-nrepl" "2.0.0")
                                   ("cider/cider-nrepl" "0.11.0")
-                                  ("mx.cider/enrich-classpath" "1.5.0")))
+                                  ("mx.cider/enrich-classpath" "1.5.1")))
       (setq-local cider-jack-in-dependencies-exclusions '()))
     (it "uses them in a lein project"
       (expect (cider-inject-jack-in-dependencies "" "repl :headless" 'lein)
@@ -292,7 +292,7 @@
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[cider/cider-nrepl \"0.11.0\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.5.0\"]")
+                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.5.1\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath/middleware"
                                 " -- repl :headless"))))
 


### PR DESCRIPTION
Delivers https://github.com/clojure-emacs/enrich-classpath/commit/b85556605590f9b334238c5704b03f0f31186375 which makes sure e.g. `lein-doo` won't pull an overly old version of Clojure, which would make Fipp fail.

I verified that 1.5.1 works:

![image](https://user-images.githubusercontent.com/1162994/146987414-f8777feb-1a0d-4505-a186-497fc6099cf8.png)
