### PR TITLE
Recompute namespace info on each shadow-cljs recompilation or evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fix the `xref-find-definitions` CIDER backend to return correct filenames.
 - Fix the `cider-xref-fn-deps` buttons to direct to the right file.
 
+- [#3393](https://github.com/clojure-emacs/cider/issues/3393): recompute namespace info on each shadow-cljs recompilation or evaluation.
 
 ### Changes
 


### PR DESCRIPTION
Fixes https://github.com/clojure-emacs/cider/issues/3393

Works thanks to https://github.com/clojure-emacs/cider-nrepl/pull/799

I tested this one locally.

The defcustoms are bit of a POC - feedback welcome. Initially I directly inlined the code, later I figured that it would pollute the main logic.

Cheers - V