### PR TITLE
#3295 Deprecate cider-*-global-options

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -156,6 +156,13 @@ default to \"powershell\"."
   :safe #'stringp
   :package-version '(cider . "0.17.0"))
 
+(defcustom cider-clojure-cli-parameters
+  nil
+  "Params passed to clojure cli to start an nREPL server via `cider-jack-in'."
+  :type 'string
+  :safe #'stringp
+  :package-version '(cider . "1.8.0"))
+
 (defcustom cider-clojure-cli-aliases
   nil
   "A list of aliases to include when using the clojure cli.
@@ -254,7 +261,8 @@ By default we favor the project-specific shadow-cljs over the system-wide."
 
 (make-obsolete-variable 'cider-lein-global-options 'cider-lein-parameters "1.8.0")
 (make-obsolete-variable 'cider-boot-global-options 'cider-boot-parameters "1.8.0")
-(make-obsolete-variable 'cider-clojure-cli-global-options 'cider-clojure-cli-aliases "1.8.0")
+(make-obsolete-variable 'cider-clojure-cli-global-options 'cider-clojure-cli-parameters "1.8.0")
+(make-obsolete-variable 'cider-clojure-cli-aliases 'cider-clojure-cli-parameters "1.8.0")
 (make-obsolete-variable 'cider-shadow-cljs-global-options 'cider-shadow-cljs-parameters "1.8.0")
 (make-obsolete-variable 'cider-gradle-global-options 'cider-gradle-parameters "1.8.0")
 (make-obsolete-variable 'cider-babashka-global-options 'cider-babashka-parameters "1.8.0")
@@ -440,7 +448,7 @@ Throws an error if PROJECT-TYPE is unknown."
   (pcase project-type
     ('lein        cider-lein-parameters)
     ('boot        cider-boot-parameters)
-    ('clojure-cli nil)
+    ('clojure-cli cider-clojure-cli-parameters)
     ('babashka    cider-babashka-parameters)
     ('shadow-cljs cider-shadow-cljs-parameters)
     ('gradle      cider-gradle-parameters)
@@ -737,7 +745,7 @@ removed, LEIN-PLUGINS, LEIN-MIDDLEWARES and finally PARAMS."
   "Removes the duplicates in DEPS."
   (cl-delete-duplicates deps :test 'equal))
 
-(defun cider-clojure-cli-jack-in-dependencies (global-options _params dependencies)
+(defun cider-clojure-cli-jack-in-dependencies (global-options params dependencies)
   "Create Clojure tools.deps jack-in dependencies.
 Does so by concatenating DEPENDENCIES and GLOBAL-OPTIONS into a suitable
 `clojure` invocation.  The main is placed in an inline alias :cider/nrepl
@@ -764,7 +772,7 @@ one used."
                       (cider-jack-in-normalized-nrepl-middlewares)
                       ","))
          (main-opts (format "\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[%s]\"" middleware)))
-    (format "%s-Sdeps '{:deps {%s} :aliases {:cider/nrepl {:main-opts [%s]}}}' -M%s:cider/nrepl"
+    (format "%s-Sdeps '{:deps {%s} :aliases {:cider/nrepl {:main-opts [%s]}}}' -M%s:cider/nrepl%s"
             (if global-options (format "%s " global-options) "")
             (string-join all-deps " ")
             main-opts
@@ -772,7 +780,8 @@ one used."
                 ;; remove exec-opts flags -A -M -T or -X from cider-clojure-cli-aliases
                 ;; concatenated with :cider/nrepl to ensure :cider/nrepl comes last
                 (format "%s" (replace-regexp-in-string "^-\\(A\\|M\\|T\\|X\\)" "" cider-clojure-cli-aliases))
-              ""))))
+              "")
+            (if params (format " %s" params) ""))))
 
 (defun cider-shadow-cljs-jack-in-dependencies (global-opts params dependencies)
   "Create shadow-cljs jack-in deps.

--- a/cider.el
+++ b/cider.el
@@ -252,13 +252,13 @@ By default we favor the project-specific shadow-cljs over the system-wide."
   :safe #'stringp
   :package-version '(cider . "1.6.0"))
 
-(make-obsolete-variable 'cider-lein-global-options 'cider-lein-parameters "1.6.0")
-(make-obsolete-variable 'cider-boot-global-options 'cider-boot-parameters "1.6.0")
-(make-obsolete-variable 'cider-clojure-cli-global-options 'cider-clojure-cli-aliases "1.6.0")
-(make-obsolete-variable 'cider-shadow-cljs-global-options 'cider-shadow-cljs-parameters "1.6.0")
-(make-obsolete-variable 'cider-gradle-global-options 'cider-gradle-parameters "1.6.0")
-(make-obsolete-variable 'cider-babashka-global-options 'cider-babashka-parameters "1.6.0")
-(make-obsolete-variable 'cider-shadow-nbb-options 'cider-nbb-parameters "1.6.0")
+(make-obsolete-variable 'cider-lein-global-options 'cider-lein-parameters "1.8.0")
+(make-obsolete-variable 'cider-boot-global-options 'cider-boot-parameters "1.8.0")
+(make-obsolete-variable 'cider-clojure-cli-global-options 'cider-clojure-cli-aliases "1.8.0")
+(make-obsolete-variable 'cider-shadow-cljs-global-options 'cider-shadow-cljs-parameters "1.8.0")
+(make-obsolete-variable 'cider-gradle-global-options 'cider-gradle-parameters "1.8.0")
+(make-obsolete-variable 'cider-babashka-global-options 'cider-babashka-parameters "1.8.0")
+(make-obsolete-variable 'cider-shadow-nbb-options 'cider-nbb-parameters "1.8.0")
 
 (defcustom cider-jack-in-default
   (if (executable-find "clojure") 'clojure-cli 'lein)

--- a/cider.el
+++ b/cider.el
@@ -252,6 +252,14 @@ By default we favor the project-specific shadow-cljs over the system-wide."
   :safe #'stringp
   :package-version '(cider . "1.6.0"))
 
+(make-obsolete-variable 'cider-lein-global-options 'cider-lein-parameters "1.6.0")
+(make-obsolete-variable 'cider-boot-global-options 'cider-boot-parameters "1.6.0")
+(make-obsolete-variable 'cider-clojure-cli-global-options 'cider-clojure-cli-aliases "1.6.0")
+(make-obsolete-variable 'cider-shadow-cljs-global-options 'cider-shadow-cljs-parameters "1.6.0")
+(make-obsolete-variable 'cider-gradle-global-options 'cider-gradle-parameters "1.6.0")
+(make-obsolete-variable 'cider-babashka-global-options 'cider-babashka-parameters "1.6.0")
+(make-obsolete-variable 'cider-shadow-nbb-options 'cider-nbb-parameters "1.6.0")
+
 (defcustom cider-jack-in-default
   (if (executable-find "clojure") 'clojure-cli 'lein)
   "The default tool to use when doing `cider-jack-in' outside a project.

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -205,7 +205,8 @@ so we'll examine them tool by tool.
 ==== Clojure CLI Options
 
 * `cider-clojure-cli-command` - the name of the `clojure` executable (`clojure` by default)
-* `cider-clojure-cli-aliases` - a list of aliases (or other parameters) to be used at jack-in time
+* `cider-clojure-cli-parameters` - the command-line parameters to start a REPL
+* `cider-clojure-cli-aliases` - a list of aliases to be used at jack-in time
 
 To use `cider-jack-in` with `tools.deps` on Windows set the
 `cider-clojure-cli-command` to `"powershell"`. This happens by default

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -200,17 +200,12 @@ so we'll examine them tool by tool.
 ==== Leiningen Options
 
 * `cider-lein-command` - the name of the Leiningen executable (`lein` by default)
-* `cider-lein-parameters` - the command-line params to start a REPL (e.g. `repl :headless`)
-* `cider-lein-global-options ` - these are passed to the command directly, in
-first position (e.g., `-o` to `lein` enables offline mode). (DEPRECATED)
-
-NOTE: Originally CIDER supported jacking in only for Leiningen, so its configuration
-options became the archetype for everything else.
+* `cider-lein-parameters` - the command-line params to start a REPL (e.g. `repl :headless` or -o to enable offline mode)
 
 ==== Clojure CLI Options
 
 * `cider-clojure-cli-command` - the name of the `clojure` executable (`clojure` by default)
-* `cider-clojure-cli-aliases` - a list of aliases to be used at jack-in time
+* `cider-clojure-cli-aliases` - a list of aliases (or other parameters) to be used at jack-in time
 
 To use `cider-jack-in` with `tools.deps` on Windows set the
 `cider-clojure-cli-command` to `"powershell"`. This happens by default
@@ -227,19 +222,16 @@ will likely result in a better overall development experience.
 * `cider-boot-parameters` - these are usually task names and their parameters
 (e.g., `dev` for launching boot's dev task instead of the standard `repl -s
 wait`)
-* `cider-boot-global-options` (DEPRECATED)
 
 ==== Gradle Options
 
 * `cider-gradle-command` - the name of the Gradle executable (`./gradlew` by default)
-* `cider-gradle-parameters` - the Gradle arguments to invoke the repl task (`clojureRepl` by default)
-* `cider-gradle-global-options` - these are usually global options to gradle, such as `--no-daemon` or `--configuration-cache` (empty by default) (DEPRECATED)
+* `cider-gradle-parameters` - the Gradle arguments to invoke the repl task (e.g. `--no-daemon` or `--configuration-cache`) (`clojureRepl` by default)
 
 ==== shadow-cljs
 
 * `cider-shadow-cljs-command` - the command to run `shadow-cljs` (`npx shadow-cljs` by default). By default we favor the project-specific shadow-cljs over the system-wide.
 * `cider-shadow-cljs-parameters` - the task to start a REPL server (`server` by default)
-* `cider-shadow-cljs-global-options` - (DEPRECATED)
 
 === Override the Jack-In Command
 

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -201,8 +201,8 @@ so we'll examine them tool by tool.
 
 * `cider-lein-command` - the name of the Leiningen executable (`lein` by default)
 * `cider-lein-parameters` - the command-line params to start a REPL (e.g. `repl :headless`)
-* `cider-lein-global-options` - these are passed to the command directly, in
-first position (e.g., `-o` to `lein` enables offline mode).
+* `cider-lein-global-options ` - these are passed to the command directly, in
+first position (e.g., `-o` to `lein` enables offline mode). (DEPRECATED)
 
 NOTE: Originally CIDER supported jacking in only for Leiningen, so its configuration
 options became the archetype for everything else.
@@ -227,19 +227,19 @@ will likely result in a better overall development experience.
 * `cider-boot-parameters` - these are usually task names and their parameters
 (e.g., `dev` for launching boot's dev task instead of the standard `repl -s
 wait`)
-* `cider-boot-global-options`
+* `cider-boot-global-options` (DEPRECATED)
 
 ==== Gradle Options
 
 * `cider-gradle-command` - the name of the Gradle executable (`./gradlew` by default)
 * `cider-gradle-parameters` - the Gradle arguments to invoke the repl task (`clojureRepl` by default)
-* `cider-gradle-global-options` - these are usually global options to gradle, such as `--no-daemon` or `--configuration-cache` (empty by default)
+* `cider-gradle-global-options` - these are usually global options to gradle, such as `--no-daemon` or `--configuration-cache` (empty by default) (DEPRECATED)
 
 ==== shadow-cljs
 
 * `cider-shadow-cljs-command` - the command to run `shadow-cljs` (`npx shadow-cljs` by default). By default we favor the project-specific shadow-cljs over the system-wide.
 * `cider-shadow-cljs-parameters` - the task to start a REPL server (`server` by default)
-* `cider-shadow-cljs-global-options`
+* `cider-shadow-cljs-global-options` - (DEPRECATED)
 
 === Override the Jack-In Command
 

--- a/doc/modules/ROOT/pages/cljs/shadow-cljs.adoc
+++ b/doc/modules/ROOT/pages/cljs/shadow-cljs.adoc
@@ -101,7 +101,7 @@ Create a `:dev` alias with an extra source path of "dev" and add the following n
 
 Supposing your build-id is `:app`, add the following to your `.dir-locals.el`
 ```elisp
-((nil . ((cider-clojure-cli-global-options . "-A:dev")
+((nil . ((cider-clojure-cli-aliases        . "-M:dev")
          (cider-preferred-build-tool       . clojure-cli)
          (cider-default-cljs-repl          . custom)
          (cider-custom-cljs-repl-init-form . "(do (user/cljs-repl))")
@@ -118,7 +118,7 @@ You can tweak the command used by `cider-jack-in-cljs` to start the `shadow-cljs
 via the following configuration variables:
 
 * `cider-shadow-cljs-command` (its default value is `npx shadow-cljs`)
-* `cider-shadow-cljs-global-options` (its default value is blank)
+* `cider-shadow-cljs-global-options` (its default value is blank) (DEPRECATED)
 * `cider-shadow-cljs-parameters` (its default value is `server`)
 
 All of this results in the following default command to start the shadow-cljs server:

--- a/doc/modules/ROOT/pages/cljs/shadow-cljs.adoc
+++ b/doc/modules/ROOT/pages/cljs/shadow-cljs.adoc
@@ -118,7 +118,6 @@ You can tweak the command used by `cider-jack-in-cljs` to start the `shadow-cljs
 via the following configuration variables:
 
 * `cider-shadow-cljs-command` (its default value is `npx shadow-cljs`)
-* `cider-shadow-cljs-global-options` (its default value is blank) (DEPRECATED)
 * `cider-shadow-cljs-parameters` (its default value is `server`)
 
 All of this results in the following default command to start the shadow-cljs server:

--- a/doc/modules/ROOT/pages/platforms/nbb.adoc
+++ b/doc/modules/ROOT/pages/platforms/nbb.adoc
@@ -23,5 +23,4 @@ NOTE: `cider-jack-in-cljs` works with nbb projects that are using `nbb.edn`.
 The jack-in command can be configured via several defcustoms:
 
 * `cider-nbb-command` (by default `nbb`)
-* `cider-nbb-global-options` (by default `nil`) (DEPRECATED)
 * `cider-nbb-parameters` (by default `nrepl-server`)

--- a/doc/modules/ROOT/pages/platforms/nbb.adoc
+++ b/doc/modules/ROOT/pages/platforms/nbb.adoc
@@ -23,5 +23,5 @@ NOTE: `cider-jack-in-cljs` works with nbb projects that are using `nbb.edn`.
 The jack-in command can be configured via several defcustoms:
 
 * `cider-nbb-command` (by default `nbb`)
-* `cider-nbb-global-options` (by default `nil`)
+* `cider-nbb-global-options` (by default `nil`) (DEPRECATED)
 * `cider-nbb-parameters` (by default `nrepl-server`)

--- a/doc/modules/ROOT/pages/troubleshooting.adoc
+++ b/doc/modules/ROOT/pages/troubleshooting.adoc
@@ -293,7 +293,7 @@ In particular, by adding it to a `deps.edn` file under an alias (eg. `:dev`)
 Or by customising the jack-in options.
 [source,lisp]
 ---
-(setq cider-clojure-cli-global-options "-J-XX:-OmitStackTraceInFastThrow")
+(setq cider-clojure-cli-aliases "-J-XX:-OmitStackTraceInFastThrow")
 ---
 
 NOTE: Leiningen disables `OmitStackTraceInFastThrow` by default.

--- a/doc/modules/ROOT/pages/troubleshooting.adoc
+++ b/doc/modules/ROOT/pages/troubleshooting.adoc
@@ -293,7 +293,7 @@ In particular, by adding it to a `deps.edn` file under an alias (eg. `:dev`)
 Or by customising the jack-in options.
 [source,lisp]
 ---
-(setq cider-clojure-cli-aliases "-J-XX:-OmitStackTraceInFastThrow")
+(setq cider-clojure-cli-parameters "-J-XX:-OmitStackTraceInFastThrow")
 ---
 
 NOTE: Leiningen disables `OmitStackTraceInFastThrow` by default.


### PR DESCRIPTION
Addresses #3295.

Marked all cider-*-global-options as obsolete and replaced with cider-*-parameters.
Also updated the documentation to mark all global-options references as deprecated.

Maybe I am wrong, but the only caveat is for clojure-cli the only configuration variable is `cider-clojure-cli-aliases` which is not intuitive for other types of parameters other than aliases. For example, in the documentation there is a reference to a jvm-option you can pass by setting `(setq cider-clojure-cli-global-options "-J-XX:-OmitStackTraceInFastThrow")`. I tried the equivalent with `cider-clojure-cli-aliases` and the command used to start the repl was this:

```
clojure -Sdeps '{:deps {nrepl/nrepl {:mvn/version "1.0.0"} cider/cider-nrepl {:mvn/version "0.29.0"}} :aliases {:cider/nrepl {:main-opts ["-m" "nrepl.cmdline" "--middleware" "[cider.nrepl/cider-middleware]"]}}}' -M-J-XX:-OmitStackTraceInFastThrow:cider/nrepl
```
As oposed to this when setting global-options:
```
clojure -J-XX:-OmitStackTraceInFastThrow -Sdeps '{:deps {nrepl/nrepl {:mvn/version "1.0.0"} cider/cider-nrepl {:mvn/version "0.29.0"}} :aliases {:cider/nrepl {:main-opts ["-m" "nrepl.cmdline" "--middleware" "[cider.nrepl/cider-middleware]"]}}}' -M:cider/nrepl
```

Does this work as expected?

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

[1]: https://docs.cider.mx/cider/contributing/hacking.html
