### PR TITLE
Style thread-first/last with new Emacs 28 indent format

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -27,8 +27,8 @@
                               (insert-rect . defun)               ;; cl-flet
                               (cl-defun . 2)
                               (with-parsed-tramp-file-name . 2)
-                              (thread-first . 1)
-                              (thread-last . 1)))))
+                              (thread-first . 0)
+                              (thread-last . 0)))))
 
 ;; To use the bug-reference stuff, do:
 ;;     (add-hook 'text-mode-hook #'bug-reference-mode)

--- a/cider-browse-spec.el
+++ b/cider-browse-spec.el
@@ -129,7 +129,8 @@ Display TITLE at the top and SPECS are indented underneath."
       (insert (cider-propertize title 'emph) "\n")
       (dolist (spec-name specs)
         (insert (propertize "  " 'spec-name spec-name))
-        (thread-first (cider-font-lock-as-clojure spec-name)
+        (thread-first
+          (cider-font-lock-as-clojure spec-name)
           (insert-text-button 'type 'cider-browse-spec--spec)
           (button-put 'spec-name spec-name))
         (insert (propertize "\n" 'spec-name spec-name)))
@@ -148,13 +149,15 @@ Display TITLE at the top and SPECS are indented underneath."
   (cond ((stringp form)
          (if (cider--qualified-keyword-p form)
              (with-temp-buffer
-               (thread-first form
+               (thread-first
+                 form
                  (insert-text-button 'type 'cider-browse-spec--spec)
                  (button-put 'spec-name form))
                (buffer-string))
            ;; to make it easier to read replace all clojure.spec ns with s/
            ;; and remove all clojure.core ns
-           (thread-last form
+           (thread-last
+             form
              (replace-regexp-in-string "^\\(clojure.spec\\|clojure.spec.alpha\\)/" "s/")
              (replace-regexp-in-string "^\\(clojure.core\\)/" ""))))
 
@@ -168,7 +171,8 @@ Display TITLE at the top and SPECS are indented underneath."
                (format "(fn [%%] %s)" (cl-reduce #'concat (mapcar #'cider-browse-spec--pprint (cl-rest (cl-rest form)))))))
             ;; prettier (s/and )
             ((cider--spec-fn-p form-tag "and")
-             (format "(s/and\n%s)" (string-join (thread-last (cl-rest form)
+             (format "(s/and\n%s)" (string-join (thread-last
+                                                  (cl-rest form)
                                                   (mapcar #'cider-browse-spec--pprint)
                                                   (mapcar (lambda (x) (format "%s" x))))
                                                 "\n")))
@@ -176,12 +180,14 @@ Display TITLE at the top and SPECS are indented underneath."
             ((cider--spec-fn-p form-tag "or")
              (let ((name-spec-pair (seq-partition (cl-rest form) 2)))
                (format "(s/or\n%s)" (string-join
-                                     (thread-last name-spec-pair
+                                     (thread-last
+                                       name-spec-pair
                                        (mapcar (lambda (s) (format "%s %s" (cl-first s) (cider-browse-spec--pprint (cl-second s))))))
                                      "\n"))))
             ;; prettier (s/merge )
             ((cider--spec-fn-p form-tag "merge")
-             (format "(s/merge\n%s)" (string-join (thread-last (cl-rest form)
+             (format "(s/merge\n%s)" (string-join (thread-last
+                                                    (cl-rest form)
                                                     (mapcar #'cider-browse-spec--pprint)
                                                     (mapcar (lambda (x) (format "%s" x))))
                                                   "\n")))
@@ -189,13 +195,14 @@ Display TITLE at the top and SPECS are indented underneath."
             ((cider--spec-fn-p form-tag "keys")
              (let ((keys-args (seq-partition (cl-rest form) 2)))
                (format "(s/keys%s)" (thread-last
-                                        keys-args
+                                      keys-args
                                       (mapcar (lambda (s)
                                                 (let ((key-type (cl-first s))
                                                       (specs-vec (cl-second s)))
                                                   (concat "\n" key-type
                                                           " ["
-                                                          (string-join (thread-last specs-vec
+                                                          (string-join (thread-last
+                                                                         specs-vec
                                                                          (mapcar #'cider-browse-spec--pprint)
                                                                          (mapcar (lambda (x) (format "%s" x))))
                                                                        "\n")
@@ -210,7 +217,8 @@ Display TITLE at the top and SPECS are indented underneath."
                        multi-method
                        retag
                        (string-join
-                        (thread-last sub-specs
+                        (thread-last
+                          sub-specs
                           (mapcar (lambda (s)
                                     (concat "\n\n" (cl-first s) " " (cider-browse-spec--pprint (cl-second s))))))
                         "\n"))))
@@ -218,7 +226,8 @@ Display TITLE at the top and SPECS are indented underneath."
             ((cider--spec-fn-p form-tag "cat")
              (let ((name-spec-pairs (seq-partition (cl-rest form) 2)))
                (format "(s/cat %s)"
-                       (thread-last name-spec-pairs
+                       (thread-last
+                         name-spec-pairs
                          (mapcar (lambda (s)
                                    (concat "\n" (cl-first s) " " (cider-browse-spec--pprint (cl-second s)))))
                          (cl-reduce #'concat)))))
@@ -226,13 +235,15 @@ Display TITLE at the top and SPECS are indented underneath."
             ((cider--spec-fn-p form-tag "alt")
              (let ((name-spec-pairs (seq-partition (cl-rest form) 2)))
                (format "(s/alt %s)"
-                       (thread-last name-spec-pairs
+                       (thread-last
+                         name-spec-pairs
                          (mapcar (lambda (s)
                                    (concat "\n" (cl-first s) " " (cider-browse-spec--pprint (cl-second s)))))
                          (cl-reduce #'concat)))))
             ;; prettier (s/fspec )
             ((cider--spec-fn-p form-tag "fspec")
-             (thread-last (seq-partition (cl-rest form) 2)
+             (thread-last
+               (seq-partition (cl-rest form) 2)
                (cl-remove-if (lambda (s) (and (stringp (cl-second s))
                                               (string-empty-p (cl-second s)))))
                (mapcar (lambda (s)

--- a/cider-client.el
+++ b/cider-client.el
@@ -135,7 +135,8 @@ will return nil instead of \"user\"."
 (defun cider-path-to-ns (relpath)
   "Transform RELPATH to Clojure namespace.
 Remove extension and substitute \"/\" with \".\", \"_\" with \"-\"."
-  (thread-last relpath
+  (thread-last
+    relpath
     (file-name-sans-extension)
     (replace-regexp-in-string "/" ".")
     (replace-regexp-in-string "_" "-")))
@@ -147,7 +148,8 @@ command falls back to `clojure-expected-ns' in the absence of an active
 nREPL connection."
   (if (cider-connected-p)
       (let* ((path (file-truename (or path buffer-file-name)))
-             (relpath (thread-last (cider-classpath-entries)
+             (relpath (thread-last
+                        (cider-classpath-entries)
                         (seq-filter #'file-directory-p)
                         (seq-map (lambda (dir)
                                    (when (file-in-directory-p path dir)
@@ -251,22 +253,22 @@ the code.  See `cider-format-code-options` for details."
   (when format-options
     (let* ((indents-dict (when (assoc "indents" format-options)
                            (thread-last
-                               (cadr (assoc "indents" format-options))
+                             (cadr (assoc "indents" format-options))
                              (map-pairs)
                              (seq-mapcat #'identity)
                              (apply #'nrepl-dict))))
            (alias-map-dict (when (assoc "alias-map" format-options)
                              (thread-last
-                                 (cadr (assoc "alias-map" format-options))
+                               (cadr (assoc "alias-map" format-options))
                                (map-pairs)
                                (seq-mapcat #'identity)
                                (apply #'nrepl-dict)))))
       (thread-last
-          (map-merge 'list
-                     (when indents-dict
-                       `(("indents" ,indents-dict)))
-                     (when alias-map-dict
-                       `(("alias-map" ,alias-map-dict))))
+        (map-merge 'list
+                   (when indents-dict
+                     `(("indents" ,indents-dict)))
+                   (when alias-map-dict
+                     `(("alias-map" ,alias-map-dict))))
         (map-pairs)
         (seq-mapcat #'identity)
         (apply #'nrepl-dict)))))
@@ -373,9 +375,9 @@ RIGHT-MARGIN specifies the maximum column-width of the printed result, and
 is included in the request if non-nil."
   (let* ((width-option (cider--print-option "right-margin" cider-print-fn))
          (print-options (thread-last
-                            (map-merge 'hash-table
-                                       `((,width-option ,right-margin))
-                                       cider-print-options)
+                          (map-merge 'hash-table
+                                     `((,width-option ,right-margin))
+                                     cider-print-options)
                           (map-pairs)
                           (seq-mapcat #'identity)
                           (apply #'nrepl-dict))))
@@ -392,7 +394,8 @@ is included in the request if non-nil."
 
 (defun cider--nrepl-pr-request-map ()
   "Map to merge into requests that do not require pretty printing."
-  (let ((print-options (thread-last cider-print-options
+  (let ((print-options (thread-last
+                         cider-print-options
                          (map-pairs)
                          (seq-mapcat #'identity)
                          (apply #'nrepl-dict))))
@@ -579,7 +582,8 @@ Optional arguments include SEARCH-NS, DOCS-P, PRIVATES-P, CASE-SENSITIVE-P."
 (defun cider-sync-request:classpath ()
   "Return a list of classpath entries."
   (cider-ensure-op-supported "classpath")
-  (thread-first '("op" "classpath")
+  (thread-first
+    '("op" "classpath")
     (cider-nrepl-send-sync-request)
     (nrepl-dict-get "classpath")))
 
@@ -596,7 +600,8 @@ Do nothing if PATH is already absolute."
 Sometimes the classpath contains entries like src/main and we need to
 resolve those to absolute paths."
   (when (cider-runtime-clojure-p)
-    (let ((classpath (thread-first "(seq (.split (System/getProperty \"java.class.path\") \":\"))"
+    (let ((classpath (thread-first
+                       "(seq (.split (System/getProperty \"java.class.path\") \":\"))"
                        (cider-sync-tooling-eval)
                        (nrepl-dict-get "value")
                        read))
@@ -615,8 +620,8 @@ resolve those to absolute paths."
   (when-let* ((dict (thread-first `("op" "completions"
                                     "ns" ,(cider-current-ns)
                                     "prefix" ,prefix)
-                      (cider-nrepl-send-sync-request (cider-current-repl)
-                                                     'abort-on-input))))
+                                  (cider-nrepl-send-sync-request (cider-current-repl)
+                                                                 'abort-on-input))))
     (nrepl-dict-get dict "completions")))
 
 (defun cider-sync-request:complete (prefix context)
@@ -627,8 +632,8 @@ CONTEXT represents a completion context for compliment."
                                     "prefix" ,prefix
                                     "context" ,context
                                     ,@(when cider-enhanced-cljs-completion-p '("enhanced-cljs-completion?" "t")))
-                      (cider-nrepl-send-sync-request (cider-current-repl)
-                                                     'abort-on-input))))
+                                  (cider-nrepl-send-sync-request (cider-current-repl)
+                                                                 'abort-on-input))))
     (nrepl-dict-get dict "completions")))
 
 (defun cider-sync-request:complete-flush-caches ()
@@ -645,7 +650,7 @@ CONTEXT represents a completion context for compliment."
                                   ,@(when symbol `("sym" ,symbol))
                                   ,@(when class `("class" ,class))
                                   ,@(when member `("member" ,member)))
-                    (cider-nrepl-send-sync-request (cider-current-repl)))))
+                                (cider-nrepl-send-sync-request (cider-current-repl)))))
     (if (member "no-info" (nrepl-dict-get var-info "status"))
         nil
       var-info)))
@@ -656,7 +661,7 @@ CONTEXT represents a completion context for compliment."
                                   "ns" ,(cider-current-ns)
                                   ,@(when symbol `("sym" ,symbol))
                                   ,@(when lookup-fn `("lookup-fn" ,lookup-fn)))
-                    (cider-nrepl-send-sync-request (cider-current-repl)))))
+                                (cider-nrepl-send-sync-request (cider-current-repl)))))
     (if (member "lookup-error" (nrepl-dict-get var-info "status"))
         nil
       (nrepl-dict-get var-info "info"))))
@@ -668,8 +673,8 @@ CONTEXT represents a completion context for compliment."
                                      ,@(when symbol `("sym" ,symbol))
                                      ,@(when class `("class" ,class))
                                      ,@(when member `("member" ,member)))
-                       (cider-nrepl-send-sync-request (cider-current-repl)
-                                                      'abort-on-input))))
+                                   (cider-nrepl-send-sync-request (cider-current-repl)
+                                                                  'abort-on-input))))
     (if (member "no-eldoc" (nrepl-dict-get eldoc "status"))
         nil
       eldoc)))
@@ -679,7 +684,7 @@ CONTEXT represents a completion context for compliment."
   (when-let* ((eldoc (thread-first `("op" "eldoc-datomic-query"
                                      "ns" ,(cider-current-ns)
                                      ,@(when symbol `("sym" ,symbol)))
-                       (cider-nrepl-send-sync-request nil 'abort-on-input))))
+                                   (cider-nrepl-send-sync-request nil 'abort-on-input))))
     (if (member "no-eldoc" (nrepl-dict-get eldoc "status"))
         nil
       eldoc)))
@@ -692,71 +697,71 @@ returned."
   (thread-first `("op" "spec-list"
                   "filter-regex" ,filter-regex
                   "ns" ,(cider-current-ns))
-    (cider-nrepl-send-sync-request)
-    (nrepl-dict-get "spec-list")))
+                (cider-nrepl-send-sync-request)
+                (nrepl-dict-get "spec-list")))
 
 (defun cider-sync-request:spec-form (spec)
   "Get SPEC's form from registry."
   (thread-first `("op" "spec-form"
                   "spec-name" ,spec
                   "ns" ,(cider-current-ns))
-    (cider-nrepl-send-sync-request)
-    (nrepl-dict-get "spec-form")))
+                (cider-nrepl-send-sync-request)
+                (nrepl-dict-get "spec-form")))
 
 (defun cider-sync-request:spec-example (spec)
   "Get an example for SPEC."
   (thread-first `("op" "spec-example"
                   "spec-name" ,spec)
-    (cider-nrepl-send-sync-request)
-    (nrepl-dict-get "spec-example")))
+                (cider-nrepl-send-sync-request)
+                (nrepl-dict-get "spec-example")))
 
 (defun cider-sync-request:ns-list ()
   "Get a list of the available namespaces."
   (thread-first `("op" "ns-list"
                   "exclude-regexps" ,cider-filtered-namespaces-regexps)
-    (cider-nrepl-send-sync-request)
-    (nrepl-dict-get "ns-list")))
+                (cider-nrepl-send-sync-request)
+                (nrepl-dict-get "ns-list")))
 
 (defun cider-sync-request:ns-vars (ns)
   "Get a list of the vars in NS."
   (thread-first `("op" "ns-vars"
                   "ns" ,ns)
-    (cider-nrepl-send-sync-request)
-    (nrepl-dict-get "ns-vars")))
+                (cider-nrepl-send-sync-request)
+                (nrepl-dict-get "ns-vars")))
 
 (defun cider-sync-request:ns-path (ns)
   "Get the path to the file containing NS."
   (thread-first `("op" "ns-path"
                   "ns" ,ns)
-    (cider-nrepl-send-sync-request)
-    (nrepl-dict-get "path")))
+                (cider-nrepl-send-sync-request)
+                (nrepl-dict-get "path")))
 
 (defun cider-sync-request:ns-vars-with-meta (ns)
   "Get a map of the vars in NS to its metadata information."
   (thread-first `("op" "ns-vars-with-meta"
                   "ns" ,ns)
-    (cider-nrepl-send-sync-request)
-    (nrepl-dict-get "ns-vars-with-meta")))
+                (cider-nrepl-send-sync-request)
+                (nrepl-dict-get "ns-vars-with-meta")))
 
 (defun cider-sync-request:ns-load-all ()
   "Load all project namespaces."
   (thread-first '("op" "ns-load-all")
-    (cider-nrepl-send-sync-request)
-    (nrepl-dict-get "loaded-ns")))
+                (cider-nrepl-send-sync-request)
+                (nrepl-dict-get "loaded-ns")))
 
 (defun cider-sync-request:resource (name)
   "Perform nREPL \"resource\" op with resource name NAME."
   (thread-first `("op" "resource"
                   "name" ,name)
-    (cider-nrepl-send-sync-request)
-    (nrepl-dict-get "resource-path")))
+                (cider-nrepl-send-sync-request)
+                (nrepl-dict-get "resource-path")))
 
 (defun cider-sync-request:resources-list ()
   "Return a list of all resources on the classpath.
 The result entries are relative to the classpath."
   (when-let* ((resources (thread-first '("op" "resources-list")
-                           (cider-nrepl-send-sync-request)
-                           (nrepl-dict-get "resources-list"))))
+                                       (cider-nrepl-send-sync-request)
+                                       (nrepl-dict-get "resources-list"))))
     (seq-map (lambda (resource) (nrepl-dict-get resource "relpath")) resources)))
 
 (defun cider-sync-request:fn-refs (ns sym)
@@ -765,8 +770,8 @@ The result entries are relative to the classpath."
   (thread-first `("op" "fn-refs"
                   "ns" ,ns
                   "sym" ,sym)
-    (cider-nrepl-send-sync-request)
-    (nrepl-dict-get "fn-refs")))
+                (cider-nrepl-send-sync-request)
+                (nrepl-dict-get "fn-refs")))
 
 (defun cider-sync-request:fn-deps (ns sym)
   "Return a list of function deps for the function identified by NS and SYM."
@@ -774,8 +779,8 @@ The result entries are relative to the classpath."
   (thread-first `("op" "fn-deps"
                   "ns" ,ns
                   "sym" ,sym)
-    (cider-nrepl-send-sync-request)
-    (nrepl-dict-get "fn-deps")))
+                (cider-nrepl-send-sync-request)
+                (nrepl-dict-get "fn-deps")))
 
 (defun cider-sync-request:format-code (code &optional format-options)
   "Perform nREPL \"format-code\" op with CODE.
@@ -794,10 +799,10 @@ FORMAT-OPTIONS is an optional configuration map for cljfmt."
 (defun cider-sync-request:format-edn (edn right-margin)
   "Perform \"format-edn\" op with EDN and RIGHT-MARGIN."
   (let* ((request (thread-last
-                      (map-merge 'list
-                                 `(("op" "format-edn")
-                                   ("edn" ,edn))
-                                 (cider--nrepl-print-request-map right-margin))
+                    (map-merge 'list
+                               `(("op" "format-edn")
+                                 ("edn" ,edn))
+                               (cider--nrepl-print-request-map right-margin))
                     (seq-mapcat #'identity)))
          (response (cider-nrepl-send-sync-request request))
          (err (nrepl-dict-get response "err")))

--- a/cider-clojuredocs.el
+++ b/cider-clojuredocs.el
@@ -43,19 +43,20 @@
   (thread-first `("op" "clojuredocs-lookup"
                   "ns" ,ns
                   "sym" ,sym)
-    (cider-nrepl-send-sync-request)
-    (nrepl-dict-get "clojuredocs")))
+                (cider-nrepl-send-sync-request)
+                (nrepl-dict-get "clojuredocs")))
 
 (defun cider-sync-request:clojuredocs-refresh ()
   "Refresh the ClojureDocs cache."
   (thread-first '("op" "clojuredocs-refresh-cache")
-    (cider-nrepl-send-sync-request)
-    (nrepl-dict-get "status")))
+                (cider-nrepl-send-sync-request)
+                (nrepl-dict-get "status")))
 
 (defun cider-clojuredocs-replace-special (name)
   "Convert the dashes in NAME to a ClojureDocs friendly format.
 We need to handle \"?\", \".\", \"..\" and \"/\"."
-  (thread-last name
+  (thread-last
+    name
     (replace-regexp-in-string "\\?" "_q")
     (replace-regexp-in-string "\\(\\.+\\)" "_\\1")
     (replace-regexp-in-string "/" "fs")))

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -119,15 +119,18 @@ PROC-BUFFER is either server or client buffer, defaults to current buffer."
                           nrepl-server-buffer)))
         (cl-loop for l on nrepl-endpoint by #'cddr
                  do (setq params (plist-put params (car l) (cadr l))))
-        (setq params (thread-first params
+        (setq params (thread-first
+                       params
                        (plist-put :project-dir nrepl-project-dir)))
         (when (buffer-live-p server-buf)
-          (setq params (thread-first params
+          (setq params (thread-first
+                         params
                          (plist-put :server (get-buffer-process server-buf))
                          (plist-put :server-command nrepl-server-command))))
         ;; repl-specific parameters (do not pollute server params!)
         (unless (nrepl-server-p proc-buffer)
-          (setq params (thread-first params
+          (setq params (thread-first
+                         params
                          (plist-put :session-name cider-session-name)
                          (plist-put :repl-type cider-repl-type)
                          (plist-put :cljs-repl-type cider-cljs-repl-type)
@@ -154,7 +157,8 @@ buffer."
         (cider--close-buffer nrepl-tunnel-buffer))
       (when no-kill
         ;; inform sentinel not to kill the server, if any
-        (thread-first (get-buffer-process repl)
+        (thread-first
+          (get-buffer-process repl)
           (process-plist)
           (plist-put :keep-server t))))
     (let ((proc (get-buffer-process repl)))
@@ -343,7 +347,8 @@ process buffer."
   "Retrieve the underlying connection's Java version."
   (with-current-buffer (cider-current-repl)
     (when nrepl-versions
-      (thread-first nrepl-versions
+      (thread-first
+        nrepl-versions
         (nrepl-dict-get "java")
         (nrepl-dict-get "version-string")))))
 
@@ -351,7 +356,8 @@ process buffer."
   "Retrieve the underlying connection's Clojure version."
   (with-current-buffer (cider-current-repl)
     (when nrepl-versions
-      (thread-first nrepl-versions
+      (thread-first
+        nrepl-versions
         (nrepl-dict-get "clojure")
         (nrepl-dict-get "version-string")))))
 
@@ -359,7 +365,8 @@ process buffer."
   "Retrieve the underlying connection's nREPL version."
   (with-current-buffer (cider-current-repl)
     (when nrepl-versions
-      (thread-first nrepl-versions
+      (thread-first
+        nrepl-versions
         (nrepl-dict-get "nrepl")
         (nrepl-dict-get "version-string")))))
 
@@ -443,7 +450,8 @@ entire session."
   (let* ((repl (or repl
                    (sesman-browser-get 'object)
                    (cider-current-repl nil 'ensure)))
-         (params (thread-first ()
+         (params (thread-first
+                   ()
                    (cider--gather-connect-params repl)
                    (plist-put :session-name (sesman-session-name-for-object 'CIDER repl))
                    (plist-put :repl-buffer repl))))
@@ -535,7 +543,8 @@ REPL defaults to the current REPL."
                               (process-put proc :cached-classpath cp)
                               cp)))
              (classpath-roots (or (process-get proc :cached-classpath-roots)
-                                  (let ((cp (thread-last classpath
+                                  (let ((cp (thread-last
+                                              classpath
                                               (seq-filter (lambda (path) (not (string-match-p "\\.jar$" path))))
                                               (mapcar #'file-name-directory)
                                               (seq-remove  #'null)
@@ -604,7 +613,8 @@ Fallback on `cider' command."
              ;; 4) restart the repls reusing the buffer
              (dolist (r repls)
                (cider-nrepl-connect
-                (thread-first ()
+                (thread-first
+                  ()
                   (cider--gather-connect-params r)
                   ;; server params (:port, :project-dir etc) have precedence
                   (cider--gather-connect-params server-buf)
@@ -616,7 +626,8 @@ Fallback on `cider' command."
       (dolist (r repls)
         (cider--close-connection r 'no-kill)
         (cider-nrepl-connect
-         (thread-first ()
+         (thread-first
+           ()
            (cider--gather-connect-params r)
            (plist-put :session-name ses-name)
            (plist-put :repl-buffer r)))))))
@@ -673,7 +684,8 @@ removed."
          (ses-name (or (plist-get params :session-name)
                        (format-spec cider-session-name-template specs)))
          (specs (append `((?s . ,ses-name)) specs)))
-    (thread-last (format-spec template specs)
+    (thread-last
+      (format-spec template specs)
       ;; remove extraneous separators
       (replace-regexp-in-string "\\([:-]\\)[:-]+" "\\1")
       (replace-regexp-in-string "\\(^[:-]\\)\\|\\([:-]$\\)" "")

--- a/cider-debug.el
+++ b/cider-debug.el
@@ -107,7 +107,7 @@ configure `cider-debug-prompt' instead."
   "List all instrumented definitions."
   (interactive)
   (if-let* ((all (thread-first (cider-nrepl-send-sync-request '("op" "debug-instrumented-defs"))
-                   (nrepl-dict-get "list"))))
+                               (nrepl-dict-get "list"))))
       (with-current-buffer (cider-popup-buffer cider-browse-ns-buffer t)
         (let ((inhibit-read-only t))
           (erase-buffer)
@@ -147,9 +147,9 @@ configure `cider-debug-prompt' instead."
   "Initialize a connection with the cider.debug middleware."
   (cider-nrepl-send-request
    (thread-last
-       (map-merge 'list
-                  '(("op" "init-debugger"))
-                  (cider--nrepl-print-request-map fill-column))
+     (map-merge 'list
+                '(("op" "init-debugger"))
+                (cider--nrepl-print-request-map fill-column))
      (seq-mapcat #'identity))
    #'cider--debug-response-handler))
 

--- a/cider-eldoc.el
+++ b/cider-eldoc.el
@@ -107,7 +107,8 @@ mapping `cider-eldoc-ns-function' on it returns an empty list."
      ((and cider-eldoc-max-class-names-to-display
            (> eldoc-class-names-length cider-eldoc-max-class-names-to-display))
       (format "(%s & %s more)"
-              (thread-first eldoc-class-names
+              (thread-first
+                eldoc-class-names
                 (seq-take cider-eldoc-max-class-names-to-display)
                 (string-join " ")
                 (cider-propertize 'ns))
@@ -116,7 +117,8 @@ mapping `cider-eldoc-ns-function' on it returns an empty list."
      ;; format the whole list but add surrounding parentheses
      ((> eldoc-class-names-length 1)
       (format "(%s)"
-              (thread-first eldoc-class-names
+              (thread-first
+                eldoc-class-names
                 (string-join " ")
                 (cider-propertize 'ns))))
 
@@ -447,10 +449,10 @@ Only useful for interop forms.  Clojure forms would be returned unchanged."
                             "inputs")))
         (if query-inputs
             (thread-first
-                (thread-last arglists
-                  (car)
-                  (remove "&")
-                  (remove "inputs"))
+              (thread-last arglists
+                           (car)
+                           (remove "&")
+                           (remove "inputs"))
               (append (car query-inputs))
               (list))
           arglists))

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -485,9 +485,9 @@ into a new error buffer."
   (let (causes)
     (cider-nrepl-send-request
      (thread-last
-         (map-merge 'list
-                    '(("op" "stacktrace"))
-                    (cider--nrepl-print-request-map fill-column))
+       (map-merge 'list
+                  '(("op" "stacktrace"))
+                  (cider--nrepl-print-request-map fill-column))
        (seq-mapcat #'identity))
      (lambda (response)
        ;; While the return value of `cider--handle-stacktrace-response' is not

--- a/cider-format.el
+++ b/cider-format.el
@@ -68,8 +68,9 @@ Uses the following heuristic to try to maintain point position:
              (pos-max (1+ (buffer-size)))
              (l 64)
              (endp (> (+ pos l) pos-max))
-             (snippet (thread-last (buffer-substring-no-properties
-                                    pos (min (+ pos l) pos-max))
+             (snippet (thread-last
+                        (buffer-substring-no-properties
+                         pos (min (+ pos l) pos-max))
                         (regexp-quote)
                         (replace-regexp-in-string "[[:space:]\t\n\r]+" "[[:space:]\t\n\r]*"))))
         (delete-region start end)

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -287,63 +287,63 @@ current-namespace."
 (defun cider-sync-request:inspect-pop ()
   "Move one level up in the inspector stack."
   (thread-first '("op" "inspect-pop")
-    (cider-nrepl-send-sync-request cider-inspector--current-repl)
-    (nrepl-dict-get "value")))
+                (cider-nrepl-send-sync-request cider-inspector--current-repl)
+                (nrepl-dict-get "value")))
 
 (defun cider-sync-request:inspect-push (idx)
   "Inspect the inside value specified by IDX."
   (thread-first `("op" "inspect-push"
                   "idx" ,idx)
-    (cider-nrepl-send-sync-request cider-inspector--current-repl)
-    (nrepl-dict-get "value")))
+                (cider-nrepl-send-sync-request cider-inspector--current-repl)
+                (nrepl-dict-get "value")))
 
 (defun cider-sync-request:inspect-refresh ()
   "Re-render the currently inspected value."
   (thread-first '("op" "inspect-refresh")
-    (cider-nrepl-send-sync-request cider-inspector--current-repl)
-    (nrepl-dict-get "value")))
+                (cider-nrepl-send-sync-request cider-inspector--current-repl)
+                (nrepl-dict-get "value")))
 
 (defun cider-sync-request:inspect-next-page ()
   "Jump to the next page in paginated collection view."
   (thread-first '("op" "inspect-next-page")
-    (cider-nrepl-send-sync-request cider-inspector--current-repl)
-    (nrepl-dict-get "value")))
+                (cider-nrepl-send-sync-request cider-inspector--current-repl)
+                (nrepl-dict-get "value")))
 
 (defun cider-sync-request:inspect-prev-page ()
   "Jump to the previous page in paginated collection view."
   (thread-first '("op" "inspect-prev-page")
-    (cider-nrepl-send-sync-request cider-inspector--current-repl)
-    (nrepl-dict-get "value")))
+                (cider-nrepl-send-sync-request cider-inspector--current-repl)
+                (nrepl-dict-get "value")))
 
 (defun cider-sync-request:inspect-set-page-size (page-size)
   "Set the page size in paginated view to PAGE-SIZE."
   (thread-first `("op" "inspect-set-page-size"
                   "page-size" ,page-size)
-    (cider-nrepl-send-sync-request cider-inspector--current-repl)
-    (nrepl-dict-get "value")))
+                (cider-nrepl-send-sync-request cider-inspector--current-repl)
+                (nrepl-dict-get "value")))
 
 (defun cider-sync-request:inspect-set-max-atom-length (max-length)
   "Set the max length of nested atoms to MAX-LENGTH."
   (thread-first `("op" "inspect-set-max-atom-length"
                   "max-atom-length" ,max-length)
-    (cider-nrepl-send-sync-request cider-inspector--current-repl)
-    (nrepl-dict-get "value")))
+                (cider-nrepl-send-sync-request cider-inspector--current-repl)
+                (nrepl-dict-get "value")))
 
 (defun cider-sync-request:inspect-set-max-coll-size (max-size)
   "Set the number of nested collection members to display before truncating.
 MAX-SIZE is the new value."
   (thread-first `("op" "inspect-set-max-coll-size"
                   "max-coll-size" ,max-size)
-    (cider-nrepl-send-sync-request cider-inspector--current-repl)
-    (nrepl-dict-get "value")))
+                (cider-nrepl-send-sync-request cider-inspector--current-repl)
+                (nrepl-dict-get "value")))
 
 (defun cider-sync-request:inspect-def-current-val (ns var-name)
   "Defines a var with VAR-NAME in NS with the current inspector value."
   (thread-first `("op" "inspect-def-current-value"
                   "ns" ,ns
                   "var-name" ,var-name)
-    (cider-nrepl-send-sync-request cider-inspector--current-repl)
-    (nrepl-dict-get "value")))
+                (cider-nrepl-send-sync-request cider-inspector--current-repl)
+                (nrepl-dict-get "value")))
 
 (defun cider-sync-request:inspect-expr (expr ns page-size max-atom-length max-coll-size)
   "Evaluate EXPR in context of NS and inspect its result.
@@ -358,8 +358,8 @@ MAX-COLL-SIZE if non nil."
                               `("max-atom-length" ,max-atom-length))
                           ,@(when max-coll-size
                               `("max-coll-size" ,max-coll-size))))
-    (cider-nrepl-send-sync-request cider-inspector--current-repl)
-    (nrepl-dict-get "value")))
+                (cider-nrepl-send-sync-request cider-inspector--current-repl)
+                (nrepl-dict-get "value")))
 
 ;; Render Inspector from Structured Values
 (defun cider-inspector--render-value (value)

--- a/cider-macroexpansion.el
+++ b/cider-macroexpansion.el
@@ -69,10 +69,10 @@ The default for DISPLAY-NAMESPACES is taken from
                   "ns" ,(cider-current-ns)
                   "display-namespaces" ,(or display-namespaces
                                             (symbol-name cider-macroexpansion-display-namespaces)))
-    (nconc (when cider-macroexpansion-print-metadata
-             '("print-meta" "true")))
-    (cider-nrepl-send-sync-request)
-    (nrepl-dict-get "expansion")))
+                (nconc (when cider-macroexpansion-print-metadata
+                         '("print-meta" "true")))
+                (cider-nrepl-send-sync-request)
+                (nrepl-dict-get "expansion")))
 
 (defun cider-macroexpand-undo (&optional arg)
   "Undo the last macroexpansion, using `undo-only'.

--- a/cider-ns.el
+++ b/cider-ns.el
@@ -256,13 +256,13 @@ refresh functions (defined in `cider-ns-refresh-before-fn' and
             (cider-nrepl-send-sync-request '("op" "refresh-clear") conn))
           (cider-nrepl-send-request
            (thread-last
-               (map-merge 'list
-                          `(("op" ,(if refresh-all? "refresh-all" "refresh")))
-                          (cider--nrepl-print-request-map fill-column)
-                          (when (and (not inhibit-refresh-fns) cider-ns-refresh-before-fn)
-                            `(("before" ,cider-ns-refresh-before-fn)))
-                          (when (and (not inhibit-refresh-fns) cider-ns-refresh-after-fn)
-                            `(("after" ,cider-ns-refresh-after-fn))))
+             (map-merge 'list
+                        `(("op" ,(if refresh-all? "refresh-all" "refresh")))
+                        (cider--nrepl-print-request-map fill-column)
+                        (when (and (not inhibit-refresh-fns) cider-ns-refresh-before-fn)
+                          `(("before" ,cider-ns-refresh-before-fn)))
+                        (when (and (not inhibit-refresh-fns) cider-ns-refresh-after-fn)
+                          `(("after" ,cider-ns-refresh-after-fn))))
              (seq-mapcat #'identity))
            (lambda (response)
              (cider-ns-refresh--handle-response response log-buffer))

--- a/cider-popup.el
+++ b/cider-popup.el
@@ -46,7 +46,7 @@ If major MODE is non-nil, enable it for the popup buffer.
 If ANCILLARY is non-nil, the buffer is added to `cider-ancillary-buffers'
 and automatically removed when killed."
   (thread-first (cider-make-popup-buffer name mode ancillary)
-    (cider-popup-buffer-display select)))
+                (cider-popup-buffer-display select)))
 
 (defun cider-popup-buffer-display (buffer &optional select)
   "Display BUFFER.

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -272,12 +272,13 @@ Run CALLBACK once the evaluation is complete."
     (cider-nrepl-request:eval
      ;; Ensure we evaluate _something_ so the initial namespace is correctly set
      (thread-first (or cider-repl-init-code '("nil"))
-       (string-join "\n"))
+                   (string-join "\n"))
      (cider-repl-init-eval-handler callback)
      nil
      (line-number-at-pos (point))
      (cider-column-number-at-pos (point))
-     (thread-last request
+     (thread-last
+       request
        (map-pairs)
        (seq-mapcat #'identity)))))
 
@@ -1039,7 +1040,7 @@ If NEWLINE is true then add a newline at the end of the input."
          (line-number-at-pos input-start)
          (cider-column-number-at-pos input-start)
          (thread-last
-             (cider--repl-request-map fill-column)
+           (cider--repl-request-map fill-column)
            (map-pairs)
            (seq-mapcat #'identity)))))))
 

--- a/cider-test.el
+++ b/cider-test.el
@@ -271,12 +271,12 @@ prompt and whether to use a new window.  Similar to `cider-find-var'."
   (let (causes)
     (cider-nrepl-send-request
      (thread-last
-         (map-merge 'list
-                    `(("op" "test-stacktrace")
-                      ("ns" ,ns)
-                      ("var" ,var)
-                      ("index" ,index))
-                    (cider--nrepl-print-request-map fill-column))
+       (map-merge 'list
+                  `(("op" "test-stacktrace")
+                    ("ns" ,ns)
+                    ("var" ,var)
+                    ("index" ,index))
+                  (cider--nrepl-print-request-map fill-column))
        (seq-mapcat #'identity))
      (lambda (response)
        (nrepl-dbind-response response (class status)
@@ -397,7 +397,8 @@ With the actual value, the outermost '(not ...)' s-expression is removed."
                   (insert (format "%12s" s)))
                 (insert-rect (s)
                   (let ((start (point)))
-                    (insert-rectangle (thread-first s
+                    (insert-rectangle (thread-first
+                                        s
                                         cider-font-lock-as-clojure
                                         (split-string "\n")))
                     (ansi-color-apply-on-region start (point)))

--- a/cider-tracing.el
+++ b/cider-tracing.el
@@ -37,7 +37,7 @@
   (thread-first `("op" "toggle-trace-var"
                   "ns" ,(cider-current-ns)
                   "sym" ,sym)
-    (cider-nrepl-send-sync-request)))
+                (cider-nrepl-send-sync-request)))
 
 (defun cider--toggle-trace-var (sym)
   "Toggle var tracing for SYM."
@@ -65,7 +65,7 @@ opposite of what that option dictates."
   "Toggle namespace tracing for NS."
   (thread-first `("op" "toggle-trace-ns"
                   "ns" ,ns)
-    (cider-nrepl-send-sync-request)))
+                (cider-nrepl-send-sync-request)))
 
 ;;;###autoload
 (defun cider-toggle-trace-ns (query)

--- a/cider-util.el
+++ b/cider-util.el
@@ -134,7 +134,8 @@ keywords."
           (if (member str '("." ".."))
               str
             ;; Remove prefix quotes, and trailing . from constructors like Record.
-            (thread-last str
+            (thread-last
+              str
               ;; constructors (Foo.)
               (string-remove-suffix ".")
               ;; quoted symbols ('sym)

--- a/cider.el
+++ b/cider.el
@@ -487,7 +487,8 @@ returned by this function does not include keyword arguments."
                                ("mx.cider/enrich-classpath" "1.9.0")))
                    (append cider-jack-in-lein-plugins
                            `(("cider/cider-nrepl" ,cider-injected-middleware-version))))))
-    (thread-last plugins
+    (thread-last
+      plugins
       (seq-filter
        (lambda (spec)
          (if-let* ((pred (plist-get (seq-drop spec 2) :predicate)))
@@ -519,7 +520,8 @@ Added to `cider-jack-in-nrepl-middlewares' (which see) when doing
   "Return a normalized list of middleware variable names.
 See `cider-jack-in-nrepl-middlewares' for the format, except that the list
 returned by this function only contains strings."
-  (thread-last cider-jack-in-nrepl-middlewares
+  (thread-last
+    cider-jack-in-nrepl-middlewares
     (seq-filter
      (lambda (spec)
        (or (not (listp spec))
@@ -619,7 +621,8 @@ Does so by concatenating DEPENDENCIES and GLOBAL-OPTIONS into a suitable
 `clojure` invocation.  The main is placed in an inline alias :cider/nrepl
 so that if your aliases contain any mains, the cider/nrepl one will be the
 one used."
-  (let* ((all-deps (thread-last dependencies
+  (let* ((all-deps (thread-last
+                     dependencies
                      (append (cider--jack-in-required-dependencies))
                      ;; Duplicates are never OK since they would result in
                      ;; `java.lang.IllegalArgumentException: Duplicate key [...]`:
@@ -1087,7 +1090,8 @@ PARAMS is a plist optionally containing :project-dir and :jack-in-cmd.
 With the prefix argument, allow editing of the jack in command; with a
 double prefix prompt for all these parameters."
   (interactive "P")
-  (let ((params (thread-first params
+  (let ((params (thread-first
+                  params
                   (cider--update-project-dir)
                   (cider--check-existing-session)
                   (cider--update-jack-in-cmd))))
@@ -1110,7 +1114,8 @@ these parameters."
         (cider-jack-in-nrepl-middlewares (append cider-jack-in-nrepl-middlewares cider-jack-in-cljs-nrepl-middlewares))
         (orig-buffer (current-buffer)))
     ;; cider--update-jack-in-cmd relies indirectly on the above dynamic vars
-    (let ((params (thread-first params
+    (let ((params (thread-first
+                    params
                     (cider--update-project-dir)
                     (cider--check-existing-session)
                     (cider--update-jack-in-cmd))))
@@ -1135,7 +1140,8 @@ only when the ClojureScript dependencies are met."
         (cider-jack-in-nrepl-middlewares (append cider-jack-in-nrepl-middlewares cider-jack-in-cljs-nrepl-middlewares))
         (orig-buffer (current-buffer)))
     ;; cider--update-jack-in-cmd relies indirectly on the above dynamic vars
-    (let ((params (thread-first params
+    (let ((params (thread-first
+                    params
                     (cider--update-project-dir)
                     (cider--check-existing-session)
                     (cider--update-jack-in-cmd)
@@ -1166,7 +1172,8 @@ server is created."
           (other-params (cider--gather-connect-params nil other-repl))
           (ses-name (unless (nrepl-server-p other-repl)
                       (sesman-session-name-for-object 'CIDER other-repl))))
-     (thread-first params
+     (thread-first
+       params
        (cider--update-do-prompt)
        (append other-params)
        (plist-put :repl-init-function nil)
@@ -1186,7 +1193,8 @@ server buffer, in which case a new session for that server is created."
          (ses-name (unless (nrepl-server-p other-repl)
                      (sesman-session-name-for-object 'CIDER other-repl))))
     (cider-nrepl-connect
-     (thread-first params
+     (thread-first
+       params
        (cider--update-do-prompt)
        (append other-params)
        (cider--update-cljs-type)
@@ -1201,7 +1209,8 @@ PARAMS is a plist optionally containing :host, :port and :project-dir.  On
 prefix argument, prompt for all the parameters."
   (interactive "P")
   (cider-nrepl-connect
-   (thread-first params
+   (thread-first
+     params
      (cider--update-project-dir)
      (cider--update-host-port)
      (cider--check-existing-session)
@@ -1217,7 +1226,8 @@ PARAMS is a plist optionally containing :host, :port, :project-dir and
 parameters regardless of their supplied or default values."
   (interactive "P")
   (cider-nrepl-connect
-   (thread-first params
+   (thread-first
+     params
      (cider--update-project-dir)
      (cider--update-host-port)
      (cider--check-existing-session)
@@ -1233,7 +1243,8 @@ PARAMS is a plist optionally containing :host, :port, :project-dir and
 :cljs-repl-type (e.g. Node, Figwheel, etc).  When SOFT-CLJS-START is
 non-nil, don't start if ClojureScript requirements are not met."
   (interactive "P")
-  (let* ((params (thread-first params
+  (let* ((params (thread-first
+                   params
                    (cider--update-project-dir)
                    (cider--update-host-port)
                    (cider--check-existing-session)
@@ -1301,7 +1312,8 @@ non-nil, don't start if ClojureScript requirements are not met."
             (setq-local buffer-file-name nil))
           (let ((default-directory proj-dir))
             (hack-dir-local-variables-non-file-buffer)
-            (thread-first params
+            (thread-first
+              params
               (plist-put :project-dir proj-dir)
               (plist-put :--context-buffer (current-buffer)))))))))
 
@@ -1388,7 +1400,8 @@ non-nil, don't start if ClojureScript requirements are not met."
                          (cider-select-endpoint)))))
       (if (equal "local-unix-domain-socket" (car endpoint))
           (plist-put params :socket-file (cdr endpoint))
-        (thread-first params
+        (thread-first
+          params
           (plist-put :host (car endpoint))
           (plist-put :port (cdr endpoint)))))))
 
@@ -1398,7 +1411,8 @@ non-nil, don't start if ClojureScript requirements are not met."
                            (current-buffer))
     (let* ((cljs-type (plist-get params :cljs-repl-type))
            (repl-init-form (cider-cljs-repl-form cljs-type)))
-      (thread-first params
+      (thread-first
+        params
         (plist-put :repl-init-function
                    (lambda ()
                      (cider--check-cljs cljs-type)

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -576,7 +576,8 @@ If NO-ERROR is non-nil, show messages instead of throwing an error."
         (error "[nREPL] SSH port forwarding failed.  Check the '%s' buffer" tunnel-buf)
       (message "[nREPL] SSH port forwarding established to localhost:%s" port)
       (let ((endpoint (nrepl--direct-connect "localhost" port)))
-        (thread-first endpoint
+        (thread-first
+          endpoint
           (plist-put :tunnel tunnel)
           (plist-put :remote-host host))))))
 
@@ -1301,7 +1302,8 @@ EVENT gives the button position on window."
   "Return the color to use when pretty-printing the nREPL message with ID.
 If ID is nil, return nil."
   (when id
-    (thread-first (string-to-number id)
+    (thread-first
+      (string-to-number id)
       (mod (length nrepl-message-colors))
       (nth nrepl-message-colors))))
 


### PR DESCRIPTION
Hi,

could you please consider patch to change the indentation style for `thread-first` and `thread-last` to `(indent 0)` from `(indent 1)`  throughout the cider code? (fixes #3204). These are non-functional changes.

An [Emacs 28 change](https://git.savannah.gnu.org/cgit/emacs.git/commit/?id=2a736738095c313ccef07d074aac4c5467b750e0) has switched the indentation style for these two functions to `0`, and this means that any new code with `thread-*` is most likely to be formatted using the now default style `0` while the user is typing the code.

The linter though is instructed in `.dir-locals.el` to look for style `1`, and as such it will issue a warning, though the user will have no clue where the indentation warning is coming from (as far as they are concerned Emacs 28 has formatted the sexp fine).

With this patch, we instruct the linter to switch to style `0`, and also make all the necessary changes in the cider code to conform to that style. It turns out this is a lot of indentation changes to the existing code.

The alternative is to keep the old style `1` when indenting the code, this will mean Emacs will indent the functions with style `1`, and thus the linter will be happy. This can be done by just adding the following line to `.dir-locals.el` (just showing thread-first here):

```
(eval . (put 'thread-first 'lisp-indent-function 1))
```

Let me know what you think, I prefer more the current patch so that we are compatible with latest Emacs changes (although I don't like there was a sudden switch to `0` out of the blue).

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

