### PR TITLE
Use .el instead of .elc file for lm-version

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -95,7 +95,10 @@
 (require 'package)
 
 (defconst cider-version
-  (lm-version (or load-file-name buffer-file-name))
+  (lm-version
+   (replace-regexp-in-string
+    "\\.elc$" ".el"
+    (or load-file-name buffer-file-name)))
   "The current version of CIDER.")
 
 (defconst cider-package-version (package-get-version)


### PR DESCRIPTION
Digging into #3113, when requiring cider on my machine `load-file-name` points to `cider.elc` rather than `cider.el`. It seems `lm-version` can't extract the version from the `.elc` file. I couldn't find a better way of getting at the `.el` file, so just replacing `.elc` with `.el` *seems* to work. I don't have a strong background in Emacs programming so I'm not sure if I've done evil or not ;-).
