### PR TITLE
Add extra keys for navigation of inspect buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 - [#3262](https://github.com/clojure-emacs/cider/issues/3262) Add navigation functionality to `npfb` keys inside inspect buffer.
+
 ### Changes
 
 - Allow using `npx nbb` as `cider-nbb-command`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+- [#3262](https://github.com/clojure-emacs/cider/issues/3262) Add navigation functionality to `npfb` keys inside inspect buffer.
+
 ## 1.6.0 (2022-12-21)
 
 ### New features

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -108,7 +108,11 @@ by clicking or navigating to them by other means."
     (define-key map "d" #'cider-inspector-def-current-val)
     (define-key map [tab] #'cider-inspector-next-inspectable-object)
     (define-key map "\C-i" #'cider-inspector-next-inspectable-object)
+    (define-key map "n" #'cider-inspector-next-inspectable-object)
     (define-key map [(shift tab)] #'cider-inspector-previous-inspectable-object)
+    (define-key map "p" #'cider-inspector-previous-inspectable-object)
+    (define-key map "f" #'forward-char)
+    (define-key map "b" #'backward-char)
     ;; Emacs translates S-TAB to BACKTAB on X.
     (define-key map [backtab] #'cider-inspector-previous-inspectable-object)
     (easy-menu-define cider-inspector-mode-menu map

--- a/doc/modules/ROOT/pages/debugging/inspector.adoc
+++ b/doc/modules/ROOT/pages/debugging/inspector.adoc
@@ -28,8 +28,11 @@ You'll have access to additional keybindings in the inspector buffer
 |===
 | Keyboard shortcut | Description
 
-| kbd:[Tab] and kbd:[Shift-Tab]
+| kbd:[Tab] and kbd:[Shift-Tab] / kdb:[n] and kbd:[p]
 | Navigate inspectable sub-objects
+
+| kbd:[f] and kbd:[b]
+| Navigate across characters on a line
 
 | kbd:[Return]
 | Inspect sub-objects


### PR DESCRIPTION
#3262
Added navigation functionality to `npfb` keys in inspect mode. Specifically `np` behave like `Tab` and `Shift-Tab` and `fb` like `C-f/b`.

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)