### PR TITLE
Fix incorrect paredit binding override in #3335

### DIFF
--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1839,6 +1839,15 @@ constructs."
 (declare-function cider-complete-at-point "cider-completion")
 (defvar cider--static-font-lock-keywords)
 
+(defun cider-repl-setup-paredit ()
+  "Override the paredit-RET binding in cider-repl-mode."
+  (let ((oldmap (cdr (assoc 'paredit-mode minor-mode-map-alist)))
+        (newmap (make-sparse-keymap)))
+    (set-keymap-parent newmap oldmap)
+    (define-key newmap (kbd "RET") nil)
+    (make-local-variable 'minor-mode-overriding-map-alist)
+    (push `(paredit-mode . ,newmap) minor-mode-overriding-map-alist)))
+
 (define-derived-mode cider-repl-mode fundamental-mode "REPL"
   "Major mode for Clojure REPL interactions.
 
@@ -1866,12 +1875,8 @@ constructs."
     (add-hook 'kill-buffer-hook #'cider-repl-history-just-save t t)
     (add-hook 'kill-emacs-hook #'cider-repl-history-just-save))
   (add-hook 'completion-at-point-functions #'cider-complete-at-point nil t)
-  (add-hook 'paredit-mode-hook
-            (lambda ()
-              (clojure-paredit-setup cider-repl-mode-map)
-              ;; Disable paredit-RET, see https://github.com/clojure-emacs/cider/issues/3288
-              (make-local-variable 'paredit-mode-map)
-              (define-key paredit-mode-map "RET" nil))))
+  (add-hook 'paredit-mode-hook (lambda () (clojure-paredit-setup cider-repl-mode-map)))
+  (cider-repl-setup-paredit))
 
 (provide 'cider-repl)
 


### PR DESCRIPTION
I reverted the previous commit and used the proper fix suggested in https://github.com/clojure-emacs/cider/commit/0fa58acd93d7305ddc823d5bd670a2e3362bacd2#commitcomment-110663006
 

-----------------

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
