### PR TITLE
Fix #3307: Incorrect special-form eldocs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Allow using `npx nbb` as `cider-nbb-command`.
 - [#3281](https://github.com/clojure-emacs/cider/pull/3281): Replace newline chars with actual newlines in `*cider-test-report*` buffer, for prettier error messages.
 - Bump the injected `cider-nrepl` to 0.30.
+- [#3307](https://github.com/clojure-emacs/cider/issues/3307): Make eldoc highlighting on emacs special forms better match the location of the point when latest `cider-nrepl` is used.
 
 ## 1.6.0 (2022-12-21)
 


### PR DESCRIPTION
Fix #3307: Incorrect special-form eldocs

This fix is the CIDER companion to [this PR](https://github.com/clojure-emacs/orchard/pull/166) in orchard, which lets us know if the symbol we're querying eldocs for is a special form or an ordinary function.

This change uses that information to deduplicate the arglists for the special form. In the process, the change adds a
`cider-eldoc-format-special-form` function, which serves as a home for special form formatting.


-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
