### PR TITLE
Add emacs-28.1 to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,14 @@ jobs:
       - setup
       - test
 
+  test-emacs-28:
+    docker:
+      - image: silex/emacs:28-dev
+        entrypoint: bash
+    steps:
+      - setup
+      - test
+
   test-emacs-master:
     docker:
       - image: silex/emacs:master-dev
@@ -78,7 +86,7 @@ jobs:
 
   test-lint:
     docker:
-      - image: silex/emacs:27-dev
+      - image: silex/emacs:28-dev
     steps:
       - setup
       - lint
@@ -89,6 +97,7 @@ workflows:
     jobs:
       - test-emacs-26
       - test-emacs-27
+      - test-emacs-28
       - test-emacs-master
       - test-lint
       - test-windows-emacs-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest]
-        emacs_version: ['26.3', '27.2']
+        emacs_version: ['26.3', '27.2', '28.1']
 
     steps:
     - name: Set up Emacs
@@ -18,7 +18,7 @@ jobs:
         version: ${{matrix.emacs_version}}
 
     - name: Install Eldev
-      run: curl -fsSL https://raw.githubusercontent.com/doublep/eldev/0.10.3/webinstall/github-eldev | sh
+      run: curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/github-eldev | sh
 
     - name: Check out the source code
       uses: actions/checkout@v2

--- a/test/cider-repl-tests.el
+++ b/test/cider-repl-tests.el
@@ -97,6 +97,17 @@
           (ansi-color-map (ansi-color-make-color-map)))
      ,@body))
 
+(defmacro text-property-make (foreground-color &optional style)
+  "Return FOREGROUND-COLOR and STYLE as a text property list."
+  (if (< emacs-major-version 28)
+      (if style
+          `(quote ((foreground-color . ,foreground-color) ,style))
+        `(quote (foreground-color . ,foreground-color)))
+    (if style
+        `(quote  (,(intern (concat  "ansi-color-" (symbol-name style)))
+                  (:foreground ,foreground-color)))
+      `(quote  (:foreground ,foreground-color)))))
+
 (describe "multiple calls to cider-repl--emit-output"
   (it "Multiple emit output calls set properties and emit text"
     (with-temp-buffer
@@ -136,25 +147,25 @@
         (expect (buffer-substring-no-properties (point-min) (point-max))
                 :to-equal "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\n")
         (expect (get-text-property 1 'font-lock-face)
-                :to-equal '(foreground-color . "black"))
+                :to-equal (text-property-make "black"))
         (expect (get-text-property 3 'font-lock-face)
                 :to-equal 'cider-repl-stdout-face)
         (expect (get-text-property 5 'font-lock-face)
-                :to-equal '(foreground-color . "red3"))
+                :to-equal (text-property-make "red3"))
         (expect (get-text-property 7 'font-lock-face)
-                :to-equal '(foreground-color . "green3"))
+                :to-equal (text-property-make "green3"))
         (expect (get-text-property 9 'font-lock-face)
-                :to-equal '(foreground-color . "yellow3"))
+                :to-equal (text-property-make "yellow3"))
         (expect (get-text-property 11 'font-lock-face)
-                :to-equal '(foreground-color . "red3"))
+                :to-equal (text-property-make "red3"))
         (expect (get-text-property 13 'font-lock-face)
-                :to-equal '(foreground-color . "green3"))
+                :to-equal (text-property-make "green3"))
         (expect (get-text-property 15 'font-lock-face)
-                :to-equal '((foreground-color . "yellow3") bold))
+                :to-equal (text-property-make "yellow3" bold))
         (expect (get-text-property 17 'font-lock-face)
-                :to-equal '(foreground-color . "red3"))
+                :to-equal (text-property-make "red3"))
         (expect (get-text-property 19 'font-lock-face)
-                :to-equal '((foreground-color . "green3") italic))
+                :to-equal (text-property-make "green3" italic))
         ))))
 
 (defun simulate-cider-output (s property)


### PR DESCRIPTION
Hi,

could you please consider patch to include Emacs-28.1, the latest Emacs release, in the CI matrix (#3189). 

The changes are as folllows:
1. Include Emacs-28 in CI matrix for Linux, MacOs.
2. Use Emacs-28 for linting.
3. Update `cider/cider-repl-tests.el` to use the new ansi text properties for Emacs-28.
4. While at it, switch github macos CI to use the master `Eldev` branch for installing the same, and not the tag. `Eldev` currently requires to download the latest release Eldev package when bootstrapping, and it has to be the same version as the installation script.

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!
