### PR TITLE
Ensure there's a leading `:` when using `cider-clojure-cli-aliases`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - [#3419](https://github.com/clojure-emacs/cider/issues/3419): Also match friendly sessions based on the buffer's ns form.
 - `cider-test`: only show diffs for collections.
 - [#3375](https://github.com/clojure-emacs/cider/pull/3375): `cider-test`: don't render a newline between expected and actual, most times.
+- Ensure there's a leading `:` when using `cider-clojure-cli-aliases`.
 - Improve `nrepl-dict` error reporting.
 - Bump the injected `piggieback` to [0.5.3](https://github.com/nrepl/piggieback/blob/0.5.3/CHANGES.md#053-2021-10-26).
 - Bump the injected `cider-nrepl` to [0.36.0](https://github.com/clojure-emacs/cider-nrepl/blob/v0.36.0/CHANGELOG.md#0360-2023-08-21).

--- a/cider.el
+++ b/cider.el
@@ -804,7 +804,10 @@ your aliases contain any mains, the cider/nrepl one will be the one used."
             (if cider-clojure-cli-aliases
                 ;; remove exec-opts flags -A -M -T or -X from cider-clojure-cli-aliases
                 ;; concatenated with :cider/nrepl to ensure :cider/nrepl comes last
-                (format "%s" (replace-regexp-in-string "^-\\(A\\|M\\|T\\|X\\)" "" cider-clojure-cli-aliases))
+                (let ((stripped (format "%s" (replace-regexp-in-string "^-\\(A\\|M\\|T\\|X\\)" "" cider-clojure-cli-aliases))))
+                  (if (string-prefix-p ":" stripped)
+                      stripped
+                    (concat ":" stripped)))
               "")
             (if params (format " %s" params) ""))))
 

--- a/cider.el
+++ b/cider.el
@@ -804,10 +804,10 @@ your aliases contain any mains, the cider/nrepl one will be the one used."
             (if cider-clojure-cli-aliases
                 ;; remove exec-opts flags -A -M -T or -X from cider-clojure-cli-aliases
                 ;; concatenated with :cider/nrepl to ensure :cider/nrepl comes last
-                (let ((stripped (format "%s" (replace-regexp-in-string "^-\\(A\\|M\\|T\\|X\\)" "" cider-clojure-cli-aliases))))
-                  (if (string-prefix-p ":" stripped)
-                      stripped
-                    (concat ":" stripped)))
+                (let ((aliases (format "%s" (replace-regexp-in-string "^-\\(A\\|M\\|T\\|X\\)" "" cider-clojure-cli-aliases))))
+                  (if (string-prefix-p ":" aliases)
+                      aliases
+                    (concat ":" aliases)))
               "")
             (if params (format " %s" params) ""))))
 

--- a/dev/tramp-sample-project/README.md
+++ b/dev/tramp-sample-project/README.md
@@ -7,7 +7,7 @@ This way, for development purposes, we can SSH into it with TRAMP and exercise C
 To get started:
 
 * In one terminal tab, run `make run` to run the Docker image
-* Once it's ready, from another tab, run `make ssh` 
+* Once it's ready, from another tab, run `make ssh` and start a repl manually from there
   * The password is `cider`
   * `cd /usr/src/app; lein repl :headless :host 0.0.0.0 :port 7888`
 

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -495,7 +495,13 @@
         (let ((cider-clojure-cli-aliases ":test"))
           (expect (cider-clojure-cli-jack-in-dependencies nil nil deps)
                   :to-equal expected))
-        (describe "should strip out leading exec opts -A -M -T -X"
+        (describe "should strip out leading exec opts -A -M -T -X, and ensure there's a leading :"
+          (let ((cider-clojure-cli-aliases ":test"))
+            (expect (cider-clojure-cli-jack-in-dependencies nil nil deps)
+                    :to-equal expected))
+          (let ((cider-clojure-cli-aliases "test"))
+            (expect (cider-clojure-cli-jack-in-dependencies nil nil deps)
+                    :to-equal expected))
           (let ((cider-clojure-cli-aliases "-A:test"))
            (expect (cider-clojure-cli-jack-in-dependencies nil nil deps)
                    :to-equal expected))


### PR DESCRIPTION
In words of Alex Miller:

> aliases should always use `:`
> in some cases, aliases without colons are tolerated (but don't do that)

This PR is a preventive measure, fixing no issue in particular.