### PR TITLE
Fix most of the build

### DIFF
--- a/cider-repl.el
+++ b/cider-repl.el
@@ -711,8 +711,8 @@ namespaces.  STRING is REPL's output."
   string)
 
 (defvar cider-repl-preoutput-hook `(,(if (< emacs-major-version 29)
-                                       'cider-repl--ansi-color-apply
-                                      'ansi-color-apply)
+                                         'cider-repl--ansi-color-apply
+                                       'ansi-color-apply)
                                     cider-repl-highlight-current-project
                                     cider-repl-highlight-spec-keywords
                                     cider-repl-add-locref-help-echo)

--- a/cider.el
+++ b/cider.el
@@ -485,7 +485,7 @@ returned by this function does not include keyword arguments."
                              `(("cider/cider-nrepl" ,cider-injected-middleware-version)
                                ("mx.cider/enrich-classpath" "1.9.0")))
                    (append cider-jack-in-lein-plugins
-                             `(("cider/cider-nrepl" ,cider-injected-middleware-version))))))
+                           `(("cider/cider-nrepl" ,cider-injected-middleware-version))))))
     (thread-last plugins
       (seq-filter
        (lambda (spec)
@@ -609,6 +609,7 @@ removed, LEIN-PLUGINS, LEIN-MIDDLEWARES and finally PARAMS."
    params))
 
 (defun cider--dedupe-deps (deps)
+  "Removes the duplicates in DEPS."
   (cl-delete-duplicates deps :test 'equal))
 
 (defun cider-clojure-cli-jack-in-dependencies (global-options _params dependencies)

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -425,15 +425,15 @@
         (spy-on 'cider-jack-in-resolve-command :and-return-value "clojure")
         (expect (plist-get (cider--update-jack-in-cmd nil) :jack-in-cmd)
                 :to-equal expected)))
-    (let ((expected (string-join '("-Sdeps '{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} "
-                                   "cider/cider-nrepl {:mvn/version \"0.28.3\"}} "
-                                   ":aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\""
-                                   " \"[cider.nrepl/cider-middleware]\"]}}}' -M:cider/nrepl")
-                                 "")))
-      (describe "should remove duplicates, yielding the same result"
-                (expect (cider-clojure-cli-jack-in-dependencies nil nil '(("nrepl/nrepl" "0.9.0")
-                                                                          ("nrepl/nrepl" "0.9.0")))
-                        :to-equal expected)))
+    (it "should remove duplicates, yielding the same result"
+        (let ((expected (string-join '("-Sdeps '{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} "
+                                       "cider/cider-nrepl {:mvn/version \"0.28.3\"}} "
+                                       ":aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\""
+                                       " \"[cider.nrepl/cider-middleware]\"]}}}' -M:cider/nrepl")
+                                     "")))
+          (expect (cider-clojure-cli-jack-in-dependencies nil nil '(("nrepl/nrepl" "0.9.0")
+                                                                    ("nrepl/nrepl" "0.9.0")))
+                  :to-equal expected)))
     (it "handles aliases correctly"
       (let ((expected (string-join '("-Sdeps '{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} "
                                      "cider/cider-nrepl {:mvn/version \"0.28.3\"}} "

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -210,6 +210,7 @@
     (before-each
       ;; FIXME: Needed because its set in an earlier test
       (setq-local cider-jack-in-lein-plugins nil)
+      (setq-local cider-jack-in-dependencies nil)
       (setq-local cider-jack-in-nrepl-middlewares '("cider.nrepl/cider-middleware"))
       (setq-local cider-jack-in-dependencies-exclusions '()))
     (it "can concat in a lein project"
@@ -397,6 +398,7 @@
                                 "YwBsAG8AagB1AHIAZQAgACIAIgBjAG0AZAAtAHAAYQByAGEAbQBzACIAIgA="))))
   (describe "when 'clojure-cli project type"
     (it "uses main opts in an alias to prevent other mains from winning"
+      (setq-local cider-jack-in-dependencies nil)
       (setq-local cider-jack-in-nrepl-middlewares '("cider.nrepl/cider-middleware"))
       (let ((expected (string-join '("clojure -Sdeps '{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} "
                                      "cider/cider-nrepl {:mvn/version \"0.28.3\"}} "
@@ -411,12 +413,14 @@
         (spy-on 'cider-jack-in-resolve-command :and-return-value "clojure")
         (expect (plist-get (cider--update-jack-in-cmd nil) :jack-in-cmd)
                 :to-equal expected)))
+    
     (it "allows specifying custom aliases with `cider-clojure-cli-aliases`"
       (let ((expected (string-join '("clojure -Sdeps '{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} "
                                      "cider/cider-nrepl {:mvn/version \"0.28.3\"}} "
                                      ":aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\""
                                      " \"[cider.nrepl/cider-middleware]\"]}}}' -M:dev:test:cider/nrepl")
                                    "")))
+        (setq-local cider-jack-in-dependencies nil)
         (setq-local cider-clojure-cli-aliases "-A:dev:test")
         (setq-local cider-allow-jack-in-without-project t)
         (setq-local cider-clojure-cli-command "clojure")
@@ -426,17 +430,17 @@
         (expect (plist-get (cider--update-jack-in-cmd nil) :jack-in-cmd)
                 :to-equal expected)))
     (it "should remove duplicates, yielding the same result"
-        (let ((expected (string-join '("-Sdeps '{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} "
-                                       "cider/cider-nrepl {:mvn/version \"0.28.3\"}} "
+        (let ((expected (string-join '("-Sdeps '{:deps {cider/cider-nrepl {:mvn/version \"0.28.3\"} "
+                                       "nrepl/nrepl {:mvn/version \"0.9.0\"}} "
                                        ":aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\""
-                                       " \"[cider.nrepl/cider-middleware]\"]}}}' -M:cider/nrepl")
+                                       " \"[cider.nrepl/cider-middleware]\"]}}}' -M:dev:test:cider/nrepl")
                                      "")))
           (expect (cider-clojure-cli-jack-in-dependencies nil nil '(("nrepl/nrepl" "0.9.0")
                                                                     ("nrepl/nrepl" "0.9.0")))
                   :to-equal expected)))
     (it "handles aliases correctly"
-      (let ((expected (string-join '("-Sdeps '{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} "
-                                     "cider/cider-nrepl {:mvn/version \"0.28.3\"}} "
+      (let ((expected (string-join '("-Sdeps '{:deps {cider/cider-nrepl {:mvn/version \"0.28.3\"} "
+                                     "nrepl/nrepl {:mvn/version \"0.9.0\"}} "
                                      ":aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\""
                                      " \"[cider.nrepl/cider-middleware]\"]}}}' -M:test:cider/nrepl")
                                    ""))
@@ -458,8 +462,8 @@
             (expect (cider-clojure-cli-jack-in-dependencies nil nil deps)
                     :to-equal expected)))))
     (it "allows for global options"
-      (let ((expected (string-join '("-J-Djdk.attach.allowAttachSelf -Sdeps '{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} "
-                                     "cider/cider-nrepl {:mvn/version \"0.28.3\"}} "
+      (let ((expected (string-join '("-J-Djdk.attach.allowAttachSelf -Sdeps '{:deps {cider/cider-nrepl {:mvn/version \"0.28.3\"} "
+                                     "nrepl/nrepl {:mvn/version \"0.9.0\"}} "
                                      ":aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\""
                                      " \"[cider.nrepl/cider-middleware]\"]}}}' -M:test:cider/nrepl")
                                    ""))


### PR DESCRIPTION
Fixes linting and tests but not `cider-util.el:377:8:Error: value returned from (fboundp 'package-get-version) is unused` (https://app.circleci.com/pipelines/github/clojure-emacs/cider/1157/workflows/80e0b8e4-6f6d-4497-81a6-5268ffac52a1/jobs/5337)
