### PR TITLE
Docs: fix some unordered lists

### DIFF
--- a/doc/modules/ROOT/pages/indent_spec.adoc
+++ b/doc/modules/ROOT/pages/indent_spec.adoc
@@ -165,18 +165,18 @@ so you wouldn't have to specify it.
 For that to happen, it's most recommended that you write idiomatic Clojure macros:
 
 * If your macro is analog to a clojure.core one, name it identically
-  * e.g. name your macro `defprotocol`, not `my-defprotocol`
-    * (this is intentful usage of Clojure's namespace system)
+ ** e.g. name your macro `defprotocol`, not `my-defprotocol`
+  *** (this is intentful usage of Clojure's namespace system)
 * If your macro is analog to a clojure.core one, mirror all its arglists
-  * The exact names that you choose for your args do not matter
-  * It's the structure of the arglists that have to match.
-  * It doesn't matter if you express a given arg as a name, or as a destructured map/vector.
+ ** The exact names that you choose for your args do not matter
+ ** It's the structure of the arglists that have to match.
+ ** It doesn't matter if you express a given arg as a name, or as a destructured map/vector.
 * Name 'body' args like using clojure.core customs
-  * good: `[opts body]`
-  * bad: `[opts etc]`
-  * good: `[& body]`
-  * bad: `[& etc]`
-  * Other commonly accepted names include `forms`, `clauses`, etc.
+ ** good: `[opts body]`
+ ** bad: `[opts etc]`
+ ** good: `[& body]`
+ ** bad: `[& etc]`
+ ** Other commonly accepted names include `forms`, `clauses`, etc.
 
 You certainly don't _have_ to follow these suggestions - it's only for your convenience,
 as the indentation produced by CIDER will be better.

--- a/doc/modules/ROOT/pages/troubleshooting.adoc
+++ b/doc/modules/ROOT/pages/troubleshooting.adoc
@@ -359,10 +359,10 @@ If any interactive feature is being shortcircuited for you with the message `No 
 that's due to one of the following reasons:
 
 * You're evaluating code in a buffer from a project that hasn't started a repl
-  * You can fix this by switching instead to a project that has.
-  * You can also, simply, start a repl in the current project.
+ ** You can fix this by switching instead to a project that has.
+ ** You can also, simply, start a repl in the current project.
 * There's a bug in the CIDER/Sesman integration
-  * Session linking generally works by determining whether the current buffer is related to the classpath of some REPL.
-  * You can obtain debug info echoed to the `*messages*` buffer by running `M-x cider-debug-sesman-friendly-session-p` on the problematic buffer.
-    * By reading it, you might be able to determine why CIDER failed to see the relationship between `(buffer-filename)` and the classpath.
-    * Feel free to created a detailed GitHub issue including this information.
+ ** Session linking generally works by determining whether the current buffer is related to the classpath of some REPL.
+ ** You can obtain debug info echoed to the `*messages*` buffer by running `M-x cider-debug-sesman-friendly-session-p` on the problematic buffer.
+  *** By reading it, you might be able to determine why CIDER failed to see the relationship between `(buffer-filename)` and the classpath.
+  *** Feel free to created a detailed GitHub issue including this information.


### PR DESCRIPTION
Fixed to render properly, following this style (i.e. using optional leading whitespace):

https://github.com/clojure-emacs/cider/blob/f5a59d1230c639235f567bfc559a620a68c9c2b5/doc/modules/ROOT/pages/indent_spec.adoc#L20-L34