### PR TITLE
`cider-clojure-cli-jack-in-dependencies`: always remove duplicates

### DIFF
--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -435,6 +435,10 @@
         (let ((cider-clojure-cli-aliases ":test"))
           (expect (cider-clojure-cli-jack-in-dependencies nil nil deps)
                   :to-equal expected))
+        (describe "should remove duplicates, yielding the same result"
+                  (expect (cider-clojure-cli-jack-in-dependencies nil nil '(("nrepl/nrepl" "0.9.0")
+                                                                            ("nrepl/nrepl" "0.9.0")))
+                          :to-equal expected))
         (describe "should strip out leading exec opts -A -M -T -X"
           (let ((cider-clojure-cli-aliases "-A:test"))
            (expect (cider-clojure-cli-jack-in-dependencies nil nil deps)

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -425,6 +425,15 @@
         (spy-on 'cider-jack-in-resolve-command :and-return-value "clojure")
         (expect (plist-get (cider--update-jack-in-cmd nil) :jack-in-cmd)
                 :to-equal expected)))
+    (let ((expected (string-join '("-Sdeps '{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} "
+                                   "cider/cider-nrepl {:mvn/version \"0.28.1\"}} "
+                                   ":aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\""
+                                   " \"[cider.nrepl/cider-middleware]\"]}}}' -M:cider/nrepl")
+                                 "")))
+      (describe "should remove duplicates, yielding the same result"
+                (expect (cider-clojure-cli-jack-in-dependencies nil nil '(("nrepl/nrepl" "0.9.0")
+                                                                          ("nrepl/nrepl" "0.9.0")))
+                        :to-equal expected)))
     (it "handles aliases correctly"
       (let ((expected (string-join '("-Sdeps '{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} "
                                      "cider/cider-nrepl {:mvn/version \"0.28.1\"}} "
@@ -435,10 +444,6 @@
         (let ((cider-clojure-cli-aliases ":test"))
           (expect (cider-clojure-cli-jack-in-dependencies nil nil deps)
                   :to-equal expected))
-        (describe "should remove duplicates, yielding the same result"
-                  (expect (cider-clojure-cli-jack-in-dependencies nil nil '(("nrepl/nrepl" "0.9.0")
-                                                                            ("nrepl/nrepl" "0.9.0")))
-                          :to-equal expected))
         (describe "should strip out leading exec opts -A -M -T -X"
           (let ((cider-clojure-cli-aliases "-A:test"))
            (expect (cider-clojure-cli-jack-in-dependencies nil nil deps)


### PR DESCRIPTION
Prevents all sorts of issues, particularly as this area is changing as of lately.

This way we guard against any misconfiguration, misunderstanding, subtle bug, etc.