### PR TITLE
Disable Lein bootclasspath optimization by default

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -521,7 +521,7 @@ where it doesn't make sense."
   (let* ((corpus (if (and cider-enrich-classpath
                           (eq project-type 'lein))
                      (append cider-jack-in-lein-plugins
-                             '(("mx.cider/enrich-classpath" "1.5.1")))
+                             '(("mx.cider/enrich-classpath" "1.5.2")))
                    cider-jack-in-lein-plugins)))
     (thread-last corpus
       (seq-filter

--- a/cider.el
+++ b/cider.el
@@ -101,7 +101,9 @@ version from the CIDER package or library.")
   "Codename used to denote stable releases.")
 
 (defcustom cider-lein-command
-  "lein"
+  ;; bootclasspath is an optimization that makes the `clojure.instant' ns unreachable,
+  ;; and can be problematic for Lein plugins (like enrich-classpath, or any user-specified plugins)
+  "LEIN_USE_BOOTCLASSPATH=no lein"
   "The command used to execute Leiningen."
   :type 'string
   :group 'cider)

--- a/doc/modules/ROOT/pages/basics/middleware_setup.adoc
+++ b/doc/modules/ROOT/pages/basics/middleware_setup.adoc
@@ -40,7 +40,7 @@ A minimal `profiles.clj` for CIDER would be:
 [source,clojure]
 ----
 {:repl {:plugins [[cider/cider-nrepl "0.27.2"]
-                  [mx.cider/enrich-classpath "1.5.1"]]}}
+                  [mx.cider/enrich-classpath "1.5.2"]]}}
 ----
 
 WARNING: Be careful not to place this in the `:user` profile, as this way CIDER's

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -123,7 +123,7 @@
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[cider/cider-nrepl \"0.10.0-SNAPSHOT\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.5.1\"]")
+                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.5.2\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath/middleware"
                                 " -- repl :headless")))
 
@@ -136,7 +136,7 @@
                          " -- update-in :plugins conj "
                          (shell-quote-argument "[cider/cider-nrepl \"0.10.0-SNAPSHOT\"]")
                          " -- update-in :plugins conj "
-                         (shell-quote-argument "[mx.cider/enrich-classpath \"1.5.1\"]")
+                         (shell-quote-argument "[mx.cider/enrich-classpath \"1.5.2\"]")
                          " -- update-in :middleware conj cider.enrich-classpath/middleware"
                          " -- repl :headless")))
 
@@ -148,7 +148,7 @@
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[cider/cider-nrepl \"0.10.0-SNAPSHOT\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.5.1\"]")
+                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.5.2\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath/middleware"
                                 " -- repl :headless")))
 
@@ -183,7 +183,7 @@
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[cider/cider-nrepl \"0.11.0\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.5.1\"]")
+                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.5.2\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath/middleware"
                                 " -- repl :headless")))
 
@@ -216,7 +216,7 @@
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[cider/cider-nrepl \"0.11.0\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.5.1\"]")
+                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.5.2\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath/middleware"
                                 " -- repl :headless")))
     (it "can concat in a boot project"
@@ -281,7 +281,7 @@
       (spy-on 'cider-jack-in-normalized-lein-plugins
               :and-return-value '(("refactor-nrepl" "2.0.0")
                                   ("cider/cider-nrepl" "0.11.0")
-                                  ("mx.cider/enrich-classpath" "1.5.1")))
+                                  ("mx.cider/enrich-classpath" "1.5.2")))
       (setq-local cider-jack-in-dependencies-exclusions '()))
     (it "uses them in a lein project"
       (expect (cider-inject-jack-in-dependencies "" "repl :headless" 'lein)
@@ -292,7 +292,7 @@
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[cider/cider-nrepl \"0.11.0\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.5.1\"]")
+                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.5.2\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath/middleware"
                                 " -- repl :headless"))))
 


### PR DESCRIPTION
* Disable Lein bootclasspath optimization by default
  * Fixes https://github.com/clojure-emacs/cider/issues/3106
* Bump enrich-classpath
  * Delivers https://github.com/clojure-emacs/enrich-classpath/commit/3f5d4fc7350911740ff42b195cefca905c43102f