### PR TITLE
Fix `clojure.core` function highlighting on ClojureScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#3355](https://github.com/clojure-emacs/cider/pull/3355): Fix `cider-mode` disabling itself after a disconnect when `cider-auto-mode` is set to nil.
 - [#3362](https://github.com/clojure-emacs/cider/issues/3362): Fix `sesman-restart` regression issue.
 - [#3236](https://github.com/clojure-emacs/cider/issues/3236): `cider-repl-set-ns` no longer changes the repl session type from `cljs:shadow` to `clj`.
+- [#3385](https://github.com/clojure-emacs/cider/issues/3385): Fix `clojure.core` function highlighting on ClojureScript.
 
 ### Changes
 

--- a/cider-resolve.el
+++ b/cider-resolve.el
@@ -107,7 +107,8 @@ This will be clojure.core or cljs.core depending on the return value of the
 function `cider-repl-type'."
   (when-let* ((repl (cider-current-repl)))
     (with-current-buffer repl
-      (cider-resolve--get-in (if (eq cider-repl-type 'cljs)
+      (cider-resolve--get-in (if (or (eq cider-repl-type 'cljs)
+                                     (eq major-mode 'clojurescript-mode))
                                  "cljs.core"
                                "clojure.core")))))
 

--- a/cider-resolve.el
+++ b/cider-resolve.el
@@ -108,7 +108,7 @@ function `cider-repl-type'."
   (when-let* ((repl (cider-current-repl)))
     (with-current-buffer repl
       (cider-resolve--get-in (if (or (eq cider-repl-type 'cljs)
-                                     (eq major-mode 'clojurescript-mode))
+                                     (derived-mode-p 'clojurescript-mode))
                                  "cljs.core"
                                "clojure.core")))))
 


### PR DESCRIPTION
Part of https://github.com/clojure-emacs/cider/issues/3385

(Needs a trivial cider-nrepl fix too, but I'm adding this as a changelog anyway. Will be upgraded in the following few days)