### PR TITLE
Increase nrepl mock server conn timeout period for recently introduced sibling tests

### DIFF
--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -591,58 +591,67 @@
   (describe "sets nrepl client local vars correctly"
       (it "for nbb project"
           (let* ((server-process (nrepl-start-mock-server-process))
-                 (server-buffer (process-buffer server-process))
-                 (client-buffer (cider-connect-sibling-cljs
-                                 '(:cljs-repl-type nbb) server-buffer)))
-            ;; native cljs REPL
-            (expect (buffer-local-value 'cider-repl-type client-buffer)
-                    :to-equal 'cljs)
-            (expect (buffer-local-value 'cider-repl-cljs-upgrade-pending client-buffer)
-                    :to-equal nil)
-            (expect (buffer-local-value 'cider-repl-init-function client-buffer)
-                    :to-be nil)
-            (delete-process (get-buffer-process client-buffer))))
+                 (server-buffer (process-buffer server-process)))
+            ;; wait for the connection to be established
+            (nrepl-tests-poll-until (local-variable-p 'nrepl-endpoint server-buffer) 5)
+            (let ((client-buffer (cider-connect-sibling-cljs
+                                  '(:cljs-repl-type nbb) server-buffer)))
+
+              ;; native cljs REPL
+              (expect (buffer-local-value 'cider-repl-type client-buffer)
+                      :to-equal 'cljs)
+              (expect (buffer-local-value 'cider-repl-cljs-upgrade-pending client-buffer)
+                      :to-equal nil)
+              (expect (buffer-local-value 'cider-repl-init-function client-buffer)
+                      :to-be nil)
+              (delete-process (get-buffer-process client-buffer)))))
       (it "for shadow project"
           (let* ((cider-shadow-default-options "a-shadow-alias")
                  (server-process (nrepl-start-mock-server-process))
-                 (server-buffer (process-buffer server-process))
-                 (client-buffer (cider-connect-sibling-cljs
-                                 '(:cljs-repl-type shadow) server-buffer)))
+                 (server-buffer (process-buffer server-process)))
+            ;; wait for the connection to be established
+            (nrepl-tests-poll-until (local-variable-p 'nrepl-endpoint server-buffer) 5)
             ;; starts as clj REPL and requires a form to switch over to cljs
-            (expect (buffer-local-value 'cider-repl-type client-buffer)
-                    :to-equal 'cljs)
-            (expect (buffer-local-value 'cider-repl-cljs-upgrade-pending client-buffer)
-                    :to-equal t)
-            (expect (buffer-local-value 'cider-repl-init-function client-buffer)
-                    :not :to-be nil)
-            (delete-process (get-buffer-process client-buffer))))
+            (let ((client-buffer (cider-connect-sibling-cljs
+                                  '(:cljs-repl-type shadow) server-buffer)))
+              (expect (buffer-local-value 'cider-repl-type client-buffer)
+                      :to-equal 'cljs)
+              (expect (buffer-local-value 'cider-repl-cljs-upgrade-pending client-buffer)
+                      :to-equal t)
+              (expect (buffer-local-value 'cider-repl-init-function client-buffer)
+                      :not :to-be nil)
+              (delete-process (get-buffer-process client-buffer)))))
       (it "for a custom cljs REPL type project"
           (cider-register-cljs-repl-type 'native-cljs)
           (let* ((server-process (nrepl-start-mock-server-process))
-                 (server-buffer (process-buffer server-process))
-                 (client-buffer (cider-connect-sibling-cljs
-                                 '(:cljs-repl-type native-cljs)
-                                 server-buffer)))
-            (expect (buffer-local-value 'cider-repl-type client-buffer)
-                    :to-equal 'cljs)
-            (expect (buffer-local-value 'cider-repl-cljs-upgrade-pending client-buffer)
-                    :to-equal nil)
-            (delete-process (get-buffer-process client-buffer))))
+                 (server-buffer (process-buffer server-process)))
+            ;; wait for the connection to be established
+            (nrepl-tests-poll-until (local-variable-p 'nrepl-endpoint server-buffer) 5)
+            (let ((client-buffer (cider-connect-sibling-cljs
+                                  '(:cljs-repl-type native-cljs)
+                                  server-buffer)))
+              (expect (buffer-local-value 'cider-repl-type client-buffer)
+                      :to-equal 'cljs)
+              (expect (buffer-local-value 'cider-repl-cljs-upgrade-pending client-buffer)
+                      :to-equal nil)
+              (delete-process (get-buffer-process client-buffer)))))
       (it "for a custom REPL type project that needs to switch to cljs"
           (cider-register-cljs-repl-type
            'not-cljs-initially "(form-to-switch-to-cljs-repl)")
           (let* ((server-process (nrepl-start-mock-server-process))
-                 (server-buffer (process-buffer server-process))
-                 (client-buffer (cider-connect-sibling-cljs
-                                 '(:cljs-repl-type not-cljs-initially)
-                                 server-buffer)))
-            (expect (buffer-local-value 'cider-repl-type client-buffer)
-                    :to-equal 'cljs)
-            (expect (buffer-local-value 'cider-repl-cljs-upgrade-pending client-buffer)
-                    :to-equal t)
-            (expect (buffer-local-value 'cider-repl-init-function client-buffer)
-                    :not :to-be nil)
-            (delete-process (get-buffer-process client-buffer))))))
+                 (server-buffer (process-buffer server-process)))
+            ;; wait for the connection to be established
+            (nrepl-tests-poll-until (local-variable-p 'nrepl-endpoint server-buffer) 5)
+            (let ((client-buffer (cider-connect-sibling-cljs
+                                  '(:cljs-repl-type not-cljs-initially)
+                                  server-buffer)))
+              (expect (buffer-local-value 'cider-repl-type client-buffer)
+                      :to-equal 'cljs)
+              (expect (buffer-local-value 'cider-repl-cljs-upgrade-pending client-buffer)
+                      :to-equal t)
+              (expect (buffer-local-value 'cider-repl-init-function client-buffer)
+                      :not :to-be nil)
+              (delete-process (get-buffer-process client-buffer)))))))
 
 (provide 'cider-tests)
 

--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -152,13 +152,10 @@
                                 server-buffer))))
 
         ;; server up and running
-        (nrepl-tests-sleep-until 2 (eq (process-status server-process) 'run))
-        (expect (process-status server-process)
-                :to-equal 'run)
+        (nrepl-tests-poll-until (eq (process-status server-process) 'run) 2)
 
         ;; server has reported its endpoint
-        (nrepl-tests-sleep-until 2 server-endpoint)
-        (expect server-endpoint :not :to-be nil)
+        (nrepl-tests-poll-until server-endpoint 2)
         (expect (plist-get (process-plist server-process) :cider--nrepl-server-ready)
                 :to-equal t)
         (condition-case error-details
@@ -183,8 +180,8 @@
               (delete-process process-client)
 
               ;; server process has been signalled
-              (nrepl-tests-sleep-until 4 (member (process-status server-process)
-                                                 '(exit signal)))
+              (nrepl-tests-poll-until (member (process-status server-process)
+                                                 '(exit signal)) 4)
               (expect (let ((status (process-status server-process)))
                         (if (eq system-type 'windows-nt)
                             (eq status 'exit)


### PR DESCRIPTION
Hi,

can you please review follow up PR to #3275 to address a spurious failure currently seen on master with one of the newly introduced `sibling` regression tests:

```
========================================
cider-connect-sibling-cljs sets nrepl client local vars correctly for a custom cljs REPL type project

Traceback (most recent call last):
  cider-connect-sibling-cljs((:cljs-repl-type native-cljs) #<buffer *nrepl-server ~/project:localhost*>)
  cider--gather-connect-params(nil #<buffer *nrepl-server ~/project:localhost*>)
  error("This is not a REPL or SERVER buffer; is there an active REPL?")
error: (error "This is not a REPL or SERVER buffer; is there an active REPL?")
``` 

There was a call to wait for the mock server process to wait for 2 seconds for the process to start up, but this seems to be borderline low for ms-windows runners, so it is now increased to 5 secs. 

I've also replaced the polling function in the nrepl tests with a copy from the one from integration tests, which also throws an error if the condition is not met (rather than silently continuing).

Thanks

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

