### PR TITLE
Bump `enrich-classpath`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* Upgrade [enrich-classpath](https://github.com/clojure-emacs/enrich-classpath), which fixes various edge cases.
+  * Remember: at the moment the enrich-classpath is disabled by default. It will soon be enabled again. If you wish to try it out, you can customize `cider-enrich-classpath` to `t`.
+  * Also remember: for it to work, on Linux, you'll also have to do something like `sudo apt install openjdk-11-source` (depending on your package manager and JDK of choice).
+
 ## 1.2.0 (2021-12-22)
 
 ### New features

--- a/cider.el
+++ b/cider.el
@@ -524,7 +524,7 @@ where it doesn't make sense."
   (let* ((corpus (if (and cider-enrich-classpath
                           (eq project-type 'lein))
                      (append cider-jack-in-lein-plugins
-                             '(("mx.cider/enrich-classpath" "1.5.1")))
+                             '(("mx.cider/enrich-classpath" "1.6.2")))
                    cider-jack-in-lein-plugins)))
     (thread-last corpus
       (seq-filter

--- a/doc/modules/ROOT/pages/basics/middleware_setup.adoc
+++ b/doc/modules/ROOT/pages/basics/middleware_setup.adoc
@@ -46,7 +46,7 @@ A minimal `profiles.clj` for CIDER would be:
 [source,clojure]
 ----
 {:repl {:plugins [[cider/cider-nrepl "0.27.2"]
-                  [mx.cider/enrich-classpath "1.5.1"]]}}
+                  [mx.cider/enrich-classpath "1.6.2"]]}}
 ----
 
 WARNING: Be careful not to place this in the `:user` profile, as this way CIDER's

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -124,7 +124,7 @@
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[cider/cider-nrepl \"0.10.0-SNAPSHOT\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.5.1\"]")
+                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.6.2\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath/middleware"
                                 " -- repl :headless")))
 
@@ -137,7 +137,7 @@
                          " -- update-in :plugins conj "
                          (shell-quote-argument "[cider/cider-nrepl \"0.10.0-SNAPSHOT\"]")
                          " -- update-in :plugins conj "
-                         (shell-quote-argument "[mx.cider/enrich-classpath \"1.5.1\"]")
+                         (shell-quote-argument "[mx.cider/enrich-classpath \"1.6.2\"]")
                          " -- update-in :middleware conj cider.enrich-classpath/middleware"
                          " -- repl :headless")))
 
@@ -149,7 +149,7 @@
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[cider/cider-nrepl \"0.10.0-SNAPSHOT\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.5.1\"]")
+                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.6.2\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath/middleware"
                                 " -- repl :headless")))
 
@@ -184,7 +184,7 @@
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[cider/cider-nrepl \"0.11.0\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.5.1\"]")
+                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.6.2\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath/middleware"
                                 " -- repl :headless")))
 
@@ -217,7 +217,7 @@
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[cider/cider-nrepl \"0.11.0\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.5.1\"]")
+                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.6.2\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath/middleware"
                                 " -- repl :headless")))
     (it "can concat in a boot project"
@@ -282,7 +282,7 @@
       (spy-on 'cider-jack-in-normalized-lein-plugins
               :and-return-value '(("refactor-nrepl" "2.0.0")
                                   ("cider/cider-nrepl" "0.11.0")
-                                  ("mx.cider/enrich-classpath" "1.5.1")))
+                                  ("mx.cider/enrich-classpath" "1.6.2")))
       (setq-local cider-jack-in-dependencies-exclusions '()))
     (it "uses them in a lein project"
       (expect (cider-inject-jack-in-dependencies "" "repl :headless" 'lein)
@@ -293,7 +293,7 @@
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[cider/cider-nrepl \"0.11.0\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.5.1\"]")
+                                (shell-quote-argument "[mx.cider/enrich-classpath \"1.6.2\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath/middleware"
                                 " -- repl :headless"))))
 


### PR DESCRIPTION
Now enrich-classpath is mrandersonized.
It also bundles fixes for Linux environments lacking JDK sources. (thanks @ikappaki!)

I tried out the release locally.

Closes https://github.com/clojure-emacs/cider/pull/3107
Fixes https://github.com/clojure-emacs/cider/issues/3106
Fixes https://github.com/clojure-emacs/cider/issues/3108

⚠️ Please let's not change the `cider-enrich-classpath` default yet, until I'm able to provide user support again.