### PR TITLE
Prevent malformed `cider-repl-history-file`s from failing `cider-jack-in`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Recompute namespace info on each fighweel-main recompilation.
 - [#3250](https://github.com/clojure-emacs/cider/issues/3250): don't lose the CIDER session over TRAMP files. 
 - [#3413](https://github.com/clojure-emacs/cider/issues/3413): Make jump-to-definition work in projects needing `cider-path-translations` (i.e. Dockerized projects). 
+- [#2436](https://github.com/clojure-emacs/cider/issues/2436): Prevent malformed `cider-repl-history-file`s from failing `cider-jack-in`.
 - Fix the `xref-find-definitions` CIDER backend to return correct filenames.
 - Fix the `cider-xref-fn-deps` buttons to direct to the right file.
 - Make TRAMP functionality work when using non-standard ports.

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -2018,7 +2018,10 @@ in an unexpected place."
   ;; apply dir-local variables to REPL buffers
   (hack-dir-local-variables-non-file-buffer)
   (when cider-repl-history-file
-    (cider-repl-history-load cider-repl-history-file)
+    (condition-case nil
+        (cider-repl-history-load cider-repl-history-file)
+      (error
+       (message "Malformed cider-repl-history-file: %s" cider-repl-history-file)))
     (add-hook 'kill-buffer-hook #'cider-repl-history-just-save t t)
     (add-hook 'kill-emacs-hook #'cider-repl-history-just-save))
   (add-hook 'completion-at-point-functions #'cider-complete-at-point nil t)


### PR DESCRIPTION
> Fixes https://github.com/clojure-emacs/cider/issues/2436

I could repro the original bug and verify it behaves nicely now.