### PR TITLE
Fix cljs type not set correctly

### DIFF
--- a/cider-connection.el
+++ b/cider-connection.el
@@ -301,7 +301,6 @@ See command `cider-mode'."
   (unless (cider-sessions)
     (cider-disable-on-existing-clojure-buffers)))
 
-
 (defun cider--set-connection-capabilities (&optional conn-buffer)
   "Set `cider-connection-capabilities' for CONN-BUFFER during repl init.
 See `cider-connection-capabilities'."


### PR DESCRIPTION
I introduced a bug with 24b9891e0b4603dca7519427d02ff4af2cfac57a
that made cljs repls not upgrade automatically anymore to cljs (repl-type).
What actually happened was that after the init function, it was set an
ultimate time, because of the "demunge" eval call I added.

1. Move the connection capability block in fron of
=cider-nrepl-init-function=, this would by itself already fix it
because then we would eval as clj repl and in the end once as cljs
repl (which sets the repl-type see cider-repl--state-handler)

2. do not make the "demunge" eval call at all, when we already know
the repl is going to be cljs (cljs or pending-cljs).
(This would by itself also be a fix).

