### PR TITLE
`cider-connect-clj&cljs`: don't render `"ClojureScript REPL type:" for JVM repls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#3355](https://github.com/clojure-emacs/cider/pull/3355): Fix `cider-mode` disabling itself after a disconnect when `cider-auto-mode` is set to nil.
 - [#3362](https://github.com/clojure-emacs/cider/issues/3362): Fix `sesman-restart` regression issue.
 - [#3236](https://github.com/clojure-emacs/cider/issues/3236): `cider-repl-set-ns` no longer changes the repl session type from `cljs:shadow` to `clj`.
+- [#3383](https://github.com/clojure-emacs/cider/issues/3383): `cider-connect-clj&cljs`: don't render `"ClojureScript REPL type:" for JVM repls. 
 
 ### Changes
 

--- a/cider.el
+++ b/cider.el
@@ -1453,8 +1453,9 @@ non-nil, don't start if ClojureScript requirements are not met."
                        copy-sequence
                        (map-delete :cljs-repl-type)))
          (clj-repl (cider-connect-clj clj-params)))
-    (when (or (not soft-cljs-start)
-              (cider--check-cljs (plist-get params :cljs-repl-type) 'no-error))
+    (when (if soft-cljs-start
+              (cider--check-cljs (plist-get params :cljs-repl-type) 'no-error)
+            t)
       (cider-connect-sibling-cljs params clj-repl))))
 
 (defvar cider-connection-init-commands

--- a/cider.el
+++ b/cider.el
@@ -1448,10 +1448,13 @@ non-nil, don't start if ClojureScript requirements are not met."
                    (cider--update-host-port)
                    (cider--check-existing-session)
                    (cider--update-cljs-type)))
-         (clj-repl (cider-connect-clj params)))
-    (if soft-cljs-start
-        (when (cider--check-cljs (plist-get params :cljs-repl-type) 'no-error)
-          (cider-connect-sibling-cljs params clj-repl))
+         (clj-params (thread-first
+                       params
+                       copy-sequence
+                       (map-delete :cljs-repl-type)))
+         (clj-repl (cider-connect-clj clj-params)))
+    (when (or (not soft-cljs-start)
+              (cider--check-cljs (plist-get params :cljs-repl-type) 'no-error))
       (cider-connect-sibling-cljs params clj-repl))))
 
 (defvar cider-connection-init-commands


### PR DESCRIPTION
> Fixes https://github.com/clojure-emacs/cider/issues/3383

I verified this one locally.

Cheers - V