### PR TITLE
Escape clojure cli command params on MS-win for native commands

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,13 @@ jobs:
 
         curl.exe -fsSL https://raw.github.com/doublep/eldev/master/webinstall/github-eldev.bat | cmd /Q
 
+    - name: Install deps.clj on MS-Windows
+      if: startsWith (matrix.os, 'windows')
+      run: |
+        iwr -Uri https://raw.githubusercontent.com/borkdude/deps.clj/master/install.ps1 -outfile install_clojure.ps1
+        .\install_clojure.ps1
+        get-command deps.exe | split-path -parent | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
     - name: Check out the source code
       uses: actions/checkout@v2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs
+
+- [#3341](https://github.com/clojure-emacs/cider/issues/3341): Escape clojure-cli args on MS-Windows on non powershell invocations.
+
 ## 1.7.0 (2023-03-23)
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-### Bugs
+### Bugs fixed
 
 - [#3341](https://github.com/clojure-emacs/cider/issues/3341): Escape clojure-cli args on MS-Windows on non powershell invocations.
 

--- a/cider.el
+++ b/cider.el
@@ -767,12 +767,12 @@ rules to quote it."
          (utf-16le-command (encode-coding-string command 'utf-16le)))
     (format "-encodedCommand %s" (base64-encode-string utf-16le-command t))))
 
-(defun cider-clojure-cli-jack-in-dependencies (global-options params dependencies command)
+(defun cider-clojure-cli-jack-in-dependencies (global-options params dependencies &optional command)
   "Create Clojure tools.deps jack-in dependencies.
 Does so by concatenating DEPENDENCIES, PARAMS and GLOBAL-OPTIONS into a
-suitable `clojure` invocation and quoting suitable for COMMAND invocation.
-The main is placed in an inline alias :cider/nrepl so that if your aliases
-contain any mains, the cider/nrepl one will be the one used."
+suitable `clojure` invocation and quoting, also accounting for COMMAND if
+provided.  The main is placed in an inline alias :cider/nrepl so that if
+your aliases contain any mains, the cider/nrepl one will be the one used."
   (let* ((all-deps (thread-last
                      dependencies
                      (append (cider--jack-in-required-dependencies))
@@ -838,12 +838,12 @@ See also `cider-jack-in-auto-inject-clojure'."
               dependencies))
     dependencies))
 
-(defun cider-inject-jack-in-dependencies (global-opts params project-type command)
+(defun cider-inject-jack-in-dependencies (global-opts params project-type &optional command)
   "Return GLOBAL-OPTS and PARAMS with injected REPL dependencies.
 These are set in `cider-jack-in-dependencies', `cider-jack-in-lein-plugins'
 and `cider-jack-in-nrepl-middlewares' are injected from the CLI according
-to the used PROJECT-TYPE and COMMAND.  Eliminates the need for hacking
-profiles.clj or the boot script for supporting CIDER with its nREPL
+to the used PROJECT-TYPE, and COMMAND if provided.  Eliminates the need for
+hacking profiles.clj or the boot script for supporting CIDER with its nREPL
 middleware and dependencies."
   (pcase project-type
     ('lein (cider-lein-jack-in-dependencies

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -148,7 +148,7 @@
       (setq-local cider-enrich-classpath t))
 
     (it "can inject dependencies in a lein project"
-      (expect (cider-inject-jack-in-dependencies "" "repl :headless" 'lein)
+      (expect (cider-inject-jack-in-dependencies "" "repl :headless" 'lein "lein")
               :to-equal (concat "update-in :dependencies conj "
                                 (shell-quote-argument "[nrepl/nrepl \"0.9.0\"]")
                                 " -- update-in :plugins conj "
@@ -160,7 +160,7 @@
 
     (it "can inject dependencies in a lein project with an exclusion"
       (setq-local cider-jack-in-dependencies-exclusions '(("nrepl/nrepl" ("org.clojure/clojure"))))
-      (expect (cider-inject-jack-in-dependencies "" "repl :headless" 'lein)
+      (expect (cider-inject-jack-in-dependencies "" "repl :headless" 'lein "lein")
               :to-equal (concat
                          "update-in :dependencies conj "
                          (shell-quote-argument "[nrepl/nrepl \"0.9.0\" :exclusions [org.clojure/clojure]]")
@@ -173,7 +173,7 @@
 
     (it "can inject dependencies in a lein project with multiple exclusions"
       (setq-local cider-jack-in-dependencies-exclusions '(("nrepl/nrepl" ("org.clojure/clojure" "foo.bar/baz"))))
-      (expect (cider-inject-jack-in-dependencies "" "repl :headless" 'lein)
+      (expect (cider-inject-jack-in-dependencies "" "repl :headless" 'lein "lein")
               :to-equal (concat "update-in :dependencies conj "
                                 (shell-quote-argument "[nrepl/nrepl \"0.9.0\" :exclusions [org.clojure/clojure foo.bar/baz]]")
                                 " -- update-in :plugins conj "
@@ -184,7 +184,7 @@
                                 " -- repl :headless")))
 
     (it "can inject dependencies in a boot project"
-      (expect (cider-inject-jack-in-dependencies "" "repl -s wait" 'boot)
+      (expect (cider-inject-jack-in-dependencies "" "repl -s wait" 'boot "boot")
               :to-equal (concat
                          "-i \"(require 'cider.tasks)\""
                          " -d "
@@ -197,7 +197,7 @@
                          " repl -s wait")))
 
     (it "can inject dependencies in a gradle project"
-      (expect (cider-inject-jack-in-dependencies "--no-daemon" ":clojureRepl" 'gradle)
+      (expect (cider-inject-jack-in-dependencies "--no-daemon" ":clojureRepl" 'gradle "grandle")
               :to-equal (concat "--no-daemon "
                                 (shell-quote-argument "-Pdev.clojurephant.jack-in.nrepl=nrepl:nrepl:0.9.0,cider:cider-nrepl:0.28.5")
                                 " :clojureRepl "
@@ -210,7 +210,7 @@
       (setq-local cider-jack-in-nrepl-middlewares '("refactor-nrepl.middleware/wrap-refactor" "cider.nrepl/cider-middleware"))
       (setq-local cider-jack-in-dependencies-exclusions '()))
     (it "can inject dependencies in a lein project"
-      (expect (cider-inject-jack-in-dependencies "" "repl :headless" 'lein)
+      (expect (cider-inject-jack-in-dependencies "" "repl :headless" 'lein "lein")
               :to-equal (concat "update-in :dependencies conj "
                                 (shell-quote-argument "[nrepl/nrepl \"0.9.0\"]")
                                 " -- update-in :plugins conj "
@@ -224,7 +224,7 @@
 
     (it "can inject dependencies in a boot project"
       (setq-local cider-jack-in-dependencies '(("refactor-nrepl" "2.0.0")))
-      (expect (cider-inject-jack-in-dependencies "" "repl -s wait" 'boot)
+      (expect (cider-inject-jack-in-dependencies "" "repl -s wait" 'boot "boot")
               :to-equal (concat "-i \"(require 'cider.tasks)\""
                                 " -d "
                                 (shell-quote-argument "nrepl/nrepl:0.9.0")
@@ -247,7 +247,7 @@
       (setq-local cider-jack-in-nrepl-middlewares '("cider.nrepl/cider-middleware"))
       (setq-local cider-jack-in-dependencies-exclusions '()))
     (it "can concat in a lein project"
-      (expect (cider-inject-jack-in-dependencies "-o -U" "repl :headless" 'lein)
+      (expect (cider-inject-jack-in-dependencies "-o -U" "repl :headless" 'lein "lein")
               :to-equal (concat "-o -U update-in :dependencies conj "
                                 (shell-quote-argument "[nrepl/nrepl \"0.9.0\"]")
                                 " -- update-in :plugins conj "
@@ -257,7 +257,7 @@
                                 " -- update-in :middleware conj cider.enrich-classpath/middleware"
                                 " -- repl :headless")))
     (it "can concat in a boot project"
-      (expect (cider-inject-jack-in-dependencies "-C -o" "repl -s wait" 'boot)
+      (expect (cider-inject-jack-in-dependencies "-C -o" "repl -s wait" 'boot "boot")
               :to-equal (concat "-C -o -i \"(require 'cider.tasks)\""
                                 " -d "
                                 (shell-quote-argument "nrepl/nrepl:0.9.0")
@@ -268,7 +268,7 @@
                                 (shell-quote-argument "cider.nrepl/cider-middleware")
                                 " repl -s wait")))
     (it "can concat in a gradle project"
-      (expect (cider-inject-jack-in-dependencies "--no-daemon" ":clojureRepl" 'gradle)
+      (expect (cider-inject-jack-in-dependencies "--no-daemon" ":clojureRepl" 'gradle "grandle")
               :to-equal (concat "--no-daemon "
                                 (shell-quote-argument "-Pdev.clojurephant.jack-in.nrepl=nrepl:nrepl:0.9.0,cider:cider-nrepl:0.28.5")
                                 " :clojureRepl "
@@ -326,7 +326,7 @@
       (setq-local cider-jack-in-dependencies-exclusions '())
       (setq-local cider-enrich-classpath t))
     (it "uses them in a lein project"
-      (expect (cider-inject-jack-in-dependencies "" "repl :headless" 'lein)
+      (expect (cider-inject-jack-in-dependencies "" "repl :headless" 'lein "lein")
               :to-equal (concat "update-in :dependencies conj "
                                 (shell-quote-argument "[nrepl/nrepl \"0.9.0\"]")
                                 " -- update-in :plugins conj "
@@ -345,7 +345,7 @@
       (setq-local cider-jack-in-dependencies '(("refactor-nrepl" "2.0.0")))
       (setq-local cider-jack-in-dependencies-exclusions '()))
     (it "uses them in a boot project"
-      (expect (cider-inject-jack-in-dependencies "" "repl -s wait" 'boot)
+      (expect (cider-inject-jack-in-dependencies "" "repl -s wait" 'boot "boot")
               :to-equal (concat "-i \"(require 'cider.tasks)\""
                                 " -d "
                                 (shell-quote-argument "nrepl/nrepl:0.9.0")
@@ -414,8 +414,8 @@
   (it "escapes double quotes by repeating them"
     (expect (cider--powershell-encode-command "\"cmd-params\"")
             :to-equal (concat "-encodedCommand "
-                              ;; Eval to reproduce reference string below: (base64-encode-string (encode-coding-string "clojure \"\"cmd-params\"\"" 'utf-16le) t)
-                              "YwBsAG8AagB1AHIAZQAgACIAIgBjAG0AZAAtAHAAYQByAGEAbQBzACIAIgA="))))
+                              ;; Eval to reproduce reference string below: (base64-encode-string (encode-coding-string "clojure "\"cmd-params\""" 'utf-16le) t)
+                              "YwBsAG8AagB1AHIAZQAgACIAYwBtAGQALQBwAGEAcgBhAG0AcwAiAA=="))))
 
 (describe "cider--update-jack-in-cmd"
   (describe "when 'clojure-cli project type and \"powershell\" command"
@@ -430,16 +430,15 @@
       (spy-on 'cider-jack-in-params :and-return-value "\"cmd-params\"")
       (expect (plist-get (cider--update-jack-in-cmd nil) :jack-in-cmd)
               :to-equal (concat "resolved-powershell -encodedCommand "
-                                ;; Eval to reproduce reference string below: (base64-encode-string (encode-coding-string "clojure \"\"cmd-params\"\"" 'utf-16le) t)
-                                "YwBsAG8AagB1AHIAZQAgACIAIgBjAG0AZAAtAHAAYQByAGEAbQBzACIAIgA="))))
+                                ;; Eval to reproduce reference string below: (base64-encode-string (encode-coding-string "clojure "\"cmd-params"\"" 'utf-16le) t)
+                                "YwBsAG8AagB1AHIAZQAgACIAYwBtAGQALQBwAGEAcgBhAG0AcwAiAA=="))))
   (describe "when 'clojure-cli project type"
     (it "uses main opts in an alias to prevent other mains from winning"
       (setq-local cider-jack-in-dependencies nil)
       (setq-local cider-jack-in-nrepl-middlewares '("cider.nrepl/cider-middleware"))
-      (let ((expected (string-join '("clojure -Sdeps '{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} "
-                                     "cider/cider-nrepl {:mvn/version \"0.28.5\"}} "
-                                     ":aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\""
-                                     " \"[cider.nrepl/cider-middleware]\"]}}}' -M:cider/nrepl")
+      (let ((expected (string-join `("clojure -Sdeps "
+                                     ,(shell-quote-argument "{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} cider/cider-nrepl {:mvn/version \"0.28.5\"}} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
+                                     " -M:cider/nrepl")
                                    "")))
         (setq-local cider-allow-jack-in-without-project t)
         (setq-local cider-clojure-cli-command "clojure")
@@ -451,10 +450,9 @@
                 :to-equal expected)))
 
     (it "allows specifying custom aliases with `cider-clojure-cli-aliases`"
-      (let ((expected (string-join '("clojure -Sdeps '{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} "
-                                     "cider/cider-nrepl {:mvn/version \"0.28.5\"}} "
-                                     ":aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\""
-                                     " \"[cider.nrepl/cider-middleware]\"]}}}' -M:dev:test:cider/nrepl")
+      (let ((expected (string-join `("clojure -Sdeps "
+                                     ,(shell-quote-argument "{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} cider/cider-nrepl {:mvn/version \"0.28.5\"}} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
+                                     " -M:dev:test:cider/nrepl")
                                    "")))
         (setq-local cider-jack-in-dependencies nil)
         (setq-local cider-clojure-cli-aliases "-A:dev:test")
@@ -465,56 +463,56 @@
         (spy-on 'cider-jack-in-resolve-command :and-return-value "clojure")
         (expect (plist-get (cider--update-jack-in-cmd nil) :jack-in-cmd)
                 :to-equal expected)))
-    (it "should remove duplicates, yielding the same result"
-        (let ((expected (string-join '("-Sdeps '{:deps {cider/cider-nrepl {:mvn/version \"0.28.5\"} "
-                                       "nrepl/nrepl {:mvn/version \"0.9.0\"}} "
-                                       ":aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\""
-                                       " \"[cider.nrepl/cider-middleware]\"]}}}' -M:dev:test:cider/nrepl")
-                                     "")))
-          (expect (cider-clojure-cli-jack-in-dependencies nil nil '(("nrepl/nrepl" "0.9.0")
-                                                                    ("nrepl/nrepl" "0.9.0")))
-                  :to-equal expected)))
+
+    (dolist (command '("clojure" "powershell"))
+      (it (format "should remove duplicates, yielding the same result (for %S command invocation)" command)
+          ;; repeat the same test for PowerShell too
+          (let ((expected (string-join `("-Sdeps "
+                                         ,(cider--shell-quote-argument "{:deps {cider/cider-nrepl {:mvn/version \"0.28.5\"} nrepl/nrepl {:mvn/version \"0.9.0\"}} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}"
+                                                                       command)
+                                         " -M:dev:test:cider/nrepl")
+                                       "")))
+            (expect (cider-clojure-cli-jack-in-dependencies nil nil '(("nrepl/nrepl" "0.9.0")
+                                                                      ("nrepl/nrepl" "0.9.0"))
+                                                            command)
+                    :to-equal expected))))
     (it "handles aliases correctly"
-      (let ((expected (string-join '("-Sdeps '{:deps {cider/cider-nrepl {:mvn/version \"0.28.5\"} "
-                                     "nrepl/nrepl {:mvn/version \"0.9.0\"}} "
-                                     ":aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\""
-                                     " \"[cider.nrepl/cider-middleware]\"]}}}' -M:test:cider/nrepl")
+      (let ((expected (string-join `("-Sdeps "
+                                     ,(shell-quote-argument "{:deps {cider/cider-nrepl {:mvn/version \"0.28.5\"} nrepl/nrepl {:mvn/version \"0.9.0\"}} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
+                                     " -M:test:cider/nrepl")
                                    ""))
             (deps '(("nrepl/nrepl" "0.9.0"))))
         (let ((cider-clojure-cli-aliases ":test"))
-          (expect (cider-clojure-cli-jack-in-dependencies nil nil deps)
+          (expect (cider-clojure-cli-jack-in-dependencies nil nil deps "clojure")
                   :to-equal expected))
         (describe "should strip out leading exec opts -A -M -T -X"
           (let ((cider-clojure-cli-aliases "-A:test"))
-           (expect (cider-clojure-cli-jack-in-dependencies nil nil deps)
+           (expect (cider-clojure-cli-jack-in-dependencies nil nil deps "clojure")
                    :to-equal expected))
           (let ((cider-clojure-cli-aliases "-M:test"))
-            (expect (cider-clojure-cli-jack-in-dependencies nil nil deps)
+            (expect (cider-clojure-cli-jack-in-dependencies nil nil deps "clojure")
                     :to-equal expected))
           (let ((cider-clojure-cli-aliases "-T:test"))
-            (expect (cider-clojure-cli-jack-in-dependencies nil nil deps)
+            (expect (cider-clojure-cli-jack-in-dependencies nil nil deps "clojure")
                     :to-equal expected))
           (let ((cider-clojure-cli-aliases "-T:test"))
-            (expect (cider-clojure-cli-jack-in-dependencies nil nil deps)
+            (expect (cider-clojure-cli-jack-in-dependencies nil nil deps "clojure")
                     :to-equal expected)))))
     (it "allows for global options"
-      (let ((expected (string-join '("-J-Djdk.attach.allowAttachSelf -Sdeps '{:deps {cider/cider-nrepl {:mvn/version \"0.28.5\"} "
-                                     "nrepl/nrepl {:mvn/version \"0.9.0\"}} "
-                                     ":aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\""
-                                     " \"[cider.nrepl/cider-middleware]\"]}}}' -M:test:cider/nrepl")
+      (let ((expected (string-join `("-J-Djdk.attach.allowAttachSelf -Sdeps "
+                                     ,(shell-quote-argument "{:deps {cider/cider-nrepl {:mvn/version \"0.28.5\"} nrepl/nrepl {:mvn/version \"0.9.0\"}} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
+                                     " -M:test:cider/nrepl")
                                    ""))
             (deps '(("nrepl/nrepl" "0.9.0"))))
         (let ((cider-clojure-cli-aliases ":test"))
-          (expect (cider-clojure-cli-jack-in-dependencies "-J-Djdk.attach.allowAttachSelf" nil deps)
+          (expect (cider-clojure-cli-jack-in-dependencies "-J-Djdk.attach.allowAttachSelf" nil deps "clojure")
                   :to-equal expected))))
     (it "allows to specify git coordinate as cider-jack-in-dependency"
       (setq-local cider-jack-in-dependencies '(("org.clojure/tools.deps" (("git/sha" . "6ae2b6f71773de7549d7f22759e8b09fec27f0d9")
                                                                           ("git/url" . "https://github.com/clojure/tools.deps/")))))
-      (let ((expected (string-join '("clojure -Sdeps '{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} "
-                                     "cider/cider-nrepl {:mvn/version \"0.28.5\"} "
-                                     "org.clojure/tools.deps { :git/sha \"6ae2b6f71773de7549d7f22759e8b09fec27f0d9\"  :git/url \"https://github.com/clojure/tools.deps/\" }} "
-                                     ":aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" "
-                                     "\"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}' -M:cider/nrepl")
+      (let ((expected (string-join `("clojure -Sdeps "
+                                     ,(shell-quote-argument "{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} cider/cider-nrepl {:mvn/version \"0.28.5\"} org.clojure/tools.deps { :git/sha \"6ae2b6f71773de7549d7f22759e8b09fec27f0d9\"  :git/url \"https://github.com/clojure/tools.deps/\" }} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
+                                     " -M:cider/nrepl")
                                    "")))
         (setq-local cider-allow-jack-in-without-project t)
         (setq-local cider-clojure-cli-command "clojure")

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -148,7 +148,7 @@
       (setq-local cider-enrich-classpath t))
 
     (it "can inject dependencies in a lein project"
-      (expect (cider-inject-jack-in-dependencies "" "repl :headless" 'lein "lein")
+      (expect (cider-inject-jack-in-dependencies "" "repl :headless" 'lein)
               :to-equal (concat "update-in :dependencies conj "
                                 (shell-quote-argument "[nrepl/nrepl \"0.9.0\"]")
                                 " -- update-in :plugins conj "
@@ -160,7 +160,7 @@
 
     (it "can inject dependencies in a lein project with an exclusion"
       (setq-local cider-jack-in-dependencies-exclusions '(("nrepl/nrepl" ("org.clojure/clojure"))))
-      (expect (cider-inject-jack-in-dependencies "" "repl :headless" 'lein "lein")
+      (expect (cider-inject-jack-in-dependencies "" "repl :headless" 'lein)
               :to-equal (concat
                          "update-in :dependencies conj "
                          (shell-quote-argument "[nrepl/nrepl \"0.9.0\" :exclusions [org.clojure/clojure]]")
@@ -173,7 +173,7 @@
 
     (it "can inject dependencies in a lein project with multiple exclusions"
       (setq-local cider-jack-in-dependencies-exclusions '(("nrepl/nrepl" ("org.clojure/clojure" "foo.bar/baz"))))
-      (expect (cider-inject-jack-in-dependencies "" "repl :headless" 'lein "lein")
+      (expect (cider-inject-jack-in-dependencies "" "repl :headless" 'lein)
               :to-equal (concat "update-in :dependencies conj "
                                 (shell-quote-argument "[nrepl/nrepl \"0.9.0\" :exclusions [org.clojure/clojure foo.bar/baz]]")
                                 " -- update-in :plugins conj "
@@ -184,7 +184,7 @@
                                 " -- repl :headless")))
 
     (it "can inject dependencies in a boot project"
-      (expect (cider-inject-jack-in-dependencies "" "repl -s wait" 'boot "boot")
+      (expect (cider-inject-jack-in-dependencies "" "repl -s wait" 'boot)
               :to-equal (concat
                          "-i \"(require 'cider.tasks)\""
                          " -d "
@@ -197,7 +197,7 @@
                          " repl -s wait")))
 
     (it "can inject dependencies in a gradle project"
-      (expect (cider-inject-jack-in-dependencies "--no-daemon" ":clojureRepl" 'gradle "grandle")
+      (expect (cider-inject-jack-in-dependencies "--no-daemon" ":clojureRepl" 'gradle)
               :to-equal (concat "--no-daemon "
                                 (shell-quote-argument "-Pdev.clojurephant.jack-in.nrepl=nrepl:nrepl:0.9.0,cider:cider-nrepl:0.28.5")
                                 " :clojureRepl "
@@ -210,7 +210,7 @@
       (setq-local cider-jack-in-nrepl-middlewares '("refactor-nrepl.middleware/wrap-refactor" "cider.nrepl/cider-middleware"))
       (setq-local cider-jack-in-dependencies-exclusions '()))
     (it "can inject dependencies in a lein project"
-      (expect (cider-inject-jack-in-dependencies "" "repl :headless" 'lein "lein")
+      (expect (cider-inject-jack-in-dependencies "" "repl :headless" 'lein)
               :to-equal (concat "update-in :dependencies conj "
                                 (shell-quote-argument "[nrepl/nrepl \"0.9.0\"]")
                                 " -- update-in :plugins conj "
@@ -224,7 +224,7 @@
 
     (it "can inject dependencies in a boot project"
       (setq-local cider-jack-in-dependencies '(("refactor-nrepl" "2.0.0")))
-      (expect (cider-inject-jack-in-dependencies "" "repl -s wait" 'boot "boot")
+      (expect (cider-inject-jack-in-dependencies "" "repl -s wait" 'boot)
               :to-equal (concat "-i \"(require 'cider.tasks)\""
                                 " -d "
                                 (shell-quote-argument "nrepl/nrepl:0.9.0")
@@ -247,7 +247,7 @@
       (setq-local cider-jack-in-nrepl-middlewares '("cider.nrepl/cider-middleware"))
       (setq-local cider-jack-in-dependencies-exclusions '()))
     (it "can concat in a lein project"
-      (expect (cider-inject-jack-in-dependencies "-o -U" "repl :headless" 'lein "lein")
+      (expect (cider-inject-jack-in-dependencies "-o -U" "repl :headless" 'lein)
               :to-equal (concat "-o -U update-in :dependencies conj "
                                 (shell-quote-argument "[nrepl/nrepl \"0.9.0\"]")
                                 " -- update-in :plugins conj "
@@ -257,7 +257,7 @@
                                 " -- update-in :middleware conj cider.enrich-classpath/middleware"
                                 " -- repl :headless")))
     (it "can concat in a boot project"
-      (expect (cider-inject-jack-in-dependencies "-C -o" "repl -s wait" 'boot "boot")
+      (expect (cider-inject-jack-in-dependencies "-C -o" "repl -s wait" 'boot)
               :to-equal (concat "-C -o -i \"(require 'cider.tasks)\""
                                 " -d "
                                 (shell-quote-argument "nrepl/nrepl:0.9.0")
@@ -268,7 +268,7 @@
                                 (shell-quote-argument "cider.nrepl/cider-middleware")
                                 " repl -s wait")))
     (it "can concat in a gradle project"
-      (expect (cider-inject-jack-in-dependencies "--no-daemon" ":clojureRepl" 'gradle "grandle")
+      (expect (cider-inject-jack-in-dependencies "--no-daemon" ":clojureRepl" 'gradle)
               :to-equal (concat "--no-daemon "
                                 (shell-quote-argument "-Pdev.clojurephant.jack-in.nrepl=nrepl:nrepl:0.9.0,cider:cider-nrepl:0.28.5")
                                 " :clojureRepl "
@@ -326,7 +326,7 @@
       (setq-local cider-jack-in-dependencies-exclusions '())
       (setq-local cider-enrich-classpath t))
     (it "uses them in a lein project"
-      (expect (cider-inject-jack-in-dependencies "" "repl :headless" 'lein "lein")
+      (expect (cider-inject-jack-in-dependencies "" "repl :headless" 'lein)
               :to-equal (concat "update-in :dependencies conj "
                                 (shell-quote-argument "[nrepl/nrepl \"0.9.0\"]")
                                 " -- update-in :plugins conj "
@@ -345,7 +345,7 @@
       (setq-local cider-jack-in-dependencies '(("refactor-nrepl" "2.0.0")))
       (setq-local cider-jack-in-dependencies-exclusions '()))
     (it "uses them in a boot project"
-      (expect (cider-inject-jack-in-dependencies "" "repl -s wait" 'boot "boot")
+      (expect (cider-inject-jack-in-dependencies "" "repl -s wait" 'boot)
               :to-equal (concat "-i \"(require 'cider.tasks)\""
                                 " -d "
                                 (shell-quote-argument "nrepl/nrepl:0.9.0")
@@ -404,6 +404,14 @@
             :to-equal '(browser-repl node-repl))
     (expect (cider--shadow-parse-builds (parseedn-read-str "[oops]"))
             :to-equal '(browser-repl node-repl))))
+
+(describe "cider--shell-quote-argument"
+  (it "can quote powershell argument"
+    (expect (cider--shell-quote-argument "one \"two\" three" "powershell")
+            :to-equal "'one \"\"two\"\" three'"))
+  (it "can quote any other argument"
+    (expect (cider--shell-quote-argument "one \"two\" three")
+            :to-equal (shell-quote-argument "one \"two\" three"))))
 
 (describe "cider--powershell-encode-command"
   (it "base64 encodes command and parameters"
@@ -483,20 +491,20 @@
                                    ""))
             (deps '(("nrepl/nrepl" "0.9.0"))))
         (let ((cider-clojure-cli-aliases ":test"))
-          (expect (cider-clojure-cli-jack-in-dependencies nil nil deps "clojure")
+          (expect (cider-clojure-cli-jack-in-dependencies nil nil deps)
                   :to-equal expected))
         (describe "should strip out leading exec opts -A -M -T -X"
           (let ((cider-clojure-cli-aliases "-A:test"))
-           (expect (cider-clojure-cli-jack-in-dependencies nil nil deps "clojure")
+           (expect (cider-clojure-cli-jack-in-dependencies nil nil deps)
                    :to-equal expected))
           (let ((cider-clojure-cli-aliases "-M:test"))
-            (expect (cider-clojure-cli-jack-in-dependencies nil nil deps "clojure")
+            (expect (cider-clojure-cli-jack-in-dependencies nil nil deps)
                     :to-equal expected))
           (let ((cider-clojure-cli-aliases "-T:test"))
-            (expect (cider-clojure-cli-jack-in-dependencies nil nil deps "clojure")
+            (expect (cider-clojure-cli-jack-in-dependencies nil nil deps)
                     :to-equal expected))
           (let ((cider-clojure-cli-aliases "-T:test"))
-            (expect (cider-clojure-cli-jack-in-dependencies nil nil deps "clojure")
+            (expect (cider-clojure-cli-jack-in-dependencies nil nil deps)
                     :to-equal expected)))))
     (it "allows for global options"
       (let ((expected (string-join `("-J-Djdk.attach.allowAttachSelf -Sdeps "
@@ -505,7 +513,7 @@
                                    ""))
             (deps '(("nrepl/nrepl" "0.9.0"))))
         (let ((cider-clojure-cli-aliases ":test"))
-          (expect (cider-clojure-cli-jack-in-dependencies "-J-Djdk.attach.allowAttachSelf" nil deps "clojure")
+          (expect (cider-clojure-cli-jack-in-dependencies "-J-Djdk.attach.allowAttachSelf" nil deps)
                   :to-equal expected))))
     (it "allows to specify git coordinate as cider-jack-in-dependency"
       (setq-local cider-jack-in-dependencies '(("org.clojure/tools.deps" (("git/sha" . "6ae2b6f71773de7549d7f22759e8b09fec27f0d9")

--- a/test/integration/integration-tests.el
+++ b/test/integration/integration-tests.el
@@ -181,7 +181,7 @@ If CLI-COMMAND is nil, then use the default."
                 (cider-itu-poll-until (not (eq (process-status nrepl-proc) 'run)) 5)
                 (expect (member (process-status nrepl-proc) '(exit signal))))))))))
 
-  (it "to clojure tools cli"
+  (it "to clojure tools cli (default)"
     (jack-in-clojure-cli-test nil))
 
   (when (eq system-type 'windows-nt)


### PR DESCRIPTION
Hi,

could you please review patch to encode clojure cli native command args on MS-Windows. It addresses #3341.

The clojure cli command line args for clojure cli invocations other than powershell also need to be escaped. 

I've relocated the escaping logic into `cider-clojure-cli-jack-in-dependencies`, assuming that powershell invocations are only relevant to clojure-cli, as is the new native escaping.

I've also added a windows-nt only clojure-cli `deps.exe` integration test to test the same. For this, I need to install the deps.clj tools in the workflow for windows-nt.

Thanks

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

