### PR TITLE
Add support for undef-all op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## New features
 
+* [#3188](https://github.com/clojure-emacs/cider/pull/3188): Add support for `undef-all` op, for removing stale vars and conflicting aliases.
+  * Add new command `cider-undef-all`.
+  * Existing commands `cider-load-buffer`, `cider-load-file`, and `cider-eval-ns-form` can be called with `C-u` prefix to execute `undef-all` before reloading the ns.
 * [#3185](https://github.com/clojure-emacs/cider/pull/3185): Add feature to `cider-eval-in-context` for automatically extracting parent let bindings when called with `C-u` prefix argument.
 * Add new interactive command `cider-inspire-me`. It does what you'd expect.
 * [#3162](https://github.com/clojure-emacs/cider/pull/3162): Save eval results into kill ring and registers.

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -1025,7 +1025,7 @@ That's set by commands like `cider-eval-last-sexp-in-context'.")
   "Return context for `cider--eval-in-context' by extracting all parent let bindings."
   (save-excursion
     (let ((res ""))
-      (condition-case er
+      (condition-case nil
           (while t
             (backward-up-list)
             (when (looking-at (rx "(" (or "when-let" "if-let" "let") (opt "*")
@@ -1045,7 +1045,7 @@ When GUESS is non-nil, attempt to extract the context from parent let-bindings."
   (let* ((code (string-trim-right
                 (buffer-substring-no-properties (car bounds) (cadr bounds))))
          (eval-context
-          (minibuffer-with-setup-hook (when guess #'beginning-of-buffer)
+          (minibuffer-with-setup-hook (if guess #'beginning-of-buffer #'ignore)
             (read-string "Evaluation context (let-style): "
                          (if guess (cider--guess-eval-context)
                            cider-previous-eval-context))))

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -1374,6 +1374,27 @@ passing arguments."
   (kill-new
    (nrepl-dict-get (cider-nrepl-sync-request:eval "*1") "value")))
 
+(defun cider-undef ()
+  "Undefine a symbol from the current ns."
+  (interactive)
+  (cider-ensure-op-supported "undef")
+  (cider-read-symbol-name
+   "Undefine symbol: "
+   (lambda (sym)
+     (cider-nrepl-send-request
+      `("op" "undef"
+        "ns" ,(cider-current-ns)
+        "sym" ,sym)
+      (cider-interactive-eval-handler (current-buffer))))))
+
+(defun cider-undef-all (&optional ns)
+  "Undefine all symbols and aliases from the namespace NS."
+  (interactive)
+  (cider-ensure-op-supported "undef-all")
+  (cider-nrepl-send-sync-request
+   `("op" "undef-all"
+     "ns" ,(or ns (cider-current-ns)))))
+
 ;; Eval keymaps
 (defvar cider-eval-pprint-commands-map
   (let ((map (define-prefix-command 'cider-eval-pprint-commands-map)))

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -158,27 +158,6 @@ the related commands `cider-repl-clear-buffer' and
       (cider-repl-clear-output))
     (switch-to-buffer origin-buffer)))
 
-(defun cider-undef ()
-  "Undefine a symbol from the current ns."
-  (interactive)
-  (cider-ensure-op-supported "undef")
-  (cider-read-symbol-name
-   "Undefine symbol: "
-   (lambda (sym)
-     (cider-nrepl-send-request
-      `("op" "undef"
-        "ns" ,(cider-current-ns)
-        "sym" ,sym)
-      (cider-interactive-eval-handler (current-buffer))))))
-
-(defun cider-undef-all (&optional ns)
-  "Undefine all symbols and aliases from the namespace NS."
-  (interactive)
-  (cider-ensure-op-supported "undef-all")
-  (cider-nrepl-send-sync-request
-   `("op" "undef-all"
-     "ns" ,(or ns (cider-current-ns)))))
-
 ;;; cider-run
 (defvar cider--namespace-history nil
   "History of user input for namespace prompts.")

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -502,6 +502,7 @@ higher precedence."
     (define-key map (kbd "C-c M-p") #'cider-insert-last-sexp-in-repl)
     (define-key map (kbd "C-c M-:") #'cider-read-and-eval)
     (define-key map (kbd "C-c C-u") #'cider-undef)
+    (define-key map (kbd "C-c C-M-u") #'cider-undef-all)
     (define-key map (kbd "C-c C-m") #'cider-macroexpand-1)
     (define-key map (kbd "C-c M-m") #'cider-macroexpand-all)
     (define-key map (kbd "C-c M-n") 'cider-ns-map)

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -171,6 +171,14 @@ the related commands `cider-repl-clear-buffer' and
         "sym" ,sym)
       (cider-interactive-eval-handler (current-buffer))))))
 
+(defun cider-undef-all (&optional ns)
+  "Undefine all symbols and aliases from the namespace NS."
+  (interactive)
+  (cider-ensure-op-supported "undef-all")
+  (cider-nrepl-send-sync-request
+   `("op" "undef-all"
+     "ns" ,(or ns (cider-current-ns)))))
+
 ;;; cider-run
 (defvar cider--namespace-history nil
   "History of user input for namespace prompts.")

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1575,7 +1575,7 @@ constructs."
   (puthash name handler cider-repl-shortcuts))
 
 (declare-function cider-toggle-trace-ns "cider-tracing")
-(declare-function cider-undef "cider-mode")
+(declare-function cider-undef "cider-eval")
 (declare-function cider-browse-ns "cider-browse-ns")
 (declare-function cider-classpath "cider-classpath")
 (declare-function cider-repl-history "cider-repl-history")

--- a/doc/modules/ROOT/pages/usage/cider_mode.adoc
+++ b/doc/modules/ROOT/pages/usage/cider_mode.adoc
@@ -123,7 +123,7 @@ kbd:[C-u C-c C-c]
 
 | `cider-eval-ns-form`
 | kbd:[C-c C-v n]
-| Eval the ns form.
+| Eval the ns form. If invoked with a prefix argument, undefine all vars and aliases in the ns first.
 
 | `cider-repl-set-ns`
 | kbd:[C-c M-n (M-)n]
@@ -151,15 +151,15 @@ kbd:[C-u C-c C-c]
 
 | `cider-load-buffer`
 | kbd:[C-c C-k]
-| Load (eval) the current buffer.
+| Load (eval) the current buffer. If invoked with a prefix argument, undefine all vars and aliases in the ns before loading.
 
 | `cider-load-file`
 | kbd:[C-c C-l]
-| Load (eval) a Clojure file.
+| Load (eval) a Clojure file. If invoked with a prefix argument, undefine all vars and aliases in the ns before loading.
 
 | `cider-load-all-files`
 | kbd:[C-c C-M-l]
-| Load (eval) all Clojure files below a directory.
+| Load (eval) all Clojure files below a directory. If invoked with a prefix argument, undefine all vars and aliases in each file before loading.
 
 | `cider-ns-refresh`
 | kbd:[C-c M-n (M-)r]
@@ -215,6 +215,10 @@ kbd:[C-c C-d C-e]
 | `cider-undef`
 | kbd:[C-c C-u]
 | Undefine a symbol. If invoked with a prefix argument it inverts the value of `cider-prompt-for-symbol`.
+
+| `cider-undef-all`
+| kbd:[C-c C-M-u]
+| Undefine all symbols and aliases in the namespace.
 
 | `cider-test-run-test`
 | kbd:[C-c C-t t] +


### PR DESCRIPTION
See https://github.com/clojure-emacs/cider-nrepl/pull/698.

Added prefix argument behaviors to `cider-load-buffer`, `-load-file`, `-load-all-files`, and `-eval-ns-form` commands, since these are likely to throw errors when some redefined namespace alias conflicts with the hidden REPL state. Conceptually something like a "hard reload".  

Also adds a standalone command `cider-undef-all`, which is somewhat less useful on its own and would usually be followed by a `load` anyway. Proposed keybinding: `C-c C-M-u` by extension of `C-c C-u`.

Also fixes a bug in my last PR #3185 (I should really avoid doing these last minute refactorings 😶) 

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
