### PR TITLE
Get :socket-file from `server-endpoint'

### DIFF
--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -169,7 +169,7 @@
                                     server-process
                                     (lambda (client-endpoint)
                                       client-buffer)
-                                    (plist-get params :socket-file))))
+                                    (plist-get server-endpoint :socket-file))))
 
               ;; client connection is open
               (expect (process-status process-client)


### PR DESCRIPTION
Fixes #3121, whereby a `params`variable was recently introduced in the test that was defined in another test using buttercup's `:var`  construct. Buttercup suggest the use of [`lexicial scope`](https://github.com/jorgenschaefer/emacs-buttercup/blob/master/docs/writing-tests.md) if this construct is used:

```
it's important to note that lexical-binding must be non-nil for :var and :var* to work properly. Within a test file this is usually set using a local file variable.
```

thus this variable disappeared with the change to switch the file to lexical scope, and whence the test failure.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x ] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x ] You've added tests (if possible) to cover your change(s)
- [x ] All tests are passing (`eldev test`)
- [x ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!