### PR TITLE
Fix profiling summary command name in dox

### DIFF
--- a/doc/modules/ROOT/pages/debugging/profiling.adoc
+++ b/doc/modules/ROOT/pages/debugging/profiling.adoc
@@ -18,7 +18,7 @@ namespace.
 Afterwards you can evaluate some code making use of those vars and their
 invocations will be automatically profiled.
 
-You can display a report of the collected profiling data with `M-x cider-profile-display-stats` (kbd:[C-c C-= S]). If you'd like to limit the displayed data to a particular var you should try
+You can display a report of the collected profiling data with `M-x cider-profile-summary` (kbd:[C-c C-= S]). If you'd like to limit the displayed data to a particular var you should try
 `M-x cider-profile-var-summary` (kbd:[C-c C-= s]).
 
 == Understanding the Report Format


### PR DESCRIPTION
Minor dox fix.

[`cider-profile-display-stats` isn't `interactive`](https://github.com/clojure-emacs/cider/blob/master/cider-profile.el#L163-L175) and [`C- C-= S` is currently bound to `cider-profile-summary`](https://github.com/clojure-emacs/cider/blob/master/cider-profile.el#L41). I'm guessing maybe this code was reworked at some point but the dox didn't get updated?
