### PR TITLE
Fix unused returned value compilation warning

### DIFF
--- a/cider-browse-ns.el
+++ b/cider-browse-ns.el
@@ -223,7 +223,7 @@ be displayed."
         (cider-find-ns nil value)
       (cider-find-var current-prefix-arg value))))
 
-(defun cider-browse-ns-handle-mouse (event) ;FIXME: Unused arg!
+(defun cider-browse-ns-handle-mouse (_event) ;FIXME: Unused arg!
   "Handle mouse click EVENT."
   (interactive "e")
   (cider-browse-ns-operate-at-point))

--- a/cider-browse-ns.el
+++ b/cider-browse-ns.el
@@ -223,7 +223,7 @@ be displayed."
         (cider-find-ns nil value)
       (cider-find-var current-prefix-arg value))))
 
-(defun cider-browse-ns-handle-mouse (_event) ;FIXME: Unused arg!
+(defun cider-browse-ns-handle-mouse (_event)
   "Handle mouse click EVENT."
   (interactive "e")
   (cider-browse-ns-operate-at-point))

--- a/cider-classpath.el
+++ b/cider-classpath.el
@@ -80,7 +80,7 @@
          (line (buffer-substring-no-properties bol eol)))
     (find-file-other-window line)))
 
-(defun cider-classpath-handle-mouse (_event) ;FIXME: Unused arg!
+(defun cider-classpath-handle-mouse (_event)
   "Handle mouse click EVENT."
   (interactive "e")
   (cider-classpath-operate-on-point))

--- a/cider-classpath.el
+++ b/cider-classpath.el
@@ -80,7 +80,7 @@
          (line (buffer-substring-no-properties bol eol)))
     (find-file-other-window line)))
 
-(defun cider-classpath-handle-mouse (event) ;FIXME: Unused arg!
+(defun cider-classpath-handle-mouse (_event) ;FIXME: Unused arg!
   "Handle mouse click EVENT."
   (interactive "e")
   (cider-classpath-operate-on-point))

--- a/cider-repl-history.el
+++ b/cider-repl-history.el
@@ -330,7 +330,7 @@ it's turned on."
      before-insert
      (point))))
 
-(defun cider-repl-history-target-overlay-at (position &optional no-error)
+(defun cider-repl-history-target-overlay-at (_position &optional no-error)
   "Return overlay at POSITION that has property `cider-repl-history-target'.
 If no such overlay, raise an error unless NO-ERROR is true, in which
 case return nil."
@@ -352,7 +352,7 @@ Might error unless NO-ERROR set."
       (unless no-error
         (error "No CIDER history item in this buffer")))))
 
-(defun cider-repl-history-do-insert (buf pt)
+(defun cider-repl-history-do-insert (_buf pt)
   "Helper function to insert text from BUF at PT into the REPL buffer.
 Also kills *cider-repl-history*."
   ;; Note: as mentioned at the top, this file is based on browse-kill-ring,

--- a/cider-repl-history.el
+++ b/cider-repl-history.el
@@ -334,7 +334,6 @@ it's turned on."
   "Return overlay at POSITION that has property `cider-repl-history-target'.
 If no such overlay, raise an error unless NO-ERROR is true, in which
 case return nil."
-  ;; FIXME: `position' is not used!
   (let ((ovs  (overlays-at (point))))
     (catch 'cider-repl-history-target-overlay-at
       (dolist (ov ovs)
@@ -364,7 +363,6 @@ Also kills *cider-repl-history*."
   ;; generic paste tool, but for inserting a previous command into an
   ;; interpreter, I felt the only useful option would be inserting it at the end
   ;; and quitting the history buffer, so that is all that's provided.
-  ;; FIXME: `buf' is not used!
   (let ((str (cider-repl-history-current-string pt)))
     (cider-repl-history-quit)
     (with-selected-window cider-repl-history-repl-window

--- a/cider-util.el
+++ b/cider-util.el
@@ -376,6 +376,8 @@ propertized (defaults to current buffer)."
 
 (defun cider--pkg-version ()
   "Extract CIDER's package version from its package metadata."
+  ;; Use `cond' below to avoid a compiler unused return value warning
+  ;; when `package-get-version' returns nil. See #3181.
   ;; FIXME: Inline the logic from package-get-version and adapt it
   (cond ((fboundp 'package-get-version)
          (package-get-version))))

--- a/cider-util.el
+++ b/cider-util.el
@@ -377,9 +377,8 @@ propertized (defaults to current buffer)."
 (defun cider--pkg-version ()
   "Extract CIDER's package version from its package metadata."
   ;; FIXME: Inline the logic from package-get-version and adapt it
-  (if (fboundp 'package-get-version)
-      (package-get-version)
-    nil))
+  (cond ((fboundp 'package-get-version)
+         (package-get-version))))
 
 (defun cider--version ()
   "Retrieve CIDER's version.


### PR DESCRIPTION
> Fixes https://github.com/clojure-emacs/cider/issues/3178

Fixes `cider--pkg-version` unused return value compilation warning, see #3178 for details.

`Error: value returned from (fboundp 'package-get-version) is unused`

Converts `if` conditional to `cond`, and fixes unused param warnings by prefixing with  param names with `_`.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!