### PR TITLE
Document updated paredit ret behaviour

### DIFF
--- a/doc/modules/ROOT/pages/additional_packages.adoc
+++ b/doc/modules/ROOT/pages/additional_packages.adoc
@@ -122,6 +122,21 @@ enable `paredit` in the REPL buffer as well:
 (add-hook 'cider-repl-mode-hook #'paredit-mode)
 ----
 
+==== Unsetting Paredit binding of RET key
+
+In more recent versions of paredit, `RET` is bound to `paredit-RET`. This
+can cause unexpected behaviour in the repl when `paredit-mode` is enabled,
+e.g. it appears to hang after hitting `RET` instead of evaluating the last
+form.
+
+You can disable the paredit behaviour by adding the following to your
+`init.el`:
+
+[source,lisp]
+----
+(define-key paredit-mode-map (kbd "RET") nil)
+----
+
 === Smartparens
 
 https://github.com/Fuco1/smartparens[smartparens] is an excellent alternative

--- a/doc/modules/ROOT/pages/troubleshooting.adoc
+++ b/doc/modules/ROOT/pages/troubleshooting.adoc
@@ -337,3 +337,16 @@ $ guix package -i openjdk:jdk
 ----
 
 NOTE: On Windows and macOS the JDK source code is bundled with the JDK.
+
+=== Hitting RET in the repl does not evaluate forms
+
+In more recent versions of paredit, `RET` is bound to `paredit-RET`. This can cause unexpected
+behaviour in the repl when `paredit-mode` is enabled, e.g. it appears to hang after hitting
+`RET` instead of evaluating the last form.
+
+You can disable the paredit behaviour by adding the following to your `init.el`:
+
+[source,lisp]
+----
+(define-key paredit-mode-map (kbd "RET") nil)
+----


### PR DESCRIPTION
Motivated by: https://github.com/clojure-emacs/cider/issues/3288

Adds documentation for the odd repl behaviour some users (myself included) have seen with newer versions of paredit, along with a fix (hat-tip to @rrudakov). 