### PR TITLE
Fix: `cider-repl-set-ns` no longer changes the repl session type from `cljs:shadow` to `clj`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [#3353](https://github.com/clojure-emacs/cider/issues/3353): Fix regression which caused new connections to prompt for reusing dead REPLs.
 - [#3355](https://github.com/clojure-emacs/cider/pull/3355): Fix `cider-mode` disabling itself after a disconnect when `cider-auto-mode` is set to nil.
 - [#3362](https://github.com/clojure-emacs/cider/issues/3362): Fix `sesman-restart` regression issue.
+- [#3236](https://github.com/clojure-emacs/cider/issues/3236): `cider-repl-set-ns` no longer changes the repl session type from `cljs:shadow` to `clj`.
 
 ### Changes
 

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -236,8 +236,11 @@ This cache is stored in the connection buffer.")
   "Handle server state contained in RESPONSE."
   (with-demoted-errors "Error in `cider-repl--state-handler': %s"
     (when (member "state" (nrepl-dict-get response "status"))
-      (nrepl-dbind-response response (repl-type changed-namespaces)
-        (when (and repl-type cider-repl-auto-detect-type)
+      (nrepl-dbind-response response (repl-type changed-namespaces session)
+        (when (and repl-type
+                   cider-repl-auto-detect-type
+                   ;; tooling sessions always run on the JVM so they are not a valid criterion:
+                   (not (equal session nrepl-tooling-session)))
           (cider-set-repl-type repl-type))
         (when (eq (cider-maybe-intern repl-type) 'cljs)
           (setq cider-repl-cljs-upgrade-pending nil))


### PR DESCRIPTION
> Closes https://github.com/clojure-emacs/cider/issues/3236

I could both repro the original issue and verify that this proposed fix works.

The minimal repro was:

```clj
(nrepl-sync-request:eval "42"
                         (cider-current-repl nil 'ensure)
                         "my.ns"
                         'tooling)
```

As soon as one evaluated that code, the cljs repl type would be change to `clj`.

Thanks much to @jellelicht for his analysis: https://github.com/clojure-emacs/cider/issues/3236#issuecomment-1246044723

Cheers - V