### PR TITLE
Support nbb as native cljs repl

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,7 @@ jobs:
       with:
         node-version: 16
     - run: npm install shadow-cljs@2.20.13 -g
+    - run: npm install nbb@1.1.152 -g
 
     - name: Test integration
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 - [#3278](https://github.com/clojure-emacs/cider/pull/3278) Introduce integration tests, which also fix a long standing issue with orphaned process on MS-Windows by contracting `taskkill`, if available, to properly kill the nREPL server process tree.
+- [#3061](https://github.com/clojure-emacs/cider/issues/3061): Add support for nbb.
 - [#3249](https://github.com/clojure-emacs/cider/pull/3249): Add support for Clojure Spec 2.
 - [#3247](https://github.com/clojure-emacs/cider/pull/3247): Add the `cider-stacktrace-analyze-at-point` and `cider-stacktrace-analyze-in-region` commands to view printed exceptions in the stacktrace inspector.
 

--- a/cider.el
+++ b/cider.el
@@ -235,21 +235,21 @@ By default we favor the project-specific shadow-cljs over the system-wide."
   "The command used to execute nbb."
   :type 'string
   :safe #'stringp
-  :package-version '(cider . "1.2.0"))
+  :package-version '(cider . "1.3.0"))
 
 (defcustom cider-nbb-global-options
   nil
   "Command line options used to execute nbb."
   :type 'string
   :safe #'stringp
-  :package-version '(cider . "1.2.0"))
+  :package-version '(cider . "1.3.0"))
 
 (defcustom cider-nbb-parameters
   "nrepl-server"
   "Params passed to nbb to start an nREPL server via `cider-jack-in'."
   :type 'string
   :safe #'stringp
-  :package-version '(cider . "1.2.0"))
+  :package-version '(cider . "1.3.0"))
 
 (defcustom cider-jack-in-default (if (executable-find "clojure") 'clojure-cli 'lein)
   "The default tool to use when doing `cider-jack-in' outside a project.

--- a/cider.el
+++ b/cider.el
@@ -1715,7 +1715,7 @@ PROJECT-DIR defaults to current project."
                         (shadow-cljs . "shadow-cljs.edn")
                         (gradle      . "build.gradle")
                         (gradle      . "build.gradle.kts")
-                        (nbb         . "package.json"))))
+                        (nbb         . "nbb.edn"))))
     (delq nil
           (mapcar (lambda (candidate)
                     (when (file-exists-p (cdr candidate))

--- a/doc/modules/ROOT/nav.adoc
+++ b/doc/modules/ROOT/nav.adoc
@@ -13,6 +13,7 @@
 * Alternative Platforms
 ** xref:platforms/overview.adoc[Overview]
 ** xref:platforms/babashka.adoc[Babashka]
+** xref:platforms/nbb.adoc[Nbb]
 ** xref:platforms/scittle_and_friends.adoc[Scittle and Friends]
 * Using CIDER
 ** xref:usage/interactive_programming.adoc[Interactive Programming]

--- a/doc/modules/ROOT/pages/platforms/nbb.adoc
+++ b/doc/modules/ROOT/pages/platforms/nbb.adoc
@@ -1,0 +1,13 @@
+= https://github.com/babashka/nbb[nbb]
+
+Nbb's main goal is to make it easy to get started with ad hoc CLJS scripting on Node.js.
+
+It is highly compatible with ClojureScript, so it works with CIDER out of the box.
+
+You can either jack in to an nbb project with `M-x clojure-jack-in-cljs`.
+
+or start its bundled nREPL server:
+
+  $ nbb nrepl-server
+
+and connect to it afterwards using `M-x cider-connect-cljs`.

--- a/doc/modules/ROOT/pages/platforms/overview.adoc
+++ b/doc/modules/ROOT/pages/platforms/overview.adoc
@@ -28,6 +28,7 @@ Right now CIDER the supports to some extent the following:
 * Babashka
 * ClojureCLR (via Arcadia's nREPL server)
 * Lumo (via https://github.com/djblue/nrepl-cljs)
+* Nbb
 
 All of them are derived from Clojure, so supporting them didn't really require much work.
 

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -597,6 +597,8 @@
             ;; native cljs REPL
             (expect (buffer-local-value 'cider-repl-type client-buffer)
                     :to-equal 'cljs)
+            (expect (buffer-local-value 'cider-repl-cljs-upgrade-pending client-buffer)
+                    :to-equal nil)
             (expect (buffer-local-value 'cider-repl-init-function client-buffer)
                     :to-be nil)
             (delete-process (get-buffer-process client-buffer))))
@@ -608,7 +610,9 @@
                                  '(:cljs-repl-type shadow) server-buffer)))
             ;; starts as clj REPL and requires a form to switch over to cljs
             (expect (buffer-local-value 'cider-repl-type client-buffer)
-                    :to-equal 'pending-cljs)
+                    :to-equal 'cljs)
+            (expect (buffer-local-value 'cider-repl-cljs-upgrade-pending client-buffer)
+                    :to-equal t)
             (expect (buffer-local-value 'cider-repl-init-function client-buffer)
                     :not :to-be nil)
             (delete-process (get-buffer-process client-buffer))))
@@ -621,6 +625,8 @@
                                  server-buffer)))
             (expect (buffer-local-value 'cider-repl-type client-buffer)
                     :to-equal 'cljs)
+            (expect (buffer-local-value 'cider-repl-cljs-upgrade-pending client-buffer)
+                    :to-equal nil)
             (delete-process (get-buffer-process client-buffer))))
       (it "for a custom REPL type project that needs to switch to cljs"
           (cider-register-cljs-repl-type
@@ -631,7 +637,9 @@
                                  '(:cljs-repl-type not-cljs-initially)
                                  server-buffer)))
             (expect (buffer-local-value 'cider-repl-type client-buffer)
-                    :to-equal 'pending-cljs)
+                    :to-equal 'cljs)
+            (expect (buffer-local-value 'cider-repl-cljs-upgrade-pending client-buffer)
+                    :to-equal t)
             (expect (buffer-local-value 'cider-repl-init-function client-buffer)
                     :not :to-be nil)
             (delete-process (get-buffer-process client-buffer))))))

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -580,46 +580,60 @@
             :to-equal (shell-quote-argument "/bin/command"))))
 
 (describe "cider-connect-sibling-cljs"
-  :var (-cider-cljs-repl-types bu-cider-shadow-default-options)
+  ;; restore:
+  ;; - `cider-cljs-repl-types` changed by `cider-register-cljs-repl-type`.
+  :var (-cider-cljs-repl-types)
   (before-all
-   (setq -cider-cljs-repl-types cider-cljs-repl-types
-         -cider-shadow-default-options cider-shadow-default-options))
+   (setq -cider-cljs-repl-types cider-cljs-repl-types))
   (after-each
-   (setq cider-cljs-repl-types -cider-cljs-repl-types
-         cider-shadow-default-options -cider-shadow-default-options))
+   (setq cider-cljs-repl-types -cider-cljs-repl-types))
 
   (describe "sets nrepl client local vars correctly"
       (it "for nbb project"
           (let* ((server-process (nrepl-start-mock-server-process))
                  (server-buffer (process-buffer server-process))
-                 (client-buffer (cider-connect-sibling-cljs '(:cljs-repl-type nbb) server-buffer)))
-            (expect (buffer-local-value 'cider-repl-type client-buffer) :to-equal 'cljs)
-            (expect (buffer-local-value 'cider-repl-init-function client-buffer) :to-be nil)
+                 (client-buffer (cider-connect-sibling-cljs
+                                 '(:cljs-repl-type nbb) server-buffer)))
+            ;; native cljs REPL
+            (expect (buffer-local-value 'cider-repl-type client-buffer)
+                    :to-equal 'cljs)
+            (expect (buffer-local-value 'cider-repl-init-function client-buffer)
+                    :to-be nil)
             (delete-process (get-buffer-process client-buffer))))
       (it "for shadow project"
-          (setq cider-shadow-default-options "a-shadow-alias")
-          (let* ((server-process (nrepl-start-mock-server-process))
+          (let* ((cider-shadow-default-options "a-shadow-alias")
+                 (server-process (nrepl-start-mock-server-process))
                  (server-buffer (process-buffer server-process))
-                 (client-buffer (cider-connect-sibling-cljs '(:cljs-repl-type shadow) server-buffer)))
-            (expect (buffer-local-value 'cider-repl-type client-buffer) :to-equal 'pending-cljs)
-            (expect (buffer-local-value 'cider-repl-init-function client-buffer) :not :to-be nil)
+                 (client-buffer (cider-connect-sibling-cljs
+                                 '(:cljs-repl-type shadow) server-buffer)))
+            ;; starts as clj REPL and requires a form to switch over to cljs
+            (expect (buffer-local-value 'cider-repl-type client-buffer)
+                    :to-equal 'pending-cljs)
+            (expect (buffer-local-value 'cider-repl-init-function client-buffer)
+                    :not :to-be nil)
             (delete-process (get-buffer-process client-buffer))))
       (it "for a custom cljs REPL type project"
           (cider-register-cljs-repl-type 'native-cljs)
           (let* ((server-process (nrepl-start-mock-server-process))
                  (server-buffer (process-buffer server-process))
-                 (client-buffer (cider-connect-sibling-cljs '(:cljs-repl-type native-cljs)
-                                                            server-buffer)))
-            (expect (buffer-local-value 'cider-repl-type client-buffer) :to-equal 'cljs)
+                 (client-buffer (cider-connect-sibling-cljs
+                                 '(:cljs-repl-type native-cljs)
+                                 server-buffer)))
+            (expect (buffer-local-value 'cider-repl-type client-buffer)
+                    :to-equal 'cljs)
             (delete-process (get-buffer-process client-buffer))))
       (it "for a custom REPL type project that needs to switch to cljs"
-          (cider-register-cljs-repl-type 'not-cljs-initially "(form-to-switch-to-cljs-repl)")
+          (cider-register-cljs-repl-type
+           'not-cljs-initially "(form-to-switch-to-cljs-repl)")
           (let* ((server-process (nrepl-start-mock-server-process))
                  (server-buffer (process-buffer server-process))
-                 (client-buffer (cider-connect-sibling-cljs '(:cljs-repl-type not-cljs-initially)
-                                                            server-buffer)))
-            (expect (buffer-local-value 'cider-repl-type client-buffer) :to-equal 'pending-cljs)
-            (expect (buffer-local-value 'cider-repl-init-function client-buffer) :not :to-be nil)
+                 (client-buffer (cider-connect-sibling-cljs
+                                 '(:cljs-repl-type not-cljs-initially)
+                                 server-buffer)))
+            (expect (buffer-local-value 'cider-repl-type client-buffer)
+                    :to-equal 'pending-cljs)
+            (expect (buffer-local-value 'cider-repl-init-function client-buffer)
+                    :not :to-be nil)
             (delete-process (get-buffer-process client-buffer))))))
 
 (provide 'cider-tests)

--- a/test/utils/nrepl-tests-utils.el
+++ b/test/utils/nrepl-tests-utils.el
@@ -25,6 +25,8 @@
 
 ;;; Code:
 
+(require 'nrepl-client)
+
 (defmacro nrepl-tests-log/init! (enable? name log-filename &optional clean?)
   "Create a NAME/log! elisp function to log messages to LOG-FILENAME,
 taking the same arguments as `message'. Messages are appended to
@@ -97,5 +99,20 @@ calling process."
           ;; invoke mock server
           " -l test/nrepl-server-mock.el -f nrepl-server-mock-start"))
 
+(defun nrepl-start-mock-server-process ()
+  "Start and return the mock nrepl server process."
+  (let* ((up? nil)
+         (server-process (nrepl-start-server-process
+                          default-directory
+                          (nrepl-server-mock-invocation-string)
+                          (lambda (server-buffer)
+                            (setq up? t))))
+         server-buffer (process-buffer server-process))
+    ;; server has reported its endpoint
+    (nrepl-tests-sleep-until 2 up?)
+    server-process))
 
 (provide 'nrepl-tests-utils)
+
+;;; nrepl-tests-utils.el ends here
+


### PR DESCRIPTION
Hi,

(while I was opening this PR, I've realised that @benjamin-asdf has arleady submitted #3272 to address the same using a more general methodology through the clj REPL. I don't think there is a source code conflict between the two. His PR appears to be allowing the clj REPL to upgrade to cljs and thus support a variaty of cljs cases, this PR is specific to nbb to support it as a native cljs REPL and goes through the established root of declaring a new project tool.  Thus I provisionally open this PR for deliberation only and should be declined in favor of benjamin's if it conflicts in any way or is considered overlapping/obsolete)

Could you please consider PR to support nbb as a native cljs repl when jacking in or connecting to cljs. Addresses #3272 

The logic will consider a project as nbb based on whether a `package.json` is present. A user can jack in using `cider-jack-in-cljs` or `cider-connect-*-cljs`

The previous logic assumed that all cljs REPLs are clojure repls that required some form to switch them over to cljs. With this update a particular project type can be declared as native cljs by not declaring any repl init forms.

I've included some tests to test the above.

It will be nice if we have integration tests to confirm we haven't broken anything when having such high level changes that cannot be unit tested (e.g. the jack in command), thus raised #3274 to discuss whether we can bring this forward.

I will also need to add nbb documentation if this is accepted. Thanks

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!
