### PR TITLE
Show per-var test timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - [#3354](https://github.com/clojure-emacs/cider/issues/3354): Add new customization variable `cider-reuse-dead-repls` to control how dead REPL buffers are reused on new connections.
 - `cider-test`: add timing information.
 - `cider-test`: only show diffs for collections.
-- `cider-test`: fail-fast by default, as controlled by the new `cider-test-fail-fast` defcustom.
+- `cider-test`: fail-fast by default, as controlled by the new `cider-test-fail-fast` defcustom and `cider-test-toggle-fail-fast` keybinding.
 - Infer indentation specs when possible ([doc](https://docs.cider.mx/cider/indent_spec.html#indentation-inference)).
 - Add new customization variable `cider-clojurec-eval-destination` to allow specifying which REPL CLJC evals are sent to.
 

--- a/cider-test.el
+++ b/cider-test.el
@@ -117,6 +117,10 @@ Add to this list to have CIDER recognize additional test defining macros."
   "When theme is changed, update `cider-test-items-background-color'."
   (setq cider-test-items-background-color (cider-scale-background-color)))
 
+(defun cider-test-toggle-fail-fast ()
+  "Toggles `cider-test-fail-fast' t <-> nil for the current buffer."
+  (interactive)
+  (setq-local cider-test-fail-fast (not cider-test-fail-fast)))
 
 ;;; Report mode & key bindings
 ;;
@@ -135,6 +139,7 @@ Add to this list to have CIDER recognize additional test defining macros."
     (define-key map (kbd "C-l") #'cider-test-run-loaded-tests)
     (define-key map (kbd "C-p") #'cider-test-run-project-tests)
     (define-key map (kbd "C-b") #'cider-test-show-report)
+    (define-key map (kbd "C-f") #'cider-test-toggle-fail-fast)
     ;; Single-key bindings defined last for display in menu
     (define-key map (kbd "r")   #'cider-test-rerun-failed-tests)
     (define-key map (kbd "t")   #'cider-test-run-test)
@@ -144,6 +149,7 @@ Add to this list to have CIDER recognize additional test defining macros."
     (define-key map (kbd "l")   #'cider-test-run-loaded-tests)
     (define-key map (kbd "p")   #'cider-test-run-project-tests)
     (define-key map (kbd "b")   #'cider-test-show-report)
+    (define-key map (kbd "f")   #'cider-test-toggle-fail-fast)
     map))
 
 (defconst cider-test-menu

--- a/doc/modules/ROOT/pages/testing/running_tests.adoc
+++ b/doc/modules/ROOT/pages/testing/running_tests.adoc
@@ -96,6 +96,8 @@ You can configure CIDER's test execution behavior in multiple ways.
 Starting from 1.8.0, CIDER has standard fail-fast functionality,
 controlled by the `cider-test-fail-fast` defcustom (default `t`).
 
+You can toggle its value for the current buffer using `cider-test-toggle-fail-fast` (`C-c C-t f` or `C-c C-t C-f`)
+
 NOTE: fail-fast will never be chosen for the "retest" functionality,
 since that would cause you to lose the majority of the tests
 that previously failed.


### PR DESCRIPTION
* Show per-var test timing in the summary
* Don't show per-testing-context timing anymore
  * It's generally not as reliable
* Add `cider-test-toggle-fail-fast` interactive command and keybindings

More details: https://github.com/clojure-emacs/cider-nrepl/pull/784

Result:

<img width="399" alt="image" src="https://github.com/clojure-emacs/cider/assets/1162994/5d63c548-9e3f-4052-b9a8-8dbc113470cb">

Worth noting, in this particular screenshot, there are quite a few vars, however with the `cider-test-fail-fast` default, typically just one will be displayed, which is cleaner.

Cheers - V