### PR TITLE
Workaround for `ansi-color-apply' Emacs bug#53808

### DIFF
--- a/cider-mode.el
+++ b/cider-mode.el
@@ -765,7 +765,7 @@ with the given LIMIT."
     value))
 
 (defun cider--compile-font-lock-keywords (symbols-plist core-plist)
-  "Return a list of font-lock rules for symbols."
+  "Return a list of font-lock rules for symbols in SYMBOLS-PLIST, CORE-PLIST."
   (let ((cider-font-lock-dynamically (if (eq cider-font-lock-dynamically t)
                                          '(function var macro core deprecated)
                                        cider-font-lock-dynamically))

--- a/cider-repl-history.el
+++ b/cider-repl-history.el
@@ -344,7 +344,7 @@ case return nil."
         (error "No CIDER history item here")))))
 
 (defun cider-repl-history-current-string (pt &optional no-error)
-  "Find the string to insert into the REPL by looking for the overlay at PT
+  "Find the string to insert into the REPL by looking for the overlay at PT.
 Might error unless NO-ERROR set."
   (let ((o (cider-repl-history-target-overlay-at pt t)))
     (if o


### PR DESCRIPTION
Hi,

could you please consider proper fix for #3153 which addresses Emacs [bug#53808](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=53808), whereby stray ESC characters in the nREPL output can block the `ansi-color-apply` Emacs fn used by the CIDER nREPL client to colorise the incoming REPL output.

The proposed patch supersedes @dpsutton 's  #1813 excelled work, which worked around the chunked nREPL output split on partial ANSI control sequences by immediately flushing out any partial control sequence caught up between the chunks (and this is why we see valid ANSI color control chars printout in the #3153 example).

The patch improves on #1813 by only flushing out the partial ANSI control seq if it determines it is definitely not a partial or full [C1 SGR](https://en.wikipedia.org/w/index.php?title=ANSI_escape_code&oldid=1070369816#Description) seq (i.e. `ESC` followed by `[` followed by zero or more `[:digit:]+;` followed by one or more digits, followed by `m`), otherwise it waits for the next chunk until the SGR seq is complete or becomes invalid.

Added additional test assertions to catch the case where ANSI color output is split at various points in the SGR seq.

Enabled only in Emacs versions < 29.

Also fixed a couple of old linter docstring warnings, while at it.

Thanks

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

