### PR TITLE
Restore xref-based jump-to-definition in Babashka

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - [#3250](https://github.com/clojure-emacs/cider/issues/3250): don't lose the CIDER session over TRAMP files. 
 - [#3413](https://github.com/clojure-emacs/cider/issues/3413): Make jump-to-definition work in projects needing `cider-path-translations` (i.e. Dockerized projects). 
 - [#2436](https://github.com/clojure-emacs/cider/issues/2436): Prevent malformed `cider-repl-history-file`s from failing `cider-jack-in`.
+- [#3456](https://github.com/clojure-emacs/cider/issues/3456): restore xref-based jump-to-definition in Babashka (and any nREPL clients not having cider-nrepl).
 - Fix the `xref-find-definitions` CIDER backend to return correct filenames.
 - Fix the `cider-xref-fn-deps` buttons to direct to the right file.
 - Fix the `cider-find-keyword` overall reliability and correctness, particularly for ClojureScript.

--- a/cider-xref-backend.el
+++ b/cider-xref-backend.el
@@ -42,7 +42,11 @@
   "Used for xref integration."
   ;; Check if `cider-nrepl` middleware is loaded. Allows fallback to other xref
   ;; backends, if cider-nrepl is not loaded.
-  (when (cider-nrepl-op-supported-p "ns-path" nil 'skip-ensure)
+  (when (or
+         ;; the main requirement:
+         (cider-nrepl-op-supported-p "ns-path" nil 'skip-ensure)
+         ;; the fallback, used for bare nrepl or babashka integrations:
+         (cider-nrepl-op-supported-p "lookup" nil 'skip-ensure))
     'cider))
 
 (cl-defmethod xref-backend-identifier-at-point ((_backend (eql cider)))
@@ -91,7 +95,6 @@ These are used for presentation purposes."
 (cl-defmethod xref-backend-definitions ((_backend (eql cider)) var)
   "Find definitions of VAR."
   (cider-ensure-connected)
-  (cider-ensure-op-supported "ns-path")
   (when-let* ((loc (cider--var-to-xref-location var)))
     (list (xref-make var loc))))
 


### PR DESCRIPTION
Fixes #3456

I tested this one locally by `cider-connect`ing to a `lein repl` session without cider-nrepl in it.

`M-x xref-find-definitions` now works (and does not work without this patch applied).

Cheers - V