### PR TITLE
 Enable `cider-enrich-classpath` by default again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Changes
 
 * [#3127](https://github.com/clojure-emacs/cider/pull/3040): Strip all exec-opts flags (`-A` `-M` `-T` `-X`) if they exist in `cider-clojure-cli-aliases`. Also addresses a duplicate `:` in the generated `clj` command.
-
+* Enable `cider-enrich-classpath` by default again.
+  
 ### Bugs fixed
 
 * Upgrade [enrich-classpath](https://github.com/clojure-emacs/enrich-classpath), which fixes various edge cases.

--- a/cider.el
+++ b/cider.el
@@ -428,7 +428,7 @@ Should be newer than the required version for optimal results."
   :package-version '(cider . "1.2.0")
   :safe #'stringp)
 
-(defcustom cider-enrich-classpath nil
+(defcustom cider-enrich-classpath t
   "Whether to use git.io/JiJVX for adding sources and javadocs to the classpath.
 
 This is done in a clean manner, without interfering with classloaders.


### PR DESCRIPTION
Enable Enrich, which after https://github.com/clojure-emacs/cider/pull/3114 isn't known to have issues.

Finally, this month of January I'm available so it's good to enable it by default and gather feedback again!