### PR TITLE
Keep repl buffers alive for reuse on sesman-restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+- Keep repl buffers alive when restarting with sesman-restart
+
 ## 1.7.0 (2023-03-23)
 
 ### New features

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -1212,8 +1212,9 @@ an `error' if the nREPL PROCESS exited because it couldn't start up."
                                   (eq (buffer-local-value 'nrepl-server-buffer b)
                                       server-buffer))
                                 (buffer-list))))
-      ;; close any known open client connections
-      (mapc #'cider--close-connection clients)
+
+      (when (string-match-p "^hangup" event)
+        (mapc #'cider--close-connection clients))
 
       (if (process-get process :cider--nrepl-server-ready)
           (progn


### PR DESCRIPTION
Closing connections in the server sentinel breaks sesman-restart because Cider tries to reuse the repl buffer on restart.

I do not know why you would only close connections on hangup or at all - I just restored the behaviour we had before the change to always close connections.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
