### PR TITLE
clojure cli aliases enhancement - exec-opts and duplicate colon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+### New features
+* [#3127](https://github.com/clojure-emacs/cider/pull/3040): clojure cli aliases enhancement - exec-opts and duplicate colon #3127
+
 ### Bugs fixed
 
 * Upgrade [enrich-classpath](https://github.com/clojure-emacs/enrich-classpath), which fixes various edge cases.

--- a/cider.el
+++ b/cider.el
@@ -158,9 +158,9 @@ default to \"powershell\"."
 (defcustom cider-clojure-cli-aliases
   nil
   "A list of aliases to include when using the clojure cli.
-Should be of the form `foo:bar`.  Any leading \"-A\" or \"-M\" will be
-stripped as these are concatenated into the \"-M[your-deps]:cider/nrepl\"
-form."
+Alias names should be of the form `:foo:bar`.
+Leading \"-A\" \"-M\" \"-T\" or \"-X\" are stripped from aliases
+then concatenated into the \"-M[your-aliases]:cider/nrepl\" form."
   :type 'string
   :safe #'stringp
   :package-version '(cider . "1.1"))
@@ -631,9 +631,9 @@ one used."
             deps-string
             main-opts
             (if cider-clojure-cli-aliases
-                ;; replace -A or -M in the jack-in-aliases to be concatenated
-                ;; with cider/nrepl to ensure cider/nrepl comes last
-                (format ":%s" (replace-regexp-in-string "^-\\(A\\\|M\\):" "" cider-clojure-cli-aliases))
+                ;; remove exec-opts flags -A -M -T or -X from cider-clojure-cli-aliases
+                ;; concatenated with :cider/nrepl to ensure :cider/nrepl comes last
+                (format "%s" (replace-regexp-in-string "^-\\(A\\|M\\|T\\|X\\)" "" cider-clojure-cli-aliases))
               ""))))
 
 (defun cider-shadow-cljs-jack-in-dependencies (global-opts params dependencies)

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -432,14 +432,20 @@
                                      " \"[cider.nrepl/cider-middleware]\"]}}}' -M:test:cider/nrepl")
                                    ""))
             (deps '(("nrepl/nrepl" "0.8.3"))))
-        (let ((cider-clojure-cli-aliases "test"))
+        (let ((cider-clojure-cli-aliases ":test"))
           (expect (cider-clojure-cli-jack-in-dependencies nil nil deps)
                   :to-equal expected))
-        (describe "should strip out leading -A and -M's"
+        (describe "should strip out leading exec opts -A -M -T -X"
           (let ((cider-clojure-cli-aliases "-A:test"))
            (expect (cider-clojure-cli-jack-in-dependencies nil nil deps)
                    :to-equal expected))
           (let ((cider-clojure-cli-aliases "-M:test"))
+            (expect (cider-clojure-cli-jack-in-dependencies nil nil deps)
+                    :to-equal expected))
+          (let ((cider-clojure-cli-aliases "-T:test"))
+            (expect (cider-clojure-cli-jack-in-dependencies nil nil deps)
+                    :to-equal expected))
+          (let ((cider-clojure-cli-aliases "-T:test"))
             (expect (cider-clojure-cli-jack-in-dependencies nil nil deps)
                     :to-equal expected)))))
     (it "allows for global options"
@@ -449,7 +455,7 @@
                                      " \"[cider.nrepl/cider-middleware]\"]}}}' -M:test:cider/nrepl")
                                    ""))
             (deps '(("nrepl/nrepl" "0.8.3"))))
-        (let ((cider-clojure-cli-aliases "test"))
+        (let ((cider-clojure-cli-aliases ":test"))
           (expect (cider-clojure-cli-jack-in-dependencies "-J-Djdk.attach.allowAttachSelf" nil deps)
                   :to-equal expected))))))
 


### PR DESCRIPTION
Strip all exec-opts flags (-A -M -T -X) if they exist in `cider-clojure-cli-aliases`

Refactor format expression to avoid duplicate colon when no flags are included
in the `cider-clojure-cli-aliases`

Resolve #3125 

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)

