### PR TITLE
Disable undo in cider-stacktrace buffer

### DIFF
--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -203,7 +203,8 @@ The error types are represented as strings."
   (setq-local electric-indent-chars nil)
   (setq-local cider-stacktrace-hidden-frame-count 0)
   (setq-local cider-stacktrace-filters cider-stacktrace-default-filters)
-  (setq-local cider-stacktrace-cause-visibility (make-vector 10 0)))
+  (setq-local cider-stacktrace-cause-visibility (make-vector 10 0))
+  (buffer-disable-undo))
 
 
 ;; Stacktrace filtering


### PR DESCRIPTION
Same issue as https://github.com/clojure-emacs/cider/issues/1004, huge ex-data from pathom in my case (https://github.com/wilkerlucio/pathom3/issues/142). Dramatic performance improvement.

might be worth doing the same for https://github.com/clojure-emacs/cider/issues/2561



-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
