### PR TITLE
Automatically extract let bindings in cider-eval-in-context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## New features
 
+* [#3185](https://github.com/clojure-emacs/cider/pull/3185): Add feature to `cider-eval-in-context` for automatically extracting parent let bindings when called with `C-u` prefix argument.
 * Add new interactive command `cider-inspire-me`. It does what you'd expect.
 * [#3162](https://github.com/clojure-emacs/cider/pull/3162): Save eval results into kill ring and registers.
   * Add new customization variable `cider-eval-register` to automatically store the last interactive eval result into the specified register.

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -1033,9 +1033,10 @@ by extracting all parent let bindings."
                 (setq res (concat (buffer-substring-no-properties beg end) ", " res)))))
         (scan-error res)))))
 
-(defun cider--eval-in-context (code &optional guess)
-  "Evaluate CODE in user-provided evaluation context."
-  (let* ((code (string-trim-right code))
+(defun cider--eval-in-context (bounds &optional guess)
+  "Evaluate code at BOUNDS in user-provided evaluation context."
+  (let* ((code (string-trim-right
+                (buffer-substring-no-properties (car bounds) (cadr bounds))))
          (eval-context
           (minibuffer-with-setup-hook (when guess #'beginning-of-buffer)
             (read-string "Evaluation context (let-style): "
@@ -1045,7 +1046,7 @@ by extracting all parent let bindings."
     (setq-local cider-previous-eval-context eval-context)
     (cider-interactive-eval code
                             nil
-                            nil
+                            bounds
                             (cider--nrepl-pr-request-map))))
 
 (defun cider-eval-last-sexp-in-context (guess)
@@ -1056,7 +1057,7 @@ The context is remembered between command invocations.
 When GUESS is non-nil, or called interactively with \\[universal-argument],
 attempt to guess the context from parent let bindings."
   (interactive "P")
-  (cider--eval-in-context (cider-last-sexp) guess))
+  (cider--eval-in-context (cider-last-sexp 'bounds) guess))
 
 (defun cider-eval-sexp-at-point-in-context (guess)
   "Evaluate the sexp around point in user-supplied context.
@@ -1067,7 +1068,7 @@ The context is remembered between command invocations.
 When GUESS is non-nil, or called interactively with \\[universal-argument],
 attempt to guess the context from parent let bindings."
   (interactive "P")
-  (cider--eval-in-context (cider-sexp-at-point) guess))
+  (cider--eval-in-context (cider-sexp-at-point 'bounds) guess))
 
 (defun cider-eval-defun-to-comment (&optional insert-before)
   "Evaluate the \"top-level\" form and insert result as comment.

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -994,7 +994,7 @@ buffer."
                             (cider--nrepl-pr-request-map))))
 
 (defun cider-eval-list-at-point (&optional output-to-current-buffer)
-  "Evaluate the list (eg. a function call, surrounded by parens) around point.
+  "Evaluate the list (eg.  a function call, surrounded by parens) around point.
 If invoked with OUTPUT-TO-CURRENT-BUFFER, output the result to current buffer."
   (interactive "P")
   (save-excursion
@@ -1015,8 +1015,7 @@ That's set by commands like `cider-eval-last-sexp-in-context'.")
 
 
 (defun cider--guess-eval-context ()
-  "Return the context suitable for input to `cider--eval-in-context'
-by extracting all parent let bindings."
+  "Return context for `cider--eval-in-context' by extracting all parent let bindings."
   (save-excursion
     (let ((res ""))
       (condition-case er
@@ -1034,7 +1033,8 @@ by extracting all parent let bindings."
         (scan-error res)))))
 
 (defun cider--eval-in-context (bounds &optional guess)
-  "Evaluate code at BOUNDS in user-provided evaluation context."
+  "Evaluate code at BOUNDS in user-provided evaluation context.
+When GUESS is non-nil, attempt to extract the context from parent let-bindings."
   (let* ((code (string-trim-right
                 (buffer-substring-no-properties (car bounds) (cadr bounds))))
          (eval-context
@@ -1055,7 +1055,7 @@ The context is just a let binding vector (without the brackets).
 The context is remembered between command invocations.
 
 When GUESS is non-nil, or called interactively with \\[universal-argument],
-attempt to guess the context from parent let bindings."
+attempt to extract the context from parent let-bindings."
   (interactive "P")
   (cider--eval-in-context (cider-last-sexp 'bounds) guess))
 
@@ -1066,7 +1066,7 @@ The context is just a let binding vector (without the brackets).
 The context is remembered between command invocations.
 
 When GUESS is non-nil, or called interactively with \\[universal-argument],
-attempt to guess the context from parent let bindings."
+attempt to extract the context from parent let-bindings."
   (interactive "P")
   (cider--eval-in-context (cider-sexp-at-point 'bounds) guess))
 

--- a/cider-find.el
+++ b/cider-find.el
@@ -109,7 +109,7 @@ Show results in a different window if OTHER-WINDOW is true."
 (defun cider-find-dwim (symbol-file)
   "Find and display the SYMBOL-FILE at point.
 SYMBOL-FILE could be a var or a resource.  If thing at point is empty then
-show dired on project.  If var is not found, try to jump to resource of the
+show Dired on project.  If var is not found, try to jump to resource of the
 same name.  When called interactively, a prompt is given according to the
 variable `cider-prompt-for-symbol'.  A single or double prefix argument
 inverts the meaning.  A prefix of `-' or a double prefix argument causes


### PR DESCRIPTION
A little convenience function I wrote a while ago for `cider-eval-in-context` commands, for the common use case of evaluating some nested sub-expression that depends on outer let bindings.

eg:
```clj
(defn complicated-fn [xs]
  (if-let [[x & r] (seq xs)]
    (let [m {:id x}]
      (cond (pred1 x) f1
            (pred2 x)
            (let [v (str x)]
              (fn []
                (assoc m :val v) ; <-- cursor here
                ))
            (pred3 x) :something-else))
    identity))
```

Here I can call `cider-eval-last-sexp-in-context` with `C-u`, letting it automatically traverse and pick up outer let bindings. The prompt now reads
```
Evaluation context (let-style): [x & r] (seq xs), m {:id x}, v (str x), 
                               ↑
                               point here
```

with the cursor at the beginning of the prompt by default, I can fill additional context eg. `xs [5]`.


https://user-images.githubusercontent.com/22216124/165936461-c637b59b-bf04-4550-a9a6-157318b4aa06.mp4


-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
