### PR TITLE
Add customizable default connection params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New features
 
+- [#3359](https://github.com/clojure-emacs/cider/pull/3359): Add customizable default connection params
+
 ### Changes
 
 - Bump the injected `cider-nrepl` to [0.56.0](https://github.com/clojure-emacs/cider-nrepl/blob/master/CHANGELOG.md#0560-2025-05-29).

--- a/cider.el
+++ b/cider.el
@@ -1443,14 +1443,21 @@ server buffer, in which case a new session for that server is created."
                    (plist-put :session-name ses-name)
                    (plist-put :repl-type 'cljs)))))
 
+(defvar-local cider-connect-default-params nil
+  "Default plist of params to pass to `cider-connect'.
+Recognized keys are :host, :port and :project-dir.")
+
 ;;;###autoload
 (defun cider-connect-clj (&optional params)
   "Initialize a Clojure connection to an nREPL server.
-PARAMS is a plist optionally containing :host, :port and :project-dir.  On
-prefix argument, prompt for all the parameters."
+PARAMS is a plist optionally containing :host, :port and :project-dir.
+If nil, use the default parameters in `cider-connect-default-params'.
+When called interactively with a prefix argument, prompt for all the
+parameters."
   (interactive "P")
   (cider-nrepl-connect
-   (thread-first params
+   ;; Make sure to copy the list, as the following steps will mutate it
+   (thread-first (or params (copy-sequence cider-connect-default-params))
                  (cider--update-project-dir)
                  (cider--update-host-port)
                  (cider--check-existing-session)

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -358,6 +358,22 @@ reads for the host and port prompts when you invoke
     ("host-b" "7888")))
 ----
 
+If you wish to bypass the prompts entirely, you can configure the variables
+`cider-connect-default-params` and `cider-connect-default-cljs-params`
+on a per-project basis using https://www.gnu.org/software/emacs/manual/html_node/emacs/Directory-Variables.html[.dir-locals.el].
+
+The following configuration allows you to type kbd:[M-x] `cider-connect-clj&cljs` kbd:[RET] and instantly connect to both JVM and shadow-cljs REPLs without answering any prompts – useful when the project always uses the same fixed endpoints for its nREPL servers.
+
+[source,lisp]
+---
+((clojure-mode
+  . ((cider-connect-default-params . (:host "localhost" :port 1234))
+     (cider-connect-default-cljs-params . (:host "localhost" :port 5678))
+     (cider-default-cljs-repl . shadow))))
+---
+
+Note that the universal argument kbd:[C-u] can be used before a command to override these settings and force the prompts to be displayed.
+
 == Working with Remote Hosts
 
 While most of the time you'd be connecting to a locally running nREPL


### PR DESCRIPTION
Context: https://clojurians.slack.com/archives/C0617A8PQ/p1687640686417379

As discussed on Slack, a naive clj-only implementation of a feature which allows the user to skip `cider-connect` prompts asking for the hostname and port.

The intended usage here is to set `cider-default-connect-params` explicitly per project as a dir-local variable, which is why it's a `defvar-local` instead of `defcustom`. 

Eg. I have a project which specifies in its deps.edn
```clj
{:aliases {:dev 
   :main-opts ["-m" "nrepl.cmdline" "--port" "2171" ,,,],,,},,,} 
```
so running `clj -M:dev` in an external terminal always starts a Cider nrepl server on the port 2171. 

Then in the project's `.dir-locals.el`:
```lisp
((clojure-mode
  . ((cider-connect-default-params . (:host "localhost" :port 2171)))))
```
Result: `M-x cider-connect` on any clj buffer within that project skips the prompts entirely, saving the friction of a couple of `RET RET` keypresses on every connect. Which can be quite frequent when investigating project crashes (or hacking on Cider itself)

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
