### PR TITLE
Apply colorization on actual/expected test output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+* [#3177](https://github.com/clojure-emacs/cider/pull/3177) Apply ANSI colorization to test assertion output
 * Use clojure-mode [5.14.0](https://github.com/clojure-emacs/clojure-mode/blob/v5.14.0/CHANGELOG.md#5140-2022-03-07).
 * [#3170](https://github.com/clojure-emacs/cider/issues/3170) Skip ensure repl available on xref functions.
 * [#3173](https://github.com/clojure-emacs/cider/issues/3173) Locally remove `cider-complete-at-point` from `completion-at-point-functions` instead of killing it as a local variable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changes
 
-* [#3177](https://github.com/clojure-emacs/cider/pull/3177) Apply ANSI colorization to test assertion output
+* [#3177](https://github.com/clojure-emacs/cider/pull/3177) Apply ANSI colorization to test assertion output.
 * Use clojure-mode [5.14.0](https://github.com/clojure-emacs/clojure-mode/blob/v5.14.0/CHANGELOG.md#5140-2022-03-07).
 * [#3170](https://github.com/clojure-emacs/cider/issues/3170) Skip ensure repl available on xref functions.
 * [#3173](https://github.com/clojure-emacs/cider/issues/3173) Locally remove `cider-complete-at-point` from `completion-at-point-functions` instead of killing it as a local variable.

--- a/cider-test.el
+++ b/cider-test.el
@@ -28,6 +28,7 @@
 
 ;;; Code:
 
+(require 'ansi-color)
 (require 'button)
 (require 'cl-lib)
 (require 'easymenu)
@@ -395,9 +396,11 @@ With the actual value, the outermost '(not ...)' s-expression is removed."
                 (insert-align-label (s)
                   (insert (format "%12s" s)))
                 (insert-rect (s)
-                  (insert-rectangle (thread-first s
-                                      cider-font-lock-as-clojure
-                                      (split-string "\n")))
+                  (let ((start (point)))
+                    (insert-rectangle (thread-first s
+                                        cider-font-lock-as-clojure
+                                        (split-string "\n")))
+                    (ansi-color-apply-on-region start (point)))
                   (beginning-of-line)))
         (cider-propertize-region (cider-intern-keys (cdr test))
           (let ((beg (point))


### PR DESCRIPTION
For matchers like matcher-combinators that rely on that.

Closes #2901

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
