### PR TITLE
Debug on exception

### DIFF
--- a/cider-eval.el
+++ b/cider-eval.el
@@ -1287,7 +1287,9 @@ command `cider-debug-defun-at-point'."
       (when inline-debug
         (cider--prompt-and-insert-inline-dbg)))
     (cider-interactive-eval (when (and debug-it (not inline-debug))
-                              (concat "#dbg\n" (cider-defun-at-point)))
+                              (if (eq '- debug-it)
+                                  (concat "#dbgexn\n" (cider-defun-at-point))
+                                (concat "#dbg\n" (cider-defun-at-point))))
                             nil
                             (cider-defun-at-point 'bounds)
                             (cider--nrepl-pr-request-map))))

--- a/doc/modules/ROOT/pages/debugging/debugger.adoc
+++ b/doc/modules/ROOT/pages/debugging/debugger.adoc
@@ -200,6 +200,19 @@ plus metadata annotation in your code. Note that you'll have to delete
 this annotation by hand; you cannot simply use kbd:[C-M-x] as you
 can to un-instrument kbd:[C-u C-M-x].
 
+== Debug on Exception
+
+There is basic experimental support for entering the debugger when an exception
+is thrown. When you instrument a function by passing a negative argument to
+`cider-eval-defun-at-point` kbd:[C-u - C-M-x] then you will enter the debugger
+whenever any form in that function throws an exception. You can also instrument
+a form manually by placing `#exn` in front to instrument just that form, or
+`#dbgexn` to instrument every form inside of it, the same difference as between
+`#break` and `#dbg`. This is mostly useful to see the values of local variables at
+the time of the exception. *locals*, *eval*, and *inject* all work as expected,
+while *continue* or *next* will simply rethrow the exception, exiting the
+debugger.
+
 == Caveats
 
 Due to the way the debugger is currently implemented there are some


### PR DESCRIPTION
Add support on the cider side to go with https://github.com/clojure-emacs/cider-nrepl/pull/769
passing a negative argument to `cider-eval-defun-at-point` will instrument it with #dbgexn
also added some documentation to the debugger docs describing the new feature

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
