### PR TITLE
cider--goto-expression-start: Do not throw if bop

### DIFF
--- a/cider-eval.el
+++ b/cider-eval.el
@@ -602,8 +602,10 @@ until we find a delimiters that's not inside a string."
   (if (and (looking-back "[])}]" (line-beginning-position))
            (null (nth 3 (syntax-ppss))))
       (backward-sexp)
-    (while (or (not (looking-at-p "[({[]"))
-               (nth 3 (syntax-ppss)))
+    (while (and (not (bobp))
+                (or
+                 (not (looking-at-p "[({[]"))
+                 (nth 3 (syntax-ppss))))
       (backward-char))))
 
 (defun cider--find-last-error-location (message)

--- a/test/cider-eval-test.el
+++ b/test/cider-eval-test.el
@@ -47,4 +47,23 @@
         (insert "🍻"))
       (expect (cider-provide-file filename) :to-equal "8J+Nuw=="))))
 
+(describe
+ "cider--goto-expression-start"
+ (it "Does not throw an error, when file does not contain a list"
+     (expect
+      (with-temp-buffer
+        (insert "foo")
+        ;; After evaling, message:
+        ;;   "Syntax error compiling at (foo.clj:0:0).
+        ;; Unable to resolve symbol: foo in this context
+        ;; "
+        ;; cider--find-last-error-location goes to location
+        ;; 0:0 and calls cider--goto-expression-start
+        (goto-char (point-min))
+        ;; no error
+        (cider--goto-expression-start)
+        'ok)
+      :to-equal 'ok)))
+
+
 (provide 'cider-eval-tests)


### PR DESCRIPTION
There is currently an edge case when you interactively eval in a source file that has no ns form (and no list form at all).  
And you eval something that throws an error. Then `cider--find-last-error-location` will try to find a list in line 0 at col 0 and throw an error. 
Edge case but not nice because you get an "error in process filter" which are slightly harder to figure out. 
With this change `cider--goto-expression-start` will return nil instead of throwing. There is only 1 usage so no other semantic is affected. 
`cider--find-last-error-location` will usually end up returning a list of (point-min) (point-min) , then so nothing is colored. 