### PR TITLE
[Fixes #3170] Skip ensure of repl available on xref functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * Use clojure-mode [5.14.0](https://github.com/clojure-emacs/clojure-mode/blob/v5.14.0/CHANGELOG.md#5140-2022-03-07).
+* [#3170](https://github.com/clojure-emacs/cider/issues/3170) Skip ensure repl available on xref functions.
 
 ## 1.3.0 (2021-03-07)
 

--- a/cider-client.el
+++ b/cider-client.el
@@ -161,9 +161,12 @@ nREPL connection."
           (clojure-expected-ns path)))
     (clojure-expected-ns path)))
 
-(defun cider-nrepl-op-supported-p (op &optional connection)
-  "Check whether the CONNECTION supports the nREPL middleware OP."
-  (nrepl-op-supported-p op (or connection (cider-current-repl nil 'ensure))))
+(defun cider-nrepl-op-supported-p (op &optional connection skip-ensure)
+  "Check whether the CONNECTION supports the nREPL middleware OP.
+Skip check if repl is active if SKIP-ENSURE is non nil."
+  (nrepl-op-supported-p op (or connection (cider-current-repl nil (if skip-ensure
+                                                                      nil
+                                                                    'ensure)))))
 
 (defun cider-ensure-op-supported (op)
   "Check for support of middleware op OP.

--- a/cider-find.el
+++ b/cider-find.el
@@ -234,7 +234,7 @@ thing at point."
   "Used for xref integration."
   ;; Check if `cider-nrepl` middleware is loaded. Allows fallback to other xref
   ;; backends, if cider-nrepl is not loaded.
-  (when (cider-nrepl-op-supported-p "ns-path")
+  (when (cider-nrepl-op-supported-p "ns-path" 'skip-ensure)
     'cider))
 
 (cl-defmethod xref-backend-identifier-at-point ((_backend (eql cider)))


### PR DESCRIPTION
Fixes #3170 adding a extra arg to skip the ensure for xref functions.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [X] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!