### PR TITLE
Add cider-stacktrace-analyze-in-region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 - [#3249](https://github.com/clojure-emacs/cider/pull/3249): Add support for Clojure Spec 2.
+- [#3247](https://github.com/clojure-emacs/cider/pull/3247) Add the `cider-stacktrace-analyze-at-point` and `cider-stacktrace-analyze-in-region` commands to view printed exceptions in the stacktrace inspector.
 
 ### Changes
 

--- a/doc/modules/ROOT/pages/usage/dealing_with_errors.adoc
+++ b/doc/modules/ROOT/pages/usage/dealing_with_errors.adoc
@@ -182,3 +182,95 @@ for instance:
 ----
 (setq cider-stacktrace-fill-column 80)
 ----
+
+=== Inspecting printed stacktraces
+
+Some of the errors you encounter as a Clojurists aren't necessarily
+evaluation errors that happened in your REPL. Many times, you see
+errors printed in a textual representation in other buffers as well,
+like log files or the REPL for example. Cider can parse and analyze
+some of those printed errors as well and show them in
+`cider-stacktrace-mode` with the following commands:
+
+* The `cider-stacktrace-analyze-at-point` command uses the `thingatpt`
+  library to extract the current stacktrace at point. It sends the
+  extracted stacktrace to the middleware in order to parse and analyze
+  it, and then shows the result in Cider's `cider-stacktrace-mode`.
+
+* The `cider-stacktrace-analyze-in-region` command does the same as
+  `cider-stacktrace-analyze-at-point`, but uses the current region to
+  extract the stacktrace.
+
+===== Examples
+
+Here is an example of a stacktrace printed with the Java
+`printStackTrace` method:
+
+[source,text]
+----
+clojure.lang.ExceptionInfo: BOOM-1 {:boom "1"}
+  at java.base/java.lang.Thread.run(Thread.java:829)
+----
+
+To open this stacktrace in the Cider stacktrace inspector, move point
+somewhere over the exception and run `M-x
+cider-stacktrace-analyze-at-point`.
+
+This also works to some extend for exceptions that are buried inside a
+string like the following exception:
+
+[source,text]
+----
+"clojure.lang.ExceptionInfo: BOOM-1 {:boom \"1\"}\n at java.base/java.lang.Thread.run(Thread.java:829)"
+----
+
+Those exceptions are often hard to read. The Cider stacktrace
+inspector can help you navigating exceptions even in those cases.
+
+===== Supported formats
+
+Cider recognizes stacktraces printed in the following formats:
+
+- `Aviso` - Exceptions printed with the
+  https://ioavisopretty.readthedocs.io/en/latest/exceptions.html[write-exception]
+  function of the https://github.com/AvisoNovate/pretty[Aviso]
+  library.
+
+- `clojure.repl` - Exceptions printed with the
+  https://clojure.github.io/clojure/branch-master/clojure.repl-api.html#clojure.repl/pst[clojure.repl/pst]
+  function.
+
+- `clojure.stacktrace` - Exceptions printed with the
+  https://clojure.github.io/clojure/branch-master/clojure.stacktrace-api.html#clojure.stacktrace/print-cause-trace[clojure.stacktrace/print-cause-trace]
+  function.
+
+- `Java` - Exceptions printed with the
+  https://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html#printStackTrace--[Throwable/printStackTrace]
+  method.
+
+- `Tagged Literal` - Exceptions printed with the
+  https://clojure.github.io/clojure/clojure.core-api.html#clojure.core/pr[clojure.core/pr]
+  function.
+
+===== Limitations
+
+- Cider only recognizes stacktraces that have been printed in one of
+  the supported formats.
+
+- The buffers in which `cider-stacktrace-analyze-at-point` or
+  `cider-stacktrace-analyze-in-region` are called in, must have a
+  Cider session associated with them. Tip: Use
+  `sesman-link-with-project` and friends in case the buffer containing
+  the exception is not linked to a Cider session.
+
+- Stacktraces are analyzed with the classpath of the Cider session the
+  buffer is associated with. If the stacktrace contains references to
+  classes not on this classpath, some information might be missing
+  from the analysis.
+
+- The `cider-stacktrace-analyze-at-point` function might not detect
+  the stacktrace at point in every situation. The thing at point might
+  be different depending on which major mode is active in a
+  buffer. When `cider-stacktrace-analyze-at-point` fails to detect the
+  stacktrace, `cider-stacktrace-analyze-in-region` can be used to
+  select the stacktrace manually.

--- a/test/cider-stacktrace-tests.el
+++ b/test/cider-stacktrace-tests.el
@@ -30,6 +30,135 @@
 (require 'buttercup)
 (require 'cider-stacktrace)
 
+;; cider-stacktrace test data
+
+(defvar cider-stacktrace-tests-boom-aviso
+  (string-join
+   '("   nrepl.middleware.interruptible-eval/evaluate/fn  interruptible_eval.clj:   87"
+     "                                               ..."
+     "                       clojure.core/with-bindings*                core.clj: 1977 (repeats 2 times)"
+     "                                clojure.core/apply                core.clj:  667"
+     "                                               ..."
+     "nrepl.middleware.interruptible-eval/evaluate/fn/fn  interruptible_eval.clj:   87"
+     "                                 clojure.core/eval                core.clj: 3202"
+     "                                               ..."
+     "          orchard.stacktrace.parser-test/eval15048               REPL Input"
+     "                                               ..."
+     "clojure.lang.ExceptionInfo: BOOM-3"
+     "    boom: \"3\""
+     "clojure.lang.ExceptionInfo: BOOM-2"
+     "    boom: \"2\""
+     "clojure.lang.ExceptionInfo: BOOM-1"
+     "    boom: \"1\"")
+   "\n"))
+
+(defvar cider-stacktrace-tests-boom-clojure
+  (string-join
+   '("#error {"
+     " :cause \"BOOM-3\""
+     " :data {:boom \"3\"}"
+     " :via"
+     " [{:type clojure.lang.ExceptionInfo"
+     "   :message \"BOOM-1\""
+     "   :data {:boom \"1\"}"
+     "   :at [clojure.lang.AFn applyToHelper \"AFn.java\" 160]}"
+     "  {:type clojure.lang.ExceptionInfo"
+     "   :message \"BOOM-2\""
+     "   :data {:boom \"2\"}"
+     "   :at [clojure.lang.AFn applyToHelper \"AFn.java\" 160]}"
+     "  {:type clojure.lang.ExceptionInfo"
+     "   :message \"BOOM-3\""
+     "   :data {:boom \"3\"}"
+     "   :at [clojure.lang.AFn applyToHelper \"AFn.java\" 156]}]"
+     " :trace"
+     " [[clojure.lang.AFn applyToHelper \"AFn.java\" 156]"
+     "  [clojure.lang.AFn applyTo \"AFn.java\" 144]"
+     "  [clojure.lang.Compiler$InvokeExpr eval \"Compiler.java\" 3706]"
+     "  [clojure.lang.Compiler$InvokeExpr eval \"Compiler.java\" 3705]"
+     "  [clojure.lang.Compiler$InvokeExpr eval \"Compiler.java\" 3705]"
+     "  [clojure.lang.Compiler$DefExpr eval \"Compiler.java\" 457]"
+     "  [clojure.lang.Compiler eval \"Compiler.java\" 7186]"
+     "  [clojure.lang.Compiler load \"Compiler.java\" 7640]"
+     "  [orchard.stacktrace.parser_test$eval10939 invokeStatic \"form-init13443654147290506544.clj\" 1]"
+     "  [orchard.stacktrace.parser_test$eval10939 invoke \"form-init13443654147290506544.clj\" 1]"
+     "  [clojure.lang.Compiler eval \"Compiler.java\" 7181]"
+     "  [clojure.lang.Compiler eval \"Compiler.java\" 7136]"
+     "  [clojure.core$eval invokeStatic \"core.clj\" 3202]"
+     "  [clojure.core$eval invoke \"core.clj\" 3198]"
+     "  [nrepl.middleware.interruptible_eval$evaluate$fn__1933$fn__1934 invoke \"interruptible_eval.clj\" 87]"
+     "  [clojure.lang.AFn applyToHelper \"AFn.java\" 152]"
+     "  [clojure.lang.AFn applyTo \"AFn.java\" 144]"
+     "  [clojure.core$apply invokeStatic \"core.clj\" 667]"
+     "  [clojure.core$with_bindings_STAR_ invokeStatic \"core.clj\" 1977]"
+     "  [clojure.core$with_bindings_STAR_ doInvoke \"core.clj\" 1977]"
+     "  [clojure.lang.RestFn invoke \"RestFn.java\" 425]"
+     "  [nrepl.middleware.interruptible_eval$evaluate$fn__1933 invoke \"interruptible_eval.clj\" 87]"
+     "  [clojure.main$repl$read_eval_print__9110$fn__9113 invoke \"main.clj\" 437]"
+     "  [clojure.main$repl$read_eval_print__9110 invoke \"main.clj\" 437]"
+     "  [clojure.main$repl$fn__9119 invoke \"main.clj\" 458]"
+     "  [clojure.main$repl invokeStatic \"main.clj\" 458]"
+     "  [clojure.main$repl doInvoke \"main.clj\" 368]"
+     "  [clojure.lang.RestFn invoke \"RestFn.java\" 1523]"
+     "  [nrepl.middleware.interruptible_eval$evaluate invokeStatic \"interruptible_eval.clj\" 84]"
+     "  [nrepl.middleware.interruptible_eval$evaluate invoke \"interruptible_eval.clj\" 56]"
+     "  [nrepl.middleware.interruptible_eval$interruptible_eval$fn__1966$fn__1970 invoke \"interruptible_eval.clj\" 152]"
+     "  [clojure.lang.AFn run \"AFn.java\" 22]"
+     "  [nrepl.middleware.session$session_exec$main_loop__2036$fn__2040 invoke \"session.clj\" 218]"
+     "  [nrepl.middleware.session$session_exec$main_loop__2036 invoke \"session.clj\" 217]"
+     "  [clojure.lang.AFn run \"AFn.java\" 22]"
+     "  [java.lang.Thread run \"Thread.java\" 829]]}")
+   "\n"))
+
+(defvar cider-stacktrace-tests-boom-java
+  (string-join '("clojure.lang.ExceptionInfo: BOOM-1 {:boom \"1\"}"
+                 "	at clojure.lang.AFn.applyToHelper(AFn.java:160)"
+                 "	at clojure.lang.AFn.applyTo(AFn.java:144)"
+                 "	at clojure.lang.Compiler$InvokeExpr.eval(Compiler.java:3706)"
+                 "	at clojure.lang.Compiler$DefExpr.eval(Compiler.java:457)"
+                 "	at clojure.lang.Compiler.eval(Compiler.java:7186)"
+                 "	at clojure.lang.Compiler.load(Compiler.java:7640)"
+                 "	at user$eval10785.invokeStatic(form-init16591543638769050486.clj:1)"
+                 "	at user$eval10785.invoke(form-init16591543638769050486.clj:1)"
+                 "	at clojure.lang.Compiler.eval(Compiler.java:7181)"
+                 "	at clojure.lang.Compiler.eval(Compiler.java:7136)"
+                 "	at clojure.core$eval.invokeStatic(core.clj:3202)"
+                 "	at clojure.core$eval.invoke(core.clj:3198)"
+                 "	at nrepl.middleware.interruptible_eval$evaluate$fn__1933$fn__1934.invoke(interruptible_eval.clj:87)"
+                 "	at clojure.lang.AFn.applyToHelper(AFn.java:152)"
+                 "	at clojure.lang.AFn.applyTo(AFn.java:144)"
+                 "	at clojure.core$apply.invokeStatic(core.clj:667)"
+                 "	at clojure.core$with_bindings_STAR_.invokeStatic(core.clj:1977)"
+                 "	at clojure.core$with_bindings_STAR_.doInvoke(core.clj:1977)"
+                 "	at clojure.lang.RestFn.invoke(RestFn.java:425)"
+                 "	at nrepl.middleware.interruptible_eval$evaluate$fn__1933.invoke(interruptible_eval.clj:87)"
+                 "	at clojure.main$repl$read_eval_print__9110$fn__9113.invoke(main.clj:437)"
+                 "	at clojure.main$repl$read_eval_print__9110.invoke(main.clj:437)"
+                 "	at clojure.main$repl$fn__9119.invoke(main.clj:458)"
+                 "	at clojure.main$repl.invokeStatic(main.clj:458)"
+                 "	at clojure.main$repl.doInvoke(main.clj:368)"
+                 "	at clojure.lang.RestFn.invoke(RestFn.java:1523)"
+                 "	at nrepl.middleware.interruptible_eval$evaluate.invokeStatic(interruptible_eval.clj:84)"
+                 "	at nrepl.middleware.interruptible_eval$evaluate.invoke(interruptible_eval.clj:56)"
+                 "	at nrepl.middleware.interruptible_eval$interruptible_eval$fn__1966$fn__1970.invoke(interruptible_eval.clj:152)"
+                 "	at clojure.lang.AFn.run(AFn.java:22)"
+                 "	at nrepl.middleware.session$session_exec$main_loop__2036$fn__2040.invoke(session.clj:218)"
+                 "	at nrepl.middleware.session$session_exec$main_loop__2036.invoke(session.clj:217)"
+                 "	at clojure.lang.AFn.run(AFn.java:22)"
+                 "	at java.base/java.lang.Thread.run(Thread.java:829)"
+                 "Caused by: clojure.lang.ExceptionInfo: BOOM-2 {:boom \"2\"}"
+                 "	at clojure.lang.AFn.applyToHelper(AFn.java:160)"
+                 "	at clojure.lang.AFn.applyTo(AFn.java:144)"
+                 "	at clojure.lang.Compiler$InvokeExpr.eval(Compiler.java:3706)"
+                 "	at clojure.lang.Compiler$InvokeExpr.eval(Compiler.java:3705)"
+                 "	... 31 more"
+                 "Caused by: clojure.lang.ExceptionInfo: BOOM-3 {:boom \"3\"}"
+                 "	at clojure.lang.AFn.applyToHelper(AFn.java:156)"
+                 "	at clojure.lang.AFn.applyTo(AFn.java:144)"
+                 "	at clojure.lang.Compiler$InvokeExpr.eval(Compiler.java:3706)"
+                 "	at clojure.lang.Compiler$InvokeExpr.eval(Compiler.java:3705)"
+                 "	... 32 more")
+               "\n"))
+
 ;;; cider-stacktrace tests
 
 ;;; Internal/Middleware error suppression
@@ -88,9 +217,9 @@
     (apply #'nrepl-dict
            (append (apply #'append
                           (mapcar (lambda (name) (list (symbol-name name)
-                                                (if (funcall numeric? name)
-                                                    4
-                                                  (symbol-name name))))
+                                                       (if (funcall numeric? name)
+                                                           4
+                                                         (symbol-name name))))
                                   names))
                    stipulated))))
 
@@ -126,3 +255,57 @@
               :to-be-truthy)
       (expect (or both shown1 shown2)
               :to-be nil))))
+
+(defun cider-stacktrace-tests--analyze-at-point (stacktrace pos)
+  "Test `cider-stacktrace-analyze-at-point' with STACKTRACE at POS."
+  (with-temp-buffer
+    (erase-buffer)
+    (insert stacktrace)
+    (goto-char pos)
+    (cider-stacktrace-analyze-at-point)))
+
+(describe "cider-stacktrace-analyze-at-point"
+  :var (cider-stacktrace-analyze-string)
+  (before-each (spy-on 'cider-stacktrace-analyze-string))
+
+  (it "should analyze the Aviso stacktrace with point at beginning"
+    (cider-stacktrace-tests--analyze-at-point cider-stacktrace-tests-boom-aviso 0)
+    (expect 'cider-stacktrace-analyze-string :to-have-been-called-with cider-stacktrace-tests-boom-aviso))
+
+  (it "should analyze the Clojure stacktrace with point at beginning"
+    (cider-stacktrace-tests--analyze-at-point cider-stacktrace-tests-boom-clojure 0)
+    (expect 'cider-stacktrace-analyze-string :to-have-been-called-with cider-stacktrace-tests-boom-clojure))
+
+  (it "should analyze the Java stacktrace with point at beginning"
+    (cider-stacktrace-tests--analyze-at-point cider-stacktrace-tests-boom-java 0)
+    (expect 'cider-stacktrace-analyze-string :to-have-been-called-with cider-stacktrace-tests-boom-java))
+
+  (it "should analyze the Clojure stacktrace with point inside"
+    (cider-stacktrace-tests--analyze-at-point cider-stacktrace-tests-boom-clojure 10)
+    (expect 'cider-stacktrace-analyze-string :to-have-been-called-with cider-stacktrace-tests-boom-clojure))
+
+  (it "should analyze the Java stacktrace with point inside"
+    (cider-stacktrace-tests--analyze-at-point cider-stacktrace-tests-boom-java 10)
+    (expect 'cider-stacktrace-analyze-string :to-have-been-called-with cider-stacktrace-tests-boom-java)))
+
+(defun cider-stacktrace-tests--analyze-in-region (stacktrace)
+  "Test `cider-stacktrace-analyze-in-region' with STACKTRACE."
+  (with-temp-buffer
+    (insert stacktrace)
+    (cider-stacktrace-analyze-in-region (point-min) (point-max))))
+
+(describe "cider-stacktrace-analyze-in-region"
+  :var (cider-stacktrace-analyze-string)
+  (before-each (spy-on 'cider-stacktrace-analyze-string))
+
+  (it "should analyze the Aviso stacktrace in region"
+    (cider-stacktrace-tests--analyze-in-region cider-stacktrace-tests-boom-aviso)
+    (expect 'cider-stacktrace-analyze-string :to-have-been-called-with cider-stacktrace-tests-boom-aviso))
+
+  (it "should analyze the Clojure stacktrace in region"
+    (cider-stacktrace-tests--analyze-in-region cider-stacktrace-tests-boom-clojure)
+    (expect 'cider-stacktrace-analyze-string :to-have-been-called-with cider-stacktrace-tests-boom-clojure))
+
+  (it "should analyze the Java stacktrace in region"
+    (cider-stacktrace-tests--analyze-in-region cider-stacktrace-tests-boom-java)
+    (expect 'cider-stacktrace-analyze-string :to-have-been-called-with cider-stacktrace-tests-boom-java)))


### PR DESCRIPTION
Add command to analyze and inspect the stacktrace in region

Please see:
- https://github.com/clojure-emacs/orchard/pull/164
- https://github.com/clojure-emacs/cider-nrepl/pull/758
-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
