### PR TITLE
If current buffer is a TRAMP buffer, use its filename for SSH tunnel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Bump the injected nREPL version to 1.0.
 - [#3291](https://github.com/clojure-emacs/cider/pull/3291): **Remove** the `'cljs-pending` `repl-type`. It is replaced by `cider-repl-cljs-upgrade-pending`.
+- [#3261](https://github.com/clojure-emacs/cider/issues/3261): If user is connecting to nREPL from a TRAMP buffer, use its connection parameters (port, username) for establishing SSH tunnel.
 
 ### Bugs fixed
 

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -262,7 +262,9 @@ config files such as `~/.ssh/config` and `~/.ssh/known_hosts`. This is known to
 cause problems with complex or nonstandard ssh configs.
 
 You can safely run `cider-jack-in-*` while working with remote files over TRAMP. CIDER
-will handle this use-case transparently for you.
+will reuse existing SSH connection's parameters (like port and username) for establishing SSH tunnel.
+The same will happen if you try to `cider-connect-*` to a host that matches the one you're currently
+connected to.
 
 == Connecting via unix domain file socket
 


### PR DESCRIPTION
> https://github.com/clojure-emacs/cider/issues/3261
https://github.com/clojure-emacs/cider/issues/2822

If current buffer is a TRAMP buffer, use its filename for SSH tunnel. This way, username and SSH port will be parsed from existing SSH connection, instead of using current username and default SSH port.

I'll edit changelog and manual (if needed) after review

-----------------

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)