### PR TITLE
Scroll repl buffer in other frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 - Remove needless quotes from the choices of `cider-jack-in-auto-inject-clojure`.
 - [#2561](https://github.com/clojure-emacs/cider/issues/2561): Disable undo in `*cider-test-report*` buffers.
 - [#3251](https://github.com/clojure-emacs/cider/pull/3251): Disable undo in `*cider-stacktrace*` buffers.
-- Consecutive overlays will not be spuriously deleted. 
+- Consecutive overlays will not be spuriously deleted.
+- [#3260](https://github.com/clojure-emacs/cider/pull/3260): Scroll REPL buffer in other frame.
 
 ## 1.5.0 (2022-08-24)
 

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -229,7 +229,7 @@ If EVAL is non-nil the form will also be evaluated.  Use
   (when cider-switch-to-repl-on-insert
     (cider-switch-to-repl-buffer))
   (let ((repl (cider-current-repl)))
-    (with-selected-window (or (get-buffer-window repl)
+    (with-selected-window (or (get-buffer-window repl t)
                               (selected-window))
       (with-current-buffer repl
         (goto-char (point-max))


### PR DESCRIPTION
This is a little fix to make the repl buffer scroll to the bottom after `cider-insert-in-repl` when it's in another frame. It doesn't currently scroll in other frames because `get-buffer-window` only considers the current one by default. Setting the opt arg `t` means to consider all windows on all existing frames (and seems to start with the selected frame).

