### PR TITLE
Feature: multiple persistent eval overlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#3127](https://github.com/clojure-emacs/cider/pull/3040): Strip all exec-opts flags (`-A` `-M` `-T` `-X`) if they exist in `cider-clojure-cli-aliases`. Also addresses a duplicate `:` in the generated `clj` command.
 * Enable `cider-enrich-classpath` by default.
 * [#3148](https://github.com/clojure-emacs/cider/pull/3148): Display error messages in multiline comment eval results, and in result overlays when `cider-show-error-buffer` is set to nil.
+* [#3149](https://github.com/clojure-emacs/cider/pull/3149): Add option `'change` to `cider-eval-result-duration`, allowing multiple eval result overlays to persist until the next change to the buffer.
 
 ### Bugs fixed
 

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -902,7 +902,11 @@ arguments and only proceed with evaluation if it returns nil."
         (start (car-safe bounds))
         (end   (car-safe (cdr-safe bounds))))
     (when (and start end)
-      (remove-overlays start end 'cider-temporary t))
+      ;; NOTE: don't use `remove-overlays' as it splits and leaves behind
+      ;; partial overlays, leading to duplicate eval results in some situations.
+      (dolist (ov (overlays-in start end))
+        (when (eq (overlay-get ov 'cider-temporary) t)
+          (delete-overlay ov))))
     (unless (and cider-interactive-eval-override
                  (functionp cider-interactive-eval-override)
                  (funcall cider-interactive-eval-override form callback bounds))

--- a/cider-overlays.el
+++ b/cider-overlays.el
@@ -44,9 +44,11 @@ applied with lower priority than the syntax highlighting."
 
 (defface cider-error-overlay-face
   '((((class color) (background light))
-     :background "orange red")
+     :background "orange red"
+     :extend t)
     (((class color) (background dark))
-     :background "firebrick"))
+     :background "firebrick"
+     :extend t))
   "Like `cider-result-overlay-face', but for evaluation errors."
   :group 'cider
   :package-version '(cider "0.25.0"))

--- a/cider-overlays.el
+++ b/cider-overlays.el
@@ -98,9 +98,11 @@ If 'at-point, display at the end of the respective sexp."
   "Duration, in seconds, of CIDER's eval-result overlays.
 If nil, overlays last indefinitely.
 If the symbol `command', they're erased after the next command.
+If the symbol `change', they last until the next change to the buffer.
 Also see `cider-use-overlays'."
   :type '(choice (integer :tag "Duration in seconds")
                  (const :tag "Until next command" command)
+                 (const :tag "Until next buffer change" change)
                  (const :tag "Last indefinitely" nil))
   :group 'cider
   :package-version '(cider . "0.10.0"))
@@ -125,10 +127,14 @@ PROPS is a plist of properties and values to add to the overlay."
     (push #'cider--delete-overlay (overlay-get o 'modification-hooks))
     o))
 
-(defun cider--remove-result-overlay ()
+(defun cider--remove-result-overlay (&rest _)
   "Remove result overlay from current buffer.
-This function also removes itself from `post-command-hook'."
-  (remove-hook 'post-command-hook #'cider--remove-result-overlay 'local)
+This function also removes itself from `post-command-hook' and
+`after-change-functions'."
+  (let ((hook (pcase cider-eval-result-duration
+                (`command 'post-command-hook)
+                (`change 'after-change-functions))))
+    (remove-hook hook #'cider--remove-result-overlay 'local))
   (remove-overlays nil nil 'category 'result))
 
 (defun cider--remove-result-overlay-after-command ()
@@ -258,7 +264,11 @@ overlay."
                  (add-hook 'post-command-hook
                            #'cider--remove-result-overlay-after-command
                            nil 'local)
-               (cider--remove-result-overlay-after-command))))
+               (cider--remove-result-overlay-after-command)))
+            (`change
+             (add-hook 'after-change-functions
+                       #'cider--remove-result-overlay
+                       nil 'local)))
           (when-let* ((win (get-buffer-window buffer)))
             ;; Left edge is visible.
             (when (and (<= (window-start win) (point) (window-end win))

--- a/doc/modules/ROOT/pages/usage/code_evaluation.adoc
+++ b/doc/modules/ROOT/pages/usage/code_evaluation.adoc
@@ -207,6 +207,24 @@ Note that this also affects the position of debugger overlays.
 (setq cider-result-overlay-position 'at-point)
 ----
 
+
+You can also customize how overlays are persisted using the variable
+`cider-eval-result-duration`.
+
+By default, its value is `'command`, meaning that result overlays disappear
+after the next user-executed command, such as moving the point or scrolling.
+
+Setting the variable to a number represents the duration in seconds until
+overlays are removed, while setting it to `'change' persists overlays until the
+next change to the buffer contents.
+
+
+[source,lisp]
+----
+(setq cider-eval-result-duration 5.0)
+(setq cider-eval-result-duration 'change)
+----
+
 === Auto-Save Clojure Buffers on Load
 
 Normally, CIDER prompts you to save a modified Clojure buffer when you


### PR DESCRIPTION
This adds a third option `'change` to `cider-eval-result-duration`, which persists eval overlays until there is a change to the buffer, allowing for easy comparisons between different forms.

A quick demo:
![overlays](https://user-images.githubusercontent.com/22216124/153443592-e408b4b5-0a63-4754-adc2-7b1dd43f6896.gif)


Note: This is how Calva behaves, see the demo at https://calva.io/try-first/

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
