### PR TITLE
Support injecting dependencies into Gradle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#3226](https://github.com/clojure-emacs/cider/pull/3226): Populate completions metadata, making it possible to change the style of completion via `completion-category-override` or `completion-category-defaults`.
 - [#2946](https://github.com/clojure-emacs/cider/issues/2946): Add custom var `cider-merge-sessions` to allow combining sessions in two different ways: Setting `cider-merge-sessions` to `'host` will merge all sessions associated with the same host within a project. Setting it to `'project` will combine all sessions of a project irrespective of their host.
 - Support Gradle jack-in via the Gradle wrapper, instead of just a globally installed `gradle` on the `PATH`.
+- Gradle projects can now inject dependencies and middleware as with other build tools (dependency injection requires [Clojurephant](https://github.com/clojurephant/clojurephant) 0.7.0-alpha.6 or higher)
 
 ## Changes
 

--- a/doc/modules/ROOT/pages/basics/middleware_setup.adoc
+++ b/doc/modules/ROOT/pages/basics/middleware_setup.adoc
@@ -12,7 +12,8 @@ automatically injects this middleware and other dependencies as required.
 NOTE: In the past, if you were setting up CIDER, you might have had to
 modify `profiles.clj` or `profile.boot`. CIDER now handles
 everything automatically and you don't need to add anything
-special to these files. The same is true of your `deps.edn` file.
+special to these files. The same is true of your `deps.edn` file and
+your `build.gradle` (as of Clojurephant 0.7.0-alpha.6).
 
 If you prefer a standalone REPL, you will need to invoke
 `cider-connect` instead of `cider-jack-in` and manually add the
@@ -45,7 +46,7 @@ A minimal `profiles.clj` for CIDER would be:
 
 [source,clojure]
 ----
-{:repl {:plugins [[cider/cider-nrepl "0.28.4"]
+{:repl {:plugins [[cider/cider-nrepl "0.28.5"]
                   [mx.cider/enrich-classpath "1.9.0"]]}}
 ----
 
@@ -95,7 +96,24 @@ run `cider-connect` or `cider-connect-cljs`.
 
 === Using Gradle
 
-NOTE: This section is currently a stub. Contributions welcome!
+NOTE: Make sure you're using https://github.com/clojurephant/clojurephant[Clojurephant] 0.4.0 or newer.
+
+.build.gradle
+[source, groovy]
+----
+dependencies {
+  devImplementation 'nrepl:nrepl:0.9.0'
+  devImplementation 'cider:cider-nrepl:0.28.5'
+}
+
+tasks.named('clojureRepl') {
+  middleware = ['cider.nrepl/cider-middleware']
+}
+----
+
+You can then launch the nREPL server from the command line via: `./gradlew clojureRepl`.
+
+For more information, see the https://clojurephant.dev[Clojurephant docs].
 
 === Using Maven
 

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -88,6 +88,8 @@ Here's how you can modify the injected dependencies for `cider-jack-in-clj`:
                     "foo/bar" "1.0")
 ----
 
+IMPORTANT: Always use the fully qualified `group/artifact` (e.g. `re-frame/re-frame`) in these dependencies, since only Leiningen supports the bare `re-frame` syntax.
+
 CIDER will also inject the most recent version of nREPL that it supports. This is a simple
 trick to override the version of nREPL bundled with your build tool (e.g. Leiningen), so you can gain
 access to the newest nREPL features. Generally that's one aspect of CIDER's inner workings
@@ -103,10 +105,6 @@ CIDER can also inject a Clojure dependency into your project, which is useful,
 for example, if your project defaults to an older version of Clojure than that
 supported by the CIDER middleware. Set `cider-jack-in-auto-inject-clojure`
 appropriately to enable this.
-
-NOTE: CIDER does not currently support
-dependency auto-injection for Gradle projects. Unfortunately there's no
-way to pass extra dependencies to Gradle via its command-line interface.
 
 === Jacking-in without a Project
 

--- a/doc/modules/ROOT/pages/cljs/configuration.adoc
+++ b/doc/modules/ROOT/pages/cljs/configuration.adoc
@@ -17,6 +17,8 @@ variable. Here's an example:
 (cider-add-to-alist 'cider-jack-in-cljs-dependencies "weasel/weasel" "0.7.1")
 ----
 
+IMPORTANT: Always use the fully qualified `group/artifact` (e.g. `re-frame/re-frame`) in these dependencies, since only Leiningen supports the bare `re-frame` syntax.
+
 Typically, modifying this variable is not needed, as ClojureScript dependencies are declared
 explicitly in your project configuration most of the time.
 

--- a/doc/modules/ROOT/pages/cljs/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/cljs/up_and_running.adoc
@@ -55,6 +55,21 @@ or in `deps.edn`:
    "[cider.nrepl/cider-middleware,cider.piggieback/wrap-cljs-repl]"]}}}
 ----
 
+or in `build.gradle`:
+
+[source, groovy]
+----
+dependencies {
+  devImplementation 'nrepl:nrepl:0.9.0'
+  devImplementation 'cider:cider-nrepl:0.28.5'
+  devImplementation 'cider:cider-piggieback:0.5.3'
+}
+
+tasks.named('clojureRepl') {
+  middleware = ['cider.nrepl/cider-middleware', 'cider.piggieback/wrap-cljs-repl']
+}
+----
+
 == Starting a ClojureScript REPL
 
 Open a ClojureScript file in your project and type kbd:[M-x]

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -140,7 +140,7 @@
   (describe "when there is a single dependency"
     (before-each
       (setq-local cider-injected-nrepl-version "0.9.0")
-      (setq-local cider-injected-middleware-version "0.28.4")
+      (setq-local cider-injected-middleware-version "0.28.5")
       (setq-local cider-jack-in-nrepl-middlewares '("cider.nrepl/cider-middleware"))
       (setq-local cider-jack-in-dependencies-exclusions '())
       (setq-local cider-enrich-classpath t))
@@ -150,7 +150,7 @@
               :to-equal (concat "update-in :dependencies conj "
                                 (shell-quote-argument "[nrepl/nrepl \"0.9.0\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[cider/cider-nrepl \"0.28.4\"]")
+                                (shell-quote-argument "[cider/cider-nrepl \"0.28.5\"]")
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[mx.cider/enrich-classpath \"1.9.0\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath/middleware"
@@ -163,7 +163,7 @@
                          "update-in :dependencies conj "
                          (shell-quote-argument "[nrepl/nrepl \"0.9.0\" :exclusions [org.clojure/clojure]]")
                          " -- update-in :plugins conj "
-                         (shell-quote-argument "[cider/cider-nrepl \"0.28.4\"]")
+                         (shell-quote-argument "[cider/cider-nrepl \"0.28.5\"]")
                          " -- update-in :plugins conj "
                          (shell-quote-argument "[mx.cider/enrich-classpath \"1.9.0\"]")
                          " -- update-in :middleware conj cider.enrich-classpath/middleware"
@@ -175,7 +175,7 @@
               :to-equal (concat "update-in :dependencies conj "
                                 (shell-quote-argument "[nrepl/nrepl \"0.9.0\" :exclusions [org.clojure/clojure foo.bar/baz]]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[cider/cider-nrepl \"0.28.4\"]")
+                                (shell-quote-argument "[cider/cider-nrepl \"0.28.5\"]")
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[mx.cider/enrich-classpath \"1.9.0\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath/middleware"
@@ -188,7 +188,7 @@
                          " -d "
                          (shell-quote-argument "nrepl/nrepl:0.9.0")
                          " -d "
-                         (shell-quote-argument "cider/cider-nrepl:0.28.4")
+                         (shell-quote-argument "cider/cider-nrepl:0.28.5")
                          " cider.tasks/add-middleware"
                          " -m "
                          (shell-quote-argument "cider.nrepl/cider-middleware")
@@ -197,7 +197,7 @@
     (it "can inject dependencies in a gradle project"
       (expect (cider-inject-jack-in-dependencies "--no-daemon" ":clojureRepl" 'gradle)
               :to-equal (concat "--no-daemon "
-                                (shell-quote-argument "-Pdev.clojurephant.jack-in.nrepl=nrepl:nrepl:0.9.0,cider:cider-nrepl:0.28.4")
+                                (shell-quote-argument "-Pdev.clojurephant.jack-in.nrepl=nrepl:nrepl:0.9.0,cider:cider-nrepl:0.28.5")
                                 " :clojureRepl "
                                 (shell-quote-argument "--middleware=cider.nrepl/cider-middleware")))))
 
@@ -214,7 +214,7 @@
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[refactor-nrepl \"2.0.0\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[cider/cider-nrepl \"0.28.4\"]")
+                                (shell-quote-argument "[cider/cider-nrepl \"0.28.5\"]")
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[mx.cider/enrich-classpath \"1.9.0\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath/middleware"
@@ -227,7 +227,7 @@
                                 " -d "
                                 (shell-quote-argument "nrepl/nrepl:0.9.0")
                                 " -d "
-                                (shell-quote-argument "cider/cider-nrepl:0.28.4")
+                                (shell-quote-argument "cider/cider-nrepl:0.28.5")
                                 " -d "
                                 (shell-quote-argument "refactor-nrepl:2.0.0")
                                 " cider.tasks/add-middleware"
@@ -249,7 +249,7 @@
               :to-equal (concat "-o -U update-in :dependencies conj "
                                 (shell-quote-argument "[nrepl/nrepl \"0.9.0\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[cider/cider-nrepl \"0.28.4\"]")
+                                (shell-quote-argument "[cider/cider-nrepl \"0.28.5\"]")
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[mx.cider/enrich-classpath \"1.9.0\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath/middleware"
@@ -260,7 +260,7 @@
                                 " -d "
                                 (shell-quote-argument "nrepl/nrepl:0.9.0")
                                 " -d "
-                                (shell-quote-argument "cider/cider-nrepl:0.28.4")
+                                (shell-quote-argument "cider/cider-nrepl:0.28.5")
                                 " cider.tasks/add-middleware"
                                 " -m "
                                 (shell-quote-argument "cider.nrepl/cider-middleware")
@@ -268,7 +268,7 @@
     (it "can concat in a gradle project"
       (expect (cider-inject-jack-in-dependencies "--no-daemon" ":clojureRepl" 'gradle)
               :to-equal (concat "--no-daemon "
-                                (shell-quote-argument "-Pdev.clojurephant.jack-in.nrepl=nrepl:nrepl:0.9.0,cider:cider-nrepl:0.28.4")
+                                (shell-quote-argument "-Pdev.clojurephant.jack-in.nrepl=nrepl:nrepl:0.9.0,cider:cider-nrepl:0.28.5")
                                 " :clojureRepl "
                                 (shell-quote-argument "--middleware=cider.nrepl/cider-middleware")))))
 
@@ -283,14 +283,14 @@
       (setq-local cider-jack-in-nrepl-middlewares '(("refactor-nrepl.middleware/wrap-refactor" :predicate middlewares-predicate) "cider.nrepl/cider-middleware" ("another/middleware"))))
     (it "includes plugins whose predicates return true"
       (expect (cider-jack-in-normalized-lein-plugins)
-              :to-equal '(("refactor-nrepl" "2.0.0") ("cider/cider-nrepl" "0.28.4"))))
+              :to-equal '(("refactor-nrepl" "2.0.0") ("cider/cider-nrepl" "0.28.5"))))
     (it "includes middlewares whose predicates return true"
       (expect (cider-jack-in-normalized-nrepl-middlewares)
               :to-equal '("refactor-nrepl.middleware/wrap-refactor" "cider.nrepl/cider-middleware" "another/middleware")))
     (it "ignores plugins whose predicates return false"
       (spy-on 'plugins-predicate :and-return-value nil)
       (expect (cider-jack-in-normalized-lein-plugins)
-              :to-equal '(("cider/cider-nrepl" "0.28.4")))
+              :to-equal '(("cider/cider-nrepl" "0.28.5")))
       (spy-on 'middlewares-predicate :and-return-value nil)
       (expect (cider-jack-in-normalized-nrepl-middlewares)
               :to-equal '("cider.nrepl/cider-middleware" "another/middleware")))
@@ -319,7 +319,7 @@
               :and-return-value '("refactor-nrepl.middleware/wrap-refactor" "cider.nrepl/cider-middleware"))
       (spy-on 'cider-jack-in-normalized-lein-plugins
               :and-return-value '(("refactor-nrepl" "2.0.0")
-                                  ("cider/cider-nrepl" "0.28.4")
+                                  ("cider/cider-nrepl" "0.28.5")
                                   ("mx.cider/enrich-classpath" "1.9.0")))
       (setq-local cider-jack-in-dependencies-exclusions '())
       (setq-local cider-enrich-classpath t))
@@ -330,7 +330,7 @@
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[refactor-nrepl \"2.0.0\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[cider/cider-nrepl \"0.28.4\"]")
+                                (shell-quote-argument "[cider/cider-nrepl \"0.28.5\"]")
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[mx.cider/enrich-classpath \"1.9.0\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath/middleware"
@@ -348,7 +348,7 @@
                                 " -d "
                                 (shell-quote-argument "nrepl/nrepl:0.9.0")
                                 " -d "
-                                (shell-quote-argument "cider/cider-nrepl:0.28.4")
+                                (shell-quote-argument "cider/cider-nrepl:0.28.5")
                                 " -d "
                                 (shell-quote-argument "refactor-nrepl:2.0.0")
                                 " cider.tasks/add-middleware"
@@ -435,7 +435,7 @@
       (setq-local cider-jack-in-dependencies nil)
       (setq-local cider-jack-in-nrepl-middlewares '("cider.nrepl/cider-middleware"))
       (let ((expected (string-join '("clojure -Sdeps '{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} "
-                                     "cider/cider-nrepl {:mvn/version \"0.28.4\"}} "
+                                     "cider/cider-nrepl {:mvn/version \"0.28.5\"}} "
                                      ":aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\""
                                      " \"[cider.nrepl/cider-middleware]\"]}}}' -M:cider/nrepl")
                                    "")))
@@ -447,10 +447,10 @@
         (spy-on 'cider-jack-in-resolve-command :and-return-value "clojure")
         (expect (plist-get (cider--update-jack-in-cmd nil) :jack-in-cmd)
                 :to-equal expected)))
-    
+
     (it "allows specifying custom aliases with `cider-clojure-cli-aliases`"
       (let ((expected (string-join '("clojure -Sdeps '{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} "
-                                     "cider/cider-nrepl {:mvn/version \"0.28.4\"}} "
+                                     "cider/cider-nrepl {:mvn/version \"0.28.5\"}} "
                                      ":aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\""
                                      " \"[cider.nrepl/cider-middleware]\"]}}}' -M:dev:test:cider/nrepl")
                                    "")))
@@ -464,7 +464,7 @@
         (expect (plist-get (cider--update-jack-in-cmd nil) :jack-in-cmd)
                 :to-equal expected)))
     (it "should remove duplicates, yielding the same result"
-        (let ((expected (string-join '("-Sdeps '{:deps {cider/cider-nrepl {:mvn/version \"0.28.4\"} "
+        (let ((expected (string-join '("-Sdeps '{:deps {cider/cider-nrepl {:mvn/version \"0.28.5\"} "
                                        "nrepl/nrepl {:mvn/version \"0.9.0\"}} "
                                        ":aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\""
                                        " \"[cider.nrepl/cider-middleware]\"]}}}' -M:dev:test:cider/nrepl")
@@ -473,7 +473,7 @@
                                                                     ("nrepl/nrepl" "0.9.0")))
                   :to-equal expected)))
     (it "handles aliases correctly"
-      (let ((expected (string-join '("-Sdeps '{:deps {cider/cider-nrepl {:mvn/version \"0.28.4\"} "
+      (let ((expected (string-join '("-Sdeps '{:deps {cider/cider-nrepl {:mvn/version \"0.28.5\"} "
                                      "nrepl/nrepl {:mvn/version \"0.9.0\"}} "
                                      ":aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\""
                                      " \"[cider.nrepl/cider-middleware]\"]}}}' -M:test:cider/nrepl")
@@ -496,7 +496,7 @@
             (expect (cider-clojure-cli-jack-in-dependencies nil nil deps)
                     :to-equal expected)))))
     (it "allows for global options"
-      (let ((expected (string-join '("-J-Djdk.attach.allowAttachSelf -Sdeps '{:deps {cider/cider-nrepl {:mvn/version \"0.28.4\"} "
+      (let ((expected (string-join '("-J-Djdk.attach.allowAttachSelf -Sdeps '{:deps {cider/cider-nrepl {:mvn/version \"0.28.5\"} "
                                      "nrepl/nrepl {:mvn/version \"0.9.0\"}} "
                                      ":aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\""
                                      " \"[cider.nrepl/cider-middleware]\"]}}}' -M:test:cider/nrepl")


### PR DESCRIPTION
Gradle doesn't have any native support, but as of 0.7.0-alpha.6, Clojurephant supports a Gradle property to list dependencies to be injected into the nREPL server.

This property is backwards compatible for users on older Clojurephant versions, since Gradle ignores unknown properties on the command line, falling back to no injection.

The middleware arguments have been supported in Clojurephant since 0.4.0-beta.4 in 2018, so I think it should be safe to start passing those in.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
