### PR TITLE
Use `clojure-find-ns` safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - [#3375](https://github.com/clojure-emacs/cider/pull/3375): `cider-test`: don't render a newline between expected and actual, most times.
 - Improve `nrepl-dict` error reporting.
 - Bump the injected `piggieback` to [0.5.3](https://github.com/nrepl/piggieback/blob/0.5.3/CHANGES.md#053-2021-10-26).
+- Bump the `clojure-mode` required version, and use `clojure-find-ns` more safely, which fixes issues such as #[2849](https://github.com/clojure-emacs/cider/issues/2849).
 - Bump the injected `cider-nrepl` to [0.36.0](https://github.com/clojure-emacs/cider-nrepl/blob/v0.36.0/CHANGELOG.md#0360-2023-08-21).
   - Improves indentation, font-locking and other metadata support for ClojureScript.
   - Updates [Orchard](https://github.com/clojure-emacs/orchard/blob/v0.14.2/CHANGELOG.md)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY: clean compile lint test-all test-integration test-unit
+.DEFAULT_GOAL := test
 
 # Per our CircleCI, linting/compiling assumes Emacs 28.
 # If you primarily use a different version, you can download Emacs 28 to a separate directory and set up:

--- a/cider-client.el
+++ b/cider-client.el
@@ -127,7 +127,7 @@ The ns is extracted from the ns form for Clojure buffers and from
 REPL's ns, otherwise fall back to \"user\".  When NO-DEFAULT is non-nil, it
 will return nil instead of \"user\"."
   (or cider-buffer-ns
-      (cider--clojure-find-ns)
+      (cider-get-ns-name)
       (when-let* ((repl (cider-current-repl)))
         (buffer-local-value 'cider-buffer-ns repl))
       (if no-default nil "user")))

--- a/cider-client.el
+++ b/cider-client.el
@@ -127,7 +127,7 @@ The ns is extracted from the ns form for Clojure buffers and from
 REPL's ns, otherwise fall back to \"user\".  When NO-DEFAULT is non-nil, it
 will return nil instead of \"user\"."
   (or cider-buffer-ns
-      (clojure-find-ns)
+      (cider--clojure-find-ns)
       (when-let* ((repl (cider-current-repl)))
         (buffer-local-value 'cider-buffer-ns repl))
       (if no-default nil "user")))

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -1415,7 +1415,7 @@ buffer, else display in a popup buffer."
   "Evaluate the current buffer's namespace form.
 When UNDEF-ALL is non-nil, unmap all symbols and aliases first."
   (interactive "P")
-  (when-let ((ns (cider--clojure-find-ns)))
+  (when-let ((ns (cider-get-ns-name)))
     (save-excursion
       (goto-char (match-beginning 0))
       (when undef-all

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -1415,7 +1415,7 @@ buffer, else display in a popup buffer."
   "Evaluate the current buffer's namespace form.
 When UNDEF-ALL is non-nil, unmap all symbols and aliases first."
   (interactive "P")
-  (when-let ((ns (clojure-find-ns)))
+  (when-let ((ns (cider--clojure-find-ns)))
     (save-excursion
       (goto-char (match-beginning 0))
       (when undef-all

--- a/cider-ns.el
+++ b/cider-ns.el
@@ -65,6 +65,7 @@
 (require 'cider-eval)
 (require 'cider-popup)
 (require 'cider-stacktrace)
+(require 'cider-util)
 
 (defcustom cider-ns-save-files-on-refresh 'prompt
   "Controls whether to prompt to save files before refreshing.
@@ -195,9 +196,9 @@ org.clojure/tools.namespace.  See Commentary of this file for a longer list
 of differences.  From the Clojure doc: \":reload forces loading of all the
 identified libs even if they are already loaded\"."
   (interactive "P")
-  (let ((ns (if prompt
-                (string-remove-prefix "'" (read-from-minibuffer "Namespace: " (clojure-find-ns)))
-              (clojure-find-ns))))
+  (when-let ((ns (if prompt
+                     (string-remove-prefix "'" (read-from-minibuffer "Namespace: " (cider--clojure-find-ns)))
+                   (cider--clojure-find-ns))))
     (cider-interactive-eval (format "(require '%s :reload)" ns))))
 
 ;;;###autoload
@@ -211,9 +212,9 @@ of differences.  From the Clojure doc: \":reload-all implies :reload and
 also forces loading of all libs that the identified libs directly or
 indirectly load via require\"."
   (interactive "P")
-  (let ((ns (if prompt
-                (string-remove-prefix "'" (read-from-minibuffer "Namespace: " (clojure-find-ns)))
-              (clojure-find-ns))))
+  (when-let ((ns (if prompt
+                     (string-remove-prefix "'" (read-from-minibuffer "Namespace: " (cider--clojure-find-ns)))
+                   (cider--clojure-find-ns))))
     (cider-interactive-eval (format "(require '%s :reload-all)" ns))))
 
 ;;;###autoload

--- a/cider-ns.el
+++ b/cider-ns.el
@@ -197,8 +197,8 @@ of differences.  From the Clojure doc: \":reload forces loading of all the
 identified libs even if they are already loaded\"."
   (interactive "P")
   (when-let ((ns (if prompt
-                     (string-remove-prefix "'" (read-from-minibuffer "Namespace: " (cider--clojure-find-ns)))
-                   (cider--clojure-find-ns))))
+                     (string-remove-prefix "'" (read-from-minibuffer "Namespace: " (cider-get-ns-name)))
+                   (cider-get-ns-name))))
     (cider-interactive-eval (format "(require '%s :reload)" ns))))
 
 ;;;###autoload
@@ -213,8 +213,8 @@ also forces loading of all libs that the identified libs directly or
 indirectly load via require\"."
   (interactive "P")
   (when-let ((ns (if prompt
-                     (string-remove-prefix "'" (read-from-minibuffer "Namespace: " (cider--clojure-find-ns)))
-                   (cider--clojure-find-ns))))
+                     (string-remove-prefix "'" (read-from-minibuffer "Namespace: " (cider-get-ns-name)))
+                   (cider-get-ns-name))))
     (cider-interactive-eval (format "(require '%s :reload-all)" ns))))
 
 ;;;###autoload

--- a/cider-test.el
+++ b/cider-test.el
@@ -41,6 +41,7 @@
 (require 'cider-popup)
 (require 'cider-stacktrace)
 (require 'cider-overlays)
+(require 'cider-util)
 
 ;;; Variables
 
@@ -852,15 +853,16 @@ is searched."
           (cider-test-update-last-test ns var)
           (cider-test-execute ns (list var)))
       ;; we're in a `clojure-mode' buffer
-      (let* ((ns  (clojure-find-ns))
-             (def (clojure-find-def)) ; it's a list of the form (deftest something)
-             (deftype (car def))
-             (var (cadr def)))
-        (if (and ns (member deftype cider-test-defining-forms))
-            (progn
-              (cider-test-update-last-test ns (list var))
-              (cider-test-execute ns (list var)))
-          (message "No test at point"))))))
+      (or (when-let* ((ns  (cider--clojure-find-ns))
+                      (def (clojure-find-def)) ; it's a list of the form (deftest something)
+                      (deftype (car def))
+                      (var (cadr def)))
+            (if (and ns (member deftype cider-test-defining-forms))
+                (progn
+                  (cider-test-update-last-test ns (list var))
+                  (cider-test-execute ns (list var)))
+              (message "No test at point")))
+          (message "No test at point")))))
 
 (defun cider-test-rerun-test ()
   "Re-run the test that was previously ran."

--- a/cider-test.el
+++ b/cider-test.el
@@ -853,7 +853,7 @@ is searched."
           (cider-test-update-last-test ns var)
           (cider-test-execute ns (list var)))
       ;; we're in a `clojure-mode' buffer
-      (or (when-let* ((ns  (cider--clojure-find-ns))
+      (or (when-let* ((ns  (cider-get-ns-name))
                       (def (clojure-find-def)) ; it's a list of the form (deftest something)
                       (deftype (car def))
                       (var (cadr def)))

--- a/cider-util.el
+++ b/cider-util.el
@@ -114,9 +114,15 @@ instead."
         (clojure-backward-logical-sexp 1)
         (cider--text-or-limits bounds (point) end)))))
 
+(defun cider--clojure-find-ns ()
+  "Calls `clojure-find-ns', supressing any errors.
+Therefore, possibly returns nil,
+so please handle that value from any callsites."
+  (clojure-find-ns :supress-errors))
+
 (defun cider-ns-form ()
   "Retrieve the ns form."
-  (when (clojure-find-ns)
+  (when (cider--clojure-find-ns)
     (save-excursion
       (goto-char (match-beginning 0))
       (cider-defun-at-point))))

--- a/cider-util.el
+++ b/cider-util.el
@@ -115,7 +115,7 @@ instead."
         (cider--text-or-limits bounds (point) end)))))
 
 (defun cider--clojure-find-ns ()
-  "Calls `clojure-find-ns', supressing any errors.
+  "Calls `clojure-find-ns', suppressing any errors.
 Therefore, possibly returns nil,
 so please handle that value from any callsites."
   (clojure-find-ns :supress-errors))

--- a/cider-util.el
+++ b/cider-util.el
@@ -114,7 +114,7 @@ instead."
         (clojure-backward-logical-sexp 1)
         (cider--text-or-limits bounds (point) end)))))
 
-(defun cider--clojure-find-ns ()
+(defun cider-get-ns-name ()
   "Calls `clojure-find-ns', suppressing any errors.
 Therefore, possibly returns nil,
 so please handle that value from any callsites."
@@ -122,7 +122,7 @@ so please handle that value from any callsites."
 
 (defun cider-ns-form ()
   "Retrieve the ns form."
-  (when (cider--clojure-find-ns)
+  (when (cider-get-ns-name)
     (save-excursion
       (goto-char (match-beginning 0))
       (cider-defun-at-point))))

--- a/cider.el
+++ b/cider.el
@@ -12,7 +12,7 @@
 ;; Maintainer: Bozhidar Batsov <bozhidar@batsov.dev>
 ;; URL: http://www.github.com/clojure-emacs/cider
 ;; Version: 1.8.0-snapshot
-;; Package-Requires: ((emacs "26") (clojure-mode "5.16.0") (parseedn "1.0.6") (queue "0.2") (spinner "1.7") (seq "2.22") (sesman "0.3.2") (transient "0.4.1"))
+;; Package-Requires: ((emacs "26") (clojure-mode "5.16.2") (parseedn "1.0.6") (queue "0.2") (spinner "1.7") (seq "2.22") (sesman "0.3.2") (transient "0.4.1"))
 ;; Keywords: languages, clojure, cider
 
 ;; This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
> Fixes https://github.com/clojure-emacs/cider/issues/2849

Bumps clojure-mode, introducing a `cider-get-ns-name` wrapper and using it everywhere.

Callsites handle nil when due.