### PR TITLE
Spec2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+- [#3249](https://github.com/clojure-emacs/cider/pull/3249): Add support for Clojure Spec 2.
+
 ### Changes
 
 - Bump the injected nREPL version to 1.0.

--- a/doc/modules/ROOT/pages/usage/misc_features.adoc
+++ b/doc/modules/ROOT/pages/usage/misc_features.adoc
@@ -318,6 +318,24 @@ meets the spec.
 
 image::spec_browser_gen_example.png[Spec Browser Example]
 
+== Clojure Spec Versions
+
+Clojure Spec has a bit of a history and is available in a couple of
+flavours:
+
+* `spec` (aka `clojure.spec`, the original release, never shipped with Clojure)
+* `spec-alpha` (aka `clojure.spec.alpha`, the original release under a different name, ships with Clojure)
+* `spec-alpha-2` (aka `clojure.alpha.spec`, the evolution, separate library, but still experimental)
+
+Cider supports the whole mix, but with a twist.
+
+* When Cider shows a list of specs, the keys from all registries are
+  shown. Registries are merged together from newest to oldest.
+
+* When Cider operates on a spec, like looking up a spec or generating
+  data for it, the operation is tried against all registries, from
+  newest to oldest, with the first successful operation winning.
+
 == Formatting Code with cljfmt
 
 While CIDER has it's own code formatting (indentation) engine, you can also

--- a/test/cider-browse-spec-tests.el
+++ b/test/cider-browse-spec-tests.el
@@ -1,0 +1,87 @@
+;;; cider-browse-spec-tests.el  -*- lexical-binding: t; -*-
+
+;; Copyright © 2012-2022 r0man, Bozhidar Batsov
+
+;; Author: r0man <roman@burningswell.com>
+;;         Bozhidar Batsov <bozhidar@batsov.dev>
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; This file is part of CIDER
+
+;;; Code:
+
+(require 'buttercup)
+(require 'cider-browse-spec)
+
+(defvar cider-browse-spec-tests--schema-vector-response
+  '("clojure.alpha.spec/schema"
+    (":example.customer/id" ":example.customer/name"))
+  "The NREPL response for a s/schema vector spec.")
+
+(defvar cider-browse-spec-tests--schema-map-response
+  '("clojure.alpha.spec/schema"
+    ((dict ":id" ":example.customer/id"
+           ":name" ":example.customer/name")))
+  "The NREPL response for a s/schema map spec.")
+
+(defvar cider-browse-spec-tests--company-addr-response
+  '("clojure.alpha.spec/union" ":test/addr"
+    (":test/company" ":test/suite"))
+  "The NREPL response for the :user/company-addr spec.")
+
+(defvar cider-browse-spec-tests--movie-times-user-response
+  '("clojure.alpha.spec/select" ":test/user"
+    (":test/id" ":test/addr"
+     (dict ":test/addr"
+           (":test/zip"))))
+  "The NREPL response for the :user/movie-times-user spec.")
+
+(defun cider-browse-spec-tests--setup-spec-form (spec-form)
+  "Setup the mocks to test rendering of SPEC-FORM."
+  (spy-on 'sesman-current-session :and-return-value t)
+  (spy-on 'cider-nrepl-op-supported-p :and-return-value t)
+  (spy-on 'cider-connected-p :and-return-value nil)
+  (spy-on 'cider--get-symbol-indent :and-return-value nil)
+  (spy-on 'cider-sync-request:spec-form :and-return-value spec-form))
+
+(describe "cider-browse-spec--browse"
+  (it "raises user-error when cider is not connected."
+    (spy-on 'sesman-current-session :and-return-value nil)
+    (expect (cider-browse-spec--browse ":example/customer") :to-throw 'user-error))
+
+  (it "raises user-error when the `spec-form' op is not supported."
+    (spy-on 'sesman-current-session :and-return-value t)
+    (spy-on 'cider-nrepl-op-supported-p :and-return-value nil)
+    (expect (cider-browse-spec--browse ":example/customer") :to-throw 'user-error))
+
+  (it "renders a s/schema map form"
+    (cider-browse-spec-tests--setup-spec-form cider-browse-spec-tests--schema-map-response)
+    (expect (cider-browse-spec--browse ":example/customer")))
+
+  (it "renders a s/schema vector form"
+    (cider-browse-spec-tests--setup-spec-form cider-browse-spec-tests--schema-vector-response)
+    (expect (cider-browse-spec--browse ":example/customer")))
+
+  (it "renders a s/select form"
+    (cider-browse-spec-tests--setup-spec-form cider-browse-spec-tests--movie-times-user-response)
+    (expect (cider-browse-spec--browse ":user/movie-times-user")))
+
+  (it "renders a s/union form"
+    (cider-browse-spec-tests--setup-spec-form cider-browse-spec-tests--company-addr-response)
+    (expect (cider-browse-spec--browse ":user/company-addr"))))


### PR DESCRIPTION
This PR add support for rendering the following Clojure Spec 2 forms:
- s/schema
- s/select
- s/union 

Support for Clojure Spec 2 has been added to the Orchard here:
https://github.com/clojure-emacs/orchard/pull/163

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
