### PR TITLE
Improve prompts for reusing dead REPLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## master (unreleased)
 
+### New features
+
+- [#3354](https://github.com/clojure-emacs/cider/issues/3354): Add new customization variable `cider-reuse-dead-repls` to control how dead REPL buffers are reused on new connections.
+
 ### Bugs fixed
 
 - [#3341](https://github.com/clojure-emacs/cider/issues/3341): Escape clojure-cli args on MS-Windows on non powershell invocations.
+- [#3353](https://github.com/clojure-emacs/cider/issues/3353): Fix regression which caused new connections to prompt for reusing dead REPLs.
 
 ## 1.7.0 (2023-03-23)
 

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -857,10 +857,10 @@ PARAMS is a plist as received by `cider-repl-create'."
                (get-buffer (caar scored-repls)))
               ((= 1 (length scored-repls))
                (when (or (eq 'auto cider-reuse-dead-repls)
-                         (y-or-n-p (format "A dead REPL %s exists.  Reuse? " (caar scored-repls))))
+                         (y-or-n-p (format "A dead REPL %s exists.  Reuse buffer? " (caar scored-repls))))
                  (get-buffer (caar scored-repls))))
-              ((y-or-n-p "Dead REPLs exist.  Reuse? ")
-               (get-buffer (completing-read "REPL to reuse: " (mapcar #'car scored-repls)
+              ((y-or-n-p "Dead REPL buffers exist.  Select one to reuse? ")
+               (get-buffer (completing-read "REPL buffer to reuse: " (mapcar #'car scored-repls)
                                             nil t nil nil (caar scored-repls)))))))))
 
 (declare-function cider-default-err-handler "cider-eval")

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -61,7 +61,6 @@ available) and the matching REPL buffer."
   :safe #'booleanp
   :package-version '(cider . "0.9.0"))
 
-;;;###autoload
 (defcustom cider-merge-sessions nil
   "Controls session combination behaviour.
 
@@ -69,7 +68,9 @@ Symbol `host' combines all sessions of a project associated with the same host.
 Symbol `project' combines all sessions of a project.
 
 All other values do not combine any sessions."
-  :type 'symbol
+  :type '(choice (const :tag "Combine all sessions with the same host" host)
+                 (const :tag "Combine all sessions from the same project" project)
+                 (other :tag "Do not combine any sessions"))
   :group 'cider
   :safe #'symbolp
   :package-version '(cider . "1.5"))

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -76,17 +76,17 @@ All other values do not combine any sessions."
   :package-version '(cider . "1.5"))
 
 (defcustom cider-reuse-dead-repls 'prompt
-  "Controls behaviour when initializing a connection with existing dead REPL buffers.
+  "How to deal with existing dead REPL buffers when initializing a connection.
 
-Possible choices are `prompt', `auto', `any', and `nil'.
+Possible choices are `prompt', `auto', `any', and nil.
 - `prompt' means to always ask the user for a decision.
 - `auto' means to automatically reuse a dead REPL without prompting the user
-  if it is the only available option. When there are multiple buffers to
+  if it is the only available option.  When there are multiple buffers to
   choose from, the user is is prompted for a choice.
 - `any' (or any other non-nil value) means to reuse any dead REPL buffer
   available, by default the most relevant according to various heuristics,
   and never prompt the user.
-- `nil' means to start a new REPL each time, ignoring existing buffers."
+- nil means to start a new REPL each time, ignoring existing buffers."
   :type '(choice (const :tag "Always prompt for what to do with dead REPLs" prompt)
                  (const :tag "Reuse dead REPL, prompting only for multiple choice" auto)
                  (const :tag "Reuse any available dead REPL and never prompt" any)

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -824,9 +824,8 @@ PARAMS is a plist as received by `cider-repl-create'."
             (delq nil
                   (mapcar (lambda (b)
                             (let ((bparams (cider--gather-connect-params nil b)))
-                              (when (and cljsp
-                                         (eq (plist-get bparams :repl-type)
-                                             'cljs))
+                              (when (eq cljsp
+                                        (eq (plist-get bparams :repl-type) 'cljs))
                                 (cons (buffer-name b)
                                       (+
                                        (if (equal proj-dir (plist-get bparams :project-dir)) 8 0)

--- a/doc/modules/ROOT/pages/usage/managing_connections.adoc
+++ b/doc/modules/ROOT/pages/usage/managing_connections.adoc
@@ -192,3 +192,18 @@ name and the REPL type specification post-fix
 You can customize session names with `cider-session-name-template` and REPL
 names with `nrepl-repl-buffer-name-template`. See also
 `cider-format-connection-params` for available formats.
+
+== Reusing dead REPLs
+
+Under normal circumstances, CIDER automatically kills the REPL buffers and cleans up after itself when ending a session.
+However, when a session is terminated unexpectedly, e.g. when it crashes or is disconnected from an external server process, the REPL buffer is left without an active connection and outputs a log:
+
+[source]
+----
+*** Closed on < date/time > ***
+----
+
+Upon starting a new connection, CIDER can detect these "dead REPLs" and offer to reuse the buffer for the new connection.
+By default, it prompts for confirmation whenever a dead REPL buffer is available for reuse, but you can customize this behaviour via the variable `cider-reuse-dead-repls`.
+Setting it to `auto` reuses a dead REPL buffer automatically, and only displays a prompt when there are multiple options to choose from.
+To suppress the prompt entirely, set it to `nil` to always start a new REPL buffer, or `any` to reuse the most relevant dead REPL.


### PR DESCRIPTION
Fixes the regression mentioned in #3353, which caused dead clj REPL buffers to not prompt for reuse.
Also changes the wording of the prompt as suggested in #3076, and implements a defcustom, allowing the user to always / never reuse dead repls. Defaults to the current behaviour of always prompting. 
I also added my preferred `auto` behaviour which skips the prompt when there's a single unambiguous `y/n` choice. 

Fixes #3353 
Closes #3076

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
