### PR TITLE
Support the Gradle wrapper for jack-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 * Upgrade injected `cider-nrepl` to [0.28.5](https://github.com/clojure-emacs/cider-nrepl/releases/tag/v0.28.5).
 * [#3200](https://github.com/clojure-emacs/cider/issues/3200): Improve cider-browse-ns interface to allow selective hiding of var types as well as grouping options.  Include private vars in result list.
+* Changed default `cider-gradle-command` to `./gradlew` to use the Gradle wrapper
+* Changed default `cider-gradle-global-options` to `""` (empty, formerly `--no-daemon`)
 
 ## 1.4.1 (2022-05-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [#3226](https://github.com/clojure-emacs/cider/pull/3226): Populate completions metadata, making it possible to change the style of completion via `completion-category-override` or `completion-category-defaults`.
 - [#2946](https://github.com/clojure-emacs/cider/issues/2946): Add custom var `cider-merge-sessions` to allow combining sessions in two different ways: Setting `cider-merge-sessions` to `'host` will merge all sessions associated with the same host within a project. Setting it to `'project` will combine all sessions of a project irrespective of their host.
+- Support Gradle jack-in via the Gradle wrapper, instead of just a globally installed `gradle` on the `PATH`.
 
 ## Changes
 

--- a/cider.el
+++ b/cider.el
@@ -196,7 +196,7 @@ By default we favor the project-specific shadow-cljs over the system-wide."
   :package-version '(cider . "0.10.0"))
 
 (defcustom cider-gradle-global-options
-  "--no-daemon"
+  ""
   "Command line options used to execute Gradle (e.g.: -m for dry run)."
   :type 'string
   :safe #'stringp

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -175,9 +175,9 @@ wait`)
 
 ==== Gradle Options
 
-* `cider-gradle-command` - the name of the Gradle executable (`gradle` by default)
-* `cider-gradle-parameters`
-* `cider-gradle-global-options`
+* `cider-gradle-command` - the name of the Gradle executable (`./gradlew` by default)
+* `cider-gradle-parameters` - the Gradle arguments to invoke the repl task (`clojureRepl` by default)
+* `cider-gradle-global-options` - these are usually global options to gradle, such as `--no-daemon` or `--configuration-cache` (empty by default)
 
 ==== shadow-cljs
 

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -525,6 +525,23 @@
               :to-equal
               "(do (require '[shadow.cljs.devtools.api :as shadow]) (shadow/watch :client-build) (shadow/watch :other-build) (shadow/nrepl-select :client-build))"))))
 
+(describe "cider--resolve-project-command"
+  (it "if command starts with ./ it resolves relative to clojure-project-dir"
+    (spy-on 'locate-file :and-return-value "/project/command")
+    (spy-on 'executable-find :and-return-value "/bin/command")
+    (expect (cider--resolve-project-command "./command")
+            :to-equal "/project/command"))
+  (it "if command starts with ../ it resolves relative to clojure-project-dir"
+    (spy-on 'locate-file :and-return-value "/project/command")
+    (spy-on 'executable-find :and-return-value "/bin/command")
+    (expect (cider--resolve-project-command "../command")
+            :to-equal "/project/command"))
+  (it "if command is bare it resolves against the exec-path"
+    (spy-on 'locate-file :and-return-value "/project/command")
+    (spy-on 'executable-find :and-return-value "/bin/command")
+    (expect (cider--resolve-project-command "command")
+            :to-equal "/bin/command")))
+
 (provide 'cider-tests)
 
 ;;; cider-tests.el ends here


### PR DESCRIPTION
Enhancing Gradle jack-in support to allow (and use by default) the Gradle wrapper `./gradlew` instead of a globally installed `gradle` command on the `PATH`. See commit messages for further details.

I'm pretty new to elisp, so I'm not sure if that `locate-file` approach I took is the preferred option. I'm open to any feedback/changes you'd like, so just let me know.

Side note: I plan to work on some more Gradle related changes, particularly support for dependency injection, as well. Once I have some of those other changes ready, I can do a more thorough documentation update to flesh out how to use Cider with Gradle.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
