### PR TITLE
`cider--sesman-friendly-session-p`: avoid semi-recursive edge case

### DIFF
--- a/cider-client.el
+++ b/cider-client.el
@@ -120,16 +120,19 @@ Useful for special buffers (e.g. REPL, doc buffers) that have to keep track
 of a namespace.  This should never be set in Clojure buffers, as there the
 namespace should be extracted from the buffer's ns form.")
 
-(defun cider-current-ns (&optional no-default)
+(defun cider-current-ns (&optional no-default no-repl-check)
   "Return the current ns.
 The ns is extracted from the ns form for Clojure buffers and from
 `cider-buffer-ns' for all other buffers.  If it's missing, use the current
-REPL's ns, otherwise fall back to \"user\".  When NO-DEFAULT is non-nil, it
-will return nil instead of \"user\"."
+REPL's ns, otherwise fall back to \"user\".
+When NO-DEFAULT is non-nil, it will return nil instead of \"user\".
+When NO-REPL-CHECK is non-nil, `cider-current-repl' will not be queried,
+improving performance (at the possible cost of accuracy)."
   (or cider-buffer-ns
       (cider-get-ns-name)
-      (when-let* ((repl (cider-current-repl)))
-        (buffer-local-value 'cider-buffer-ns repl))
+      (unless no-repl-check
+        (when-let* ((repl (cider-current-repl)))
+          (buffer-local-value 'cider-buffer-ns repl)))
       (if no-default nil "user")))
 
 (defun cider-path-to-ns (relpath)

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1802,7 +1802,10 @@ The checking is done as follows:
                                         classpath-roots)))
                         translated))
             (when-let ((ns (condition-case nil
-                               (substring-no-properties (cider-current-ns :no-default))
+                               (substring-no-properties (cider-current-ns :no-default
+                                                                          ;; important - don't query the repl,
+                                                                          ;; avoiding a recursive invocation of `cider--sesman-friendly-session-p`:
+                                                                          :no-repl-check))
                              (error nil))))
               ;; if the ns form matches with a ns of all runtime namespaces, we can consider the buffer to match
               ;; (this is a bit lax, but also quite useful)


### PR DESCRIPTION
In the following profiling data, one can see how `sesman-current-sessions` ends up calling itself:

```
       14109  89% - ...
       13684  86%  - sesman-current-sessions
       13684  86%   - sesman--friendly-sessions
       13684  86%    - seq-filter
       13684  86%     - seq-map
       13684  86%      - apply
       13684  86%       - #<compiled 0x18438d3d527778b4>
       13684  86%        - mapcar
       13684  86%         - #<compiled -0x1c3c5aba76cb956a>
       13684  86%          - #<compiled 0xa07ea5fb0bf551>
       13684  86%           - sesman-friendly-session-p
       13684  86%            - apply
       13684  86%             - #<compiled 0x12ba488e81173447>
       13684  86%              - cider--sesman-friendly-session-p
       13681  86%               - cider-current-ns
       13681  86%                - cider-current-repl
       13681  86%                 - cider-repls
       13681  86%                  - sesman-current-session
       13681  86%                   - sesman--friendly-sessions
       13681  86%                    - seq-filter
       13681  86%                     - seq-map
       13678  86%                      - apply
       13678  86%                       - #<compiled 0x18438d3d527778b4>
       13674  86%                        - mapcar
       13674  86%                         - #<compiled -0x1c3c5aadc99b3d6a>
       13661  86%                          - #<compiled 0xa07ea5fb0bf551>
       13650  86%                           - sesman-friendly-session-p
       13647  86%                            - apply
       13647  86%                             - #<compiled 0x12ba488e81173447>
       13581  85%                              - cider--sesman-friendly-session-p
       10132  64%                               - file-truename
        7722  48%                                - file-truename
        5634  35%                                 - file-truename
        3819  24%                                  - file-truename
        2233  14%                                   - file-truename
         777   4%                                      file-truename
        1499   9%                               + cider-current-ns
        1143   7%                               + seq-find
         405   2%                               + cider--all-path-translations
          81   0%                               + cider-tramp-prefix
          50   0%                               + seq-filter
          20   0%                                 process-get
           6   0%                                 process-live-p
           5   0%                               + cider-classpath-entries
```

This PR avoids hitting the `(cider-current-repl)` call that was responsible for that.