### PR TITLE
Custom coordinates in jack-in-dependecies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 - [#3262](https://github.com/clojure-emacs/cider/issues/3262): Add navigation functionality to `npfb` keys inside the data inspector's buffer.
+- [#3310](https://github.com/clojure-emacs/cider/issues/3310): Add ability to use custom coordinates in jack-in-dependecies
 
 ### Changes
 

--- a/cider.el
+++ b/cider.el
@@ -708,7 +708,15 @@ one used."
                      ;; `java.lang.IllegalArgumentException: Duplicate key [...]`:
                      (cider--dedupe-deps)
                      (seq-map (lambda (dep)
-                                (format "%s {:mvn/version \"%s\"}" (car dep) (cadr dep))))))
+                                (if (listp (cadr dep))
+                                    (format "%s {%s}"
+                                            (car dep)
+                                            (seq-reduce
+                                             (lambda (acc v)
+                                               (concat acc (format " :%s \"%s\" " (car v) (cdr v))))
+                                             (cadr dep)
+                                             ""))
+                                  (format "%s {:mvn/version \"%s\"}" (car dep) (cadr dep)))))))
          (middleware (mapconcat
                       (apply-partially #'format "%s")
                       (cider-jack-in-normalized-nrepl-middlewares)

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -86,6 +86,13 @@ Here's how you can modify the injected dependencies for `cider-jack-in-clj`:
 ;; auto-inject version 1.0 of the library foo/bar
 (cider-add-to-alist 'cider-jack-in-dependencies
                     "foo/bar" "1.0")
+;; if you want to have full control over the coordinate description set it as an alist
+;; auto-inject {:git/sha "6ae2b6f71773de7549d7f22759e8b09fec27f0d9" for library org.clojure/tools.deps
+;;              :git/url "https://github.com/clojure/tools.deps/"}
+(cider-add-to-alist 'cider-jack-in-dependencies
+                    "org.clojure/tools.deps"
+                    '(("git/sha" . "6ae2b6f71773de7549d7f22759e8b09fec27f0d9")
+                      ("git/url" . "https://github.com/clojure/tools.deps/")))
 ----
 
 IMPORTANT: Always use the fully qualified `group/artifact` (e.g. `re-frame/re-frame`) in these dependencies, since only Leiningen supports the bare `re-frame` syntax.

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -506,7 +506,24 @@
             (deps '(("nrepl/nrepl" "0.9.0"))))
         (let ((cider-clojure-cli-aliases ":test"))
           (expect (cider-clojure-cli-jack-in-dependencies "-J-Djdk.attach.allowAttachSelf" nil deps)
-                  :to-equal expected))))))
+                  :to-equal expected))))
+    (it "allows to specify git coordinate as cider-jack-in-dependency"
+      (setq-local cider-jack-in-dependencies '(("org.clojure/tools.deps" (("git/sha" . "6ae2b6f71773de7549d7f22759e8b09fec27f0d9")
+                                                                          ("git/url" . "https://github.com/clojure/tools.deps/")))))
+      (let ((expected (string-join '("clojure -Sdeps '{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} "
+                                     "cider/cider-nrepl {:mvn/version \"0.28.5\"} "
+                                     "org.clojure/tools.deps { :git/sha \"6ae2b6f71773de7549d7f22759e8b09fec27f0d9\"  :git/url \"https://github.com/clojure/tools.deps/\" }} "
+                                     ":aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" "
+                                     "\"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}' -M:cider/nrepl")
+                                   "")))
+        (setq-local cider-allow-jack-in-without-project t)
+        (setq-local cider-clojure-cli-command "clojure")
+        (setq-local cider-inject-dependencies-at-jack-in t)
+        (setq-local cider-clojure-cli-aliases nil)
+        (spy-on 'cider-project-type :and-return-value 'clojure-cli)
+        (spy-on 'cider-jack-in-resolve-command :and-return-value "clojure")
+        (expect (plist-get (cider--update-jack-in-cmd nil) :jack-in-cmd)
+                :to-equal expected)))))
 
 (defmacro with-temp-shadow-config (contents &rest body)
   "Run BODY with a mocked shadow-cljs.edn project file with the CONTENTS."


### PR DESCRIPTION
Add ability to use custom coordinates in jack-in-dependecies.
Custom coordinates will be described as an alist, which will later be expanded into a clojure map.

Example:
```elisp
(cider-add-to-alist 'cider-jack-in-dependencies
                    "org.clojure/tools.deps"
                    '(("git/sha" . "6ae2b6f71773de7549d7f22759e8b09fec27f0d9")
                      ("git/url" . "https://github.com/clojure/tools.deps/")))
```

Related issue: https://github.com/clojure-emacs/cider/issues/3310

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)