### PR TITLE
Add numeric prefix arg to `cider-jack-in' for non-projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#3262](https://github.com/clojure-emacs/cider/issues/3262): Add navigation functionality to `npfb` keys inside the data inspector's buffer.
 - [#3310](https://github.com/clojure-emacs/cider/issues/3310): Add ability to use custom coordinates in jack-in-dependencies.
 * [#766](https://github.com/clojure-emacs/cider-nrepl/issues/766): Complete local bindings for ClojureScript files.
+- [#3179](https://github.com/clojure-emacs/cider/issues/3179): Introduce `cider-jack-in-universal` to support jacking-in without a project from a set of pre-configured Clojure project tools.
 
 ### Changes
 

--- a/cider.el
+++ b/cider.el
@@ -1190,6 +1190,7 @@ nil."
     (define-key map (kbd "j j") #'cider-jack-in-clj)
     (define-key map (kbd "j s") #'cider-jack-in-cljs)
     (define-key map (kbd "j m") #'cider-jack-in-clj&cljs)
+    (define-key map (kbd "j u") #'cider-jack-in-universal)
     (define-key map (kbd "C-j j") #'cider-jack-in-clj)
     (define-key map (kbd "C-j s") #'cider-jack-in-cljs)
     (define-key map (kbd "C-j m") #'cider-jack-in-clj&cljs)

--- a/cider.el
+++ b/cider.el
@@ -1616,6 +1616,8 @@ canceled the action, signal quit."
 ;;; Aliases
 
 ;;;###autoload
+(defalias 'cider-jack-in #'cider-jack-in-clj)
+;;;###autoload
 (defalias 'cider-connect #'cider-connect-clj)
 
 

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -129,15 +129,13 @@ disable the warning displayed when jacking-in outside a project.
 
 `cider-jack-in-universal` kbd:[C-c C-x j u] is another way to quickly
 jack in without a project choosing from a list of pre-configured
-Clojure build tools as setup in
-`cider-jack-in-universal-options`. When this command is called from
-outside of a project, the user is given the option to select to jack
-in with one of the pre-configured tools, as well as to confirm the
-root directory to use as a base. If the command is called from within
-a project directory, it behaves exactly the same as `cider-jack-in`
-does.
+Clojure build tools. When this command is called from outside of a
+project, the user is given the option to select to jack in with one of
+the pre-configured tools, as well as to confirm the root directory to
+use as a base. If the command is called from within a project
+directory, it behaves exactly the same as `cider-jack-in` does.
 
-It utilizes Emacs'
+It utilizes Emacs's
 https://www.gnu.org/software/emacs/manual/html_node/elisp/Prefix-Command-Arguments.html[numeric
 prefix arguments] to quickly jack in to a project type. Numeric prefix
 arguments can be set with the Meta key followed by a number.
@@ -150,7 +148,7 @@ The following clojure build tools are supported so far
 - kbd:[M-4 C-c C-x j u] jack-in using nbb.
 
 Here is an example of how to bind F12 for quickly bringing up a
-babashka REPL
+babashka REPL:
 
 [source,lisp]
 ----
@@ -158,6 +156,25 @@ babashka REPL
                                 (interactive)
                                 (cider-jack-in-universal 3)))
 ----
+
+The list of available build tools to consider is configured in
+`cider-jack-in-universal-options`. Each element of the list consists
+of the tool name and its setup options. Taking `nbb` as an example
+from the list:
+
+[source,lisp]
+----
+(nbb         (:prefix-arg 4 :cmd (:jack-in-type cljs :project-type nbb :cljs-repl-type nbb :edit-project-dir t)))
+----
+
+with
+
+. `:prefix-arg` assigns the `nbb` tool name a numerical argument prefix of 4.
+. `:cmd` how to invoke the command.
+.. `:jack-in-type` use a `cljs` repl.
+.. `:project-type` use `nbb` (see `jack-in-command`) to bring up the nREPL server.
+.. `:cljs-repl-type` client uses the `nbb` cljs repl type (see `cider-cljs-repl-types`) to initialize server.
+.. `:edit-project-dir` ask the user to confirm root directory to use as base.
 
 === Customizing the Jack-in Command Behavior
 

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -125,6 +125,40 @@ but was subsequently switched to `clj`, Clojure's basic startup command.
 TIP: You can set `cider-allow-jack-in-without-project` to `t` if you'd like to
 disable the warning displayed when jacking-in outside a project.
 
+==== Universal jack-in
+
+`cider-jack-in-universal` kbd:[C-c C-x j u] is another way to quickly
+jack in without a project choosing from a list of pre-configured
+Clojure build tools as setup in
+`cider-jack-in-universal-options`. When this command is called from
+outside of a project, the user is given the option to select to jack
+in with one of the pre-configured tools, as well as to confirm the
+root directory to use as a base. If the command is called from within
+a project directory, it behaves exactly the same as `cider-jack-in`
+does.
+
+It utilizes Emacs'
+https://www.gnu.org/software/emacs/manual/html_node/elisp/Prefix-Command-Arguments.html[numeric
+prefix arguments] to quickly jack in to a project type. Numeric prefix
+arguments can be set with the Meta key followed by a number.
+
+The following clojure build tools are supported so far
+
+- kbd:[M-1 C-c C-x j u] jack-in using clojure-cli.
+- kbd:[M-2 C-c C-x j u] jack-in using leiningen.
+- kbd:[M-3 C-c C-x j u] jack-in using babashka.
+- kbd:[M-4 C-c C-x j u] jack-in using nbb.
+
+Here is an example of how to bind F12 for quickly bringing up a
+babashka REPL
+
+[source,lisp]
+----
+(global-set-key (kbd "<f12>") (lambda ()
+                                (interactive)
+                                (cider-jack-in-universal 3)))
+----
+
 === Customizing the Jack-in Command Behavior
 
 You can use kbd:[C-u M-x] `cider-jack-in` kbd:[RET] to

--- a/test/integration/integration-tests.el
+++ b/test/integration/integration-tests.el
@@ -53,7 +53,7 @@
                    (client-is-connected* (cider-itu-nrepl-client-connected-ref-make!))
 
                    ;; jack in and get repl buffer
-                   (nrepl-proc (cider-jack-in-clj '()))
+                   (nrepl-proc (cider-jack-in '()))
                    (nrepl-buf (process-buffer nrepl-proc)))
 
               ;; wait until the client has successfully connected to the
@@ -263,7 +263,7 @@
               (cider-itu-poll-until (eq (gv-deref client-is-connected*) 'connected) 5)
 
               ;; give it some time to setup the clj REPL
-              (cider-itu-poll-until (cider-repls 'clj nil) 5)
+              (cider-itu-poll-until (cider-repls 'cljs nil) 5)
 
               ;; send command to the REPL, and push stdout/stderr to
               ;; corresponding eval-xxx variables.
@@ -393,7 +393,124 @@
                    (with-temp-buffer
                      (insert-file-contents "nrepl-mdlw-log.log")
                      (message ":ikappaki/nrepl-mdlw-log-dump\n%s\n" (buffer-string)))
-                 (message ":!nrepl-mdlw-log-found"))))))))))
+                 (message ":!nrepl-mdlw-log-found")))))))))
+
+  ;; jacking in without a current project
+  ;;
+  (it "no project, user choice to nbb"
+    (with-cider-test-sandbox
+      (with-temp-dir temp-dir
+        ;; setup empty project dir
+        (let* ((project-dir temp-dir))
+          ;; respond with nbb when asked which project to jack in to.
+          (spy-on 'completing-read :and-return-value "nbb")
+
+          (with-temp-buffer
+            ;; set default directory to temp project
+            (setq-local default-directory project-dir)
+
+            (let* (;; Get a gv reference so as to poll if the client has
+                   ;; connected to the nREPL server.
+                   (client-is-connected* (cider-itu-nrepl-client-connected-ref-make!))
+
+                   ;; jack in and get repl buffer
+                   (nrepl-proc (cider-jack-in '()))
+                   (nrepl-buf (process-buffer nrepl-proc)))
+
+              ;; wait until the client has successfully connected to the
+              ;; nREPL server.
+              (cider-itu-poll-until (eq (gv-deref client-is-connected*) 'connected) 5)
+
+              ;; give it some time to setup the clj REPL
+              (cider-itu-poll-until (cider-repls 'cljs nil) 5)
+
+              ;; send command to the REPL, and push stdout/stderr to
+              ;; corresponding eval-xxx variables.
+              (let ((repl-buffer (cider-current-repl))
+                    (eval-err '())
+                    (eval-out '()))
+                (expect repl-buffer :not :to-be nil)
+
+                ;; send command to the REPL
+                (cider-interactive-eval
+                 ;; ask REPL to return a string that uniquely identifies it.
+                 "(print :nbb? (some? (nbb.core/version)))"
+                 (lambda (return)
+                   (nrepl-dbind-response
+                       return
+                       (out err)
+                     (when err (push err eval-err))
+                     (when out (push out eval-out)))) )
+
+                ;; wait for a response to come back.
+                (cider-itu-poll-until (or eval-err eval-out) 5)
+
+                ;; ensure there are no errors and response is as expected.
+                (expect eval-err :to-equal '())
+                (expect eval-out :to-equal '(":nbb? true"))
+
+                ;; exit the REPL.
+                (cider-quit repl-buffer)
+
+                ;; wait for the REPL to exit
+                (cider-itu-poll-until (not (eq (process-status nrepl-proc) 'run)) 5)
+                (expect (member (process-status nrepl-proc) '(exit signal))))))))))
+
+  (it "no project, numeric prefix argument, to leiningen"
+    (with-cider-test-sandbox
+      (with-temp-dir temp-dir
+        ;; setup empty dir
+        (let* ((project-dir temp-dir))
+          (with-temp-buffer
+            ;; set default directory to temp project
+            (setq-local default-directory project-dir)
+
+            (let* (;; Get a gv reference so as to poll if the client has
+                   ;; connected to the nREPL server.
+                   (client-is-connected* (cider-itu-nrepl-client-connected-ref-make!))
+
+                   ;; jack in and get repl buffer
+                   (nrepl-proc (cider-jack-in 2))
+                   (nrepl-buf (process-buffer nrepl-proc)))
+
+              ;; wait until the client has successfully connected to the
+              ;; nREPL server.
+              (cider-itu-poll-until (eq (gv-deref client-is-connected*) 'connected) 90)
+
+              ;; give it some time to setup the clj REPL
+              (cider-itu-poll-until (cider-repls 'clj nil) 90)
+
+              ;; send command to the REPL, and push stdout/stderr to
+              ;; corresponding eval-xxx variables.
+              (let ((repl-buffer (cider-current-repl))
+                    (eval-err '())
+                    (eval-out '()))
+                (expect repl-buffer :not :to-be nil)
+
+                ;; send command to the REPL
+                (cider-interactive-eval
+                 ;; ask REPL to return a string that uniquely identifies it.
+                 "(print :clojure? (some? (clojure-version)))"
+                 (lambda (return)
+                   (nrepl-dbind-response
+                       return
+                       (out err)
+                     (when err (push err eval-err))
+                     (when out (push out eval-out)))) )
+
+                ;; wait for a response to come back.
+                (cider-itu-poll-until (or eval-err eval-out) 10)
+
+                ;; ensure there are no errors and response is as expected.
+                (expect eval-err :to-equal '())
+                (expect eval-out :to-equal '(":clojure? true"))
+
+                ;; exit the REPL.
+                (cider-quit repl-buffer)
+
+                ;; wait for the REPL to exit
+                (cider-itu-poll-until (not (eq (process-status nrepl-proc) 'run)) 15)
+                (expect (member (process-status nrepl-proc) '(exit signal)))))))))))
 
 (provide 'integration-tests)
 

--- a/test/integration/integration-tests.el
+++ b/test/integration/integration-tests.el
@@ -53,7 +53,7 @@
                    (client-is-connected* (cider-itu-nrepl-client-connected-ref-make!))
 
                    ;; jack in and get repl buffer
-                   (nrepl-proc (cider-jack-in '()))
+                   (nrepl-proc (cider-jack-in-clj '()))
                    (nrepl-buf (process-buffer nrepl-proc)))
 
               ;; wait until the client has successfully connected to the
@@ -402,8 +402,17 @@
       (with-temp-dir temp-dir
         ;; setup empty project dir
         (let* ((project-dir temp-dir))
-          ;; respond with nbb when asked which project to jack in to.
-          (spy-on 'completing-read :and-return-value "nbb")
+          ;; fake user input
+          (spy-on 'completing-read
+                  :and-call-fake (lambda (prompt _collection &optional _predicate _require-match
+                                                 initial-input _hist _def _inherit-input-method)
+                                   (pcase prompt
+                                     ;; select nbb
+                                     ("No project found in current dir, select project type to jack in: "
+                                      "nbb")
+                                     ;; project src directory, use suggested
+                                     ("Project: " initial-input)
+                                     (_ (error ":integration-test-unsupported-prompt-error %S" prompt)))))
 
           (with-temp-buffer
             ;; set default directory to temp project
@@ -414,7 +423,7 @@
                    (client-is-connected* (cider-itu-nrepl-client-connected-ref-make!))
 
                    ;; jack in and get repl buffer
-                   (nrepl-proc (cider-jack-in '()))
+                   (nrepl-proc (cider-jack-in-universal '()))
                    (nrepl-buf (process-buffer nrepl-proc)))
 
               ;; wait until the client has successfully connected to the
@@ -461,6 +470,14 @@
       (with-temp-dir temp-dir
         ;; setup empty dir
         (let* ((project-dir temp-dir))
+          ;; fake user input
+          (spy-on 'completing-read
+                  :and-call-fake (lambda (prompt _collection &optional _predicate _require-match
+                                                 initial-input _hist _def _inherit-input-method)
+                                   (pcase prompt
+                                     ;; project src directory
+                                     ("Project: " initial-input)
+                                     (_ (error ":integration-test-unsupported-prompt-error %S" prompt)))))
           (with-temp-buffer
             ;; set default directory to temp project
             (setq-local default-directory project-dir)
@@ -469,8 +486,11 @@
                    ;; connected to the nREPL server.
                    (client-is-connected* (cider-itu-nrepl-client-connected-ref-make!))
 
-                   ;; jack in and get repl buffer
-                   (nrepl-proc (cider-jack-in 2))
+                   ;; jack in and get repl buffer.
+                   ;;
+                   ;; The numerical prefix arg for `lein` in
+                   ;; `cider-jack-in-universal-options' is 2.
+                   (nrepl-proc (cider-jack-in-universal 2))
                    (nrepl-buf (process-buffer nrepl-proc)))
 
               ;; wait until the client has successfully connected to the


### PR DESCRIPTION
Hi @bbatsov,

as per #3179, could you please consider a draft PoC  to  upgrade the `cider-jack-in` alias to a command that maintains its current behavior (i.e. calling `cider-jack-in-clj`) but in addition

1. When there is no current project, prompts user to select one to jack in from a list of `babashka`, `clojure-cli`, `lein` or `nbb`.
2. Accepts numeric prefix arguments to jack in to a project, even if there is project in the current dir (`M-1 M-X cider-jack-in` for `clojure-cli`, `M-2` for `lein`, `M-3` for `babashka` and `M-4` for `nbb`).

this PoC is open for discussion, so I haven't added a changelog entry or updated the documentation yet.

Thanks

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

