### PR TITLE
Fix time subtraction bug in nrepl-client

### DIFF
--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -902,8 +902,9 @@ If TOOLING, use the tooling session rather than the standard session."
                  (setq time0 (current-time)))
         ;; break out in case we don't receive a response for a while
         (when (and nrepl-sync-request-timeout
-                   (> (cadr (time-subtract (current-time) time0))
-                      nrepl-sync-request-timeout))
+                   (time-less-p
+                    nrepl-sync-request-timeout
+                    (time-subtract nil time0)))
           (error "Sync nREPL request timed out %s" request)))
       ;; Clean up the response, otherwise we might repeatedly ask for input.
       (nrepl-dict-put response "status" (remove "need-input" status))


### PR DESCRIPTION
* nrepl-client.el (nrepl-send-sync-request): Port to future Emacs,
and fix bug on current and older Emacs when the clock modulo 2**16
wraps around.

(I'm afraid I have not done the stuff in the checkboxes as I'm not familiar with the cider workflow. I don't know what eldev is, for example. However, the patch is quite simple and should work.)

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
