### PR TITLE
Allow user provided jack-in-cmd for jack-in

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -510,11 +510,14 @@ specifying the artifact ID, and the second element the version number."
                        (string :tag "Artifact ID")
                        (string :tag "Version"))))
 
-(defvar-local cider-jack-in-command nil
-  "The custom command used to start a nrepl server when using `cider-jack-in`.
+(defvar-local cider-jack-in-cmd nil
+  "The custom command used to start a nrepl server.
+This is used by `cider-jack-in`.
 
-If this variable is set, its value will be used as the command to start
-the nrepl server instead of the default command inferred from the project type.
+If this variable is set, its value will be
+used as the command to start the nrepl server
+instead of the default command inferred from
+the project type.
 
 This allows for fine-grained control over the jack-in process.
 The value should be a string representing the command to start
@@ -1506,7 +1509,7 @@ PARAMS is a plist with the following keys (non-exhaustive list)
 `cider-jack-in-command' for the list of valid types)."
   (cond
    ((plist-get params :jack-in-cmd) params)
-   (cider-jack-in-command (plist-put params :jack-in-cmd cider-jack-in-command))
+   (cider-jack-in-cmd (plist-put params :jack-in-cmd cider-jack-in-cmd))
    (t (let* ((params (cider--update-do-prompt params))
            (project-dir (plist-get params :project-dir))
            (params-project-type (plist-get params :project-type))

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -251,7 +251,7 @@ The precedence order for determining the Jack-In Command is:
 2) `cider-jack-in-command` if set as a directory local variable, and
 3) inferred from the project type (the default).
 
-==== Settign a project wide command
+==== Setting a project-wide command
 
 You can set a local variable `cider-jack-in-command` to override the jack-in command.
 

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -258,7 +258,7 @@ You can set a local variable `cider-jack-in-command` to override the jack-in com
 [source,emacs-lisp]
 ----
 ((nil
-  (cider-jack-in-command . "nbb nrepl-server")))
+  (cider-jack-in-cmd . "nbb nrepl-server")))
 ----
 
 ==== Passing the Command Programmatically as a Parameter

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -241,7 +241,7 @@ wait`)
 * `cider-shadow-cljs-parameters` - the task to start a REPL server (`server` by default)
 * `cider-shadow-cljs-global-options`
 
-=== Override Jack-In Command
+=== Override the Jack-In Command
 
 Which Jack-In Command is used is based on the project type. You can override the Jack-In Command either project-wide or as an argument in Lisp.
 This allows for fine-grained control over how cider starts the nrepl-server.
@@ -251,7 +251,7 @@ The precedence order for determining the Jack-In Command is:
 2) `cider-jack-in-command` if set as a directory local variable, and
 3) inferred from the project type (the default).
 
-==== Project wide with .dir-locals.el
+==== Settign a project wide command
 
 You can set a local variable `cider-jack-in-command` to override the jack-in command.
 
@@ -261,7 +261,7 @@ You can set a local variable `cider-jack-in-command` to override the jack-in com
   (cider-jack-in-command . "nbb nrepl-server")))
 ----
 
-==== Parameter
+==== Passing the Command Programmatically as a Parameter
 
 You can provide an override Jack-In command as an argument to `cider-jack-in`.
 Here is an example Nbb Jack-In command, providing a custom `:jack-in-cmd`.

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -271,7 +271,7 @@ Here is an example Nbb Jack-In command, providing a custom `:jack-in-cmd`.
 (defun cider-jack-in-nbb-2 ()
   "Start a Cider nREPL server with the 'nbb nrepl-server' command."
   (interactive)
-  (cider-jack-in '(:jack-in-cmd "nbb nrepl-server")))
+  (cider-jack-in-clj '(:jack-in-cmd "nbb nrepl-server")))
 ----
 
 

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -241,6 +241,40 @@ wait`)
 * `cider-shadow-cljs-parameters` - the task to start a REPL server (`server` by default)
 * `cider-shadow-cljs-global-options`
 
+=== Override Jack-In Command
+
+Which Jack-In Command is used is based on the project type. You can override the Jack-In Command either project-wide or as an argument in Lisp.
+This allows for fine-grained control over how cider starts the nrepl-server.
+
+The precedence order for determining the Jack-In Command is:
+1) :jack-in-cmd if provided as a parameter,
+2) `cider-jack-in-command` if set as a directory local variable, and
+3) inferred from the project type (the default).
+
+==== Project wide with .dir-locals.el
+
+You can set a local variable `cider-jack-in-command` to override the jack-in command.
+
+[source,emacs-lisp]
+----
+((nil
+  (cider-jack-in-command . "nbb nrepl-server")))
+----
+
+==== Parameter
+
+You can provide an override Jack-In command as an argument to `cider-jack-in`.
+Here is an example Nbb Jack-In command, providing a custom `:jack-in-cmd`.
+
+[source,emacs-lisp]
+----
+(defun cider-jack-in-nbb-2 ()
+  "Start a Cider nREPL server with the 'nbb nrepl-server' command."
+  (interactive)
+  (cider-jack-in '(:jack-in-cmd "nbb nrepl-server")))
+----
+
+
 == Connect to a Running nREPL Server
 
 If you have an nREPL server already running, CIDER can connect to

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -523,7 +523,22 @@
         (spy-on 'cider-project-type :and-return-value 'clojure-cli)
         (spy-on 'cider-jack-in-resolve-command :and-return-value "clojure")
         (expect (plist-get (cider--update-jack-in-cmd nil) :jack-in-cmd)
-                :to-equal expected)))))
+                :to-equal expected))))
+  (describe "Override jack-in command"
+   (it "Uses the param, if provided"
+    (let* ((params '(:jack-in-cmd "Snowcrash"))
+           (params (cider--update-jack-in-cmd params)))
+      (expect params :to-equal '(:jack-in-cmd "Snowcrash"))))
+   (it "Uses the `cider-jack-in-command', if provided"
+    (let* ((params '())
+           (cider-jack-in-command "Seveneves")
+           (params (cider--update-jack-in-cmd params)))
+      (expect params :to-equal '(:jack-in-cmd "Seveneves"))))
+   (it "Uses params over `cider-jack-in-command', if provided"
+    (let* ((params '(:jack-in-cmd "Snowcrash"))
+           (cider-jack-in-command "Seveneves")
+           (params (cider--update-jack-in-cmd params)))
+      (expect params :to-equal '(:jack-in-cmd "Snowcrash"))))))
 
 (defmacro with-temp-shadow-config (contents &rest body)
   "Run BODY with a mocked shadow-cljs.edn project file with the CONTENTS."

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -529,14 +529,14 @@
     (let* ((params '(:jack-in-cmd "Snowcrash"))
            (params (cider--update-jack-in-cmd params)))
       (expect params :to-equal '(:jack-in-cmd "Snowcrash"))))
-   (it "Uses the `cider-jack-in-command', if provided"
+   (it "Uses the `cider-jack-in-cmd', if provided"
     (let* ((params '())
-           (cider-jack-in-command "Seveneves")
+           (cider-jack-in-cmd "Seveneves")
            (params (cider--update-jack-in-cmd params)))
       (expect params :to-equal '(:jack-in-cmd "Seveneves"))))
-   (it "Uses params over `cider-jack-in-command', if provided"
+   (it "Uses params over `cider-jack-in-cmd', if provided"
     (let* ((params '(:jack-in-cmd "Snowcrash"))
-           (cider-jack-in-command "Seveneves")
+           (cider-jack-in-cmd "Seveneves")
            (params (cider--update-jack-in-cmd params)))
       (expect params :to-equal '(:jack-in-cmd "Snowcrash"))))))
 


### PR DESCRIPTION
```lisp

;; currently cider--update-jack-in-cmd updates the cmd based on the project type
;; This does not feel  powerful. I want would like the freedom to provide my own jack-in-cmd

;; source code change:

(if params-provided
    params
  ... update-params )

;; the equivalent of the proposed change
(advice-add
 'cider--update-jack-in-cmd
 :before-until
 (defun cider-dont-update-jack-in-cmd-when-given (params)
   (when (plist-get params :jack-in-cmd) params)))

;; now a nbb jack in command becomes:

(cider-jack-in '(:jack-in-cmd "nbb nrepl-server"))
```