### PR TITLE
Show available nrepl ports when connecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - [#3236](https://github.com/clojure-emacs/cider/issues/3236): `cider-repl-set-ns` no longer changes the repl session type from `cljs:shadow` to `clj`.
 - [#3383](https://github.com/clojure-emacs/cider/issues/3383): `cider-connect-clj&cljs`: don't render `"ClojureScript REPL type:" for JVM repls. 
 - [#3331](https://github.com/clojure-emacs/cider/issues/3331): `cider-eval`: never jump to spurious locations, as sometimes conveyed by nREPL.  
-- [#3390](https://github.com/clojure-emacs/cider/issues/3390) Enhance cider-connect to show all nREPLs available ports, instead of only Leinengen ones.
+- [#3390](https://github.com/clojure-emacs/cider/issues/3390): Enhance cider-connect to show all nREPLs available ports, instead of only Leiningen ones.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [#3236](https://github.com/clojure-emacs/cider/issues/3236): `cider-repl-set-ns` no longer changes the repl session type from `cljs:shadow` to `clj`.
 - [#3383](https://github.com/clojure-emacs/cider/issues/3383): `cider-connect-clj&cljs`: don't render `"ClojureScript REPL type:" for JVM repls. 
 - [#3331](https://github.com/clojure-emacs/cider/issues/3331): `cider-eval`: never jump to spurious locations, as sometimes conveyed by nREPL.  
+- [#3390](https://github.com/clojure-emacs/cider/issues/3390) Enhance cider-connect to show all nREPLs available ports, instead of only Leinengen ones.
 
 ### Changes
 

--- a/cider.el
+++ b/cider.el
@@ -1826,7 +1826,7 @@ Use `cider-ps-running-nrepls-command' and
 (defun cider--running-other-nrepl-paths ()
   "Retrieve project paths of running nREPL servers other than Lein ones."
   (let* ((take-non-lein-nrepl-pids
-          "ps u | grep java | grep -v leiningen | grep nrepl.cmdline | awk '{print $2}' | tr '\012' ,")
+          "ps u | grep java | grep -v leiningen | grep nrepl.cmdline | awk '{print $2}' | paste -s -d,")
          (take-external-paths
           (concat
            "lsof -a -d cwd -p $("

--- a/cider.el
+++ b/cider.el
@@ -1837,13 +1837,14 @@ Use `cider-ps-running-nrepls-command' and
 (defun cider--running-local-nrepl-paths ()
   "Retrieve project paths of running nREPL servers.
 Do it by looping over the open REPL buffers."
-  (seq-map
-   (lambda (b)
-     (with-current-buffer b
-       (plist-get (cider--gather-connect-params) :project-dir)))
-   (seq-filter
-    (lambda (b) (string-prefix-p "*cider-repl" (buffer-name b)))
-    (buffer-list))))
+  (thread-last
+    (buffer-list)
+    (seq-filter
+     (lambda (b) (string-prefix-p "*cider-repl" (buffer-name b))))
+    (seq-map
+     (lambda (b)
+       (with-current-buffer b
+         (plist-get (cider--gather-connect-params) :project-dir))))))
 
 (defun cider--running-nrepl-paths ()
   "Retrieve project paths of running nREPL servers.

--- a/cider.el
+++ b/cider.el
@@ -1824,7 +1824,7 @@ Use `cider-ps-running-nrepls-command' and
     paths))
 
 (defun cider--running-other-nrepl-paths ()
-  "Retrieve project paths of other running nREPL servers."
+  "Retrieve project paths of running nREPL servers other than Lein ones."
   (let* ((take-non-lein-nrepl-pids
           "ps u | grep java | grep -v leiningen | grep nrepl.cmdline | awk '{print $2}' | tr '\012' ,")
          (take-external-paths

--- a/cider.el
+++ b/cider.el
@@ -1828,7 +1828,7 @@ Use `cider-ps-running-nrepls-command' and
             (setq paths (cons (match-string 1) paths)))))
       paths)))
 
-(defun cider--running-other-nrepl-paths ()
+(defun cider--running-non-lein-nrepl-paths ()
   "Retrieve project paths of running nREPL servers other than Lein ones."
   (unless (cider--windows-p)
     (let* ((take-non-lein-nrepl-pids
@@ -1859,7 +1859,7 @@ Search for lein or java processes including nrepl.command nREPL"
   (let ((paths (append
                 (cider--running-lein-nrepl-paths)
                 (cider--running-local-nrepl-paths)
-                (cider--running-other-nrepl-paths))))
+                (cider--running-non-lein-nrepl-paths))))
     (seq-uniq paths)))
 
 (defun cider--identify-buildtools-present (&optional project-dir)

--- a/cider.el
+++ b/cider.el
@@ -1844,7 +1844,8 @@ Do it by looping over the open REPL buffers."
     (seq-map
      (lambda (b)
        (with-current-buffer b
-         (plist-get (cider--gather-connect-params) :project-dir))))))
+         (plist-get (cider--gather-connect-params) :project-dir))))
+    (seq-filter #'identity)))
 
 (defun cider--running-nrepl-paths ()
   "Retrieve project paths of running nREPL servers.


### PR DESCRIPTION
Improve cider-connect to show all available ports of running nREPLs.
Fixes https://github.com/clojure-emacs/cider/issues/3390
See recording for a peek :)

https://github.com/clojure-emacs/cider/assets/6580039/02105147-a71e-43f5-a7d0-ddfe53ad7c67

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [X] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`eldev test`)
- [X] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [X] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
