### PR TITLE
Allow combining all sesman sessions of a project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * [#3195](https://github.com/clojure-emacs/cider/issues/3195): Revert the change that resulted in `(error "Cyclic keymap inheritance")` on `cider-test-run-test`.
 
+* [#2946](https://github.com/clojure-emacs/cider/issues/2946): Add custom var `cider-merge-sessions` to allow combining sessions in two different ways: Setting `cider-merge-sessions` to `'host` will merge all sessions associated with the same host within a project. Setting it to `'project` will combine all sessions of a project irrespective of their host.
+
 ## 1.4.0 (2022-05-02)
 
 ## New features

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -61,6 +61,19 @@ available) and the matching REPL buffer."
   :safe #'booleanp
   :package-version '(cider . "0.9.0"))
 
+;;;###autoload
+(defcustom cider-merge-sessions nil
+  "Controls session combination behaviour.
+
+Symbol `host' combines all sessions of a project associated with the same host.
+Symbol `project' combines all sessions of a project.
+
+All other values do not combine any sessions."
+  :type 'symbol
+  :group 'cider
+  :safe #'symbolp
+  :package-version '(cider . "1.5"))
+
 (defconst cider-required-nrepl-version "0.6.0"
   "The minimum nREPL version that's known to work properly with CIDER.")
 
@@ -862,6 +875,33 @@ no linked session or there is no REPL of TYPE within the current session."
           ((listp type) (member buffer-repl-type type))
           (t (string= type buffer-repl-type)))))
 
+(defun cider--get-host-from-session (session)
+  "Returns the host associated with SESSION."
+  (plist-get (cider--gather-session-params session)
+             :host))
+
+(defun cider--make-sessions-list-with-hosts (sessions)
+  "Makes a list of SESSIONS and their hosts.
+Returns a list of the form ((session1 host1) (session2 host2) ...)."
+  (mapcar (lambda (session)
+            (list session (cider--get-host-from-session session)))
+          sessions))
+
+(defun cider--get-sessions-with-same-host (session sessions)
+  "Returns a list of SESSIONS with the same host as SESSION."
+  (mapcar #'car
+          (seq-filter (lambda (x)
+                        (string-equal (cadr x)
+                                      (cider--get-host-from-session session)))
+                      (cider--make-sessions-list-with-hosts sessions))))
+
+(defun cider--extract-connections (sessions)
+  "Returns a flattened list of all session buffers in SESSIONS."
+  (cl-reduce (lambda (x y)
+               (append x (cdr y)))
+             sessions
+             :initial-value '()))
+
 (defun cider-repls (&optional type ensure)
   "Return cider REPLs of TYPE from the current session.
 If TYPE is nil or multi, return all REPLs.  If TYPE is a list of types,
@@ -871,9 +911,24 @@ throw an error if no linked session exists."
                ((listp type)
                 (mapcar #'cider-maybe-intern type))
                ((cider-maybe-intern type))))
-        (repls (cdr (if ensure
-                        (sesman-ensure-session 'CIDER)
-                      (sesman-current-session 'CIDER)))))
+        (repls (pcase cider-merge-sessions
+                 ('host
+                  (if ensure
+                      (or (cider--extract-connections (cider--get-sessions-with-same-host
+                                                       (sesman-current-session 'CIDER)
+                                                       (sesman-current-sessions 'CIDER)))
+                          (user-error "No linked %s sessions" 'CIDER))
+                    (cider--extract-connections (cider--get-sessions-with-same-host
+                                                 (sesman-current-session 'CIDER)
+                                                 (sesman-current-sessions 'CIDER)))))
+                 ('project
+                  (if ensure
+                      (or (cider--extract-connections (sesman-current-sessions 'CIDER))
+                          (user-error "No linked %s sessions" 'CIDER))
+                    (cider--extract-connections (sesman-current-sessions 'CIDER))))
+                 (_ (cdr (if ensure
+                             (sesman-ensure-session 'CIDER)
+                           (sesman-current-session 'CIDER)))))))
     (or (seq-filter (lambda (b)
                       (cider--match-repl-type type b))
                     repls)

--- a/doc/modules/ROOT/pages/usage/managing_connections.adoc
+++ b/doc/modules/ROOT/pages/usage/managing_connections.adoc
@@ -71,10 +71,22 @@ You can add new REPLs to the current session with:
 
 A very common use-case would be to run `cider-jack-in-clj` for some project and then follow up with `cider-connect-sibling-cljs`.
 
-NOTE: Unless there are both Clojure and ClojureScript REPLs in the same session smart-dispatch commands (e.g. evaluate the code
-in the right Clojure/ClojureScript REPL, toggle between Clojure and ClojureScript REPL) won't work. A very common problem
-newcomers experience is to create a Clojure REPL and a ClojureScript REPL in separate sessions and wonder why those are not
+[NOTE]
+====
+Unless there are both Clojure and ClojureScript REPLs in the same
+session smart-dispatch commands (e.g. evaluate the code in the right
+Clojure/ClojureScript REPL, toggle between Clojure and ClojureScript REPL) won't
+work. A very common problem newcomers experience is to create a Clojure REPL and
+a ClojureScript REPL in separate sessions and wonder why those are not
 interacting properly with one another.
+
+In the case of using separate config files for the clj and cljs dependencies
+(e.g. clj dependencies in `deps.edn` and cljs dependencies in `shadow-cljs.edn`)
+it is currently impossible to group those two repls in the same session.
+However, this can be worked around with `cider-merge-sessions`. Setting it to
+`'host` will combine all sessions associated with the same host within a
+project. Setting it to `'project` will combine all sessions in the same project.
+====
 
 === Session Life-Cycle Management
 


### PR DESCRIPTION
- Makes cider-repls return the combination of all sesman sessions
  associated with a project --> allows using multiple repls with different dependency files (e.g. clojure-cli for clj files and shadow-cljs for cljs files) and have CIDER still select the correct repl without having to move the point into the repl first (see issue referenced below)
- Adds the custom var `cider-merge-sessions` for toggling the new functionality to avoid changing the defaults and allow for making it project-specific via `.dir-locals.el`

Closes clojure-emacs/cider#2946.
-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [X] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`eldev test`)
- [X] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [X] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
