### PR TITLE
Start bb nREPL server at a random port

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ commands:
           command: eldev -dtT compile --warnings-as-errors
 
 jobs:
-  test-emacs-26:
+  test-ubuntu-emacs-26:
     docker:
       - image: silex/emacs:26-dev
         entrypoint: bash
@@ -62,7 +62,7 @@ jobs:
       - setup
       - test
 
-  test-emacs-27:
+  test-ubuntu-emacs-27:
     docker:
       - image: silex/emacs:27-dev
         entrypoint: bash
@@ -70,7 +70,7 @@ jobs:
       - setup
       - test
 
-  test-emacs-28:
+  test-ubuntu-emacs-28:
     docker:
       - image: silex/emacs:28-dev
         entrypoint: bash
@@ -78,7 +78,7 @@ jobs:
       - setup
       - test
 
-  test-emacs-master:
+  test-ubuntu-emacs-master:
     docker:
       - image: silex/emacs:master-dev
         entrypoint: bash
@@ -114,10 +114,10 @@ workflows:
   version: 2
   ci-test-matrix:
     jobs:
-      - test-emacs-26
-      - test-emacs-27
-      - test-emacs-28
-      - test-emacs-master
+      - test-ubuntu-emacs-26
+      - test-ubuntu-emacs-27
+      - test-ubuntu-emacs-28
+      - test-ubuntu-emacs-master
       - test-lint
       - test-macos-emacs-latest
       - test-windows-emacs-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [#3260](https://github.com/clojure-emacs/cider/pull/3260): Scroll REPL buffer in other frame.
 - [#3061](https://github.com/clojure-emacs/cider/issues/3061): Allow
   to use `cider-connect-clj` for self-hosted cljs repls (e.g. `nbb`).
+- [#3293](https://github.com/clojure-emacs/cider/issues/3293): Can't jack in to more than one bb projects.
 
 ## 1.5.0 (2022-08-24)
 

--- a/cider.el
+++ b/cider.el
@@ -224,7 +224,7 @@ By default we favor the project-specific shadow-cljs over the system-wide."
   :package-version '(cider . "1.2.0"))
 
 (defcustom cider-babashka-parameters
-  "nrepl-server"
+  "nrepl-server :0"
   "Params passed to babashka to start an nREPL server via `cider-jack-in'."
   :type 'string
   :safe #'stringp

--- a/cider.el
+++ b/cider.el
@@ -224,7 +224,7 @@ By default we favor the project-specific shadow-cljs over the system-wide."
   :package-version '(cider . "1.2.0"))
 
 (defcustom cider-babashka-parameters
-  "nrepl-server :0"
+  "nrepl-server localhost:0"
   "Params passed to babashka to start an nREPL server via `cider-jack-in'."
   :type 'string
   :safe #'stringp


### PR DESCRIPTION
Hi,

could you please consider PR to start bb nREPL server at a random port. It fixes #3293.

The `:0` format eligibility to start the server has been confirmed by @borkdude on chat.

I did not bother to include a test for such a small change, but here is the output from the bb integration test that shows port is now not 1667 but random:

```
[00:11.202]  [nREPL] Starting server via /opt/hostedtoolcache/Babashka/1.0.165/x64/bb nrepl-server :0
[00:11.209]  [nREPL] server started on 33711
[00:11.209]  [nREPL] Establishing direct connection to 127.0.0.1:33711 ...
[00:11.209]  [nREPL] Direct connection to 127.0.0.1:33711 established
[00:11.393]  Connected! In the absence of parentheses, chaos prevails.
[00:12.145]  [nREPL] Connection closed
[00:12.146]  nREPL server exited.
jack in
  to babashka
  to babashka (1.15s)
```

I've also piggybacked an update to the circleci job names to include `ubuntu` so names are aligned with the rest of the jobs, if you don't mind.

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks