### PR TITLE
Introduce `cider-ignored-error-phases`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - `cider-test`: add timing information.
 - `cider-test`: fail-fast by default, as controlled by the new `cider-test-fail-fast` defcustom and `cider-test-toggle-fail-fast` keybinding.
 - Infer indentation specs when possible ([doc](https://docs.cider.mx/cider/indent_spec.html#indentation-inference)).
+- [#3418](https://github.com/clojure-emacs/cider/issues/3418): Introduce `cider-clojure-compilation-error-phases`.
+  - This prevents stacktraces from showing up whenever the [:clojure.error/phase](https://clojure.org/reference/repl_and_main#_at_repl) indicates that it's a compilation error.
 - Add new customization variable `cider-clojurec-eval-destination` to allow specifying which REPL CLJC evals are sent to.
 - [#3354](https://github.com/clojure-emacs/cider/issues/3354): Add new customization variable `cider-reuse-dead-repls` to control how dead REPL buffers are reused on new connections.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@
 - [#3375](https://github.com/clojure-emacs/cider/pull/3375): `cider-test`: don't render a newline between expected and actual, most times.
 - Improve `nrepl-dict` error reporting.
 - Bump the injected `piggieback` to [0.5.3](https://github.com/nrepl/piggieback/blob/0.5.3/CHANGES.md#053-2021-10-26).
-- Bump the injected `cider-nrepl` to [0.35.1](https://github.com/clojure-emacs/cider-nrepl/blob/v0.35.1/CHANGELOG.md#0351-2023-08-18).
+- Bump the injected `cider-nrepl` to [0.36.0](https://github.com/clojure-emacs/cider-nrepl/blob/v0.36.0/CHANGELOG.md#0360-2023-08-21).
   - Improves indentation, font-locking and other metadata support for ClojureScript.
   - Updates [Orchard](https://github.com/clojure-emacs/orchard/blob/v0.14.2/CHANGELOG.md)
     - introduces support for displaying the docstring and arglists of 'indirect' vars (e.g. `(def foo bar)`) for Clojure/Script.
@@ -51,7 +51,8 @@
     - avoiding side-effecting `->` evaluation for pure-ClojureScript chains.
   - Updates [Compliment](https://github.com/alexander-yakushev/compliment/blob/0.4.0/CHANGELOG.md#040-2023-07-05)
     - Supports better completions for var-quote (`#'some/var`).
-  - Updates [Haystack](https://github.com/clojure-emacs/haystack/blob/v0.1.0/CHANGELOG.md#010).
+  - Updates [Haystack](https://github.com/clojure-emacs/haystack/blob/0077b5c49f4aef1c7f89d5430d6dda2f9e7d78d4/CHANGELOG.md#020-2023-08-20).
+    - Now, in `*cider-error*`, more internal stackframes will be hidden under the `tooling` category.
 
 ## 1.7.0 (2023-03-23)
 

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -523,7 +523,8 @@ It delegates the actual error content to the eval or op handler."
 (defconst cider-clojure-1.10-error `(sequence
                                      "Syntax error "
                                      (minimal-match (zero-or-more anything))
-                                     "compiling "
+                                     (or "compiling "
+                                         "macroexpanding ")
                                      (minimal-match (zero-or-more anything))
                                      "at ("
                                      (group-n 2 (minimal-match (zero-or-more anything)))

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -496,7 +496,14 @@ When it reaches 3, it wraps to 0."
   (cider-stacktrace-toggle 'repl))
 
 (defun cider-stacktrace-toggle-tooling ()
-  "Toggle display of Tooling stack frames (compiler, nREPL middleware, etc)."
+  "Toggle display of tooling stack frames.
+
+These include:
+
+  * Clojure compiler and runtime internals
+     * may be `.clj' or `.java' files.
+  * nREPL internals
+  * CIDER internals."
   (interactive)
   (cider-stacktrace-toggle 'tooling))
 

--- a/cider.el
+++ b/cider.el
@@ -489,7 +489,7 @@ the artifact.")
 (defconst cider-latest-clojure-version "1.10.1"
   "Latest supported version of Clojure.")
 
-(defconst cider-required-middleware-version "0.35.1"
+(defconst cider-required-middleware-version "0.36.0"
   "The CIDER nREPL version that's known to work properly with CIDER.")
 
 (defcustom cider-injected-middleware-version cider-required-middleware-version

--- a/dev/docker-sample-project/project.clj
+++ b/dev/docker-sample-project/project.clj
@@ -2,4 +2,4 @@
   :dependencies [[org.clojure/clojure "1.11.1"]
                  [clj-http "3.12.3"]]
   :source-paths ["src"]
-  :plugins [[cider/cider-nrepl "0.35.1"]])
+  :plugins [[cider/cider-nrepl "0.36.0"]])

--- a/dev/tramp-sample-project/project.clj
+++ b/dev/tramp-sample-project/project.clj
@@ -2,4 +2,4 @@
   :dependencies [[org.clojure/clojure "1.11.1"]
                  [clj-http "3.12.3"]]
   :source-paths ["src"]
-  :plugins [[cider/cider-nrepl "0.35.1"]])
+  :plugins [[cider/cider-nrepl "0.36.0"]])

--- a/doc/modules/ROOT/pages/basics/middleware_setup.adoc
+++ b/doc/modules/ROOT/pages/basics/middleware_setup.adoc
@@ -32,7 +32,7 @@ Use the convenient plugin for defaults, either in your project's
 
 [source,clojure]
 ----
-:plugins [[cider/cider-nrepl "0.35.1"]
+:plugins [[cider/cider-nrepl "0.36.0"]
           [mx.cider/enrich-classpath "x.y.z"]]
 ----
 
@@ -46,9 +46,8 @@ A minimal `profiles.clj` for CIDER would be:
 
 [source,clojure]
 ----
-{:repl {:plugins [[cider/cider-nrepl "0.35.1"]
+{:repl {:plugins [[cider/cider-nrepl "0.36.0"]
                   [mx.cider/enrich-classpath "1.9.0"]]}}
-----
 
 WARNING: Be careful not to place this in the `:user` profile, as this way CIDER's
 middleware will always get loaded, causing `lein` to start slower.  You really
@@ -67,7 +66,7 @@ all of their projects using a `~/.boot/profile.boot` file like so:
 (require 'boot.repl)
 
 (swap! boot.repl/*default-dependencies*
-       concat '[[cider/cider-nrepl "0.35.1"]])
+       concat '[[cider/cider-nrepl "0.36.0"]])
 
 (swap! boot.repl/*default-middleware*
        conj 'cider.nrepl/cider-middleware)
@@ -84,11 +83,11 @@ run `cider-connect` or `cider-connect-cljs`.
 
 [source,clojure]
 ----
-  :cider-clj {:extra-deps {cider/cider-nrepl {:mvn/version "0.35.1"}}
+  :cider-clj {:extra-deps {cider/cider-nrepl {:mvn/version "0.36.0"}}
               :main-opts ["-m" "nrepl.cmdline" "--middleware" "[cider.nrepl/cider-middleware]"]}
 
   :cider-cljs {:extra-deps {org.clojure/clojurescript {:mvn/version "1.10.339"}
-                            cider/cider-nrepl {:mvn/version "0.35.1"}
+                            cider/cider-nrepl {:mvn/version "0.36.0"}
                             cider/piggieback {:mvn/version "0.5.3"}}
                :main-opts ["-m" "nrepl.cmdline" "--middleware"
                            "[cider.nrepl/cider-middleware,cider.piggieback/wrap-cljs-repl]"]}

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -67,7 +67,7 @@ simple - CIDER simply passes the extra dependencies and nREPL configuration to
 your build tool in the command it runs to start the nREPL server. Here's how
 this looks for `tools.deps`:
 
-  $ clojure -Sdeps '{:deps {nrepl {:mvn/version "0.6.0"} cider/cider-nrepl {:mvn/version "0.35.1"}}}' -m nrepl.cmdline --middleware '["cider.nrepl/cider-middleware"]'
+  $ clojure -Sdeps '{:deps {nrepl {:mvn/version "0.6.0"} cider/cider-nrepl {:mvn/version "0.36.0"}}}' -m nrepl.cmdline --middleware '["cider.nrepl/cider-middleware"]'
 
 TIP: If you don't want `cider-jack-in` to inject dependencies automatically, set
 `cider-inject-dependencies-at-jack-in` to `nil`. Note that you'll have to setup
@@ -292,7 +292,7 @@ It is also possible for plain `clj`, although the command is somewhat longer:
 
 [source,sh]
 ----
-$ clj -Sdeps '{:deps {cider/cider-nrepl {:mvn/version "0.35.1"}}}' -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"
+$ clj -Sdeps '{:deps {cider/cider-nrepl {:mvn/version "0.36.0"}}}' -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"
 ----
 
 Alternatively, you can start nREPL either manually or using the facilities

--- a/doc/modules/ROOT/pages/cljs/shadow-cljs.adoc
+++ b/doc/modules/ROOT/pages/cljs/shadow-cljs.adoc
@@ -62,7 +62,7 @@ And connect to it with `cider-connect`.
 ...For that to work, `shadow-cljs.edn` contents like the following are assumed:
 
 ```clj
- :dependencies [[cider/cider-nrepl "0.35.1"] ;; mandatory (unless it's inherited from deps.edn or otherwise present in the classpath of shadow-cljs's JVM process)
+ :dependencies [[cider/cider-nrepl "0.36.0"] ;; mandatory (unless it's inherited from deps.edn or otherwise present in the classpath of shadow-cljs's JVM process)
                 [refactor-nrepl/refactor-nrepl "3.9.0"]] ;; refactor-nrepl is optional
 
  :nrepl {:middleware [cider.nrepl/cider-middleware ;; it's advisable to explicitly add this middleware. It's automatically added by shadow-cljs (if available in the classpath), unless `:nrepl {:cider false}`

--- a/doc/modules/ROOT/pages/usage/dealing_with_errors.adoc
+++ b/doc/modules/ROOT/pages/usage/dealing_with_errors.adoc
@@ -23,6 +23,19 @@ temporary overlay or in the echo area:
 (setq cider-show-error-buffer nil)
 ----
 
+Starting from CIDER 1.8.0, only runtime exceptions (and not compilation errors)
+will cause a stacktrace buffer to be shown. This better follows Clojure 1.10's
+https://clojure.org/reference/repl_and_main#_at_repl[intended semantics].
+This behavior is controlled by the `cider-clojure-compilation-error-phases` configuration option.
+If you wish for the error phase to be ignored, and to only take `cider-show-error-buffer` into account,
+please customize:
+
+[source,lisp]
+----
+(setq cider-clojure-compilation-error-phases nil)
+----
+
+
 At times, the error being displayed will originate from a bug in CIDER
 itself. These internal errors might frequently occur and interrupt
 your workflow, but you might not want to suppress *all* stacktrace

--- a/test/cider-eval-tests.el
+++ b/test/cider-eval-tests.el
@@ -48,3 +48,12 @@
       (with-temp-file filename
         (insert "🍻"))
       (expect (cider-provide-file filename) :to-equal "8J+Nuw=="))))
+
+(describe "cider-extract-error-info"
+  (it "Matches Clojure compilation exceptions"
+    (expect (cider-extract-error-info cider-compilation-regexp "Syntax error compiling clojure.core/let at (src/haystack/analyzer.clj:18:1).\n[1] - failed: even-number-of-forms? at: [:bindings] spec: :clojure.core.specs.alpha/bindings\n")
+            :to-equal '("src/haystack/analyzer.clj" 18 1 cider-error-highlight-face "Syntax error compiling clojure.core/let at (src/haystack/analyzer.clj:18:1).\n[1] - failed: even-number-of-forms? at: [:bindings] spec: :clojure.core.specs.alpha/bindings\n"))
+    (expect (cider-extract-error-info cider-compilation-regexp "Syntax error macroexpanding clojure.core/let at (src/haystack/analyzer.clj:18:1).\n[1] - failed: even-number-of-forms? at: [:bindings] spec: :clojure.core.specs.alpha/bindings\n")
+            :to-equal '("src/haystack/analyzer.clj" 18 1 cider-error-highlight-face "Syntax error macroexpanding clojure.core/let at (src/haystack/analyzer.clj:18:1).\n[1] - failed: even-number-of-forms? at: [:bindings] spec: :clojure.core.specs.alpha/bindings\n"))
+    (expect (cider-extract-error-info cider-compilation-regexp "Syntax error FOOING clojure.core/let at (src/haystack/analyzer.clj:18:1).\n[1] - failed: even-number-of-forms? at: [:bindings] spec: :clojure.core.specs.alpha/bindings\n")
+            :to-equal nil)))

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -144,7 +144,7 @@
   (describe "when there is a single dependency"
     (before-each
       (setq-local cider-injected-nrepl-version "0.9.0")
-      (setq-local cider-injected-middleware-version "0.35.1")
+      (setq-local cider-injected-middleware-version "0.36.0")
       (setq-local cider-jack-in-nrepl-middlewares '("cider.nrepl/cider-middleware"))
       (setq-local cider-jack-in-dependencies-exclusions '())
       (setq-local cider-enrich-classpath t))
@@ -154,7 +154,7 @@
               :to-equal (concat "update-in :dependencies conj "
                                 (shell-quote-argument "[nrepl/nrepl \"0.9.0\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[cider/cider-nrepl \"0.35.1\"]")
+                                (shell-quote-argument "[cider/cider-nrepl \"0.36.0\"]")
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[mx.cider/enrich-classpath \"1.9.0\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath/middleware"
@@ -167,7 +167,7 @@
                          "update-in :dependencies conj "
                          (shell-quote-argument "[nrepl/nrepl \"0.9.0\" :exclusions [org.clojure/clojure]]")
                          " -- update-in :plugins conj "
-                         (shell-quote-argument "[cider/cider-nrepl \"0.35.1\"]")
+                         (shell-quote-argument "[cider/cider-nrepl \"0.36.0\"]")
                          " -- update-in :plugins conj "
                          (shell-quote-argument "[mx.cider/enrich-classpath \"1.9.0\"]")
                          " -- update-in :middleware conj cider.enrich-classpath/middleware"
@@ -179,7 +179,7 @@
               :to-equal (concat "update-in :dependencies conj "
                                 (shell-quote-argument "[nrepl/nrepl \"0.9.0\" :exclusions [org.clojure/clojure foo.bar/baz]]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[cider/cider-nrepl \"0.35.1\"]")
+                                (shell-quote-argument "[cider/cider-nrepl \"0.36.0\"]")
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[mx.cider/enrich-classpath \"1.9.0\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath/middleware"
@@ -192,7 +192,7 @@
                          " -d "
                          (shell-quote-argument "nrepl/nrepl:0.9.0")
                          " -d "
-                         (shell-quote-argument "cider/cider-nrepl:0.35.1")
+                         (shell-quote-argument "cider/cider-nrepl:0.36.0")
                          " cider.tasks/add-middleware"
                          " -m "
                          (shell-quote-argument "cider.nrepl/cider-middleware")
@@ -201,7 +201,7 @@
     (it "can inject dependencies in a gradle project"
       (expect (cider-inject-jack-in-dependencies "--no-daemon" ":clojureRepl" 'gradle)
               :to-equal (concat "--no-daemon "
-                                (shell-quote-argument "-Pdev.clojurephant.jack-in.nrepl=nrepl:nrepl:0.9.0,cider:cider-nrepl:0.35.1")
+                                (shell-quote-argument "-Pdev.clojurephant.jack-in.nrepl=nrepl:nrepl:0.9.0,cider:cider-nrepl:0.36.0")
                                 " :clojureRepl "
                                 (shell-quote-argument "--middleware=cider.nrepl/cider-middleware")))))
 
@@ -218,7 +218,7 @@
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[refactor-nrepl \"2.0.0\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[cider/cider-nrepl \"0.35.1\"]")
+                                (shell-quote-argument "[cider/cider-nrepl \"0.36.0\"]")
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[mx.cider/enrich-classpath \"1.9.0\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath/middleware"
@@ -231,7 +231,7 @@
                                 " -d "
                                 (shell-quote-argument "nrepl/nrepl:0.9.0")
                                 " -d "
-                                (shell-quote-argument "cider/cider-nrepl:0.35.1")
+                                (shell-quote-argument "cider/cider-nrepl:0.36.0")
                                 " -d "
                                 (shell-quote-argument "refactor-nrepl:2.0.0")
                                 " cider.tasks/add-middleware"
@@ -253,7 +253,7 @@
               :to-equal (concat "-o -U update-in :dependencies conj "
                                 (shell-quote-argument "[nrepl/nrepl \"0.9.0\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[cider/cider-nrepl \"0.35.1\"]")
+                                (shell-quote-argument "[cider/cider-nrepl \"0.36.0\"]")
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[mx.cider/enrich-classpath \"1.9.0\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath/middleware"
@@ -264,7 +264,7 @@
                                 " -d "
                                 (shell-quote-argument "nrepl/nrepl:0.9.0")
                                 " -d "
-                                (shell-quote-argument "cider/cider-nrepl:0.35.1")
+                                (shell-quote-argument "cider/cider-nrepl:0.36.0")
                                 " cider.tasks/add-middleware"
                                 " -m "
                                 (shell-quote-argument "cider.nrepl/cider-middleware")
@@ -272,7 +272,7 @@
     (it "can concat in a gradle project"
       (expect (cider-inject-jack-in-dependencies "--no-daemon" ":clojureRepl" 'gradle)
               :to-equal (concat "--no-daemon "
-                                (shell-quote-argument "-Pdev.clojurephant.jack-in.nrepl=nrepl:nrepl:0.9.0,cider:cider-nrepl:0.35.1")
+                                (shell-quote-argument "-Pdev.clojurephant.jack-in.nrepl=nrepl:nrepl:0.9.0,cider:cider-nrepl:0.36.0")
                                 " :clojureRepl "
                                 (shell-quote-argument "--middleware=cider.nrepl/cider-middleware")))))
 
@@ -287,14 +287,14 @@
       (setq-local cider-jack-in-nrepl-middlewares '(("refactor-nrepl.middleware/wrap-refactor" :predicate middlewares-predicate) "cider.nrepl/cider-middleware" ("another/middleware"))))
     (it "includes plugins whose predicates return true"
       (expect (cider-jack-in-normalized-lein-plugins)
-              :to-equal '(("refactor-nrepl" "2.0.0") ("cider/cider-nrepl" "0.35.1"))))
+              :to-equal '(("refactor-nrepl" "2.0.0") ("cider/cider-nrepl" "0.36.0"))))
     (it "includes middlewares whose predicates return true"
       (expect (cider-jack-in-normalized-nrepl-middlewares)
               :to-equal '("refactor-nrepl.middleware/wrap-refactor" "cider.nrepl/cider-middleware" "another/middleware")))
     (it "ignores plugins whose predicates return false"
       (spy-on 'plugins-predicate :and-return-value nil)
       (expect (cider-jack-in-normalized-lein-plugins)
-              :to-equal '(("cider/cider-nrepl" "0.35.1")))
+              :to-equal '(("cider/cider-nrepl" "0.36.0")))
       (spy-on 'middlewares-predicate :and-return-value nil)
       (expect (cider-jack-in-normalized-nrepl-middlewares)
               :to-equal '("cider.nrepl/cider-middleware" "another/middleware")))
@@ -323,7 +323,7 @@
               :and-return-value '("refactor-nrepl.middleware/wrap-refactor" "cider.nrepl/cider-middleware"))
       (spy-on 'cider-jack-in-normalized-lein-plugins
               :and-return-value '(("refactor-nrepl" "2.0.0")
-                                  ("cider/cider-nrepl" "0.35.1")
+                                  ("cider/cider-nrepl" "0.36.0")
                                   ("mx.cider/enrich-classpath" "1.9.0")))
       (setq-local cider-jack-in-dependencies-exclusions '())
       (setq-local cider-enrich-classpath t))
@@ -334,7 +334,7 @@
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[refactor-nrepl \"2.0.0\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[cider/cider-nrepl \"0.35.1\"]")
+                                (shell-quote-argument "[cider/cider-nrepl \"0.36.0\"]")
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[mx.cider/enrich-classpath \"1.9.0\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath/middleware"
@@ -352,7 +352,7 @@
                                 " -d "
                                 (shell-quote-argument "nrepl/nrepl:0.9.0")
                                 " -d "
-                                (shell-quote-argument "cider/cider-nrepl:0.35.1")
+                                (shell-quote-argument "cider/cider-nrepl:0.36.0")
                                 " -d "
                                 (shell-quote-argument "refactor-nrepl:2.0.0")
                                 " cider.tasks/add-middleware"
@@ -447,7 +447,7 @@
       (setq-local cider-jack-in-dependencies nil)
       (setq-local cider-jack-in-nrepl-middlewares '("cider.nrepl/cider-middleware"))
       (let ((expected (string-join `("clojure -Sdeps "
-                                     ,(shell-quote-argument "{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} cider/cider-nrepl {:mvn/version \"0.35.1\"}} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
+                                     ,(shell-quote-argument "{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} cider/cider-nrepl {:mvn/version \"0.36.0\"}} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
                                      " -M:cider/nrepl")
                                    "")))
         (setq-local cider-allow-jack-in-without-project t)
@@ -461,7 +461,7 @@
 
     (it "allows specifying custom aliases with `cider-clojure-cli-aliases`"
       (let ((expected (string-join `("clojure -Sdeps "
-                                     ,(shell-quote-argument "{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} cider/cider-nrepl {:mvn/version \"0.35.1\"}} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
+                                     ,(shell-quote-argument "{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} cider/cider-nrepl {:mvn/version \"0.36.0\"}} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
                                      " -M:dev:test:cider/nrepl")
                                    "")))
         (setq-local cider-jack-in-dependencies nil)
@@ -478,7 +478,7 @@
       (it (format "should remove duplicates, yielding the same result (for %S command invocation)" command)
           ;; repeat the same test for PowerShell too
           (let ((expected (string-join `("-Sdeps "
-                                         ,(cider--shell-quote-argument "{:deps {cider/cider-nrepl {:mvn/version \"0.35.1\"} nrepl/nrepl {:mvn/version \"0.9.0\"}} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}"
+                                         ,(cider--shell-quote-argument "{:deps {cider/cider-nrepl {:mvn/version \"0.36.0\"} nrepl/nrepl {:mvn/version \"0.9.0\"}} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}"
                                                                        command)
                                          " -M:dev:test:cider/nrepl")
                                        "")))
@@ -488,7 +488,7 @@
                     :to-equal expected))))
     (it "handles aliases correctly"
       (let ((expected (string-join `("-Sdeps "
-                                     ,(shell-quote-argument "{:deps {cider/cider-nrepl {:mvn/version \"0.35.1\"} nrepl/nrepl {:mvn/version \"0.9.0\"}} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
+                                     ,(shell-quote-argument "{:deps {cider/cider-nrepl {:mvn/version \"0.36.0\"} nrepl/nrepl {:mvn/version \"0.9.0\"}} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
                                      " -M:test:cider/nrepl")
                                    ""))
             (deps '(("nrepl/nrepl" "0.9.0"))))
@@ -510,7 +510,7 @@
                     :to-equal expected)))))
     (it "allows for global options"
       (let ((expected (string-join `("-J-Djdk.attach.allowAttachSelf -Sdeps "
-                                     ,(shell-quote-argument "{:deps {cider/cider-nrepl {:mvn/version \"0.35.1\"} nrepl/nrepl {:mvn/version \"0.9.0\"}} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
+                                     ,(shell-quote-argument "{:deps {cider/cider-nrepl {:mvn/version \"0.36.0\"} nrepl/nrepl {:mvn/version \"0.9.0\"}} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
                                      " -M:test:cider/nrepl")
                                    ""))
             (deps '(("nrepl/nrepl" "0.9.0"))))
@@ -521,7 +521,7 @@
       (setq-local cider-jack-in-dependencies '(("org.clojure/tools.deps" (("git/sha" . "6ae2b6f71773de7549d7f22759e8b09fec27f0d9")
                                                                           ("git/url" . "https://github.com/clojure/tools.deps/")))))
       (let ((expected (string-join `("clojure -Sdeps "
-                                     ,(shell-quote-argument "{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} cider/cider-nrepl {:mvn/version \"0.35.1\"} org.clojure/tools.deps { :git/sha \"6ae2b6f71773de7549d7f22759e8b09fec27f0d9\"  :git/url \"https://github.com/clojure/tools.deps/\" }} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
+                                     ,(shell-quote-argument "{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} cider/cider-nrepl {:mvn/version \"0.36.0\"} org.clojure/tools.deps { :git/sha \"6ae2b6f71773de7549d7f22759e8b09fec27f0d9\"  :git/url \"https://github.com/clojure/tools.deps/\" }} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
                                      " -M:cider/nrepl")
                                    "")))
         (setq-local cider-allow-jack-in-without-project t)


### PR DESCRIPTION
Commits:

* Use cider-nrepl 0.36.0
  * Supports this PR, and also [broadens](https://github.com/clojure-emacs/haystack/pull/11) the semantics of the `tooling` filter:

<img width="533" alt="image" src="https://github.com/clojure-emacs/haystack/assets/1162994/8da000be-1738-4dd1-8588-0769cbd08a33">

* Introduce `cider-ignored-error-phases`
  * Fixes https://github.com/clojure-emacs/cider/issues/3418
* `cider-auto-jump-to-error`: also recognise macroexpansion errors
  * Mostly unrelated, but also very small.

### QA

This PR's main focus is easy to QA:

* `(setq cider-show-error-buffer 'always)`
* enter an invalid token like `::::a` in the REPL
  * no stacktrace will show up, a concise message will be printed at the repl
* enter an invalid macroexpansion like `(let [1])` in the REPL
  * no stacktrace will show up, a concise message will be printed at the repl
* enter an expr that will cause a runtime exception like `(/ 2 0)`
  * the `*cider-error*` buffer will show up
  * if the `tooling` filter is on, notably few stack frames will be visible
  * the usual output will also be visible at the REPL output.

Cheers - V