### PR TITLE
Improve `nrepl-dict` error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Changes
 
 - Bump the injected `cider-nrepl` to [0.32](https://github.com/clojure-emacs/cider-nrepl/blob/master/CHANGELOG.md).
+- Improve `nrepl-dict` error reporting.
 
 ## 1.7.0 (2023-03-23)
 

--- a/nrepl-dict.el
+++ b/nrepl-dict.el
@@ -86,14 +86,14 @@ Return new dict.  Dict is modified by side effects."
   (if (nrepl-dict-p dict)
       (cl-loop for l on (cdr dict) by #'cddr
                collect (car l))
-    (error "Not an nREPL dict")))
+    (error "Not an nREPL dict object: %s" dict)))
 
 (defun nrepl-dict-vals (dict)
   "Return all the values in the nREPL DICT."
   (if (nrepl-dict-p dict)
       (cl-loop for l on (cdr dict) by #'cddr
                collect (cadr l))
-    (error "Not an nREPL dict")))
+    (error "Not an nREPL dict object: %s" dict)))
 
 (defun nrepl-dict-map (fn dict)
   "Map FN on nREPL DICT.
@@ -101,7 +101,7 @@ FN must accept two arguments key and value."
   (if (nrepl-dict-p dict)
       (cl-loop for l on (cdr dict) by #'cddr
                collect (funcall fn (car l) (cadr l)))
-    (error "Not an nREPL dict")))
+    (error "Not an nREPL dict object: %s" dict)))
 
 (defun nrepl-dict-merge (dict1 dict2)
   "Destructively merge DICT2 into DICT1.


### PR DESCRIPTION
Makes these `error` call follow the pattern already existing in this file.