### PR TITLE
Improve the reliability of `cider-find-keyword`

### DIFF
--- a/cider-client.el
+++ b/cider-client.el
@@ -747,6 +747,8 @@ The option is kept for backwards compatibility.
 
 Note that even when favoring a url, the url itself might be nil,
 in which case we'll fall back to the resource name."
+  (unless ns
+    (error "No ns provided"))
   (let ((response (cider-nrepl-send-sync-request `("op" "ns-path"
                                                    "ns" ,ns))))
     (nrepl-dbind-response response (path url)


### PR DESCRIPTION
* `cider-sync-request:ns-path`: add a precondition
  * This would have saved me a confusing stacktrace.
* Improve the reliability of `cider--find-keyword-loc`
  * Allow to jump to a qualified keyword within the same ns
  * Avoid hitting `cider-sync-request:ns-path` when nothing was parsed
  * Explicitly forbid querying non-qualified keywords

Cheers - V