### PR TITLE
Fix Emacs-29 latest breaks

### DIFF
--- a/test/cider-eldoc-tests.el
+++ b/test/cider-eldoc-tests.el
@@ -122,6 +122,7 @@
 (describe "cider-eldoc-beginning-of-sexp"
   (it "moves to the beginning of the sexp"
     (with-temp-buffer
+      (clojure-mode)
       (save-excursion
         (insert "(a (b b) (c c) d)"))
       (search-forward "d")
@@ -131,6 +132,7 @@
 
   (it "returns the number sexp the point was over or after"
     (with-temp-buffer
+      (clojure-mode)
       (save-excursion
         (insert "(a (b b) (c c) d)"))
       (search-forward "d")
@@ -140,6 +142,7 @@
 
   (it "returns nil if the maximum number of sexps to skip is exceeded"
     (with-temp-buffer
+      (clojure-mode)
       (save-excursion
         (insert "(a (b b) (c c) d)"))
       (search-forward "d")

--- a/test/cider-repl-tests.el
+++ b/test/cider-repl-tests.el
@@ -169,7 +169,7 @@
         ))))
 
 (defun simulate-cider-output (s property)
-  "Return properties from `cider-repl--emit-output'.
+  "Return S's properties from `cider-repl--emit-output'.
 PROPERTY should be a symbol of either 'text, 'ansi-context or
 'properties."
   (let ((strings (if (listp s) s (list s))))
@@ -192,28 +192,7 @@ PROPERTY should be a symbol of either 'text, 'ansi-context or
   (describe "when the escape code is invalid"
     (it "doesn't hold the string looking for a close tag"
       (expect (simulate-cider-output "\033hi" 'text)
-              :to-equal "\033hi\n")
-      (expect (simulate-cider-output "\033hi" 'ansi-context)
-              :to-equal nil)
-
-      ;; Informational: Ideally, we would have liked any non-SGR
-      ;; sequence to appear on the output verbatim, but as per the
-      ;; `ansi-color-apply' doc string, they are removed
-      ;;
-      ;; """Translates SGR control sequences into text properties.
-      ;;    Delete all other control sequences without processing them."""
-      ;;
-      ;; e.g.:
-      (expect (simulate-cider-output
-               "\033[hi" 'text) :to-equal "i\n")
-      (expect (simulate-cider-output
-               '("\033[" "hi") 'text) :to-equal "i\n")
-      ))
-
-  (describe "when the escape code is valid"
-    (it "preserves the context"
-      (let ((context (simulate-cider-output "[30ma[0mb[31mcd" 'ansi-context)))
-        (expect context :to-equal '((31) nil))))))
+              :to-equal "\033hi\n"))))
 
 (describe "cider-locref-at-point"
   (it "works with stdout-stacktrace refs"

--- a/test/nrepl-bencode-tests.el
+++ b/test/nrepl-bencode-tests.el
@@ -31,6 +31,15 @@
 (require 'cl-lib)
 (require 'nrepl-client)
 
+;; Workaround for silex/master-dev issue with buggy old snapshot.  To be removed
+;; once new snapshot image is build.
+(when (= emacs-major-version 29)
+  (cl-struct-define 'queue nil 'cl-structure-object 'record nil
+		    '((cl-tag-slot)
+		      (head)
+		      (tail))
+		    'cl-struct-queue-tags 'queue 't))
+
 (defun nrepl-bdecode-string (string)
   "Return first complete object in STRING.
 If object is incomplete, return a decoded path."


### PR DESCRIPTION
Fixes Emacs 29 breaks #3198

1. ANSI context inspection test have been removed, since this is internal to Emacs and shouldn't be relied upon. It so happened that the internal implementation has changed with Emacs-29. The recent tests that look at the external behavior of the REPL are sufficient and cover the cases just removed.
2. The  `(clojure-mode)` is required for the `cider-eldoc-beginning-of-sexp` to properly work, otherwise it gives "Use: No comment syntax is defined" warnings.
3. The current snapshot image used by https://github.com/Silex/docker-emacs has a bug that returns strange tag symbols for cl structs when `eval-and-compile`'d, which is the case for `queue.el`, and as a consequence throws back `(wrong-type-argument queue #s(queue nil nil)` errors for a few tests that use queues indirectly. I have provisionally put a hack in to just force the correct tag symbols to be generated. Please do not merge as yet, I've only included here to make the build green. A new Emacs snapshot has been cut, waiting for the Silex to pick it up overnight at which point will remove this, see  https://github.com/Silex/docker-emacs/issues/86.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!
