### PR TITLE
Allow "npx nbb" as the cider-nbb-command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## master (unreleased)
+- Allow using `npx nbb` as `cider-nbb-command`.
 
 ## 1.6.0 (2022-12-21)
 

--- a/cider.el
+++ b/cider.el
@@ -377,12 +377,16 @@ Throws an error if PROJECT-TYPE is unknown."
     ('shadow-cljs (let ((parts (split-string cider-shadow-cljs-command)))
                     (when-let* ((command (cider--resolve-command (car parts))))
                       (mapconcat #'identity (cons command (cdr parts)) " "))))
+    ;; here we have to account for the possibility that the command is either
+    ;; "nbb" (default) or "npx nbb".
+    ('nbb (let ((parts (split-string cider-nbb-command)))
+            (when-let* ((command (cider--resolve-command (car parts))))
+              (mapconcat #'identity (cons command (cdr parts)) " "))))
     ;; here we have to account for use of the Gradle wrapper which is
     ;; a shell script within their project, so if they have a clearly
     ;; relative path like "./gradlew" use locate file instead of checking
     ;; the exec-path
     ('gradle (cider--resolve-project-command cider-gradle-command))
-    ('nbb (cider--resolve-command cider-nbb-command))
     (_ (user-error "Unsupported project type `%S'" project-type))))
 
 (defun cider-jack-in-global-options (project-type)


### PR DESCRIPTION
Users of nbb may prefer the version in the project versus the global version. Unlike shadow-cljs don't default to the npx command as default, but allow the command to function when set as `cider-nbb-command`.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
