### PR TITLE
Add tip to docs for evaluating in comments

### DIFF
--- a/doc/modules/ROOT/pages/usage/code_evaluation.adoc
+++ b/doc/modules/ROOT/pages/usage/code_evaluation.adoc
@@ -302,6 +302,44 @@ You can also use the command `cider-kill-last-result`(kbd:[C-c C-v k]) after any
 eval command to store its result in the kill ring. This works even when the
 `cider-eval-register` feature is disabled.
 
+=== Evaluating inside comments
+
+By default, when using the defun-style eval commands inside a comment the return value is always `nil`. Calling `cider-eval-defun-up-to-point` with point at `<point>` also returns `nil`:
+
+[source,clojure]
+----
+(comment
+  (let [b "str"]
+    (-> b
+        keyword<point> ;;=> nil
+        name))
+  *e)
+----
+
+However, as it is often desirable to treat the form the point is in as if was not inside a comment, `clojure-mode` supplies the variable `clojure-toplevel-inside-comment-form`. If this variable is set to `t` then instead of `nil` we get:
+
+[source,clojure]
+----
+(comment
+  (let [b "str"]
+    (-> b
+        keyword<point> ;;=> :str
+        name))
+  *e)
+----
+
+With `cider-eval-defun-at-point` we get:
+
+[source,clojure]
+----
+(comment
+  (let [b "str"]
+    (-> b
+        keyword<point>
+        name));;=> "str"
+  *e)
+----
+
 
 == Keybindings
 


### PR DESCRIPTION
Document clojure-toplevel-inside-comment-form for changing the
behaviour of defun-style commands.

Result of #3213.

@yuhan0 is this expressive enough or should I add a codeblock to demonstrate?

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
