### PR TITLE
Allow fallback to xref backends if cider-nrepl is unloaded

### DIFF
--- a/cider-find.el
+++ b/cider-find.el
@@ -232,7 +232,10 @@ thing at point."
 ;; CIDER's xref backend was added in CIDER 1.2.
 (defun cider--xref-backend ()
   "Used for xref integration."
-  'cider)
+  ;; Check if `cider-nrepl` middleware is loaded. Allows fallback to other xref
+  ;; backends, if cider-nrepl is not loaded.
+  (when (cider-nrepl-op-supported-p "ns-path")
+    'cider))
 
 (cl-defmethod xref-backend-identifier-at-point ((_backend (eql cider)))
   "Return the relevant identifier at point."


### PR DESCRIPTION
This commit addresses the following use-case: Connecting to a running
REPL which does not have `cider-nrepl` middleware loaded.

This can happen when connecting to remote REPLs, and even
locally (admittedly minor use-case) if you don't want to turn the
middleware on.

If `cider--xref-backend` returns nil, `xref` will move on to the next
backend. This allows using something like `dumb-jump` to move around
in the code-base, while also getting the benefits of a REPL window.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s): No, I think this is a minor change, it is useful to me so I'm pushing it back to the community.
- [ ] All tests are passing (`eldev test`): Did not check this, I hope they are. 
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes: Did not check linter, but there are no errors from `M-x checkdoc`
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality): Not sure this is user-visible, it simply improves the UX
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality):same as above

Thanks!