### PR TITLE
Fix broken cider-eval-ns-form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * [#3195](https://github.com/clojure-emacs/cider/issues/3195): Revert the change that resulted in `(error "Cyclic keymap inheritance")` on `cider-test-run-test`.
 * [#3182](https://github.com/clojure-emacs/cider/issues/3182): Don't try to invoke
 JVM-specific code outside of JVM Clojure.
+* [#3202](https://github.com/clojure-emacs/cider/pull/3202): Fix `cider-eval-ns-form`
+  * Do not always perform `undef-all`. Undef only with `C-u` prefix.
+  * Fix extraction of namespace name.
 
 ## 1.4.0 (2022-05-02)
 

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -1333,7 +1333,7 @@ buffer, else display in a popup buffer."
 (defun cider-eval-ns-form (&optional undef-all)
   "Evaluate the current buffer's namespace form.
 When UNDEF-ALL is non-nil, unmap all symbols and aliases first."
-  (interactive "p")
+  (interactive "P")
   (when (clojure-find-ns)
     (save-excursion
       (goto-char (match-beginning 0))

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -1334,11 +1334,11 @@ buffer, else display in a popup buffer."
   "Evaluate the current buffer's namespace form.
 When UNDEF-ALL is non-nil, unmap all symbols and aliases first."
   (interactive "P")
-  (when (clojure-find-ns)
+  (when-let ((ns (clojure-find-ns)))
     (save-excursion
       (goto-char (match-beginning 0))
       (when undef-all
-        (cider-undef-all (match-string 0)))
+        (cider-undef-all ns))
       (cider-eval-defun-at-point))))
 
 (defun cider-read-and-eval (&optional value)


### PR DESCRIPTION
This pull request fixes bugs in `cider-eval-ns-form` introduced by recent addition of `undef-all` parameter:

1. There was a typo in `interactive` parameter. `"p"` is a number which evaluates to true even if it is 0. Parameter is used in `when` condition, so undef-all branch is always executed.

2. It uses magic value of `(match-string 0)`. For me it returns string `(ns` and undef fails. Probably regexp in `clojure-find-ns` was recently changed, which broke `cider-eval-ns-form` without anybody noticing. I do not think it is a good idea to rely on magic side-effects of previous functions, so I replaced match-string with return value of `cider-find-ns`.

There is a last issue with undef in general. It undefs symbols of classes which are imported by default (eg `Throwable`). But I guess this is more an issue of nrepl middleware.