### PR TITLE
Introduce integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,18 @@ commands:
           name: Install unzip
           command: apt-get update && apt-get install unzip
 
+  macos-setup:
+    steps:
+      - checkout
+      - run:
+          name: Install Emacs latest
+          command: |
+            echo "HOMEBREW_NO_AUTO_UPDATE=1" >> $BASH_ENV
+            brew install homebrew/cask/emacs
+      - run:
+          name: Install Eldev
+          command: curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/circle-eldev > x.sh && source ./x.sh
+
   setup-windows:
     steps:
       - checkout
@@ -74,6 +86,13 @@ jobs:
       - setup
       - test
 
+  test-macos-emacs-latest:
+    macos:
+      xcode: "14.0.0"
+    steps:
+      - macos-setup
+      - test
+
   test-windows-emacs-latest:
     executor: win/default
     steps:
@@ -100,4 +119,5 @@ workflows:
       - test-emacs-28
       - test-emacs-master
       - test-lint
+      - test-macos-emacs-latest
       - test-windows-emacs-latest

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,2 @@
+[codespell]
+skip = .git,.eldev,logo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,26 +3,68 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  test:
+  integration:
+    # Run integration tests for all OSs and EMACS_VERSIONs.
     runs-on: ${{matrix.os}}
 
     strategy:
       matrix:
-        os: [macos-latest]
-        emacs_version: ['26.3', '27.2', '28.1']
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        emacs_version: ['26.3', '27.2', '28.2']
 
     steps:
     - name: Set up Emacs
+      if: "!startsWith (matrix.os, 'windows')"
       uses: purcell/setup-emacs@master
       with:
         version: ${{matrix.emacs_version}}
 
+    - name: Set up Emacs on Windows
+      if: startsWith (matrix.os, 'windows')
+      uses: jcs090218/setup-emacs-windows@master
+      with:
+        version: ${{matrix.emacs_version}}
+
     - name: Install Eldev
+      if: "!startsWith (matrix.os, 'windows')"
       run: curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/github-eldev | sh
+
+    - name: Install Eldev on MS-Windows
+      if: startsWith (matrix.os, 'windows')
+      run: |
+        # Remove expired DST Root CA X3 certificate. Workaround
+        # for https://debbugs.gnu.org/cgi/bugreport.cgi?bug=51038
+        # bug on Emacs 27.2.
+        gci cert:\LocalMachine\Root\DAC9024F54D8F6DF94935FB1732638CA6AD77C13
+        gci cert:\LocalMachine\Root\DAC9024F54D8F6DF94935FB1732638CA6AD77C13 | Remove-Item
+
+        curl.exe -fsSL https://raw.github.com/doublep/eldev/master/webinstall/github-eldev.bat | cmd /Q
 
     - name: Check out the source code
       uses: actions/checkout@v2
 
-    - name: Test the project
+    - name: Prepare java
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        # shadow requires java 11
+        java-version: 11
+
+    - name: Install Clojure Tools
+      # Use SHA until
+      # https://github.com/DeLaGuardo/setup-clojure/issues/78 is
+      # released
+      uses: DeLaGuardo/setup-clojure@1376ded6747c79645e82c856f16375af5f5de307
+      with:
+        bb: '1.0.165'
+        cli: '1.10.3.1013'
+        lein: '2.9.10'
+
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16
+    - run: npm install shadow-cljs@2.20.13 -g
+
+    - name: Test integration
       run: |
-        eldev -p -dtT test
+        eldev -p -dtTC test --test-type integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- [#3278](https://github.com/clojure-emacs/cider/pull/3278) Introduce integration tests, which also fix a long standing issue with orphaned process on MS-Windows by contracting `taskkill`, if available, to properly kill the nREPL server process tree.
 - [#3249](https://github.com/clojure-emacs/cider/pull/3249): Add support for Clojure Spec 2.
 - [#3247](https://github.com/clojure-emacs/cider/pull/3247) Add the `cider-stacktrace-analyze-at-point` and `cider-stacktrace-analyze-in-region` commands to view printed exceptions in the stacktrace inspector.
 

--- a/Eldev
+++ b/Eldev
@@ -10,12 +10,36 @@
 
 (eldev-add-loading-roots 'test "test/utils")
 
-;; Otherwise `cider-test.el' will be considered a test file.
-(setf eldev-test-fileset "./test/")
-;; This file is _supposed_ to be excluded from automated testing.  Since Eldev
-;; uses everything inside `test/' subdirectory, tell it to leave this file alone
-;; explicitly.
-(setf eldev-standard-excludes `(:or ,eldev-standard-excludes "test/cider-tests--no-auto.el"))
+(defvar cider-test-type 'main)
+(setf eldev-standard-excludes `(:or ,eldev-standard-excludes
+                                    ;; Avoid including files in test "projects".
+                                    (eldev-pcase-exhaustive cider-test-type
+                                                            (`main        "./test/*/")
+                                                            (`integration '("./test/"   "!./test/integration"))
+                                                            (`all         '("./test/*/" "!./test/integration")))
+                                    "test/integration/projects"
+                                    ;; This file is _supposed_ to be excluded
+                                    ;; from automated testing.
+                                    "test/cider-tests--no-auto.el"))
+
+(eldev-defoption cider-test-selection (type)
+  "Select tests to run; type can be `main', `integration' or `all'"
+  :options        (-T --test-type)
+  :for-command    test
+  :value          TYPE
+  :default-value  cider-test-type
+  (unless (memq (intern type) '(main integration all))
+    (signal 'eldev-wrong-option-usage `("unknown test type `%s'" ,type)))
+  (setf cider-test-type (intern type)))
+
+(add-hook 'eldev-test-hook
+          (lambda ()
+            (eldev-verbose "Using cider tests of type `%s'" cider-test-type)))
+(add-hook 'eldev-executing-command-hook
+          (lambda (command)
+            (unless (eq command 'test)
+              ;; So that e.g. byte-compilation works on all tests.
+              (setf cider-test-type 'all))))
 
 ;; CIDER cannot be compiled otherwise.
 (setf eldev-build-load-before-byte-compiling t)

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -180,6 +180,8 @@ buffer."
                      ;; Sync request will hang if the server is dead.
                      (process-live-p (get-buffer-process nrepl-server-buffer))))
         (nrepl-sync-request:close repl)
+        ;; give a chance to the REPL to respond to the closing of the connection
+        (sleep-for 0.5)
         (delete-process proc)))
     (when-let* ((messages-buffer (and nrepl-log-messages
                                       (nrepl-messages-buffer repl))))

--- a/doc/modules/ROOT/pages/contributing/hacking.adoc
+++ b/doc/modules/ROOT/pages/contributing/hacking.adoc
@@ -95,7 +95,7 @@ Run integration tests with:
 
  $ eldev[.bat] test --test-type integration
 
-or all tests with
+or all tests with:
 
  $ eldev[.bat] test --test-type all
 

--- a/doc/modules/ROOT/pages/contributing/hacking.adoc
+++ b/doc/modules/ROOT/pages/contributing/hacking.adoc
@@ -84,9 +84,20 @@ all the details.
 
 If you prefer running all tests outside Emacs that's also an option.
 
-Run all tests with:
+There are two test types, `main` (unit tests) and `integration`. By
+default only main tests are run.
 
- $ eldev test
+Run all unit tests with:
+
+ $ eldev[.bat] test
+
+Run integration tests with:
+
+ $ eldev[.bat] test --test-type integration
+
+or all tests with
+
+ $ eldev[.bat] test --test-type all
 
 NOTE: Tests may not run correctly inside Emacs' `shell-mode` buffers. Running
 them in a terminal is recommended.

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -555,11 +555,12 @@
               "(do (require '[shadow.cljs.devtools.api :as shadow]) (shadow/browser-repl))")))
   (describe "can watch multiple builds"
     (it "watches 2 builds and selects user-defined builds"
-      (setq-local cider-shadow-default-options "client-build")
-      (setq-local cider-shadow-watched-builds '("client-build" "other-build"))
-      (expect (cider-shadow-cljs-init-form)
-              :to-equal
-              "(do (require '[shadow.cljs.devtools.api :as shadow]) (shadow/watch :client-build) (shadow/watch :other-build) (shadow/nrepl-select :client-build))"))))
+      (with-temp-buffer
+        (setq-local cider-shadow-default-options "client-build")
+        (setq-local cider-shadow-watched-builds '("client-build" "other-build"))
+        (expect (cider-shadow-cljs-init-form)
+                :to-equal
+                "(do (require '[shadow.cljs.devtools.api :as shadow]) (shadow/watch :client-build) (shadow/watch :other-build) (shadow/nrepl-select :client-build))")))))
 
 (describe "cider--resolve-project-command"
   (it "if command starts with ./ it resolves relative to clojure-project-dir"

--- a/test/integration/integration-test-utils.el
+++ b/test/integration/integration-test-utils.el
@@ -1,0 +1,114 @@
+;;; integration-test-utils.el  -*- lexical-binding: t; -*-
+
+;; Copyright © 2022 Ioannis Kappas
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; Helper utils for use by integration tests.
+;;
+;; All helper functions should begin with `cider-itu-`.
+
+;; This file is part of CIDER
+
+;;; Code:
+
+(require 'buttercup)
+(require 'cider)
+(require 'cl-lib)
+
+(defmacro with-cider-test-sandbox (&rest body)
+  "Run BODY inside sandbox, with key cider global vars restored on exit.
+
+Only the following variables are currently restored, please add more as the
+test coverage increases:
+
+`cider-connected-hook`."
+  (declare (indent 0))
+  ;; for dynamic vars, just use a binding under the same name.
+  `(let ((cider-connected-hook cider-connected-hook))
+     ,@body))
+
+;; https://emacs.stackexchange.com/a/55031
+(defmacro with-temp-dir (temp-dir &rest body)
+  "Create a temporary directory and bind it to TEMP-DIR while evaluating BODY.
+Remove the temp directory at the end of evaluation."
+  (declare (indent 1))
+  `(let ((,temp-dir (make-temp-file "" t)))
+    (unwind-protect
+      (progn
+        ,@body)
+      (condition-case err
+          (delete-directory ,temp-dir t)
+        (error
+         (message ":with-temp-dir-error :cannot-remove-temp-dir %S" err))))))
+
+(defmacro cider-itu-poll-until (condition timeout-secs)
+  "Poll every 0.2 secs until CONDITION becomes true or error out if TIMEOUT-SECS elapses."
+  (let* ((interval-secs 0.2)
+         (count (truncate (/ timeout-secs interval-secs))))
+    `(cl-loop repeat ,count
+              for condition = ,condition
+              if condition
+                return condition
+              else
+                do (sleep-for ,interval-secs)
+              finally (error ":cider-itu-poll-until-errored :timed-out-after-secs %d :waiting-for %S"
+                               ,timeout-secs (quote ,condition)))))
+
+(defun cider-itu-nrepl-client-connected-ref-make! ()
+  "Returns a gv ref to signal when the client is connected to the nREPL server.
+This is done by adding a hook to `cider-connected-hook' and must be run
+inside `with-cider-test-sandbox'.
+
+Use `gv-deref' to deref the value.
+
+The generalized variable can have the following values
+
+'!connected the client has not yet connected to the nREPL server.
+'connected  the client has connected to the nREPL server."
+  (let ((is-connected '!connected))
+    (add-hook 'cider-connected-hook
+              (lambda ()
+                (setq is-connected 'connected)))
+    (gv-ref is-connected)))
+
+(describe "in integration utils test"
+  (it "that cider-itu-poll-until works when sexpr eventually becomes true."
+    (let ((stack '(nil 123 456)))
+      (expect (cider-itu-poll-until (progn (message ":looping... %S" stack) (pop stack)) 1) :to-equal 123)
+      (expect stack :to-equal '(456)))
+    (expect (cider-itu-poll-until nil 1) :to-throw 'error))
+
+  (it "that sand box can restore CIDER global vars."
+    (let ((count (length cider-connected-hook)))
+      (with-cider-test-sandbox
+       (add-hook 'cider-connected-hook (lambda ()))
+       (expect (length cider-connected-hook) :to-be (1+ count)))
+      (expect (length cider-connected-hook) :to-be count)))
+
+  (it "that `cider-itu-nrepl-client-connected-ref-make!' return ref changes value when client is connected."
+    (with-cider-test-sandbox
+      (let ((is-connected* (cider-itu-nrepl-client-connected-ref-make!)))
+        (expect (gv-deref is-connected*) :to-equal '!connected)
+        (run-hooks 'cider-connected-hook)
+        (expect (gv-deref is-connected*) :to-equal 'connected)))))
+
+
+(provide 'integration-test-utils)
+
+;;; integration-test-utils.el ends here

--- a/test/integration/integration-tests.el
+++ b/test/integration/integration-tests.el
@@ -50,7 +50,7 @@ Remove the temp directory at the end of evaluation."
   ;; very long time to bring up/respond/shutdown, and thus sleep duration values
   ;; are set rather high.
 
-  (it "to bb"
+  (it "to babashka"
       (with-temp-dir temp-dir
         ;; set up a project directory in temp
         (let* ((project-dir temp-dir)
@@ -221,9 +221,9 @@ Remove the temp directory at the end of evaluation."
                       (nrepl-tests-sleep-until 15 (not (eq (process-status nrepl-proc) 'run)))
                       (expect (member (process-status nrepl-proc) '(exit signal)))))
                 (when-let ((nrepl-error-buffer (get-buffer "*nrepl-error*")))
-                (with-current-buffer nrepl-error-buffer
-                  (message ":*nrepl-error* %S"
-                           (substring-no-properties (buffer-string))))))))))))
+                  (with-current-buffer nrepl-error-buffer
+                    (message ":*nrepl-error* %S"
+                             (substring-no-properties (buffer-string))))))))))))
 
 (provide 'integration-tests)
 

--- a/test/integration/integration-tests.el
+++ b/test/integration/integration-tests.el
@@ -1,0 +1,231 @@
+;;; integration-tests.el  -*- lexical-binding: t; -*-
+
+;; Copyright © 2022 Ioannis Kappas
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; Integration tests
+
+;; This file is part of CIDER
+
+;;; Code:
+
+(require 'buttercup)
+(require 'cider)
+(require 'nrepl-dict)
+(require 'nrepl-tests-utils "test/utils/nrepl-tests-utils")
+
+;; https://emacs.stackexchange.com/a/55031
+(defmacro with-temp-dir (temp-dir &rest body)
+  "Create a temporary directory and bind it to TEMP-DIR while evaluating BODY.
+Remove the temp directory at the end of evaluation."
+  `(let ((,temp-dir (make-temp-file "" t)))
+    (unwind-protect
+      (progn
+        ,@body)
+      (condition-case err
+          (delete-directory ,temp-dir t)
+        (error
+         (message ":with-temp-dir-error :cannot-remove-temp-dir %S" err))))))
+
+(describe "jack in"
+  ;; See "bb" case for basic commentary
+  ;;
+  ;; It has been observed that some REPLs (Clojure cli, shadow) might take a
+  ;; very long time to bring up/respond/shutdown, and thus sleep duration values
+  ;; are set rather high.
+
+  (it "to bb"
+      (with-temp-dir temp-dir
+        ;; set up a project directory in temp
+        (let* ((project-dir temp-dir)
+               (bb-edn (expand-file-name "bb.edn" project-dir)))
+          (write-region "{}" nil bb-edn)
+
+          (with-temp-buffer
+            ;; set default directory to temp project
+            (setq-local default-directory project-dir)
+
+            (unwind-protect
+                ;; jack in and get repl buffer
+                (let* ((nrepl-proc (cider-jack-in-clj '()))
+                       (nrepl-buf (process-buffer nrepl-proc)))
+                  ;; give it some time to setup the clj REPL
+                  (nrepl-tests-sleep-until 5 (cider-repls 'clj nil))
+
+                  ;; send command to the REPL, and stdout/stderr to
+                  ;; corresponding eval- variables.
+                  (let ((repl-buffer (cider-current-repl))
+                        (eval-err '())
+                        (eval-out '()))
+                    (expect repl-buffer :not :to-be nil)
+
+                    ;; send command to the REPL
+                    (cider-interactive-eval
+                     ;; ask REPL to return a string that uniquely identifies it.
+                     "(print :bb? (some? (System/getProperty \"babashka.version\")))"
+                     (lambda (return)
+                       (nrepl-dbind-response
+                           return
+                           (out err)
+                         (when err (push err eval-err))
+                         (when out (push out eval-out)))) )
+
+                    ;; wait for the response to come back.
+                    (nrepl-tests-sleep-until 5 eval-out)
+
+                    ;; ensure there are no errors and response is as expected.
+                    (expect eval-err :to-equal '())
+                    (expect eval-out :to-equal '(":bb? true"))
+
+                    ;; exit the REPL.
+                    (cider-quit repl-buffer)
+
+                    ;; wait for the REPL to exit
+                    (nrepl-tests-sleep-until 5 (not (eq (process-status nrepl-proc) 'run)))
+                    (expect (member (process-status nrepl-proc) '(exit signal)))))
+
+              ;; useful for debugging on errors
+              (when-let ((nrepl-error-buffer (get-buffer "*nrepl-error*")))
+                (with-current-buffer nrepl-error-buffer
+                  (message ":*nrepl-error* %S" (substring-no-properties (buffer-string))))))))))
+
+  (it "to clojure tools cli"
+      (with-temp-dir temp-dir
+        (let* ((project-dir temp-dir)
+               (deps-edn (expand-file-name "deps.edn" project-dir)))
+          (write-region "{}" nil deps-edn)
+          (with-temp-buffer
+            (setq-local default-directory project-dir)
+            (unwind-protect
+                (let* ((nrepl-proc (cider-jack-in-clj `()))
+                       (nrepl-buf (process-buffer nrepl-proc)))
+
+                  ;; high duration since on windows it takes a long time to startup
+                  (nrepl-tests-sleep-until 90 (cider-repls 'clj nil))
+                  (let ((repl-buffer (cider-current-repl))
+                        (eval-err '())
+                        (eval-out '()))
+                    (expect repl-buffer :not :to-be nil)
+                    (cider-interactive-eval
+                     "(print :clojure? (some? (clojure-version)))"
+                     (lambda (return)
+                       (nrepl-dbind-response
+                           return
+                           (out err)
+                         (when err (push err eval-err))
+                         (when out (push out eval-out)))) )
+                    (nrepl-tests-sleep-until 10 eval-out)
+                    (expect eval-err :to-equal '())
+                    (expect eval-out :to-equal '(":clojure? true"))
+                    (cider-quit repl-buffer)
+                    (nrepl-tests-sleep-until 15 (not (eq (process-status nrepl-proc) 'run)))
+                    (expect (member (process-status nrepl-proc) '(exit signal)))))
+              (when-let ((nrepl-error-buffer (get-buffer "*nrepl-error*")))
+                (with-current-buffer nrepl-error-buffer
+                  (message ":*nrepl-error* %S" (substring-no-properties (buffer-string))))))))))
+
+  (it "to leiningen"
+      (with-temp-dir temp-dir
+        (let* ((project-dir temp-dir)
+               (project-clj (expand-file-name "project.clj" project-dir)))
+          (write-region "(defproject cider/integration \"test\"
+                           :dependencies [[org.clojure/clojure \"1.10.3\"]])"
+                        nil project-clj)
+          (with-temp-buffer
+            (setq-local default-directory project-dir)
+            (unwind-protect
+                (let* ((nrepl-proc (cider-jack-in-clj `()))
+                       (nrepl-buf (process-buffer nrepl-proc)))
+                  (nrepl-tests-sleep-until 90 (cider-repls 'clj nil))
+                  (let ((repl-buffer (cider-current-repl))
+                        (eval-err '())
+                        (eval-out '()))
+                    (expect repl-buffer :not :to-be nil)
+                    (cider-interactive-eval
+                     "(print :clojure? (some? (clojure-version)))"
+                     (lambda (return)
+                       (nrepl-dbind-response
+                           return
+                           (out err)
+                         (when err (push err eval-err))
+                         (when out (push out eval-out)))) )
+                    (nrepl-tests-sleep-until 10 eval-out)
+                    (expect eval-err :to-equal '())
+                    (expect eval-out :to-equal '(":clojure? true"))
+                    (cider-quit repl-buffer)
+                    (nrepl-tests-sleep-until 15 (not (eq (process-status nrepl-proc) 'run)))
+                    (expect (member (process-status nrepl-proc) '(exit signal)))
+                    (sleep-for 0.5)))
+              (when-let ((nrepl-error-buffer (get-buffer "*nrepl-error*")))
+                (with-current-buffer nrepl-error-buffer
+                  (message ":*nrepl-error* %S"
+                           (substring-no-properties (buffer-string))))))))))
+
+  (it "to shadow"
+      ;; shadow asks user whether they want to open a browser, force to no
+      (spy-on 'y-or-n-p)
+
+      (with-temp-dir temp-dir
+        (let* ((project-dir temp-dir)
+               (shadow-cljs-edn (expand-file-name "shadow-cljs.edn" project-dir))
+               (package-json    (expand-file-name "package.json"    project-dir)))
+          (write-region "{}" nil shadow-cljs-edn)
+          (write-region "{\"dependencies\":{\"shadow-cljs\": \"^2.20.13\"}}" nil package-json)
+          (let ((default-directory project-dir))
+            (message ":npm-install...")
+            (shell-command "npm install")
+            (message ":npm-install :done"))
+          (let ((cider-preferred-build-tool 'shadow-cljs)
+                ;; request for a node repl, so that shadow forks one.
+                (cider-shadow-default-options ":node-repl"))
+            (with-temp-buffer
+              (setq-local default-directory project-dir)
+              (unwind-protect
+                  (let* ((nrepl-proc (cider-jack-in-cljs '(:cljs-repl-type shadow)))
+                         (nrepl-buf (process-buffer nrepl-proc)))
+                    (nrepl-tests-sleep-until 120 (cider-repls 'cljs nil))
+                    (expect (cider-repls 'cljs nil) :not :to-be nil)
+                    (let ((repl-buffer (cider-current-repl))
+                          (eval-err '())
+                          (eval-out '()))
+                      (expect repl-buffer :not :to-be nil)
+                      (sleep-for 2)
+                      (cider-interactive-eval
+                       "(print :cljs? (some? *clojurescript-version*))"
+                       (lambda (return)
+                         (nrepl-dbind-response
+                             return
+                             (out err)
+                           (when err (push err eval-err))
+                           (when out (push out eval-out)))) )
+                      (nrepl-tests-sleep-until 10 eval-out)
+                      (expect eval-err :to-equal '())
+                      (expect eval-out :to-equal '(":cljs? true\n"))
+                      (cider-quit repl-buffer)
+                      (nrepl-tests-sleep-until 15 (not (eq (process-status nrepl-proc) 'run)))
+                      (expect (member (process-status nrepl-proc) '(exit signal)))))
+                (when-let ((nrepl-error-buffer (get-buffer "*nrepl-error*")))
+                (with-current-buffer nrepl-error-buffer
+                  (message ":*nrepl-error* %S"
+                           (substring-no-properties (buffer-string))))))))))))
+
+(provide 'integration-tests)
+
+;;; integration-tests.el ends here
+

--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -159,7 +159,8 @@
         ;; server has reported its endpoint
         (nrepl-tests-sleep-until 2 server-endpoint)
         (expect server-endpoint :not :to-be nil)
-
+        (expect (plist-get (process-plist server-process) :cider--nrepl-server-ready)
+                :to-equal t)
         (condition-case error-details
             ;; start client process
             (let* ((client-buffer (get-buffer-create ":nrepl-lifecycle/client"))
@@ -182,10 +183,12 @@
               (delete-process process-client)
 
               ;; server process has been signalled
-              (nrepl-tests-sleep-until 4 (eq (process-status server-process)
-                                             'signal))
-              (expect (process-status server-process)
-                      :to-equal 'signal))
+              (nrepl-tests-sleep-until 4 (member (process-status server-process)
+                                                 '(exit signal)))
+              (expect (let ((status (process-status server-process)))
+                        (if (eq system-type 'windows-nt)
+                            (eq status 'exit)
+                          (eq status 'signal)))))
           (error
            ;; there may be some useful information in the nrepl buffer on error
            (when-let ((nrepl-error-buffer (get-buffer "*nrepl-error*")))

--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -159,8 +159,7 @@
         ;; server has reported its endpoint
         (nrepl-tests-sleep-until 2 server-endpoint)
         (expect server-endpoint :not :to-be nil)
-        (expect (plist-get (process-plist server-process) :cider--nrepl-server-ready)
-                :to-equal t)
+
         (condition-case error-details
             ;; start client process
             (let* ((client-buffer (get-buffer-create ":nrepl-lifecycle/client"))
@@ -183,12 +182,10 @@
               (delete-process process-client)
 
               ;; server process has been signalled
-              (nrepl-tests-sleep-until 4 (member (process-status server-process)
-                                                 '(exit signal)))
-              (expect (let ((status (process-status server-process)))
-                        (if (eq system-type 'windows-nt)
-                            (eq status 'exit)
-                          (eq status 'signal)))))
+              (nrepl-tests-sleep-until 4 (eq (process-status server-process)
+                                             'signal))
+              (expect (process-status server-process)
+                      :to-equal 'signal))
           (error
            ;; there may be some useful information in the nrepl buffer on error
            (when-let ((nrepl-error-buffer (get-buffer "*nrepl-error*")))

--- a/test/utils/nrepl-tests-utils.el
+++ b/test/utils/nrepl-tests-utils.el
@@ -25,6 +25,8 @@
 
 ;;; Code:
 
+(require 'nrepl-client)
+
 (defmacro nrepl-tests-log/init! (enable? name log-filename &optional clean?)
   "Create a NAME/log! elisp function to log messages to LOG-FILENAME,
 taking the same arguments as `message'. Messages are appended to
@@ -97,5 +99,19 @@ calling process."
           ;; invoke mock server
           " -l test/nrepl-server-mock.el -f nrepl-server-mock-start"))
 
+(defun nrepl-start-mock-server-process ()
+  "Start and return the mock nrepl server process."
+  (let* ((up? nil)
+         (server-process (nrepl-start-server-process
+                          default-directory
+                          (nrepl-server-mock-invocation-string)
+                          (lambda (server-buffer)
+                            (setq up? t)))))
+    ;; server has reported its endpoint
+    (nrepl-tests-sleep-until 2 up?)
+    server-process))
 
 (provide 'nrepl-tests-utils)
+
+;;; nrepl-tests-utils.el ends here
+

--- a/test/utils/nrepl-tests-utils.el
+++ b/test/utils/nrepl-tests-utils.el
@@ -25,8 +25,6 @@
 
 ;;; Code:
 
-(require 'nrepl-client)
-
 (defmacro nrepl-tests-log/init! (enable? name log-filename &optional clean?)
   "Create a NAME/log! elisp function to log messages to LOG-FILENAME,
 taking the same arguments as `message'. Messages are appended to
@@ -99,19 +97,5 @@ calling process."
           ;; invoke mock server
           " -l test/nrepl-server-mock.el -f nrepl-server-mock-start"))
 
-(defun nrepl-start-mock-server-process ()
-  "Start and return the mock nrepl server process."
-  (let* ((up? nil)
-         (server-process (nrepl-start-server-process
-                          default-directory
-                          (nrepl-server-mock-invocation-string)
-                          (lambda (server-buffer)
-                            (setq up? t)))))
-    ;; server has reported its endpoint
-    (nrepl-tests-sleep-until 2 up?)
-    server-process))
 
 (provide 'nrepl-tests-utils)
-
-;;; nrepl-tests-utils.el ends here
-


### PR DESCRIPTION
Hi, 

can you please consider patch to introduce integration tests to CIDER. It addresses #3274.

Other than adding integration tests for jack-in covering the major project tools, it also fixes a long standing issue with nREPL leaving orphaned child processes on MS-Windows after being killed,. The issue is fixed by contracting the external `taskkill` MS-Windows program to do the job.

The integration tests appear to work consistently across all platforms, and have already discovered a bug with shadow reported under #3277, thus it will currently show as failing. 

I haven't updated the changelog yet, waiting for some review feedback.

Detailed changelog in order of appears as follows:

1. Migrated macos regression tests to circle ci, but with a reduced set to only cover Emacs latest version.
2. Replaced existing macos only testing github action to run the integration tests across macos, ubuntu and windows latest on Emacs 28, 27 and 26. It was nearly impossible to do so on circleci across all platforms, thus a github action was chosen.
3. Updated the `Eldev` project file to support integration test via a new `--test-type` command line option (the template was taken from the `Eldev` tool's project file itself).
4. The cider server is given now a 0.5 sec opportunity to execute the `close` op before the server is killed.
5. The hacking section in documentation has been updated to mention integration tests.
6. The `nrepl--kill-process` has been updated to address the orphaned child process menace under MS-Windows, whereby the nREPL child processes were most likely to be left orphaned after the parent process was killed. The kill is now done by contracting the external `taskkill` windows program to do the job if available, and falls back to the previous logic otherwise.
7. The `nrepl-server-sentinel` has been simplified to only report an error if the nREPL process couldn't bootstrap itself, or send an exit message otherwise. The old code only closed client connections on `hangup` (i.e. HUP signal), but the new logic will close clients on any fatal signal. Not sure why the old code only did this on HUP, but it seems sensible to me that any open client connection should close when the server has exited.
8. Fixed an issue in `cider-tests.el` that a couple of buffer local shadow-cljs variables were set as global by mistake, thus affecting other tests (and in particular the integration tests).
9. Updated nrepl-client-tests.el to test the new nrepl plist property to indicate that the nREPL server has been successfully brought up, and also test that the new process-status `exit` returned on MS-Windows with `taskkill` is set.
10. Introduced integration tests covering jack-in for bb, clojure cli, lein and shadow.

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
