### PR TITLE
fix mispelled word `bellow`

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -377,7 +377,7 @@ Throws an error if PROJECT-TYPE is unknown."
     ('shadow-cljs (let ((parts (split-string cider-shadow-cljs-command)))
                     (when-let* ((command (cider--resolve-command (car parts))))
                       (mapconcat #'identity (cons command (cdr parts)) " "))))
-    ;; TODO: Address the duplicated code bellow.
+    ;; TODO: Address the duplicated code below.
     ;; here we have to account for the possibility that the command is either
     ;; "nbb" (default) or "npx nbb".
     ('nbb (let ((parts (split-string cider-nbb-command)))


### PR DESCRIPTION
Long standing error reported in pull request CI

```
Run codespell --ignore-words=codespell.txt || exit 1
./cider.el:380: bellow ==> below
Error: Process completed with exit code 1.
```