### PR TITLE
`cider-eval`: never jump to spurious locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [#3362](https://github.com/clojure-emacs/cider/issues/3362): Fix `sesman-restart` regression issue.
 - [#3236](https://github.com/clojure-emacs/cider/issues/3236): `cider-repl-set-ns` no longer changes the repl session type from `cljs:shadow` to `clj`.
 - [#3383](https://github.com/clojure-emacs/cider/issues/3383): `cider-connect-clj&cljs`: don't render `"ClojureScript REPL type:" for JVM repls. 
+- [#3331](https://github.com/clojure-emacs/cider/issues/3331): `cider-eval`: never jump to spurious locations, as sometimes conveyed by nREPL.  
 
 ### Changes
 

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -626,7 +626,7 @@ If location could not be found, return nil."
                     (goto-char (point-min))
                     (forward-line (1- line))
                     (move-to-column col)
-                    ;; if this condition is true, it means that `col` was a spuriously large value,
+                    ;; if this condition is false, it means that `col` was a spuriously large value,
                     ;; therefore the whole calculation should be discarded:
                     (when (or (not col) ;; if there's no col info, we cannot judge if it's spurious/not
                               ;; (current-column) never goes past the last column in the actual file,

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -625,12 +625,19 @@ If location could not be found, return nil."
                     (widen)
                     (goto-char (point-min))
                     (forward-line (1- line))
-                    (move-to-column (or col 0))
-                    (let ((begin (progn (if col (cider--goto-expression-start) (back-to-indentation))
-                                        (point)))
-                          (end (progn (if col (forward-list) (move-end-of-line nil))
-                                      (point))))
-                      (list begin end buffer))))))))))))
+                    (move-to-column col)
+                    ;; if this condition is true, it means that `col` was a spuriously large value,
+                    ;; therefore the whole calculation should be discarded:
+                    (when (or (not col) ;; if there's no col info, we cannot judge if it's spurious/not
+                              ;; (current-column) never goes past the last column in the actual file,
+                              ;; so if it's <, then the message had spurious info:
+                              (= (+ 1 (current-column))
+                                 col))
+                      (let ((begin (progn (if col (cider--goto-expression-start) (back-to-indentation))
+                                          (point)))
+                            (end (progn (if col (forward-list) (move-end-of-line nil))
+                                        (point))))
+                        (list begin end buffer)))))))))))))
 
 (defun cider-handle-compilation-errors (message eval-buffer)
   "Highlight and jump to compilation error extracted from MESSAGE.

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -625,14 +625,14 @@ If location could not be found, return nil."
                     (widen)
                     (goto-char (point-min))
                     (forward-line (1- line))
-                    (move-to-column col)
+                    (move-to-column (or col 0))
                     ;; if this condition is false, it means that `col` was a spuriously large value,
                     ;; therefore the whole calculation should be discarded:
                     (when (or (not col) ;; if there's no col info, we cannot judge if it's spurious/not
-                              ;; (current-column) never goes past the last column in the actual file,
+                              ;; (current-column) never goes past the last column in the actual line,
                               ;; so if it's <, then the message had spurious info:
-                              (= (+ 1 (current-column))
-                                 col))
+                              (>= (1+ (current-column))
+                                  col))
                       (let ((begin (progn (if col (cider--goto-expression-start) (back-to-indentation))
                                           (point)))
                             (end (progn (if col (forward-list) (move-end-of-line nil))


### PR DESCRIPTION
> Fixes https://github.com/clojure-emacs/cider/issues/3331

Maybe not the best possible fix, since in #3331 my analysis suggests fixing this at nrepl level.

Anyway, this fix seems fairly universal:

* We fix the current issue, allowing us to deprioritize the nrepl one which seems complex.
* We fix the issue for users of older nrepls
* We might also prevent unforeseen cases by which column info might also be spurious
  * e.g. `eval` coming from runtime-powered tools like refactor-nrepl, eastwood, etc. that might live in the same JVM.

I verified locally that it works as intended.

Cheers - V