### PR TITLE
Make logview optional

### DIFF
--- a/Eldev
+++ b/Eldev
@@ -9,6 +9,7 @@
 (eldev-use-plugin 'autoloads)
 
 (eldev-add-loading-roots 'test "test/utils")
+(eldev-add-extra-dependencies 'runtime '(:package logview :optional t))
 
 (defvar cider-test-type 'main)
 (setf eldev-standard-excludes `(:or ,eldev-standard-excludes

--- a/cider.el
+++ b/cider.el
@@ -12,7 +12,7 @@
 ;; Maintainer: Bozhidar Batsov <bozhidar@batsov.dev>
 ;; URL: http://www.github.com/clojure-emacs/cider
 ;; Version: 1.8.0-snapshot
-;; Package-Requires: ((emacs "26") (clojure-mode "5.16.0") (parseedn "1.0.6") (queue "0.2") (spinner "1.7") (seq "2.22") (sesman "0.3.2") (logview "0.16.1") (transient "0.4.1"))
+;; Package-Requires: ((emacs "26") (clojure-mode "5.16.0") (parseedn "1.0.6") (queue "0.2") (spinner "1.7") (seq "2.22") (sesman "0.3.2") (transient "0.4.1"))
 ;; Keywords: languages, clojure, cider
 
 ;; This program is free software: you can redistribute it and/or modify

--- a/doc/modules/ROOT/pages/debugging/logging.adoc
+++ b/doc/modules/ROOT/pages/debugging/logging.adoc
@@ -25,6 +25,15 @@ logging related actions.
 - link:../usage/pretty_printing.html[Pretty Print] log events.
 - Show log events in the CIDER link:inspector.html[Inspector]
 - Show log event exceptions in the CIDER link:../usage/dealing_with_errors.html[Stacktrace Mode]
+- Integration with https://github.com/doublep/logview[logview]
+
+== Dependencies
+
+https://github.com/doublep/logview[Logview] is an optional dependency
+of CIDER Log Mode. We recommend using it, since it is responsible for
+coloring the log events and it provides other useful features, such as
+syntax highlighting, filtering and more. It is used automatically when
+available and its use can be customized via `+cider-log-use-logview+`.
 
 == Usage
 


### PR DESCRIPTION
This PR makes logview optional. If it is available (fboundp) it will be used otherwise not. 
-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
