### PR TITLE
Locate multiple ports for a single project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Bugs fixed
 
 * [#3235](https://github.com/clojure-emacs/cider/issues/3235): Check `name` is a TRAMP file in `cider--client-tramp-filename` via `tramp-tramp-file-p`.
+- [#3234](https://github.com/clojure-emacs/cider/pull/3234) Autocomplete multiple available ports on nRepl connect.
 
 ## 1.4.1 (2022-05-25)
 

--- a/cider.el
+++ b/cider.el
@@ -1625,10 +1625,11 @@ of remote SSH hosts."
 When DIR is non-nil also look for nREPL port files in DIR.  Return a list
 of list of the form (project-dir port)."
   (let* ((paths (cider--running-nrepl-paths))
-         (proj-ports (mapcar (lambda (d)
-                               (when-let* ((port (and d (nrepl-extract-port (cider--file-path d)))))
-                                 (list (file-name-nondirectory (directory-file-name d)) port)))
-                             (cons (clojure-project-dir dir) paths))))
+         (proj-ports (apply #'append
+                            (mapcar (lambda (d)
+                                      (mapcar (lambda (p) (list (file-name-nondirectory (directory-file-name d)) p))
+                                              (and d (nrepl-extract-ports (cider--file-path d)))))
+                                    (cons (clojure-project-dir dir) paths)))))
     (seq-uniq (delq nil proj-ports))))
 
 (defun cider--running-nrepl-paths ()

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -237,6 +237,16 @@ PARAMS is as in `nrepl-make-buffer-name'."
       (nrepl--port-from-file (expand-file-name "target/repl-port" dir))
       (nrepl--port-from-file (expand-file-name ".shadow-cljs/nrepl.port" dir))))
 
+(defun nrepl-extract-ports (dir)
+  "Read ports from applicable repl-port files in directory DIR."
+  (delq nil
+        (list (nrepl--port-from-file (expand-file-name "repl-port" dir))
+              (nrepl--port-from-file (expand-file-name ".nrepl-port" dir))
+              (nrepl--port-from-file (expand-file-name "target/repl-port" dir))
+              (nrepl--port-from-file (expand-file-name ".shadow-cljs/nrepl.port" dir)))))
+
+(make-obsolete 'nrepl-extract-port 'nrepl-extract-ports "1.4.2")
+
 (defun nrepl--port-from-file (file)
   "Attempts to read port from a file named by FILE."
   (when (file-exists-p file)


### PR DESCRIPTION
Searching for a nrepl port to connect to would return a maximum of one
port per project, ignoring any others that you might want to connect
to. This creates a case where when connecting to a shadow-cljs nrepl
server the port is not presented to you as a completion when you
already have another nrepl server running.

This commit changes nrepl-extract-port to nrepl-extract-ports and the
return type from a single port to a list of ports (including nils
where a specific project type nrepl port file doesn't exist) to
provide the full view of nrepl servers that are available in the
project, and then the cider-locate-running-nrepl-ports fn is changed
to accommodate that.

This fixes #3140.

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
