### PR TITLE
Revert "Inherit test-report mode from cider-popup-mode"

### DIFF
--- a/cider-test.el
+++ b/cider-test.el
@@ -188,6 +188,7 @@ Add to this list to have CIDER recognize additional test defining macros."
     ;; "run the test at point".  But it's not as nice as rerunning all tests in
     ;; this buffer.
     (define-key map "g" #'cider-test-run-test)
+    (define-key map "q" #'cider-popup-buffer-quit-function)
     (easy-menu-define cider-test-report-mode-menu map
       "Menu for CIDER's test result mode"
       '("Test-Report"
@@ -208,7 +209,7 @@ Add to this list to have CIDER recognize additional test defining macros."
         ["Display expected/actual diff" cider-test-ediff]))
     map))
 
-(define-derived-mode cider-test-report-mode cider-popup-buffer-mode "Test Report"
+(define-derived-mode cider-test-report-mode fundamental-mode "Test Report"
   "Major mode for presenting Clojure test results.
 
 \\{cider-test-report-mode-map}"


### PR DESCRIPTION
This change resulted in "Cyclic keymap inheritance" errors for some users, see #3195

I can't reproduce the error, but it seems many people are affected and it's probably not worth the breakage ultimately.
(so much for non-user-visible changes!)


-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
