### PR TITLE
GitHub CI integration for macos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest]
-        emacs_version: ['27.2']
+        emacs_version: ['26.3', '27.2']
 
     steps:
     - name: Set up Emacs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ${{matrix.os}}
+
+    strategy:
+      matrix:
+        os: [macos-latest]
+        emacs_version: ['27.2']
+
+    steps:
+    - name: Set up Emacs
+      uses: purcell/setup-emacs@master
+      with:
+        version: ${{matrix.emacs_version}}
+
+    - name: Install Eldev
+      run: curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/github-eldev | sh
+
+    - name: Check out the source code
+      uses: actions/checkout@v2
+
+    - name: Test the project
+      run: |
+        eldev -p -dtT test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         version: ${{matrix.emacs_version}}
 
     - name: Install Eldev
-      run: curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/github-eldev | sh
+      run: curl -fsSL https://raw.githubusercontent.com/doublep/eldev/0.10.3/webinstall/github-eldev | sh
 
     - name: Check out the source code
       uses: actions/checkout@v2


### PR DESCRIPTION
Hi,

could you please consider adding a new GitHub workflow to run the cider tests on the macos platform, as to have wider test coverage, as described in #3116.

It does not appear to be possible to have a free macos executor after having a quick look at this page https://circleci.com/docs/2.0/hello-world-macos/ :

```
Prerequisites

To follow along with this document you will need:

-    An account on CircleCI.
-    A subscription to a paid plan to enable building on the macOS executor.
```

thus the switch for this particular platform to GitHub worfklow, which is free.

All tests pass on macos-latest on Emacs 27.2.

I understand this fragments the ci admin files a little, but it adds quite a lot of value.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x ] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x ] You've added tests (if possible) to cover your change(s)
- [x ] All tests are passing (`eldev test`)
- [x ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!