### PR TITLE
Avoid expensive `file-truename` call when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Improve the presentation of `xref` data.
 - [#3419](https://github.com/clojure-emacs/cider/issues/3419): Also match friendly sessions based on the buffer's ns form.
 - `cider-test`: only show diffs for collections.
+- Avoid expensive `file-truename` call when possible.
 - [#3375](https://github.com/clojure-emacs/cider/pull/3375): `cider-test`: don't render a newline between expected and actual, most times.
 - Improve `nrepl-dict` error reporting.
 - Bump the injected `piggieback` to [0.5.3](https://github.com/nrepl/piggieback/blob/0.5.3/CHANGES.md#053-2021-10-26).


### PR DESCRIPTION
> See also https://clojurians.slack.com/archives/C0617A8PQ/p1692876466054909

`file-truename` can be slow (different Emacs projects work around this in a number of ways). Apparently, it checks for symlinks as it traverses each directory of a given path.

This PR observes the `buffer-file-truename` buffer-local variable, that has that info already computed for us.

https://www.gnu.org/software/emacs/manual/html_node/elisp/Buffer-File-Name.html#index-buffer_002dfile_002dtruename

I've tried it successfully locally, and over TRAMP.