### PR TITLE
Replace newline chars with newlines in test report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## master (unreleased)
 - Allow using `npx nbb` as `cider-nbb-command`.
 
+### Changes
+
+- [#3281](https://github.com/clojure-emacs/cider/pull/3281): Replace newline chars with actual newlines in `*cider-test-report*` buffer, for prettier error messages.
+
 ## 1.6.0 (2022-12-21)
 
 ### New features

--- a/cider-test.el
+++ b/cider-test.el
@@ -478,6 +478,12 @@ With the actual value, the outermost '(not ...)' s-expression is removed."
                       (cider-test-render-assertion buffer test)))))
               vars))
            results)))
+      ;; Replace any newline chars with actual newlines to make long error
+      ;; messages more readable
+      (goto-char (point-min))
+      (while (search-forward "\\n" nil t)
+        (replace-match "
+"))
       (goto-char (point-min))
       (current-buffer))))
 


### PR DESCRIPTION
When the library / app under test returns long error messages on test
failures it will often include newlines.  These are today displayed as
`\\n` and we get an error message on one very long line.

This commit turns these newline characters into actual newlines, which
makes the content of the `*cider-test-report*` buffer much more pleasant
to read.

Before:

![image](https://user-images.githubusercontent.com/1006557/205971484-fbd59544-f8ec-46fc-8912-3019d94f61af.png)


After:
![image](https://user-images.githubusercontent.com/1006557/205971315-18f6e894-fb34-4e9f-b526-13600856ff52.png)

