### PR TITLE
Eval UX improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#3127](https://github.com/clojure-emacs/cider/pull/3040): Strip all exec-opts flags (`-A` `-M` `-T` `-X`) if they exist in `cider-clojure-cli-aliases`. Also addresses a duplicate `:` in the generated `clj` command.
 * Enable `cider-enrich-classpath` by default.
+* [#3148](https://github.com/clojure-emacs/cider/pull/3148): Display error messages in multiline comment eval results, and in result overlays when `cider-show-error-buffer` is set to nil.
 
 ### Bugs fixed
 
@@ -13,6 +14,7 @@
   * Remember: at the moment the enrich-classpath is disabled by default. It will soon be enabled again. If you wish to try it out, you can customize `cider-enrich-classpath` to `t`.
   * Also remember: for it to work, on Linux, you'll also have to do something like `sudo apt install openjdk-11-source` (depending on your package manager and JDK of choice).
 * [#3145](https://github.com/clojure-emacs/cider/pull/3145): Allow fallback to other `xref` backends if cider-nrepl is not loaded.
+* [#3148](https://github.com/clojure-emacs/cider/pull/3148): Fix eval result overlays at point inheriting the faces of following text.
 
 ## 1.2.0 (2021-12-22)
 

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -819,7 +819,8 @@ COMMENT-POSTFIX is the text to output after the last line."
      (lambda (_buffer value)
        (setq res (concat res value)))
      nil
-     nil
+     (lambda (_buffer err)
+       (setq res (concat res err)))
      (lambda (buffer)
        (with-current-buffer buffer
          (save-excursion

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -1209,7 +1209,7 @@ buffer.  It constructs an expression to eval in the following manner:
     (cider-interactive-eval code
                             (when output-to-current-buffer
                               (cider-eval-print-handler))
-                            nil
+                            (list beg-of-defun (point))
                             (cider--nrepl-pr-request-map))))
 
 (defun cider--matching-delimiter (delimiter)
@@ -1240,7 +1240,7 @@ buffer.  It constructs an expression to eval in the following manner:
     (cider-interactive-eval code
                             (when output-to-current-buffer
                               (cider-eval-print-handler))
-                            nil
+                            (list beg-of-sexp (point))
                             (cider--nrepl-pr-request-map))))
 
 (defun cider-pprint-eval-defun-at-point (&optional output-to-current-buffer)

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -727,7 +727,11 @@ when `cider-auto-inspect-after-eval' is non-nil."
                                  (lambda (_buffer out)
                                    (cider-emit-interactive-eval-output out))
                                  (lambda (_buffer err)
-                                   (cider-emit-interactive-eval-err-output err)
+                                   (unless cider-show-error-buffer
+                                     ;; Display errors as temporary overlays
+                                     (let ((cider-result-use-clojure-font-lock nil))
+                                       (cider--display-interactive-eval-result
+                                        err end 'cider-error-overlay-face)))
                                    (cider-handle-compilation-errors err eval-buffer))
                                  (when (and cider-auto-inspect-after-eval
                                             (boundp 'cider-inspector-buffer)

--- a/cider-overlays.el
+++ b/cider-overlays.el
@@ -210,7 +210,9 @@ overlay."
                       (pcase cider-result-overlay-position
                         ('at-eol (line-end-position))
                         ('at-point (point)))))
-               (display-string (format format value))
+               ;; Specify `default' face, otherwise unformatted text will
+               ;; inherit the face of the following text.
+               (display-string (format (propertize format 'face 'default) value))
                (o nil))
           (remove-overlays beg end 'category type)
           (funcall (if cider-overlays-use-font-lock

--- a/cider-overlays.el
+++ b/cider-overlays.el
@@ -42,6 +42,15 @@ applied with lower priority than the syntax highlighting."
   :group 'cider
   :package-version '(cider "0.9.1"))
 
+(defface cider-error-overlay-face
+  '((((class color) (background light))
+     :background "orange red")
+    (((class color) (background dark))
+     :background "firebrick"))
+  "Like `cider-result-overlay-face', but for evaluation errors."
+  :group 'cider
+  :package-version '(cider "0.25.0"))
+
 (defcustom cider-result-use-clojure-font-lock t
   "If non-nil, interactive eval results are font-locked as Clojure code."
   :group 'cider

--- a/cider-overlays.el
+++ b/cider-overlays.el
@@ -262,9 +262,11 @@ overlay."
 
 
 ;;; Displaying eval result
-(defun cider--display-interactive-eval-result (value &optional point)
+(defun cider--display-interactive-eval-result (value &optional point overlay-face)
   "Display the result VALUE of an interactive eval operation.
 VALUE is syntax-highlighted and displayed in the echo area.
+OVERLAY-FACE is the face applied to the overlay, which defaults to
+`cider-result-overlay-face' if nil.
 If POINT and `cider-use-overlays' are non-nil, it is also displayed in an
 overlay at the end of the line containing POINT.
 Note that, while POINT can be a number, it's preferable to be a marker, as
@@ -276,7 +278,8 @@ focused."
          (used-overlay (when (and point cider-use-overlays)
                          (cider--make-result-overlay font-value
                            :where point
-                           :duration cider-eval-result-duration))))
+                           :duration cider-eval-result-duration
+                           :prepend-face (or overlay-face 'cider-result-overlay-face)))))
     (message
      "%s"
      (propertize (format "%s%s" cider-eval-result-prefix font-value)

--- a/doc/modules/ROOT/pages/usage/dealing_with_errors.adoc
+++ b/doc/modules/ROOT/pages/usage/dealing_with_errors.adoc
@@ -15,7 +15,8 @@ TIP: Use kbd:[q] to quickly close an error buffer.
 
 By default, when an exception occurs, CIDER will display the exception
 in an error buffer using `cider-stacktrace-mode`. You can suppress
-this behavior, however:
+this behavior, which causes just the error message to be output as a
+temporary overlay or in the echo area:
 
 [source,lisp]
 ----


### PR DESCRIPTION
This is the first of a bunch of tweaks on my local copy of Cider that I've been using for almost 2 years now and never got around to submitting. I hope it's alright if I group several related changes together in a single PR, much of the friction comes from having to rebase commits and write multiple changelogs. 

- Overlay text takes on the face of the following text - this is especially noticeable with coloured parens and `cider-result-overlay-position` set to `'at-point'`.
Before (using cider-eval-last-sexp, the text takes on the yellow of the closing paren next to it):
![image](https://user-images.githubusercontent.com/22216124/153422229-4ded94da-cd95-413a-a342-155af887bea2.png)
After:
![image](https://user-images.githubusercontent.com/22216124/153422319-c7520a31-56ff-494a-a557-c4a79eb16413.png)


- When an error occurs *and* `cider-show-error-buffer` is set to nil, an overlay is created with an error indicating face. Currently there is no indication at all of the type or presence of error. 
I've been using this setting for some time now and find it much more responsive and less distracting than a stacktrace buffer popping up and needing to be dismissed. Most of the time a simple error message is enough information, and one can use `cider-selector` to bring up the stacktrace buffer if needed.

![image](https://user-images.githubusercontent.com/22216124/153425013-98fc31a1-f8c3-4b61-9f2d-49f26a824a5a.png)

- Similarly with `cider-eval-to-comment` commands, it helps (especially for teaching purposes) to have the error output to the comment:
![image](https://user-images.githubusercontent.com/22216124/153428925-cccc9252-46f4-4049-a928-58c01b4582b6.png)


I don't think tests or user manual updates are needed here? 

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
