### PR TITLE
Mention full JDK as a prerequisite

### DIFF
--- a/doc/modules/ROOT/pages/basics/installation.adoc
+++ b/doc/modules/ROOT/pages/basics/installation.adoc
@@ -20,6 +20,9 @@ You'll also need a recent version of either the Clojure CLI tools or your
 favorite build tool (Leiningen, Boot, or Gradle) to be able to start CIDER via
 `cider-jack-in`. Generally it's a good idea to use the latest stable versions.
 
+Make sure you have a complete JDK installation. Many Linux distributions
+provide only the runtime support by default.
+
 == Installation via package.el
 
 CIDER is available on all major `package.el` community


### PR DESCRIPTION
CIDER apparently needs a full JDK (see #3339), rather than just a Java runtime. This is not obvious, so it should be stated explicitly in the list of prerequisites.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
(the remaining items do not apply as only the documentation is modified).
