### PR TITLE
Display debug-on-exception messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- [#3366](https://github.com/clojure-emacs/cider/pull/3366): Support display of error overlays with #dbg! and #break! reader macros.
 - [#3622](https://github.com/clojure-emacs/cider/pull/3461): Basic support for using CIDER from [clojure-ts-mode](https://github.com/clojure-emacs/clojure-ts-mode).
   - The `clojure-mode` dependency is still required for CIDER to function.
   - Some features like `cider-dynamic-indentation` and `cider-font-lock-dynamically` do not work with `clojure-ts-mode` (yet).

--- a/cider-debug.el
+++ b/cider-debug.el
@@ -125,17 +125,16 @@ configure `cider-debug-prompt' instead."
 
 (defun cider--debug-response-handler (response)
   "Handles RESPONSE from the cider.debug middleware."
-  (nrepl-dbind-response response (status id causes)
+  (nrepl-dbind-response response (status id causes caught-msg)
     (when (member "enlighten" status)
       (cider--handle-enlighten response))
     (when (or (member "eval-error" status)
               (member "stack" status))
       ;; TODO: Make the error buffer a bit friendlier when we're just printing
       ;; the stack.
-      (nrepl-dbind-response response (causes caught-msg)
-        (if cider-show-error-buffer
-            (cider--render-stacktrace-causes causes)
-          (cider--debug-display-result-overlay nil caught-msg))))
+      (if cider-show-error-buffer
+          (cider--render-stacktrace-causes causes)
+        (cider--debug-display-result-overlay nil caught-msg)))
     (when (member "need-debug-input" status)
       (cider--handle-debug response))
     (when (member "done" status)
@@ -158,7 +157,8 @@ configure `cider-debug-prompt' instead."
   "Used as an overlay's before-string prop to place a fringe arrow.")
 
 (defun cider--debug-display-result-overlay (value caught)
-  "Place an overlay at point displaying VALUE."
+  "Place an overlay at point displaying VALUE.
+When CAUGHT is non-nil, display it as an error message overlay."
   (when cider-debug-use-overlays
     ;; This is cosmetic, let's ensure it doesn't break the session no matter what.
     (ignore-errors


### PR DESCRIPTION
Support for https://github.com/clojure-emacs/cider-nrepl/pull/772

A quick PR without the proper changelogs / updates to manual, etc. Changes untested after being rebased on master branch, but I've been dogfooding them on a messy local branch with many (hopefully unrelated) changes for the last month or two. Might be able to clean things up a bit this weekend.

Does not provide feature for auto-inserting `#dbg!` macros or instrumenting defns (eg. with negative argument) - see #3337

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
