### PR TITLE
Don't scale down time for overlay tests on MacOS

### DIFF
--- a/test/cider-overlay-tests.el
+++ b/test/cider-overlay-tests.el
@@ -67,7 +67,7 @@ being set that way"
 (defun cider-overlay--safe-to-speed-up-tests ()
   (and (<= 28 emacs-major-version)
        (not (member system-type
-                    '(ms-dos windows-nt cygwin)))))
+                    '(ms-dos windows-nt cygwin darwin)))))
 
 (describe "cider--make-result-overlay"
   :var (overlay-count this-command)


### PR DESCRIPTION
Overlay tests involve testing the timer functionality of overlays, and require the use of sleep. The tests scale all time-related arguments by a certain factor to avoid overly inflating test-running times.

The scaling factor was initially set at 1 order of magnitude slower than the consistently succeeding value on my machine, but the value is apparently still too fast for the MacOS test runner, so I have added MacOS to the list of platforms unsafe to do this optimization for.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
