### PR TITLE
Don't pass a nil callback when calling `cider/get-state`

### DIFF
--- a/cider-repl.el
+++ b/cider-repl.el
@@ -992,7 +992,7 @@ nREPL ops, it may be convenient to prevent inserting a prompt.")
     (when (nrepl-op-supported-p "cider/get-state" conn)
       (nrepl-send-request '("op" "cider/get-state")
                           (lambda (_response)
-                            ;; No action is necessary
+                            ;; No action is necessary: this request results in `cider-repl--state-handler` being called.
                             )
                           conn))))
 

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -990,7 +990,11 @@ nREPL ops, it may be convenient to prevent inserting a prompt.")
   "Invokes `cider/get-state' when it's possible to do so."
   (when-let ((conn (cider-current-repl 'cljs)))
     (when (nrepl-op-supported-p "cider/get-state" conn)
-      (nrepl-send-request '("op" "cider/get-state") nil conn))))
+      (nrepl-send-request '("op" "cider/get-state")
+                          (lambda (_response)
+                            ;; No action is necessary
+                            )
+                          conn))))
 
 (defun cider--maybe-get-state-for-shadow-cljs (buffer &optional err)
   "Refresh the changed namespaces metadata given BUFFER and ERR (stderr string).

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -480,7 +480,7 @@ older requests with \"done\" status."
                         (gethash id nrepl-completed-requests))))
       (if callback
           (funcall callback response)
-        (error "[nREPL] No response handler with id %s found in %s" id (buffer-name))))))
+        (error "[nREPL] No response handler with id %s found for %s" id (buffer-name))))))
 
 (defun nrepl-client-sentinel (process message)
   "Handle sentinel events from PROCESS.

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -480,7 +480,7 @@ older requests with \"done\" status."
                         (gethash id nrepl-completed-requests))))
       (if callback
           (funcall callback response)
-        (error "[nREPL] No response handler with id %s found" id)))))
+        (error "[nREPL] No response handler with id %s found in %s" id (buffer-name))))))
 
 (defun nrepl-client-sentinel (process message)
   "Handle sentinel events from PROCESS.


### PR DESCRIPTION
* Don't pass a nil callback when calling `cider/get-state`
  * Was causing a warning.
* Improve `No response handler` message