### PR TITLE
Eval into register, kill last eval result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ## New features
 
 * Add new interactive command `cider-inspire-me`. It does what you'd expect.
+* [#3162](https://github.com/clojure-emacs/cider/pull/3162): Save eval results into kill ring and registers.
+  * Add new customization variable `cider-eval-register` to automatically store the last interactive eval result into the specified register.
+  * Add interactive command `cider-kill-last-result` to manually save the last eval result into kill ring. 
 
 ### Changes
 

--- a/cider-client.el
+++ b/cider-client.el
@@ -397,8 +397,8 @@ is included in the request if non-nil."
                          (seq-mapcat #'identity)
                          (apply #'nrepl-dict))))
     (map-merge 'list
-               `(("nrepl.middleware.print/print" "cider.nrepl.pprint/pr"
-                  "nrepl.middleware.print/stream?" nil))
+               `(("nrepl.middleware.print/print" "cider.nrepl.pprint/pr")
+                 ("nrepl.middleware.print/stream?" nil))
                (unless (nrepl-dict-empty-p print-options)
                  `(("nrepl.middleware.print/options" ,print-options)))
                (when cider-print-quota

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -1349,6 +1349,7 @@ passing arguments."
     (define-key map (kbd "z") #'cider-eval-defun-up-to-point)
     (define-key map (kbd "c") #'cider-eval-last-sexp-in-context)
     (define-key map (kbd "b") #'cider-eval-sexp-at-point-in-context)
+    (define-key map (kbd "k") #'cider-kill-last-result)
     (define-key map (kbd "f") 'cider-eval-pprint-commands-map)
 
     ;; duplicates with C- for convenience
@@ -1364,6 +1365,7 @@ passing arguments."
     (define-key map (kbd "C-z") #'cider-eval-defun-up-to-point)
     (define-key map (kbd "C-c") #'cider-eval-last-sexp-in-context)
     (define-key map (kbd "C-b") #'cider-eval-sexp-at-point-in-context)
+    (define-key map (kbd "C-k") #'cider-kill-last-result)
     (define-key map (kbd "C-f") 'cider-eval-pprint-commands-map)
     map))
 

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -167,6 +167,15 @@ If t, save the file without confirmation."
   :group 'cider
   :package-version '(cider . "0.16.0"))
 
+(defcustom cider-eval-register ?e
+  "The text register assigned to the most recent evaluation result.
+When non-nil, the return value of all CIDER eval commands are
+automatically written into this register."
+  :type '(choice character
+                 (const nil))
+  :group 'cider
+  :package-version '(cider . "1.4.0"))
+
 
 ;;; Utilities
 
@@ -651,7 +660,9 @@ The handler simply inserts the result value in BUFFER."
     (nrepl-make-response-handler (or buffer eval-buffer)
                                  (lambda (_buffer value)
                                    (with-current-buffer buffer
-                                     (insert value)))
+                                     (insert value))
+                                   (when cider-eval-register
+                                     (set-register cider-eval-register value))                                   )
                                  (lambda (_buffer out)
                                    (cider-repl-emit-interactive-stdout out))
                                  (lambda (_buffer err)
@@ -723,7 +734,9 @@ when `cider-auto-inspect-after-eval' is non-nil."
                                          (cider--make-fringe-overlays-for-region beg end)
                                          (setq fringed t))
                                      (cider--make-fringe-overlay end))
-                                   (cider--display-interactive-eval-result value end))
+                                   (cider--display-interactive-eval-result value end)
+                                   (when cider-eval-register
+                                     (set-register cider-eval-register value)))
                                  (lambda (_buffer out)
                                    (cider-emit-interactive-eval-output out))
                                  (lambda (_buffer err)
@@ -768,7 +781,9 @@ Optional argument DONE-HANDLER lambda will be run once load is complete."
                                    (insert
                                     (if (derived-mode-p 'cider-clojure-interaction-mode)
                                         (format "\n%s\n" value)
-                                      value))))
+                                      value)))
+                                 (when cider-eval-register
+                                   (set-register cider-eval-register value)))
                                (lambda (_buffer out)
                                  (cider-emit-interactive-eval-output out))
                                (lambda (_buffer err)
@@ -785,7 +800,9 @@ comment prefix to use."
                                    (save-excursion
                                      (goto-char (marker-position location))
                                      (insert (concat comment-prefix
-                                                     value "\n")))))
+                                                     value "\n"))))
+                                 (when cider-eval-register
+                                   (set-register cider-eval-register value)))
                                (lambda (_buffer out)
                                  (cider-emit-interactive-eval-output out))
                                (lambda (_buffer err)

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -1310,6 +1310,12 @@ passing arguments."
          (form (format "(%s)" fn-name)))
     (cider-read-and-eval (cons form (length form)))))
 
+(defun cider-kill-last-result ()
+  "Save the last evaluated result into the kill ring."
+  (interactive)
+  (kill-new
+   (nrepl-dict-get (cider-nrepl-sync-request:eval "*1") "value")))
+
 ;; Eval keymaps
 (defvar cider-eval-pprint-commands-map
   (let ((map (define-prefix-command 'cider-eval-pprint-commands-map)))

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -788,23 +788,20 @@ Optional argument DONE-HANDLER lambda will be run once load is complete."
 
 (defun cider-eval-print-handler (&optional buffer)
   "Make a handler for evaluating and printing result in BUFFER."
-  (let ((res ""))
-    (nrepl-make-response-handler (or buffer (current-buffer))
-                                 (lambda (buffer value)
-                                   (with-current-buffer buffer
-                                     (insert
-                                      (if (derived-mode-p 'cider-clojure-interaction-mode)
-                                          (format "\n%s\n" value)
-                                        value)))
-                                   (when cider-eval-register
-                                     (setq res (concat res value))))
-                                 (lambda (_buffer out)
-                                   (cider-emit-interactive-eval-output out))
-                                 (lambda (_buffer err)
-                                   (cider-emit-interactive-eval-err-output err))
-                                 (lambda (_buffer)
-                                   (when cider-eval-register
-                                     (set-register cider-eval-register res))))))
+  ;; NOTE: cider-eval-register behavior is not implemented here for performance reasons.
+  ;; See https://github.com/clojure-emacs/cider/pull/3162
+  (nrepl-make-response-handler (or buffer (current-buffer))
+                               (lambda (buffer value)
+                                 (with-current-buffer buffer
+                                   (insert
+                                    (if (derived-mode-p 'cider-clojure-interaction-mode)
+                                        (format "\n%s\n" value)
+                                      value))))
+                               (lambda (_buffer out)
+                                 (cider-emit-interactive-eval-output out))
+                               (lambda (_buffer err)
+                                 (cider-emit-interactive-eval-err-output err))
+                               ()))
 
 (defun cider-eval-print-with-comment-handler (buffer location comment-prefix)
   "Make a handler for evaluating and printing commented results in BUFFER.
@@ -871,6 +868,8 @@ COMMENT-POSTFIX is the text to output after the last line."
 (defun cider-popup-eval-handler (&optional buffer)
   "Make a handler for printing evaluation results in popup BUFFER.
 This is used by pretty-printing commands."
+  ;; NOTE: cider-eval-register behavior is not implemented here for performance reasons.
+  ;; See https://github.com/clojure-emacs/cider/pull/3162
   (nrepl-make-response-handler
    (or buffer (current-buffer))
    (lambda (buffer value)

--- a/doc/modules/ROOT/pages/usage/code_evaluation.adoc
+++ b/doc/modules/ROOT/pages/usage/code_evaluation.adoc
@@ -275,6 +275,34 @@ Additionally, there's the variable `cider-redirect-server-output-to-repl` that c
 
 NOTE: The redirection functionality is implemented in `cider-nrepl` as nREPL middleware. If you're using CIDER without `cider-nrepl` no output redirection is going to take place.
 
+
+
+=== Storing eval results
+
+By default CIDER stores the return value of the most recent evaluation command
+in the text register `e`. You can access these contents via `insert-register`
+(kbd:[C-x r i]).
+
+This is often useful for closer inspection or textual manipulation of a
+transiently displayed eval result, without having to re-evaluate the form with a
+specialized command like `cider-insert-last-sexp-in-repl`.
+
+You can customize which register is used with the variable `cider-eval-register`, or set
+it to `nil` to disable the feature.
+
+[source,lisp]
+----
+(setq cider-eval-register nil)
+----
+
+TIP: The built-in xref:debugging/inspector.adoc[inspector] can be used to view
+and navigate through complex nested results.
+
+You can also use the command `cider-kill-last-result`(kbd:[C-c C-v k]) after any
+eval command to store its result in the kill ring. This works even when the
+`cider-eval-register` feature is disabled.
+
+
 == Keybindings
 
 You might have noticed that CIDER typically has 2-3 different keybindings for
@@ -383,6 +411,10 @@ kbd:[C-u C-c C-c]
 | `cider-load-all-files`
 | kbd:[C-c C-M-l]
 | Load (eval) all Clojure files below a directory.
+
+| `cider-kill-last-result`
+| kbd:[C-c C-v k]
+| Save the last evaluated result into the kill ring.
 |===
 
 TIP: You'll find all evaluation commands and their keybindings in the `CIDER Eval` menu.


### PR DESCRIPTION
A quick naive implementation of the features as discussed in #3143.

I think there are a few complications around `*print-level*`/`*print-length*` options and print streaming. 
One common use case I can see for this feature is being able to copy some large eval output into a separate buffer / tool and analyse it further - eg. large strings, which Cider's builtin inspector does not handle very well. Probably the most user-friendly thing to do in that case is temporarily override the print length and level options to nil, allowing for the entire result to be copied without truncation.
But this will slow down the use of regular eval commands, where it also makes sense to just copy verbatim what the user sees in the overlay / minibuffer message into the eval register. 
Maybe only override print options in the case of an explicit `cider-kill-last-result` command? Or have it be toggled by universal-argument? 
Note: I had tried to implement a similar `cider-inspector-copy-val` command in the past, but found the need to accumulate large results in chunks due to nrepl's print streaming and gave up halfway. `cider-print-quota` also comes into this, and whether to use pretty printing. 


### Defaults: 
Should eval-register be enabled by default and clobber users' `?e` registers? Presumably a register power user would find it easy enough to disable.
Suggested key binding for kill-last-result: `C-c C-v k`? 

No tests written yet (due to issues running the testing framework)

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
