### PR TITLE
Fix custom-declare-variable wider than 80 chars warning

### DIFF
--- a/cider-debug.el
+++ b/cider-debug.el
@@ -205,13 +205,15 @@ Can be toggled at any time with `\\[cider-debug-toggle-locals]'."
     (?t "trace" "trace")
     (?q "quit" "quit"))
   "A list of debugger command specs.
-Specs are in the format (KEY COMMAND-NAME DISPLAY-NAME?)
-where KEY is a character which is mapped to the command
-COMMAND-NAME is a valid debug command to be passed to the cider-nrepl middleware
-DISPLAY-NAME is the string displayed in the debugger overlay
 
-If DISPLAY-NAME is nil, that command is hidden from the overlay but still callable.
-The rest of the commands are displayed in the same order as this list."
+Specs are in the format (KEY COMMAND-NAME DISPLAY-NAME?)  where KEY is a
+character which is mapped to the command COMMAND-NAME is a valid debug
+command to be passed to the cider-nrepl middleware DISPLAY-NAME is the
+string displayed in the debugger overlay
+
+If DISPLAY-NAME is nil, that command is hidden from the overlay but still
+callable.  The rest of the commands are displayed in the same order as this
+list."
   :type '(alist :key-type character
                 :value-type (list
                              (string :tag "command name")

--- a/cider-eldoc.el
+++ b/cider-eldoc.el
@@ -45,7 +45,7 @@
   "Extra commands to be added to eldoc's safe commands list.")
 
 (defcustom cider-eldoc-max-num-sexps-to-skip 30
-  "The maximum number of sexps to skip while searching the beginning of current sexp."
+  "Max number of sexps to skip while searching the beginning of current sexp."
   :type 'integer
   :group 'cider
   :package-version '(cider . "0.10.1"))

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -1022,7 +1022,8 @@ That's set by commands like `cider-eval-last-sexp-in-context'.")
 
 
 (defun cider--guess-eval-context ()
-  "Return context for `cider--eval-in-context' by extracting all parent let bindings."
+  "Return context for `cider--eval-in-context'.
+This is done by extracting all parent let bindings."
   (save-excursion
     (let ((res ""))
       (condition-case nil

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -622,7 +622,8 @@ The value can also be t, which means to font-lock as much as possible."
   :package-version '(cider . "0.10.0"))
 
 (defcustom cider-font-lock-reader-conditionals t
-  "Apply font-locking to unused reader conditional expressions depending on the buffer CIDER connection type."
+  "Apply font-locking to unused reader conditional expressions.
+The result depends on the buffer CIDER connection type."
   :type 'boolean
   :group 'cider
   :package-version '(cider . "0.15.0"))
@@ -978,7 +979,8 @@ SYM and INFO is passed to `cider-docview-render'"
      (buffer-substring-no-properties (point-min) (1- (point))))))
 
 (defcustom cider-use-tooltips t
-  "If non-nil, CIDER displays mouse-over tooltips, as well as the `help-echo' mechanism."
+  "If non-nil, CIDER displays mouse-over tooltips.
+It does this as well as the `help-echo' mechanism."
   :group 'cider
   :type 'boolean
   :package-version '(cider "0.12.0"))

--- a/cider-repl-history.el
+++ b/cider-repl-history.el
@@ -180,7 +180,8 @@ Setting this variable to nil means no limit."
   :package-version '(cider . "0.15.0"))
 
 (defcustom cider-repl-history-display-duplicate-highest t
-  "When `cider-repl-history-display-duplicates' is nil, then display highest (most recent) duplicate items in the command history."
+  "If non-nil, then display most recent duplicate items in the command history.
+Only takes effect when `cider-repl-history-display-duplicates' is nil."
   :type 'boolean
   :package-version '(cider . "0.15.0"))
 

--- a/cider.el
+++ b/cider.el
@@ -297,7 +297,8 @@ This variable is used by `cider-connect'."
   :package-version '(cider . "0.9.0"))
 
 (defcustom cider-inject-dependencies-at-jack-in t
-  "When nil, do not inject repl dependencies (most likely nREPL middlewares) at `cider-jack-in' time."
+  "When nil, do not inject repl dependencies at `cider-jack-in' time.
+The repl dependendcies are most likely to be nREPL middlewares."
   :type 'boolean
   :safe #'booleanp
   :version '(cider . "0.11.0"))

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -111,7 +111,9 @@
   :type 'boolean)
 
 (defcustom nrepl-use-ssh-fallback-for-remote-hosts nil
-  "If non-nil, attempt to connect via ssh to remote hosts when unable to connect directly."
+  "If non-nil, Use ssh as a fallback to connect to remote hosts.
+It will attempt to connect via ssh to remote hosts when unable to connect
+directly."
   :type 'boolean)
 
 (defcustom nrepl-sync-request-timeout 10


### PR DESCRIPTION
Fixes eldev-lint byte-compilation warnings treated as errors in `eldev-lint` CI action (#3191).

warnings fixed by splitting the long lines as follows.

Feel free to suggest better shorten descriptions. I was not 100% sure what is meant by "as well as the help echo mechanism" in the `cider-user-tooltips` variable, so perhaps this needs correction.

```
eldev -dtT compile

[00:00.546]  
             In toplevel form:
             nrepl-client.el:113:1: Warning: custom-declare-variable
                 `nrepl-use-ssh-fallback-for-remote-hosts' docstring wider than 80
                 characters

[00:01.194]  
             In cider--guess-eval-context:
             cider-eval.el:1024:8: Warning: docstring wider than 80 characters

[00:01.260]  
             In toplevel form:
             cider-debug.el:191:1: Warning: custom-declare-variable
                 `cider-debug-prompt-commands' docstring wider than 80 characters

[00:01.391]  
             In toplevel form:
             cider-mode.el:624:1: Warning: custom-declare-variable
                 `cider-font-lock-reader-conditionals' docstring wider than 80 characters
[00:01.409]  cider-mode.el:980:1: Warning: custom-declare-variable `cider-use-tooltips'
                 docstring wider than 80 characters

[00:01.456]  
             In toplevel form:
             cider-repl-history.el:182:1: Warning: custom-declare-variable
                 `cider-repl-history-display-duplicate-highest' docstring wider than 80
                 characters

[00:01.610]  
             In toplevel form:
             cider.el:299:1: Warning: custom-declare-variable
                 `cider-inject-dependencies-at-jack-in' docstring wider than 80 characters
```



-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
