### PR TITLE
Increase nrepl response timeout in integration tests

### DIFF
--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -951,7 +951,7 @@ If TOOLING, use the tooling session rather than the standard session."
                    (time-less-p
                     nrepl-sync-request-timeout
                     (time-subtract nil time0)))
-          (error "Sync nREPL request timed out %s" request)))
+          (error "Sync nREPL request timed out %s after %s secs." request nrepl-sync-request-timeout)))
       ;; Clean up the response, otherwise we might repeatedly ask for input.
       (nrepl-dict-put response "status" (remove "need-input" status))
       (accept-process-output nil 0.01))


### PR DESCRIPTION
Hi,

could you please review patch to increase the nREPL response timeout for the slow `clojure cli` and `shadow` by 10secs. It attempts to fix #3298 

It also
1. removes a noise buffer from integration tests diagnostics
2. removes setting `cider-preferred-build-tool 'shadow-cljs` which was unnecessary to begin with.

thanks

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
