### PR TITLE
Added evaluate and tap commands last-sexp and sexp-at-point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#2946](https://github.com/clojure-emacs/cider/issues/2946): Add custom var `cider-merge-sessions` to allow combining sessions in two different ways: Setting `cider-merge-sessions` to `'host` will merge all sessions associated with the same host within a project. Setting it to `'project` will combine all sessions of a project irrespective of their host.
 - Support Gradle jack-in via the Gradle wrapper (`gradlew`), instead of just a globally installed `gradle` on the `PATH`.
 - Gradle projects can now inject dependencies and middleware as with other build tools (dependency injection requires [Clojurephant](https://github.com/clojurephant/clojurephant) 0.7.0 or higher).
+- [#3239](https://github.com/clojure-emacs/cider/issues/3239): Added commands to evaluate and tap last sexp and sexp at point.
 
 ## Changes
 

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -1016,6 +1016,25 @@ If invoked with OUTPUT-TO-CURRENT-BUFFER, output the result to current buffer."
     (goto-char (cadr (cider-sexp-at-point 'bounds)))
     (cider-eval-last-sexp output-to-current-buffer)))
 
+(defun cider-tap-last-sexp (&optional output-to-current-buffer)
+  "Evaluate and tap the expression preceding point.
+If invoked with OUTPUT-TO-CURRENT-BUFFER, print the result in the current
+buffer."
+  (interactive "P")
+  (let ((tapped-form (concat "(clojure.core/doto " (cider-last-sexp) " (clojure.core/tap>))")))
+    (cider-interactive-eval tapped-form
+                            (when output-to-current-buffer (cider-eval-print-handler))
+                            nil
+                            (cider--nrepl-pr-request-map))))
+
+(defun cider-tap-sexp-at-point (&optional output-to-current-buffer)
+  "Evaluate and tap the expression around point.
+If invoked with OUTPUT-TO-CURRENT-BUFFER, output the result to current buffer."
+  (interactive "P")
+  (save-excursion
+    (goto-char (cadr (cider-sexp-at-point 'bounds)))
+    (cider-tap-last-sexp output-to-current-buffer)))
+
 (defvar-local cider-previous-eval-context nil
   "The previous evaluation context if any.
 That's set by commands like `cider-eval-last-sexp-in-context'.")
@@ -1422,8 +1441,10 @@ passing arguments."
     (define-key map (kbd "n") #'cider-eval-ns-form)
     (define-key map (kbd "d") #'cider-eval-defun-at-point)
     (define-key map (kbd "e") #'cider-eval-last-sexp)
+    (define-key map (kbd "q") #'cider-tap-last-sexp)
     (define-key map (kbd "l") #'cider-eval-list-at-point)
     (define-key map (kbd "v") #'cider-eval-sexp-at-point)
+    (define-key map (kbd "t") #'cider-tap-sexp-at-point)
     (define-key map (kbd "o") #'cider-eval-sexp-up-to-point)
     (define-key map (kbd ".") #'cider-read-and-eval-defun-at-point)
     (define-key map (kbd "z") #'cider-eval-defun-up-to-point)
@@ -1438,8 +1459,10 @@ passing arguments."
     (define-key map (kbd "C-n") #'cider-eval-ns-form)
     (define-key map (kbd "C-d") #'cider-eval-defun-at-point)
     (define-key map (kbd "C-e") #'cider-eval-last-sexp)
+    (define-key map (kbd "C-q") #'cider-tap-last-sexp)
     (define-key map (kbd "C-l") #'cider-eval-list-at-point)
     (define-key map (kbd "C-v") #'cider-eval-sexp-at-point)
+    (define-key map (kbd "C-t") #'cider-tap-sexp-at-point)
     (define-key map (kbd "C-o") #'cider-eval-sexp-up-to-point)
     (define-key map (kbd "C-.") #'cider-read-and-eval-defun-at-point)
     (define-key map (kbd "C-z") #'cider-eval-defun-up-to-point)

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -320,10 +320,12 @@ If invoked with a prefix ARG eval the expression after inserting it."
     "--"
     ["Eval current list" cider-eval-list-at-point]
     ["Eval current sexp" cider-eval-sexp-at-point]
+    ["Eval and tap current sexp" cider-tap-sexp-at-point]
     ["Eval current sexp to point" cider-eval-sexp-up-to-point]
     ["Eval current sexp in context" cider-eval-sexp-at-point-in-context]
     "--"
     ["Eval last sexp" cider-eval-last-sexp]
+    ["Eval and tap last sexp" cider-tap-last-sexp]
     ["Eval last sexp in context" cider-eval-last-sexp-in-context]
     ["Eval last sexp and insert" cider-eval-print-last-sexp
      :keys "\\[universal-argument] \\[cider-eval-last-sexp]"]

--- a/doc/modules/ROOT/pages/usage/code_evaluation.adoc
+++ b/doc/modules/ROOT/pages/usage/code_evaluation.adoc
@@ -382,6 +382,11 @@ Below is a listing of most keybindings for evaluation commands:
 kbd:[C-c C-e]
 | Evaluate the form preceding point and display the result in the echo area and/or in an buffer overlay (according to `cider-use-overlays`).  If invoked with a prefix argument, insert the result into the current buffer.
 
+| `cider-tap-last-sexp`
+| kbd:[C-c C-v q] +
+kbd:[C-c C-v C-q]
+| Like `cider-eval-last-sexp` but also taps the result.
+
 | `cider-eval-last-sexp-and-replace`
 | kbd:[C-c C-v w]
 | Evaluate the form preceding point and replace it with its result.
@@ -422,6 +427,11 @@ kbd:[C-c C-v C-v]
 | kbd:[C-u C-M-x] +
 kbd:[C-u C-c C-c]
 | Debug the top level form under point and walk through its evaluation
+
+| `cider-tap-sexp-at-point`
+| kbd:[C-c C-v t] +
+kbd:[C-c C-v C-t]
+| Evaluate and tap the form around point.
 
 | `cider-eval-defun-up-to-point`
 | kbd:[C-c C-v z]


### PR DESCRIPTION
This PR solves #3239 by adding two commands that evaluate and tap either the last-sexp or the sexp-at-point. 
This is simply done by wrapping the form in a `(doto *form* (tap>))`.

I've not added any tests, since I couldn't find much in the `cider-eval-tests.el`. I'll happily do it if anybody can point me in the right direction.

I've not chosen any keybinding for this. I don't have any clue on how to pick them.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
