### PR TITLE
Introduce `cider-stacktrace-navigate-to-other-window` defcustom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@
 ### Changes
 
 - [#3390](https://github.com/clojure-emacs/cider/issues/3390): Enhance `cider-connect` to show all nREPLs available ports, instead of only Leiningen ones.
-- [#3408](https://github.com/clojure-emacs/cider/issues/3408): `cider-connect`: check `.nrepl-port`-like files for liveness, hiding them if they don't reflect an active port. 
+- [#3408](https://github.com/clojure-emacs/cider/issues/3408): `cider-connect`: check `.nrepl-port`-like files for liveness, hiding them if they don't reflect an active port.
+- Introduce `cider-stacktrace-navigate-to-other-window` defcustom.
 - Preserve the `:cljs-repl-type` more reliably.
 - Improve the presentation of `xref` data.
 - `cider-test`: only show diffs for collections.

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -56,6 +56,12 @@ If nil, messages will not be wrapped.  If truthy but non-numeric,
   :type 'list
   :package-version '(cider . "0.6.0"))
 
+(defcustom cider-stacktrace-navigate-to-other-window t
+  "If truthy, navigating from a stack frame will use other window.
+Pick nil if you prefer the same window as *cider-error*."
+  :type 'boolean
+  :package-version '(cider . "1.8.0"))
+
 (make-obsolete 'cider-stacktrace-print-length 'cider-stacktrace-print-options "0.20")
 (make-obsolete 'cider-stacktrace-print-level 'cider-stacktrace-print-options "0.20")
 (make-obsolete-variable 'cider-stacktrace-print-options 'cider-print-options "0.21")
@@ -528,12 +534,6 @@ Achieved by destructively manipulating `cider-stacktrace-suppressed-errors'."
         (button-put button 'face 'cider-stacktrace-suppressed-button-face)
         (button-put button 'help-echo "Click to promote these stacktraces."))
       (button-put button 'suppressed (not suppressed)))))
-
-(defcustom cider-stacktrace-navigate-to-other-window t
-  "If truthy, navigating from a stack frame will use other window.
-Pick nil if you prefer the same window as *cider-error*."
-  :type 'boolean
-  :package-version '(cider . "1.8.0"))
 
 (defun cider-stacktrace-navigate (button)
   "Navigate to the stack frame source represented by the BUTTON."

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -529,6 +529,12 @@ Achieved by destructively manipulating `cider-stacktrace-suppressed-errors'."
         (button-put button 'help-echo "Click to promote these stacktraces."))
       (button-put button 'suppressed (not suppressed)))))
 
+(defcustom cider-stacktrace-navigate-to-other-window t
+  "If truthy, navigating from a stack frame will use other window.
+Pick nil if you prefer the same window as *cider-error*."
+  :type 'boolean
+  :package-version '(cider . "1.8.0"))
+
 (defun cider-stacktrace-navigate (button)
   "Navigate to the stack frame source represented by the BUTTON."
   (let* ((var (button-get button 'var))
@@ -547,7 +553,7 @@ Achieved by destructively manipulating `cider-stacktrace-suppressed-errors'."
                 (button-get button 'file)))
          ;; give priority to `info` files as `info` returns full paths.
          (info (nrepl-dict-put info "file" file)))
-    (cider--jump-to-loc-from-info info t)
+    (cider--jump-to-loc-from-info info cider-stacktrace-navigate-to-other-window)
     (forward-line line-shift)
     (back-to-indentation)))
 

--- a/doc/modules/ROOT/pages/usage/dealing_with_errors.adoc
+++ b/doc/modules/ROOT/pages/usage/dealing_with_errors.adoc
@@ -67,6 +67,9 @@ If you wish to reuse `*cider-error*`'s window instead, please configure:
 (setq cider-stacktrace-navigate-to-other-window nil)
 ----
 
+If you have customized this setting, when you have navigated to a given source file,
+you can navigate back to `*cider-error*` with `Ctrl-X <left>` or `M-x xref-pop-marker-stack`.
+
 == Navigating Stacktraces
 
 CIDER comes with a powerful solution for dealing with Clojure

--- a/doc/modules/ROOT/pages/usage/dealing_with_errors.adoc
+++ b/doc/modules/ROOT/pages/usage/dealing_with_errors.adoc
@@ -58,6 +58,15 @@ To disable auto-selection of the error buffer when it's displayed:
 (setq cider-auto-select-error-buffer nil)
 ----
 
+By default, when you jump to the source of a given stack frame,
+an Emacs window other than that of `*cider-error*` will be chosen.
+If you wish to resuse `*cider-error*`'s window instead, please configure:
+
+[source,lisp]
+----
+(setq cider-stacktrace-navigate-to-other-window nil)
+----
+
 == Navigating Stacktraces
 
 CIDER comes with a powerful solution for dealing with Clojure

--- a/doc/modules/ROOT/pages/usage/dealing_with_errors.adoc
+++ b/doc/modules/ROOT/pages/usage/dealing_with_errors.adoc
@@ -60,7 +60,7 @@ To disable auto-selection of the error buffer when it's displayed:
 
 By default, when you jump to the source of a given stack frame,
 an Emacs window other than that of `*cider-error*` will be chosen.
-If you wish to resuse `*cider-error*`'s window instead, please configure:
+If you wish to reuse `*cider-error*`'s window instead, please configure:
 
 [source,lisp]
 ----


### PR DESCRIPTION
By default, when you jump to the source of a given stack frame, an Emacs window other than that of `*cider-error*` will be chosen.

`cider-stacktrace-navigate-to-other-window` offers to remain in the same window instead.