### PR TITLE
Allow ignoring top-level comments in eval-defun-up-to-point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+## New features
+
+* Add `cider-eval-defun-up-to-point-in-comment` which when set to true makes `cider-eval-defun-up-to-point` ignore top-level comment blocks and treats the next-to-top-level form before point as top-level.
+
 ## 1.4.1 (2022-05-25)
 
 ## Changes


### PR DESCRIPTION
Adds custom var cider-eval-defun-up-to-point-in-comment to make
cider-eval-defun-up-to-point ignore top-level comments and treat
the form before point as top-level.

To try it out:
- Set `cider-eval-defun-up-to-point-in-comment` (suggestions for a better name welcome) to `t`
- Go to a comment form and put point at the `^`
```
(comment
  (* 5 25)
  (let [b "str"]
    (-> b
        keyword^
        name))
  *e)
```
- Execute `cider-eval-defun-up-to-point`
- Return value of `:str` instead of `nil`

Not sure how to write tests for this, but it seems none of the eval commands in `cider-eval.el` have tests so maybe that is okay?
I did not add a section to the user manual since the command itself only shows up in a table. I can write something up though if it is deemed necessary.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`eldev test`)
- [X] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
