### PR TITLE
Set project directory in CircleCI to `cider`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,17 @@ jobs:
       - test
 
   test-lint:
+    # There's issue with `package-get-version' that could fail to
+    # return the cider package version, if the parent directory where
+    # it is called from, is not named `cider', i.e. it does not have
+    # the same name as the file wherein the package version is defined
+    # at. In our case, the package version is defined in `cider.el',
+    # thus the parent directory of the checkout should be named
+    # `cider'. Otherwise it could cause compilation warnings, thus we
+    # fix the directory name here. See
+    # https://lists.gnu.org/archive/html/emacs-devel/2021-12/msg02963.html
+    # for a discussion.
+    working_directory: ~/cider
     docker:
       - image: silex/emacs:27-dev
     steps:


### PR DESCRIPTION
Hi,

a simple hack to work around the unused value compilation warning as described in #3118.

Basically, it sets the directory where the code is checked out to `cider`, so that the `package-get-version` can figure out the filename where to look for the cider package version (i.e. `cider.el`).

`package-get-version` does not look very mature at the moment, given the unexpected issue that is caused with the compilation warning (and not so easy to track), and it appears there still some work to be done as per this discussion https://lists.gnu.org/archive/html/emacs-devel/2021-12/msg02963.html. Would it be a better idea not to use it yet perhaps than trying to patch its shortcomings?

Linter tests now pass on Ubuntu.

----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x ] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ x] You've added tests (if possible) to cover your change(s)
- [x ] All tests are passing (`eldev test`)
- [x ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!
