### PR TITLE
Replace `beginning-of-defun` fn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 
 ### Changes
 
+- Improve support for multiple forms in the same line by replacing `beginning-of-defun` fn.
 - [#3390](https://github.com/clojure-emacs/cider/issues/3390): Enhance `cider-connect` to show all nREPLs available ports, instead of only Leiningen ones.
 - [#3408](https://github.com/clojure-emacs/cider/issues/3408): `cider-connect`: check `.nrepl-port`-like files for liveness, hiding them if they don't reflect an active port.
 - Introduce `cider-stacktrace-navigate-to-other-window` defcustom.

--- a/cider-completion.el
+++ b/cider-completion.el
@@ -140,7 +140,7 @@ form, with symbol at point replaced by __prefix__."
       (let* ((pref-end (point))
              (pref-start (cider-completion-symbol-start-pos))
              (context (cider-defun-at-point))
-             (_ (beginning-of-defun))
+             (_ (beginning-of-defun-raw))
              (expr-start (point)))
         (concat (when pref-start (substring context 0 (- pref-start expr-start)))
                 "__prefix__"

--- a/cider-debug.el
+++ b/cider-debug.el
@@ -762,7 +762,7 @@ The boolean value of FORCE will be sent in the reply."
           (progn ;; Get to the proper line & column in the file
             (forward-line (1- (- line (line-number-at-pos))))
             (move-to-column column))
-        (beginning-of-defun))
+        (beginning-of-defun-raw))
       ;; Is HERE inside the sexp being debugged?
       (when (or (< here (point))
                 (save-excursion

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -1362,7 +1362,7 @@ buffer.  It constructs an expression to eval in the following manner:
 - It balances this bit of code by closing all open expressions;
 - It evaluates the resulting code using `cider-interactive-eval'."
   (interactive "P")
-  (let* ((beg-of-defun (save-excursion (beginning-of-defun) (point)))
+  (let* ((beg-of-defun (save-excursion (beginning-of-defun-raw) (point)))
          (code (buffer-substring-no-properties beg-of-defun (point)))
          (code (cider--insert-closing-delimiters code)))
     (cider-interactive-eval code

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -952,7 +952,7 @@ before point."
     ;; If the inside of a `ns' form changed, reparse it from the start.
     (when (and (not (bobp))
                (get-text-property (1- (point)) 'cider-block-dynamic-font-lock))
-      (ignore-errors (beginning-of-defun)))
+      (ignore-errors (beginning-of-defun-raw)))
     (save-excursion
       ;; Move up until we reach a sexp that encloses the entire region (or
       ;; a top-level sexp), and set that as the new BEG.

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -540,7 +540,7 @@ If given a negative value of ARG, move to the beginning of defun."
   (if (and (not (cider-repl--at-prompt-start-p))
            (cider-repl--in-input-area-p))
       (goto-char cider-repl-input-start-mark)
-    (beginning-of-defun)))
+    (beginning-of-defun-raw)))
 
 (defun cider-repl-end-of-defun ()
   "Move to end of defun."

--- a/cider-util.el
+++ b/cider-util.el
@@ -71,12 +71,12 @@ Setting this to nil removes the fontification restriction."
 
 (defun cider-in-string-p ()
   "Return non-nil if point is in a string."
-  (let ((beg (save-excursion (beginning-of-defun) (point))))
+  (let ((beg (save-excursion (beginning-of-defun-raw) (point))))
     (nth 3 (parse-partial-sexp beg (point)))))
 
 (defun cider-in-comment-p ()
   "Return non-nil if point is in a comment."
-  (let ((beg (save-excursion (beginning-of-defun) (point))))
+  (let ((beg (save-excursion (beginning-of-defun-raw) (point))))
     (nth 4 (parse-partial-sexp beg (point)))))
 
 (defun cider--tooling-file-p (file-name)


### PR DESCRIPTION
Context - Same as https://github.com/clojure-emacs/clojure-mode/pull/663

The functions affected have no direct test coverage atm. Manually tested the below scenario.
```
(println "Hi") (->> [1 2 3 4] (map inc)| (filter odd?))
```
Before the change println form is also executed with M-x `cider-eval-defun-up-to-point`.(cursor at |)
