### PR TITLE
`cider-test`: don't render a newline between expected and actual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Bump the injected `cider-nrepl` to [0.34](https://github.com/clojure-emacs/cider-nrepl/blob/v0.34.0/CHANGELOG.md#0340-2023-08-03).
 - Improve `nrepl-dict` error reporting.
 - Preserve the `:cljs-repl-type` more reliably.
+- [#3375](https://github.com/clojure-emacs/cider/pull/3375): `cider-test`: don't render a newline between expected and actual, most times. 
 
 ## 1.7.0 (2023-03-23)
 

--- a/cider-test.el
+++ b/cider-test.el
@@ -401,12 +401,10 @@ With the actual value, the outermost '(not ...)' s-expression is removed."
       (insert "\n\n"))))
 
 (defun cider-test--string-contains-newline (input-string)
-  "Returns whether INPUT-STRING contains a newline.
-Ignores any newlines at the end of the string."
+  "Returns whether INPUT-STRING contains an escaped newline."
   (when (stringp input-string)
-    (let ((trimmed-string (replace-regexp-in-string "\n\\'" "" input-string)))
-      (and (string-match-p "\n" trimmed-string)
-           t))))
+    (and (string-match-p "\\n" input-string)
+         t)))
 
 (defun cider-test-render-assertion (buffer test)
   "Emit into BUFFER report detail for the TEST assertion."

--- a/cider-test.el
+++ b/cider-test.el
@@ -437,6 +437,7 @@ With the actual value, the outermost '(not ...)' s-expression is removed."
                   (cl-destructuring-bind (actual (removed added)) d
                     (insert-label "actual")
                     (insert-rect actual)
+                    (insert "\n")
                     (insert-label "diff")
                     (insert "- ")
                     (insert-rect removed)

--- a/cider-test.el
+++ b/cider-test.el
@@ -426,7 +426,12 @@ With the actual value, the outermost '(not ...)' s-expression is removed."
             (when message  (cider-insert message 'font-lock-string-face t))
             (when expected
               (insert-label "expected")
-              (insert-rect expected))
+              (insert-rect expected)
+              ;; insert a newline between expected and actual only when both values are large enough
+              ;; to justify the readability improvement.
+              ;; our heuristic for a 'large enough' object is the presence of diffs:
+              (when diffs
+                (insert "\n")))
             (if diffs
                 (dolist (d diffs)
                   (cl-destructuring-bind (actual (removed added)) d

--- a/cider-test.el
+++ b/cider-test.el
@@ -426,8 +426,7 @@ With the actual value, the outermost '(not ...)' s-expression is removed."
             (when message  (cider-insert message 'font-lock-string-face t))
             (when expected
               (insert-label "expected")
-              (insert-rect expected)
-              (insert "\n"))
+              (insert-rect expected))
             (if diffs
                 (dolist (d diffs)
                   (cl-destructuring-bind (actual (removed added)) d

--- a/cider-test.el
+++ b/cider-test.el
@@ -400,6 +400,14 @@ With the actual value, the outermost '(not ...)' s-expression is removed."
         (cider-insert "t" 'font-lock-constant-face t))
       (insert "\n\n"))))
 
+(defun cider-test--string-contains-newline (input-string)
+  "Returns whether INPUT-STRING contains a newline.
+Ignores any newlines at the end of the string."
+  (when (stringp input-string)
+    (let ((trimmed-string (replace-regexp-in-string "\n\\'" "" input-string)))
+      (and (string-match-p "\n" trimmed-string)
+           t))))
+
 (defun cider-test-render-assertion (buffer test)
   "Emit into BUFFER report detail for the TEST assertion."
   (with-current-buffer buffer
@@ -427,10 +435,10 @@ With the actual value, the outermost '(not ...)' s-expression is removed."
             (when expected
               (insert-label "expected")
               (insert-rect expected)
-              ;; insert a newline between expected and actual only when both values are large enough
-              ;; to justify the readability improvement.
-              ;; our heuristic for a 'large enough' object is the presence of diffs:
-              (when diffs
+              ;; Only place a newline between expected and actual when the values are deemed 'dense',
+              ;; otherwise favor compact output:
+              (when (or (cider-test--string-contains-newline expected)
+                        (cider-test--string-contains-newline actual))
                 (insert "\n")))
             (if diffs
                 (dolist (d diffs)

--- a/test/cider-test-tests.el
+++ b/test/cider-test-tests.el
@@ -1,0 +1,43 @@
+;;; cider-test-tests.el  -*- lexical-binding: t; -*-
+
+;; Copyright © 2023 Bozhidar Batsov
+
+;; Author: Bozhidar Batsov <bozhidar@batsov.dev>
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; This file is part of CIDER
+
+;;; Code:
+
+(require 'buttercup)
+(require 'cider-test)
+
+(describe "cider-test--string-contains-newline"
+  (expect (cider-test--string-contains-newline "Hello World")
+          :to-equal
+          nil)
+  (expect (cider-test--string-contains-newline "Hello World\n")
+          :to-equal
+          nil)
+  (expect (cider-test--string-contains-newline "Hello\nWorld")
+          :to-equal
+          t)
+  (expect (cider-test--string-contains-newline "Hello\nWorld\n")
+          :to-equal
+          t))

--- a/test/cider-test-tests.el
+++ b/test/cider-test-tests.el
@@ -29,15 +29,9 @@
 (require 'cider-test)
 
 (describe "cider-test--string-contains-newline"
-  (expect (cider-test--string-contains-newline "Hello World")
-          :to-equal
-          nil)
-  (expect (cider-test--string-contains-newline "Hello World\n")
-          :to-equal
-          nil)
   (expect (cider-test--string-contains-newline "Hello\nWorld")
           :to-equal
-          t)
-  (expect (cider-test--string-contains-newline "Hello\nWorld\n")
+          nil)
+  (expect (cider-test--string-contains-newline "Hello\\nWorld")
           :to-equal
           t))


### PR DESCRIPTION
Before:

<img width="366" alt="Screen Shot 2023-07-21 at 17 57 03" src="https://github.com/clojure-emacs/cider/assets/1162994/d36ea098-e6ed-461e-b5b0-2eca7a207da2">

After:

<img width="367" alt="Screen Shot 2023-07-21 at 17 56 30" src="https://github.com/clojure-emacs/cider/assets/1162994/da1d5085-dd5a-4568-b920-ac037a26bf88">

Personally I just didn't like this newline. For large reports it can make quite a difference.

Cheers - V