### PR TITLE
Add a Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+.PHONY: clean compile lint test-all test-integration test-unit
+
+# Per our CircleCI, linting/compiling assumes Emacs 28.
+# If you primarily use a different version, you can download Emacs 28 to a separate directory and set up:
+# export ELDEV_EMACS="$HOME/emacs28/Emacs.app/Contents/MacOS/Emacs"
+
+# Remove byte-compilation artifacts, which can alter the result of the test suite:
+clean:
+	cd ~/.emacs.d; find . -type f -name "*.elc" -exec rm {} +
+
+# You can find a generic `eldev` installation script in https://github.com/emacs-eldev/eldev/blob/master/webinstall/eldev
+# (Don't use the one defined for CircleCI in your local machine)
+
+lint: clean
+	eldev lint
+
+# Checks for byte-compilation warnings.
+compile: clean
+	 eldev -dtT compile --warnings-as-errors
+
+test-all: clean
+	eldev -dtT -p test --test-type all
+
+test-integration: clean
+	eldev -dtT -p test --test-type integration
+
+test-unit: clean
+	eldev -dtT -p test
+
+test: lint test-unit compile

--- a/doc/modules/ROOT/pages/contributing/hacking.adoc
+++ b/doc/modules/ROOT/pages/contributing/hacking.adoc
@@ -90,14 +90,20 @@ default only main tests are run.
 Run all unit tests with:
 
  $ eldev[.bat] test
+ # Or:
+ $ make test-unit
 
 Run integration tests with:
 
  $ eldev[.bat] test --test-type integration
+ # Or:
+ $ make test-integration
 
 or all tests with:
 
  $ eldev[.bat] test --test-type all
+ # Or:
+ $ make test-all
 
 NOTE: Tests may not run correctly inside Emacs' `shell-mode` buffers. Running
 them in a terminal is recommended.
@@ -105,10 +111,14 @@ them in a terminal is recommended.
 You can also check for compliance with a variety of coding standards in batch mode (including docstrings):
 
  $ eldev lint
+ # Or:
+ $ make lint
 
 To check for byte-compilation warnings you can just compile the project with Eldev:
 
- $ eldev compile
+ $ eldev -dtT compile --warnings-as-errors
+ # Or:
+ # make compile
 
 ==== Running the tests in CircleCI
 


### PR DESCRIPTION
Adds a Makefile, primarily for development convenience (iteration was fairly slow with CCI or GHA).

I could make our CI files use the Makefile, for DRYness.

Cheers - V