### PR TITLE
Fix error in cider-clojuredocs-lookup

### DIFF
--- a/cider-clojuredocs.el
+++ b/cider-clojuredocs.el
@@ -145,7 +145,11 @@ opposite of what that option dictates."
   (let ((docs (cider-sync-request:clojuredocs-lookup (cider-current-ns) sym)))
     (pop-to-buffer (cider-create-clojuredocs-buffer (cider-clojuredocs--content docs)))
     ;; highlight the symbol in question in the docs buffer
-    (highlight-regexp (cadr (split-string sym "/")) 'bold)))
+    (highlight-regexp
+     (regexp-quote
+      (or (cadr (split-string sym "/"))
+          sym))
+     'bold)))
 
 ;;;###autoload
 (defun cider-clojuredocs (&optional arg)


### PR DESCRIPTION
Issue:
cider-clojuredocs pops the doc buffer
but then still asks you for a symbol.

The issue is that
cider-clojuredocs-lookup passes nil to highlight-regexp,
which then throws an error.
It's only an issue when sym doesn't have a `/`.

and upstream cider-try-symbol-at-point handles all errors with
asking for a symbol.

Also `sym` can be something like `.` at this point so calling regexp-quote makes sense.

