### PR TITLE
Fix `sesman-restart` regression issue with SIGHUP handling in server

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,4 +78,7 @@ jobs:
 
     - name: Test integration
       run: |
-        eldev -p -dtTC test --test-type integration
+        # The tests occasionally fail on macos&win in what is seems to
+        # be GH connectivity runner issues. We attempt to address this
+        # problem by rerunning the tests more than once.
+        eldev -p -dtTC test --test-type integration || eldev -p -dtTC test --test-type integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#3341](https://github.com/clojure-emacs/cider/issues/3341): Escape clojure-cli args on MS-Windows on non powershell invocations.
 - [#3353](https://github.com/clojure-emacs/cider/issues/3353): Fix regression which caused new connections to prompt for reusing dead REPLs.
 - [#3355](https://github.com/clojure-emacs/cider/pull/3355): Fix `cider-mode` disabling itself after a disconnect when `cider-auto-mode` is set to nil.
+- [#3362](https://github.com/clojure-emacs/cider/issues/3362): Fix `sesman-restart` regression issue.
 
 ### Changes
 

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -687,8 +687,9 @@
             (setq endpoint-bef nrepl-endpoint))
 
           (sesman-restart)
-          ;; wait until a new server is brought up, i.e. the port has
-          ;; changed. It will throw if it doesn't.
+          ;; wait until a new server is brought up by continuously checking that
+          ;; the port has changed. If it remains the same, an exception is
+          ;; thrown, causing the test to fail.
           (nrepl-tests-poll-until (when-let ((repl (cider-current-repl)))
                                     (with-current-buffer repl
                                       (setq endpoint-aft nrepl-endpoint)


### PR DESCRIPTION
Hi,

can you please consider fix for `sesman-restart` regression issue. Fixes #3362.

It basically restores handling of sighup to close the connections, and add a test to confirm its working.

The mock server has been updated to respond the `eval` and `close` op codes. I've re-jiggled a bit with the log functions in there to make them more useful.

Thanks

cc @chopptimus

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)



*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
