### PR TITLE
Misc bugfixes

### DIFF
--- a/cider-eldoc.el
+++ b/cider-eldoc.el
@@ -286,7 +286,7 @@ if the maximum number of sexps to skip is exceeded."
             (error))
           (while
               (let ((p (point)))
-                (forward-sexp -1)
+                (clojure-backward-logical-sexp 1)
                 (when (< (point) p)
                   (setq num-skipped-sexps
                         (unless (and cider-eldoc-max-num-sexps-to-skip

--- a/cider-eldoc.el
+++ b/cider-eldoc.el
@@ -412,7 +412,7 @@ This includes the arglist and ns and symbol name (if available)."
                                         "type" type)))
                 ;; add context dependent args if requested by defcustom
                 ;; do not cache this eldoc info to avoid showing info
-                                        ;: of the previous context
+                ;; of the previous context
                 (if cider-eldoc-display-context-dependent-info
                     (cond
                      ;; add inputs of datomic query

--- a/cider-eldoc.el
+++ b/cider-eldoc.el
@@ -346,7 +346,7 @@ Then go back to the point and return its eldoc."
 
 (defun cider-eldoc-info-in-current-sexp ()
   "Return eldoc information from the sexp.
-If `cider-eldoc-display-for-symbol-at-poin' is non-nil and
+If `cider-eldoc-display-for-symbol-at-point' is non-nil and
 the symbol at point has a valid eldoc available, return that.
 Otherwise return the eldoc of the first symbol of the sexp."
   (or (when cider-eldoc-display-for-symbol-at-point

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -830,11 +830,15 @@ RESULT will be preceded by COMMENT-PREFIX.
 CONTINUED-PREFIX is inserted for each additional line of output.
 COMMENT-POSTFIX is inserted after final text output."
   (unless (string= result "")
-    (let ((lines (split-string result "[\n]+" t)))
+    (clojure-indent-line)
+    (let ((lines (split-string result "[\n]+" t))
+          (beg (point))
+          (col (current-indentation)))
       ;; only the first line gets the normal comment-prefix
       (insert (concat comment-prefix (pop lines)))
       (dolist (elem lines)
         (insert (concat "\n" continued-prefix elem)))
+      (indent-rigidly beg (point) col)
       (unless (string= comment-postfix "")
         (insert comment-postfix)))))
 

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -857,6 +857,8 @@ COMMENT-POSTFIX is the text to output after the last line."
        (with-current-buffer buffer
          (save-excursion
            (goto-char (marker-position location))
+           ;; edge case: defun at eob
+           (unless (bolp) (insert "\n"))
            (cider-maybe-insert-multiline-comment res comment-prefix continued-prefix comment-postfix)))
        (when cider-eval-register
          (set-register cider-eval-register res)))

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -738,6 +738,7 @@ when `cider-auto-inspect-after-eval' is non-nil."
                                  (lambda (_buffer out)
                                    (cider-emit-interactive-eval-output out))
                                  (lambda (_buffer err)
+                                   (cider-emit-interactive-eval-err-output err)
                                    (unless cider-show-error-buffer
                                      ;; Display errors as temporary overlays
                                      (let ((cider-result-use-clojure-font-lock nil))

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -823,7 +823,7 @@ comment prefix to use."
                                        (insert (concat comment-prefix
                                                        res "\n"))))
                                    (when cider-eval-register
-                                     (set-register cider-eval-register value))))))
+                                     (set-register cider-eval-register res))))))
 
 (defun cider-maybe-insert-multiline-comment (result comment-prefix continued-prefix comment-postfix)
   "Insert eval RESULT at current location if RESULT is not empty.

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -368,6 +368,7 @@ MAX-COLL-SIZE if non nil."
   (cider-inspector-render cider-inspector-buffer value)
   (cider-popup-buffer-display cider-inspector-buffer cider-inspector-auto-select-buffer)
   (when cider-inspector-fill-frame (delete-other-windows))
+  (ignore-errors (cider-inspector-next-inspectable-object 1))
   (with-current-buffer cider-inspector-buffer
     (when (eq cider-inspector-last-command 'cider-inspector-pop)
       (setq cider-inspector-last-command nil)

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -1004,7 +1004,8 @@ See \(info \"(elisp) Special Properties\")"
   (while-no-input
     (when (and (bufferp obj)
                (cider-connected-p)
-               cider-use-tooltips (not help-at-pt-display-when-idle))
+               cider-use-tooltips
+               (not (eq help-at-pt-display-when-idle t)))
       (with-current-buffer obj
         (ignore-errors
           (save-excursion

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1229,9 +1229,9 @@ command will prompt for the name of the namespace to switch to."
       ;; NOTE: `require' and `in-ns' are special forms in ClojureScript.
       ;; That's why we eval them separately instead of combining them with `do'.
       (when cider-repl-require-ns-on-set
-        (cider-nrepl-sync-request:eval (format "(require '%s)" ns) connection))
-      (cider-nrepl-request:eval (format "(in-ns '%s)" ns)
-                                (cider-repl-switch-ns-handler connection)))))
+        (cider-sync-tooling-eval (format "(require '%s)" ns) nil connection))
+      (cider-tooling-eval (format "(in-ns '%s)" ns)
+                          (cider-repl-switch-ns-handler connection)))))
 
 
 ;;; Location References

--- a/cider-test.el
+++ b/cider-test.el
@@ -188,7 +188,6 @@ Add to this list to have CIDER recognize additional test defining macros."
     ;; "run the test at point".  But it's not as nice as rerunning all tests in
     ;; this buffer.
     (define-key map "g" #'cider-test-run-test)
-    (define-key map "q" #'cider-popup-buffer-quit-function)
     (easy-menu-define cider-test-report-mode-menu map
       "Menu for CIDER's test result mode"
       '("Test-Report"
@@ -209,7 +208,7 @@ Add to this list to have CIDER recognize additional test defining macros."
         ["Display expected/actual diff" cider-test-ediff]))
     map))
 
-(define-derived-mode cider-test-report-mode fundamental-mode "Test Report"
+(define-derived-mode cider-test-report-mode cider-popup-buffer-mode "Test Report"
   "Major mode for presenting Clojure test results.
 
 \\{cider-test-report-mode-map}"


### PR DESCRIPTION
Here are some non-user-visible changes and bugs I've discovered and fixed in the past. Most should be self explanatory, in particular the cider-eval-to-comment bug concerns multiline output in `(comment)` forms, which currently produces:
```clj
(comment

  (repeat 5 "long lines of text for multiline pprint")
  ;; => ("long lines of text for multiline pprint"
;;     "long lines of text for multiline pprint"
;;     "long lines of text for multiline pprint"
;;     "long lines of text for multiline pprint"
;;     "long lines of text for multiline pprint")

  )
```
-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
