### PR TITLE
Disable enrich-classpath again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Changes
 
 * [#3127](https://github.com/clojure-emacs/cider/pull/3040): Strip all exec-opts flags (`-A` `-M` `-T` `-X`) if they exist in `cider-clojure-cli-aliases`. Also addresses a duplicate `:` in the generated `clj` command.
-* Enable `cider-enrich-classpath` by default.
 * [#3148](https://github.com/clojure-emacs/cider/pull/3148): Display error messages in multiline comment eval results, and in result overlays when `cider-show-error-buffer` is set to nil.
 * [#3149](https://github.com/clojure-emacs/cider/pull/3149): Add option `'change` to `cider-eval-result-duration`, allowing multiple eval result overlays to persist until the next change to the buffer.
 * `cider-jack-in-lein-plugins` no longer affects non-Leiningen projects.

--- a/cider.el
+++ b/cider.el
@@ -425,7 +425,7 @@ Should be newer than the required version for optimal results."
   :package-version '(cider . "1.2.0")
   :safe #'stringp)
 
-(defcustom cider-enrich-classpath t
+(defcustom cider-enrich-classpath nil
   "Whether to use git.io/JiJVX for adding sources and javadocs to the classpath.
 
 This is done in a clean manner, without interfering with classloaders.


### PR DESCRIPTION
The bad news: as I'm finding out, for big/complex enough projects, the "Leiningen plugin" approach turns out not be suitable for fine-grained classpath manipulation, as enrich-classpath needs to perform.

The reasons being:

* Lein by design doesn't have a classpath manipulation API (e.g. place this resource/dependency _last_ in the classpath)
* Lein's classpath generation is less deterministic than it seemed at first, so one cannot trick it into doing something specific.

The good news: the fix for Lein is implemented already: it will basically use the [.sh](https://github.com/clojure-emacs/enrich-classpath/blob/670ac9b5992bdafc5ca4c9374163ede880575d8b/tools.deps/src/cider/enrich_classpath/clojure.sh) script that was devised for tools.deps usage. 

That script / the underlying code is able to manipulate the classpath at will - one can place stuff at the tail, or also in a very specific order.

So whenever I have the chance to finish the tools.deps integration, I'll also reintroduce Enrich for Lein. Which of course warrants another round of QA.

Fixes https://github.com/clojure-emacs/cider/issues/3159