### PR TITLE
Always match friendly sessions for special buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
 - Preserve the `:cljs-repl-type` more reliably.
 - Improve the presentation of `xref` data.
 - [#3419](https://github.com/clojure-emacs/cider/issues/3419): Also match friendly sessions based on the buffer's ns form.
-- Always match friendly sessions for special buffers like `*cider-error*`, `*cider-result*`, etc.
+- Always match friendly sessions for `cider-ancillary-buffers` (like `*cider-error*`, `*cider-result*`, etc).
 - `cider-test`: only show diffs for collections.
 - [#3375](https://github.com/clojure-emacs/cider/pull/3375): `cider-test`: don't render a newline between expected and actual, most times.
 - Ensure there's a leading `:` when using `cider-clojure-cli-aliases`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - Preserve the `:cljs-repl-type` more reliably.
 - Improve the presentation of `xref` data.
 - [#3419](https://github.com/clojure-emacs/cider/issues/3419): Also match friendly sessions based on the buffer's ns form.
+- Always match friendly sessions for special buffers like `*cider-error*`, `*cider-result*`, etc.
 - `cider-test`: only show diffs for collections.
 - [#3375](https://github.com/clojure-emacs/cider/pull/3375): `cider-test`: don't render a newline between expected and actual, most times.
 - Ensure there's a leading `:` when using `cider-clojure-cli-aliases`.

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1750,75 +1750,79 @@ constructs."
                      (mapconcat #'identity (cider-repl--available-shortcuts) ", "))))
         (error "No command selected")))))
 
+(defvar cider--project-agnostic-buffer-names
+  '("*cider-error*" "*cider-result*")
+  "The buffer names known to be project- agnostic/reusable, and from CIDER.")
 
 (defun cider--sesman-friendly-session-p (session &optional debug)
   "Check if SESSION is a friendly session, DEBUG optionally.
 
 The checking is done as follows:
 
+* Consider if the buffer belongs to `cider--project-agnostic-buffer-names`
 * Consider the buffer's filename, strip any Docker/TRAMP details from it
 * Check if that filename belongs to the classpath,
   or to the classpath roots (e.g. the project root dir)
 * As a fallback, check if the buffer's ns form
   matches any of the loaded namespaces."
   (setcdr session (seq-filter #'buffer-live-p (cdr session)))
-  (when-let* ((repl (cadr session))
-              (proc (get-buffer-process repl))
-              (file (file-truename (or (buffer-file-name) default-directory))))
-    ;; With avfs paths look like /path/to/.avfs/path/to/some.jar#uzip/path/to/file.clj
-    (when (string-match-p "#uzip" file)
-      (let ((avfs-path (directory-file-name (expand-file-name (or (getenv "AVFSBASE")  "~/.avfs/")))))
-        (setq file (replace-regexp-in-string avfs-path "" file t t))))
-    (when-let ((tp (cider-tramp-prefix (current-buffer))))
-      (setq file (string-remove-prefix tp file)))
-    (when (process-live-p proc)
-      (let* ((classpath (or (process-get proc :cached-classpath)
-                            (let ((cp (with-current-buffer repl
-                                        (cider-classpath-entries))))
-                              (process-put proc :cached-classpath cp)
-                              cp)))
-             (ns-list (or (process-get proc :all-namespaces)
-                          (let ((ns-list (with-current-buffer repl
-                                           (cider-sync-request:ns-list))))
-                            (process-put proc :all-namespaces ns-list)
-                            ns-list)))
-             (classpath-roots (or (process-get proc :cached-classpath-roots)
-                                  (let ((cp (thread-last
-                                              classpath
-                                              (seq-filter (lambda (path) (not (string-match-p "\\.jar$" path))))
-                                              (mapcar #'file-name-directory)
-                                              (seq-remove  #'null)
-                                              (seq-uniq))))
-                                    (process-put proc :cached-classpath-roots cp)
-                                    cp))))
-        (or (seq-find (lambda (path) (string-prefix-p path file))
-                      classpath)
-            (seq-find (lambda (path) (string-prefix-p path file))
-                      classpath-roots)
-            (when-let* ((cider-path-translations (cider--all-path-translations))
-                        (translated (cider--translate-path file 'to-nrepl :return-all)))
-              (seq-find (lambda (translated-path)
-                          (or (seq-find (lambda (path)
-                                          (string-prefix-p path translated-path))
-                                        classpath)
-                              (seq-find (lambda (path)
-                                          (string-prefix-p path translated-path))
-                                        classpath-roots)))
-                        translated))
-            (when-let ((ns (condition-case nil
-                               (substring-no-properties (cider-current-ns :no-default
-                                                                          ;; important - don't query the repl,
-                                                                          ;; avoiding a recursive invocation of `cider--sesman-friendly-session-p`:
-                                                                          :no-repl-check))
-                             (error nil))))
-              ;; if the ns form matches with a ns of all runtime namespaces, we can consider the buffer to match
-              ;; (this is a bit lax, but also quite useful)
-              (with-current-buffer repl
-                (or (when cider-repl-ns-cache ;; may be nil on repl startup
-                      (member ns (nrepl-dict-keys cider-repl-ns-cache)))
-                    (member ns ns-list))))
-            (when debug
-              (list file "was not determined to belong to classpath:" classpath "or classpath-roots:" classpath-roots)))))))
+  (or (member (buffer-name) cider--project-agnostic-buffer-names)
+      (when-let* ((repl (cadr session))
+                  (proc (get-buffer-process repl))
+                  (file (file-truename (or (buffer-file-name) default-directory))))
+        ;; With avfs paths look like /path/to/.avfs/path/to/some.jar#uzip/path/to/file.clj
+        (when (string-match-p "#uzip" file)
+          (let ((avfs-path (directory-file-name (expand-file-name (or (getenv "AVFSBASE")  "~/.avfs/")))))
+            (setq file (replace-regexp-in-string avfs-path "" file t t))))
+        (when-let ((tp (cider-tramp-prefix (current-buffer))))
+          (setq file (string-remove-prefix tp file)))
+        (when (process-live-p proc)
+          (let* ((classpath (or (process-get proc :cached-classpath)
+                                (let ((cp (with-current-buffer repl
+                                            (cider-classpath-entries))))
+                                  (process-put proc :cached-classpath cp)
+                                  cp)))
+                 (ns-list (or (process-get proc :all-namespaces)
+                              (let ((ns-list (with-current-buffer repl
+                                               (cider-sync-request:ns-list))))
+                                (process-put proc :all-namespaces ns-list)
+                                ns-list)))
+                 (classpath-roots (or (process-get proc :cached-classpath-roots)
+                                      (let ((cp (thread-last classpath
+                                                             (seq-filter (lambda (path) (not (string-match-p "\\.jar$" path))))
+                                                             (mapcar #'file-name-directory)
+                                                             (seq-remove  #'null)
+                                                             (seq-uniq))))
+                                        (process-put proc :cached-classpath-roots cp)
+                                        cp))))
+            (or (seq-find (lambda (path) (string-prefix-p path file))
+                          classpath)
+                (seq-find (lambda (path) (string-prefix-p path file))
+                          classpath-roots)
+                (when-let* ((cider-path-translations (cider--all-path-translations))
+                            (translated (cider--translate-path file 'to-nrepl :return-all)))
+                  (seq-find (lambda (translated-path)
+                              (or (seq-find (lambda (path)
+                                              (string-prefix-p path translated-path))
+                                            classpath)
+                                  (seq-find (lambda (path)
+                                              (string-prefix-p path translated-path))
+                                            classpath-roots)))
+                            translated))
+                (when-let ((ns (condition-case nil
+                                   (substring-no-properties (cider-current-ns :no-default
+                                                                              ;; important - don't query the repl,
+                                                                              ;; avoiding a recursive invocation of `cider--sesman-friendly-session-p`:
+                                                                              :no-repl-check))
+                                 (error nil))))
+                  ;; if the ns form matches with a ns of all runtime namespaces, we can consider the buffer to match
+                  ;; (this is a bit lax, but also quite useful)
+                  (with-current-buffer repl
+                    (or (when cider-repl-ns-cache ;; may be nil on repl startup
+                          (member ns (nrepl-dict-keys cider-repl-ns-cache)))
+                        (member ns ns-list))))
+                (when debug
+                  (list file "was not determined to belong to classpath:" classpath "or classpath-roots:" classpath-roots))))))))
 
 (defun cider-debug-sesman-friendly-session-p ()
   "`message's debugging information relative to friendly sessions.

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1750,23 +1750,21 @@ constructs."
                      (mapconcat #'identity (cider-repl--available-shortcuts) ", "))))
         (error "No command selected")))))
 
-(defvar cider--project-agnostic-buffer-names
-  '("*cider-error*" "*cider-result*")
-  "The buffer names known to be project- agnostic/reusable, and from CIDER.")
-
 (defun cider--sesman-friendly-session-p (session &optional debug)
   "Check if SESSION is a friendly session, DEBUG optionally.
 
 The checking is done as follows:
 
-* Consider if the buffer belongs to `cider--project-agnostic-buffer-names`
+* Consider if the buffer belongs to `cider-ancillary-buffers`
 * Consider the buffer's filename, strip any Docker/TRAMP details from it
 * Check if that filename belongs to the classpath,
   or to the classpath roots (e.g. the project root dir)
 * As a fallback, check if the buffer's ns form
   matches any of the loaded namespaces."
   (setcdr session (seq-filter #'buffer-live-p (cdr session)))
-  (or (member (buffer-name) cider--project-agnostic-buffer-names)
+  (or (and (member (buffer-name) cider-ancillary-buffers)
+           (not (or (equal major-mode 'cider-repl-mode)
+                    (derived-mode-p 'cider-repl-mode))))
       (when-let* ((repl (cadr session))
                   (proc (get-buffer-process repl))
                   (file (file-truename (or (buffer-file-name) default-directory))))

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1762,9 +1762,7 @@ The checking is done as follows:
 * As a fallback, check if the buffer's ns form
   matches any of the loaded namespaces."
   (setcdr session (seq-filter #'buffer-live-p (cdr session)))
-  (or (and (member (buffer-name) cider-ancillary-buffers)
-           (not (or (equal major-mode 'cider-repl-mode)
-                    (derived-mode-p 'cider-repl-mode))))
+  (or (member (buffer-name) cider-ancillary-buffers)
       (when-let* ((repl (cadr session))
                   (proc (get-buffer-process repl))
                   (file (file-truename (or (buffer-file-name) default-directory))))

--- a/test/cider-connection-tests.el
+++ b/test/cider-connection-tests.el
@@ -60,6 +60,12 @@
   (before-each
     (setq sesman-sessions-hashmap (make-hash-table :test #'equal)
           sesman-links-alist nil
+          cider-ancillary-buffers (seq-filter (lambda (s)
+                                                ;; sometimes "*temp*" buffers can sneak into cider-ancillary-buffers.
+                                                ;; Those are the artifact of some other test, and can break these tests
+                                                ;; by affecting the logic in cider--sesman-friendly-session-p.
+                                                (string-prefix-p "*cider" s))
+                                              cider-ancillary-buffers)
           ses-name "a-session"
           ses-name2 "b-session"))
 


### PR DESCRIPTION
`*cider-error*`, `*cider-result*`, and possibly others, always deserve to get an associated repl, if possible.

This normally already is the case, because their `default-directory` matches that of the current repl.

However, for some reason, occasionally their default-directory will be something like `~/.emacs.d` which matches no repl's dir.

So this PR fixes that heisenbug.

But it also is an overall improvement, because conceptually, `*cider-error*` / `*cider-result*` belong to no project in particular, so if a repl is available, it should be considered 'friendly' to it.

Cheers - V