### PR TITLE
Add preliminary support for clojure-ts-mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,4 +99,8 @@ jobs:
         cd dev; ../clojure.sh clojure -M:gen; cd -
         wc -l test/File.edn
         eldev -p -dtTC test --test-type enrich || eldev -p -dtTC test --test-type enrich
-        
+
+    - name: Test clojure-ts-mode
+      if: startsWith (matrix.emacs_version, '29')
+      run: |
+        eldev -p -dtTC test --test-type clojure-ts-mode || eldev -p -dtTC test --test-type clojure-ts-mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - [#3352](https://github.com/clojure-emacs/cider/pull/3496): Introduce [`cider-eval-dwim`](https://docs.cider.mx/cider/usage/cider_mode.html#key-reference).
 - Add new customization variable [`cider-clojurec-eval-destination`](https://docs.cider.mx/cider/cljs/up_and_running.html#working-with-cljc-files) to allow specifying which REPL .cljc evals are sent to.
 - [#3354](https://github.com/clojure-emacs/cider/issues/3354): Add new customization variable [`cider-reuse-dead-repls`](https://docs.cider.mx/cider/usage/managing_connections.html#reusing-dead-repls) to control how dead REPL buffers are reused on new connections.
+- Basic support for using CIDER from [clojure-ts-mode](https://github.com/clojure-emacs/clojure-ts-mode) 
 
 ### Bugs fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - [#3354](https://github.com/clojure-emacs/cider/issues/3354): Add new customization variable [`cider-reuse-dead-repls`](https://docs.cider.mx/cider/usage/managing_connections.html#reusing-dead-repls) to control how dead REPL buffers are reused on new connections.
 - Basic support for using CIDER from [clojure-ts-mode](https://github.com/clojure-emacs/clojure-ts-mode) 
 - [#3461](https://github.com/clojure-emacs/cider/pull/3461) Basic support for using CIDER from [clojure-ts-mode](https://github.com/clojure-emacs/clojure-ts-mode) 
+- [#3461](https://github.com/clojure-emacs/cider/pull/3461) Basic support for using CIDER with [clojure-ts-mode](https://github.com/clojure-emacs/clojure-ts-mode)
   - The clojure-mode dependency is still required for CIDER to function
   - some features like `cider-dynamic-indentation` and `cider-font-lock-dynamically` do not work with clojure-ts-mode (yet).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@
 - Add new customization variable [`cider-clojurec-eval-destination`](https://docs.cider.mx/cider/cljs/up_and_running.html#working-with-cljc-files) to allow specifying which REPL .cljc evals are sent to.
 - [#3354](https://github.com/clojure-emacs/cider/issues/3354): Add new customization variable [`cider-reuse-dead-repls`](https://docs.cider.mx/cider/usage/managing_connections.html#reusing-dead-repls) to control how dead REPL buffers are reused on new connections.
 - Basic support for using CIDER from [clojure-ts-mode](https://github.com/clojure-emacs/clojure-ts-mode) 
+- [#3461](https://github.com/clojure-emacs/cider/pull/3461) Basic support for using CIDER from [clojure-ts-mode](https://github.com/clojure-emacs/clojure-ts-mode) 
+  - The clojure-mode dependency is still required for CIDER to function
+  - some features like `cider-dynamic-indentation` and `cider-font-lock-dynamically` do not work with clojure-ts-mode (yet).
 
 ### Bugs fixed
 

--- a/Eldev
+++ b/Eldev
@@ -22,24 +22,33 @@
 (setf eldev-standard-excludes `(:or ,eldev-standard-excludes
                                     ;; Avoid including files in test "projects".
                                     (eldev-pcase-exhaustive cider-test-type
-                                                            (`main        "./test/*/")
-                                                            (`integration '("./test/"   "!./test/integration"))
-                                                            (`enrich      '("./test/"   "!./test/enrich"))
-                                                            (`all         '("./test/*/" "!./test/integration")))
+                                                            (`main            "./test/*/")
+                                                            (`integration     '("./test/"   "!./test/integration"))
+                                                            (`enrich          '("./test/"   "!./test/enrich"))
+                                                            (`clojure-ts-mode '("./test/*/" "!./test/clojure-ts-mode"))
+                                                            (`all             '("./test/*/" "!./test/integration")))
                                     "test/integration/projects"
                                     ;; This file is _supposed_ to be excluded
                                     ;; from automated testing.
                                     "test/cider-tests--no-auto.el"))
 
 (eldev-defoption cider-test-selection (type)
-  "Select tests to run; type can be `main', `integration', `enrich' or `all'"
+  "Select tests to run; type can be `main', `integration', `enrich', `clojure-ts-mode' or `all'"
   :options        (-T --test-type)
   :for-command    test
   :value          TYPE
   :default-value  cider-test-type
-  (unless (memq (intern type) '(main integration enrich all))
+  (unless (memq (intern type) '(main integration enrich clojure-ts-mode all))
     (signal 'eldev-wrong-option-usage `("unknown test type `%s'" ,type)))
   (setf cider-test-type (intern type)))
+
+(add-hook 'eldev-load-dependencies-hook
+          (lambda (type additional-sets)
+            (when (and (eq cider-test-type 'clojure-ts-mode)
+                       (member 'runtime additional-sets))
+              (message "Installing tree-sitter grammars")
+              (require 'clojure-ts-mode)
+              (clojure-ts--ensure-grammars))))
 
 (add-hook 'eldev-test-hook
           (lambda ()

--- a/Eldev
+++ b/Eldev
@@ -10,6 +10,7 @@
 
 (eldev-add-loading-roots 'test "test/utils")
 (eldev-add-extra-dependencies 'runtime '(:package logview :optional t))
+(eldev-add-extra-dependencies 'runtime '(:package clojure-ts-mode :optional t))
 
 ;; slightly increase the maximum (applies to checkdoc and the byte compiler alike)
 (setq byte-compile-docstring-max-column 100)

--- a/cider-clojuredocs.el
+++ b/cider-clojuredocs.el
@@ -29,6 +29,7 @@
 (require 'cider-common)
 (require 'subr-x)
 (require 'cider-popup)
+(require 'cider-util)
 
 (require 'nrepl-dict)
 
@@ -160,7 +161,7 @@ Prompts for the symbol to use, or uses the symbol at point, depending on
 the value of `cider-prompt-for-symbol'.  With prefix arg ARG, does the
 opposite of what that option dictates."
   (interactive "P")
-  (when (derived-mode-p 'clojurescript-mode)
+  (when (cider-clojurescript-major-mode-p)
     (user-error "`cider-clojuredocs' doesn't support ClojureScript"))
   (funcall (cider-prompt-for-symbol-function arg)
            "ClojureDocs doc for"

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -306,6 +306,7 @@ message in the REPL area."
 See command `cider-mode'."
   (interactive)
   (add-hook 'clojure-mode-hook #'cider-mode)
+  (add-hook 'clojure-ts-mode-hook #'cider-mode)
   (dolist (buffer (cider-util--clojure-buffers))
     (with-current-buffer buffer
       (unless cider-mode
@@ -800,9 +801,9 @@ multi.  This function infers connection type based on the major mode.
 For the REPL type use the function `cider-repl-type'."
   (with-current-buffer (or buffer (current-buffer))
     (cond
-     ((derived-mode-p 'clojurescript-mode) 'cljs)
-     ((derived-mode-p 'clojurec-mode) cider-clojurec-eval-destination)
-     ((derived-mode-p 'clojure-mode) 'clj)
+     ((cider-clojurescript-major-mode-p) 'cljs)
+     ((cider-clojurec-major-mode-p) cider-clojurec-eval-destination)
+     ((cider-clojure-major-mode-p) 'clj)
      (cider-repl-type))))
 
 (defun cider-set-repl-type (&optional type)

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -1421,7 +1421,7 @@ command `cider-debug-defun-at-point'."
   (interactive "P")
   (let ((inline-debug (eq 16 (car-safe debug-it))))
     (when debug-it
-      (when (derived-mode-p 'clojurescript-mode)
+      (when (cider-clojurescript-major-mode-p)
         (when (y-or-n-p (concat "The debugger doesn't support ClojureScript yet, and we need help with that."
                                 "  \nWould you like to read the Feature Request?"))
           (browse-url "https://github.com/clojure-emacs/cider/issues/1416"))

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -549,14 +549,16 @@ higher precedence."
                            (cider--menu-add-help-strings (symbol-value variable))))
     map))
 
-;; This menu works as an easy entry-point into CIDER.  Even if cider.el isn't
-;; loaded yet, this will be shown in Clojure buffers next to the "Clojure"
-;; menu.
 ;;;###autoload
-(with-eval-after-load 'clojure-mode
-  (easy-menu-define cider-clojure-mode-menu-open clojure-mode-map
+(defun cider--setup-menu-for-clojure-major-mode (mode-map)
+  "Setup a Cider menu for a Clojure major mode's MODE-MAP.
+
+This menu works as an easy entry-point into CIDER.  Even if cider.el isn't
+loaded yet, this will be shown in Clojure buffers next to the Clojure menu."
+  (easy-menu-define cider-clojure-mode-menu-open mode-map
     "Menu for Clojure mode.
-  This is displayed in `clojure-mode' buffers, if `cider-mode' is not active."
+  This is displayed in `clojure-mode' and `clojure-ts-mode' buffers,
+  if `cider-mode' is not active."
     `("CIDER" :visible (not cider-mode)
       ["Start a Clojure REPL" cider-jack-in-clj
        :help "Starts an nREPL server and connects a Clojure REPL to it."]
@@ -570,6 +572,14 @@ higher precedence."
        :help "Starts an nREPL server, connects a Clojure REPL to it, and then a ClojureScript REPL."]
       "--"
       ["View user manual" cider-view-manual])))
+
+;;;###autoload
+(with-eval-after-load 'clojure-mode
+  (cider--setup-menu-for-clojure-major-mode clojure-mode-map))
+
+;;;###autoload
+(with-eval-after-load 'clojure-ts-mode
+  (cider--setup-menu-for-clojure-major-mode clojure-ts-mode-map))
 
 ;;; Dynamic indentation
 (defcustom cider-dynamic-indentation t

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -579,7 +579,9 @@ loaded yet, this will be shown in Clojure buffers next to the Clojure menu."
 
 ;;;###autoload
 (with-eval-after-load 'clojure-ts-mode
-  (cider--setup-menu-for-clojure-major-mode clojure-ts-mode-map))
+  (cider--setup-menu-for-clojure-major-mode
+   (with-suppressed-warnings ((free-vars clojure-ts-mode-map))
+     clojure-ts-mode-map)))
 
 ;;; Dynamic indentation
 (defcustom cider-dynamic-indentation t

--- a/cider-ns.el
+++ b/cider-ns.el
@@ -78,7 +78,7 @@ If t, save the files without confirmation."
   :group 'cider
   :package-version '(cider . "0.15.0"))
 
-(defcustom cider-ns-save-files-on-refresh-modes '(clojure-mode)
+(defcustom cider-ns-save-files-on-refresh-modes '(clojure-mode clojure-ts-mode)
   "Controls which files might be saved before refreshing.
 If a list of modes, any buffers visiting files on the classpath whose major
 mode is derived from any of the modes might be saved.

--- a/cider-selector.el
+++ b/cider-selector.el
@@ -67,8 +67,8 @@ is visible, but not focused."
                          (null (get-buffer-window buffer 'visible))))
            return buffer
            finally (if consider-visible-p
-                       (error "Can't find unshown buffer in %S" mode)
-                     (cider-selector--recently-visited-buffer mode t))))
+                       (error "Can't find unshown buffer in %S" modes)
+                     (cider-selector--recently-visited-buffer modes t))))
 
 ;;;###autoload
 (defun cider-selector (&optional other-window)

--- a/cider-selector.el
+++ b/cider-selector.el
@@ -49,15 +49,18 @@ DESCRIPTION is a one-line description of what the key selects.")
 Not meant to be set by users.  It's used internally
 by `cider-selector'.")
 
-(defun cider-selector--recently-visited-buffer (mode &optional consider-visible-p)
-  "Return the most recently visited buffer, deriving its `major-mode' from MODE.
+(defun cider-selector--recently-visited-buffer (modes &optional consider-visible-p)
+  "Return the most recently visited buffer, deriving its `major-mode' from MODES.
+MODES may be a symbol for a single mode, or a list of mode symbols.
 CONSIDER-VISIBLE-P will allow handling of visible windows as well.
 First pass only considers buffers that are not already visible.
 Second pass will attempt one of visible ones for scenarios where the window
 is visible, but not focused."
   (cl-loop for buffer in (buffer-list)
            when (and (with-current-buffer buffer
-                       (derived-mode-p mode))
+                       (apply #'derived-mode-p (if (listp modes)
+                                                   modes
+                                                 (list modes))))
                      ;; names starting with space are considered hidden by Emacs
                      (not (string-match-p "^ " (buffer-name buffer)))
                      (or consider-visible-p
@@ -134,7 +137,7 @@ is chosen.  The returned buffer is selected with
 
 (def-cider-selector-method ?c
   "Most recently visited clojure-mode buffer."
-  (cider-selector--recently-visited-buffer 'clojure-mode))
+  (cider-selector--recently-visited-buffer '(clojure-mode clojure-ts-mode)))
 
 (def-cider-selector-method ?e
   "Most recently visited emacs-lisp-mode buffer."

--- a/cider-util.el
+++ b/cider-util.el
@@ -57,10 +57,24 @@ Setting this to nil removes the fontification restriction."
     (maphash (lambda (k _v) (setq keys (cons k keys))) hashtable)
     keys))
 
+(defun cider-clojure-major-mode-p ()
+  "Return non-nil if current buffer is managed by a Clojure major mode."
+  (derived-mode-p 'clojure-mode 'clojure-ts-mode))
+
+(defun cider-clojurescript-major-mode-p ()
+  "Return non-nil if current buffer is managed by a ClojureScript major mode."
+  (derived-mode-p 'clojurescript-mode 'clojurescript-ts-mode))
+
+(defun cider-clojurec-major-mode-p ()
+  "Return non-nil if current buffer is managed by a ClojureC major mode."
+  (derived-mode-p 'clojurec-mode 'clojurec-ts-mode))
+
 (defun cider-util--clojure-buffers ()
   "Return a list of all existing `clojure-mode' buffers."
   (seq-filter
-   (lambda (buffer) (with-current-buffer buffer (derived-mode-p 'clojure-mode)))
+   (lambda (buffer)
+     (with-current-buffer buffer
+       (cider-clojure-major-mode-p)))
    (buffer-list)))
 
 (defun cider-current-dir ()
@@ -91,7 +105,7 @@ which nREPL uses for temporary evaluation file names."
 
 If BUFFER is provided act on that buffer instead."
   (with-current-buffer (or buffer (current-buffer))
-    (or (derived-mode-p 'clojurec-mode))))
+    (or (cider-clojurec-major-mode-p))))
 
 
 ;;; Thing at point

--- a/cider.el
+++ b/cider.el
@@ -2121,30 +2121,29 @@ alternative to the default is `cider-random-tip'."
 (add-hook 'cider-connected-hook #'cider--maybe-inspire-on-connect)
 
 ;;;###autoload
-(defun cider--setup-clojure-major-mode (mode)
-  "Setup Cider key bindings and hooks for a Clojure major MODE."
-  (cl-flet ((concat-symbol (symbol suffix)
-              (intern (concat (symbol-name mode) suffix))))
-    (let ((mode-map (eval (concat-symbol mode "-map"))))
-      (define-key mode-map (kbd "C-c M-x") #'cider)
-      (define-key mode-map (kbd "C-c M-j") #'cider-jack-in-clj)
-      (define-key mode-map (kbd "C-c M-J") #'cider-jack-in-cljs)
-      (define-key mode-map (kbd "C-c M-c") #'cider-connect-clj)
-      (define-key mode-map (kbd "C-c M-C") #'cider-connect-cljs)
-      (define-key mode-map (kbd "C-c C-x") 'cider-start-map)
-      (define-key mode-map (kbd "C-c C-s") 'sesman-map)
-      (require 'sesman)
-      (sesman-install-menu mode-map)
-      (add-hook (concat-symbol mode "-hook")
-                (lambda () (setq-local sesman-system 'CIDER))))))
+(defun cider--setup-clojure-major-mode (mode-map mode-hook)
+  "Setup Cider key bindings on a Clojure mode's MODE-MAP and hooks in MODE-HOOK."
+  (define-key mode-map (kbd "C-c M-x") #'cider)
+  (define-key mode-map (kbd "C-c M-j") #'cider-jack-in-clj)
+  (define-key mode-map (kbd "C-c M-J") #'cider-jack-in-cljs)
+  (define-key mode-map (kbd "C-c M-c") #'cider-connect-clj)
+  (define-key mode-map (kbd "C-c M-C") #'cider-connect-cljs)
+  (define-key mode-map (kbd "C-c C-x") 'cider-start-map)
+  (define-key mode-map (kbd "C-c C-s") 'sesman-map)
+  (require 'sesman)
+  (sesman-install-menu mode-map)
+  (add-hook mode-hook (lambda () (setq-local sesman-system 'CIDER))))
 
 ;;;###autoload
 (with-eval-after-load 'clojure-mode
-  (cider--setup-clojure-major-mode 'clojure-mode))
+  (cider--setup-clojure-major-mode clojure-mode-map 'clojure-mode-hook))
 
 ;;;###autoload
 (with-eval-after-load 'clojure-ts-mode
-  (cider--setup-clojure-major-mode 'clojure-ts-mode))
+  (cider--setup-clojure-major-mode
+   (with-suppressed-warnings ((free-vars clojure-ts-mode-map))
+     clojure-ts-mode-map)
+   'clojure-ts-mode-hook))
 
 (provide 'cider)
 

--- a/cider.el
+++ b/cider.el
@@ -2121,17 +2121,30 @@ alternative to the default is `cider-random-tip'."
 (add-hook 'cider-connected-hook #'cider--maybe-inspire-on-connect)
 
 ;;;###autoload
+(defun cider--setup-clojure-major-mode (mode)
+  "Setup Cider key bindings and hooks for a Clojure major MODE."
+  (cl-flet ((concat-symbol (symbol suffix)
+              (intern (concat (symbol-name mode) suffix))))
+    (let ((mode-map (eval (concat-symbol mode "-map"))))
+      (define-key mode-map (kbd "C-c M-x") #'cider)
+      (define-key mode-map (kbd "C-c M-j") #'cider-jack-in-clj)
+      (define-key mode-map (kbd "C-c M-J") #'cider-jack-in-cljs)
+      (define-key mode-map (kbd "C-c M-c") #'cider-connect-clj)
+      (define-key mode-map (kbd "C-c M-C") #'cider-connect-cljs)
+      (define-key mode-map (kbd "C-c C-x") 'cider-start-map)
+      (define-key mode-map (kbd "C-c C-s") 'sesman-map)
+      (require 'sesman)
+      (sesman-install-menu mode-map)
+      (add-hook (concat-symbol mode "-hook")
+                (lambda () (setq-local sesman-system 'CIDER))))))
+
+;;;###autoload
 (with-eval-after-load 'clojure-mode
-  (define-key clojure-mode-map (kbd "C-c M-x") #'cider)
-  (define-key clojure-mode-map (kbd "C-c M-j") #'cider-jack-in-clj)
-  (define-key clojure-mode-map (kbd "C-c M-J") #'cider-jack-in-cljs)
-  (define-key clojure-mode-map (kbd "C-c M-c") #'cider-connect-clj)
-  (define-key clojure-mode-map (kbd "C-c M-C") #'cider-connect-cljs)
-  (define-key clojure-mode-map (kbd "C-c C-x") 'cider-start-map)
-  (define-key clojure-mode-map (kbd "C-c C-s") 'sesman-map)
-  (require 'sesman)
-  (sesman-install-menu clojure-mode-map)
-  (add-hook 'clojure-mode-hook (lambda () (setq-local sesman-system 'CIDER))))
+  (cider--setup-clojure-major-mode 'clojure-mode))
+
+;;;###autoload
+(with-eval-after-load 'clojure-ts-mode
+  (cider--setup-clojure-major-mode 'clojure-ts-mode))
 
 (provide 'cider)
 

--- a/doc/modules/ROOT/pages/additional_packages.adoc
+++ b/doc/modules/ROOT/pages/additional_packages.adoc
@@ -2,7 +2,7 @@
 
 There are many additional Emacs packages that can enhance your Clojure programming
 experience. The majority of the minor modes listed here should be enabled for both
-`cider-repl-mode` and `clojure-mode` for optimal effects.
+`cider-repl-mode`, `clojure-mode`, and `clojure-ts-mode` for optimal effects.
 
 The packages listed here belong to three categories:
 

--- a/doc/modules/ROOT/pages/caveats.adoc
+++ b/doc/modules/ROOT/pages/caveats.adoc
@@ -83,3 +83,17 @@ provide the dependencies by editing your `~/.lein/profiles.clj` as described in
 the xref:basics/middleware_setup.adoc#setting-up-a-standalone-repl[standalone REPL] section.
 * Adjust the value of `cider-injected-nrepl-version` to the same nREPL version as the
 one that's bundled with Leiningen.
+
+== Clojure-ts-mode integration
+
+Cider has basic support for working with
+https://github.com/clojure-emacs/clojure-ts-mode[clojure-ts-mode] buffers, but it still depends on
+https://github.com/clojure-emacs/clojure-mode[clojure-mode] for certain functionality, like
+extracting information about clojure code out of the buffer. We hope to make clojure-ts-mode capable
+of providing cider with all the functionality it needs to interact with clojure buffers, but that
+will take some time.
+
+Additionally, some features like
+xref:config/indentation.adoc#dynamic-indentation[`cider-dynamic-indentation`]
+and xref:config/syntax_highlighting.adoc#dynamic-syntax-highlighting[`cider-font-lock-dynamically`]
+are not supported by clojure-ts-mode.

--- a/doc/modules/ROOT/pages/index.adoc
+++ b/doc/modules/ROOT/pages/index.adoc
@@ -5,10 +5,9 @@ that **R**ocks!
 
 CIDER extends Emacs with support for xref:usage/interactive_programming.adoc[interactive programming] in Clojure. The
 features are centered around xref:usage/cider_mode.adoc[cider-mode], an Emacs minor-mode that complements
-https://github.com/clojure-emacs/clojure-mode[clojure-mode]. While `clojure-mode` supports editing Clojure source files,
-`cider-mode` adds support for interacting with a running Clojure process for
-compilation, debugging, definition and documentation lookup, running tests and
-so on.
+https://github.com/clojure-emacs/clojure-mode[clojure-mode] and https://github.com/clojure-emacs/clojure-ts-mode[clojure-ts-mode].
+While `clojure-mode` supports editing Clojure source files, `cider-mode` adds support for interacting with a running Clojure process for
+compilation, debugging, definition and documentation lookup, running tests and so on.
 
 .Inspired by SLIME
 ****

--- a/doc/modules/ROOT/pages/usage/cider_mode.adoc
+++ b/doc/modules/ROOT/pages/usage/cider_mode.adoc
@@ -18,7 +18,14 @@ it, so you can be productive.
 (add-hook 'clojure-mode-hook #'cider-mode)
 ----
 
-NOTE: There's no need to enable it explicitly for modes derived from `clojure-mode` like `clojurescript-mode`.
+or if you are using `clojure-ts-mode`
+
+[source,lisp]
+----
+(add-hook 'clojure-ts-mode-hook #'cider-mode)
+----
+
+NOTE: There's no need to enable it explicitly for modes derived from `clojure-mode` or `clojure-ts-mode` like `clojurescript-mode` and `clojurescript-ts-mode`.
 
 == Disabling cider-mode
 

--- a/doc/modules/ROOT/pages/usage/cider_mode.adoc
+++ b/doc/modules/ROOT/pages/usage/cider_mode.adoc
@@ -18,7 +18,7 @@ it, so you can be productive.
 (add-hook 'clojure-mode-hook #'cider-mode)
 ----
 
-or if you are using `clojure-ts-mode`
+or if you are using `clojure-ts-mode`:
 
 [source,lisp]
 ----

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -77,6 +77,7 @@
 (require 'sesman)
 (require 'tramp)
 
+(require 'cider-util)
 
 ;;; Custom
 
@@ -853,7 +854,7 @@ the corresponding type of response."
                                                  value ns out err status id)
       (when (buffer-live-p buffer)
         (with-current-buffer buffer
-          (when (and ns (not (derived-mode-p 'clojure-mode)))
+          (when (and ns (not (cider-clojure-major-mode-p)))
             (cider-set-buffer-ns ns))))
       (cond ((and content-type content-type-handler)
              (funcall content-type-handler buffer

--- a/test/cider-selector-tests.el
+++ b/test/cider-selector-tests.el
@@ -29,39 +29,27 @@
 
 (require 'buttercup)
 (require 'cider-selector)
+(require 'cider-selector-test-utils "test/utils/cider-selector-test-utils")
 (require 'cider-connection-test-utils "test/utils/cider-connection-test-utils")
 
 ;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
 
 ;; selector
-(defun cider-invoke-selector-method-by-key (ch)
-  (let ((method (cl-find ch cider-selector-methods :key #'car)))
-    (funcall (cl-third method))))
-
-(defun cider--test-selector-method (method buffer-mode buffer-name)
-  (with-temp-buffer
-    (rename-buffer buffer-name)
-    (setq major-mode buffer-mode)
-    (let ((expected-buffer (current-buffer)))
-      ;; switch to another buffer
-      (with-temp-buffer
-        (cider-invoke-selector-method-by-key method)
-        (expect (current-buffer) :to-equal expected-buffer)))))
 
 (describe "cider-seletor-method-c"
   (it "switches to most recently visited clojure-mode buffer"
-    (cider--test-selector-method ?c 'clojure-mode "*testfile*.clj")))
+    (cider-test-selector-method ?c 'clojure-mode "*testfile*.clj")))
 
 (describe "cider-seletor-method-e"
   (it "switches to most recently visited emacs-lisp-mode buffer"
     (kill-buffer "*scratch*")
-    (cider--test-selector-method ?e 'emacs-lisp-mode "*testfile*.el")))
+    (cider-test-selector-method ?e 'emacs-lisp-mode "*testfile*.el")))
 
 (describe "cider-seletor-method-r"
   :var (cider-current-repl)
   (it "switches to current REPL buffer"
     (spy-on 'cider-current-repl :and-return-value "*cider-repl xyz*")
-    (cider--test-selector-method ?r 'cider-repl-mode "*cider-repl xyz*")))
+    (cider-test-selector-method ?r 'cider-repl-mode "*cider-repl xyz*")))
 
 ;; FIXME: should work but doesn't with a nonsense error
 ;; (describe "cider-selector-method-m"
@@ -70,18 +58,18 @@
 ;;       (with-repl-buffer "a-session" 'clj _
 ;;         (setq-local nrepl-messages-buffer buf)
 ;;         (message "%S" (nrepl-messages-buffer (cider-current-repl)))
-;;         (cider--test-selector-method ?m nil "*nrepl-messages some-id*")))))
+;;         (cider-test-selector-method ?m nil "*nrepl-messages some-id*")))))
 
 (describe "cider-seletor-method-x"
   (it "switches to *cider-error* buffer"
-    (cider--test-selector-method ?x 'cider-stacktrace-mode "*cider-error*")))
+    (cider-test-selector-method ?x 'cider-stacktrace-mode "*cider-error*")))
 
 (describe "cider-seletor-method-d"
   (it "switches to *cider-doc* buffer"
-    (cider--test-selector-method ?d 'cider-stacktrace-mode "*cider-doc*")))
+    (cider-test-selector-method ?d 'cider-stacktrace-mode "*cider-doc*")))
 
 (describe "cider-seletor-method-s"
   :var (cider-scratch-find-or-create-buffer)
   (it "switches to *cider-scratch* buffer"
     (spy-on 'cider-scratch-find-or-create-buffer :and-return-value "*cider-scratch*")
-    (cider--test-selector-method ?s 'cider-docview-mode "*cider-scratch*")))
+    (cider-test-selector-method ?s 'cider-docview-mode "*cider-scratch*")))

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -374,3 +374,21 @@ and some other vars (like clojure.core/filter).
       (expect (cider--find-symbol-xref) :to-equal "clojure.core/map")
       (expect (cider--find-symbol-xref) :to-equal "clojure.core/filter")
       (expect (cider--find-symbol-xref) :to-equal nil))))
+
+(describe "major-mode-predicates"
+  (with-temp-buffer
+    (it "matches clojure-mode"
+      (clojure-mode)
+      (expect (cider-clojure-major-mode-p) :to-be-truthy)
+      (expect (cider-clojurescript-major-mode-p) :not :to-be-truthy)
+      (expect (cider-clojurec-major-mode-p) :not :to-be-truthy))
+    (it "matches clojurescript-mode"
+      (clojurescript-mode)
+      (expect (cider-clojure-major-mode-p) :to-be-truthy)
+      (expect (cider-clojurescript-major-mode-p) :to-be-truthy)
+      (expect (cider-clojurec-major-mode-p) :not :to-be-truthy))
+    (it "matches clojurec-mode"
+      (clojurec-mode)
+      (expect (cider-clojure-major-mode-p) :to-be-truthy)
+      (expect (cider-clojurescript-major-mode-p) :not :to-be-truthy)
+      (expect (cider-clojurec-major-mode-p) :to-be-truthy))))

--- a/test/clojure-ts-mode/cider-connection-ts-tests.el
+++ b/test/clojure-ts-mode/cider-connection-ts-tests.el
@@ -56,5 +56,3 @@
       (expect (cider-repl-type-for-buffer) :to-be 'multi))))
 
 (provide 'cider-connection-ts-tests)
-
-;;; clojure-connection-ts-tests.el ends here

--- a/test/clojure-ts-mode/cider-connection-ts-tests.el
+++ b/test/clojure-ts-mode/cider-connection-ts-tests.el
@@ -1,0 +1,60 @@
+;;; cider-connection-ts-tests.el  -*- lexical-binding: t; -*-
+
+;; Copyright © 2012-2023 Tim King, Bozhidar Batsov
+
+;; Author: Tim King <kingtim@gmail.com>
+;;         Bozhidar Batsov <bozhidar@batsov.dev>
+;;         Artur Malabarba <bruce.connor.am@gmail.com>
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; This file is part of CIDER
+
+;;; Code:
+
+(require 'buttercup)
+(require 'clojure-ts-mode)
+(require 'cider-connection)
+
+(describe "Enable cider-minor mode on clojure-ts-mode buffers"
+  (setq clojure-ts-mode-hook nil)
+  (with-temp-buffer
+    (clojure-ts-mode)
+    (it "should enable cider-mode in the clojure-ts-mode buffer"
+      (cider-enable-on-existing-clojure-buffers)
+      (expect local-minor-modes :to-contain 'cider-mode)
+      (expect clojure-ts-mode-hook :to-contain #'cider-mode))
+    (it "should disable cider-mode in the clojure-ts-mode-buffer"
+      (cider-disable-on-existing-clojure-buffers)
+      (expect local-minor-modes :not :to-contain 'cider-mode))))
+
+(describe "cider-repl-type-for-buffers"
+  (it "correctly detects corresponding repl type based on clojure-ts-* major mode"
+    (with-temp-buffer
+      (clojure-ts-mode)
+      (expect (cider-repl-type-for-buffer) :to-be 'clj))
+    (with-temp-buffer
+      (clojurescript-ts-mode)
+      (expect (cider-repl-type-for-buffer) :to-be 'cljs))
+    (with-temp-buffer
+      (clojurec-ts-mode)
+      (expect (cider-repl-type-for-buffer) :to-be 'multi))))
+
+(provide 'cider-connection-ts-tests)
+
+;;; clojure-connection-ts-tests.el ends here

--- a/test/clojure-ts-mode/cider-selector-ts-tests.el
+++ b/test/clojure-ts-mode/cider-selector-ts-tests.el
@@ -1,0 +1,40 @@
+;;; cider-selector-ts-tests.el  -*- lexical-binding: t; -*-
+
+;; Copyright © 2012-2023 Tim King, Bozhidar Batsov
+
+;; Author: Tim King <kingtim@gmail.com>
+;;         Bozhidar Batsov <bozhidar@batsov.dev>
+;;         Artur Malabarba <bruce.connor.am@gmail.com>
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; This file is part of CIDER
+
+;;; Code:
+
+(require 'buttercup)
+(require 'clojure-ts-mode)
+(require 'cider-selector-test-utils "test/cider-selector-tests")
+
+(describe "cider-seletor-method-c"
+  (it "switches to most recently visited clojure-ts-mode buffer"
+    (cider-test-selector-method ?c 'clojure-ts-mode "*treesitter-test*.clj")))
+
+(provide 'cider-selector-ts-tests)
+
+;;; clojure-selector-ts-tests.el ends here

--- a/test/clojure-ts-mode/cider-selector-ts-tests.el
+++ b/test/clojure-ts-mode/cider-selector-ts-tests.el
@@ -36,5 +36,3 @@
     (cider-test-selector-method ?c 'clojure-ts-mode "*treesitter-test*.clj")))
 
 (provide 'cider-selector-ts-tests)
-
-;;; clojure-selector-ts-tests.el ends here

--- a/test/clojure-ts-mode/cider-util-ts-tests.el
+++ b/test/clojure-ts-mode/cider-util-ts-tests.el
@@ -1,0 +1,61 @@
+;;; cider-util-ts-tests.el  -*- lexical-binding: t; -*-
+
+;; Copyright © 2012-2023 Tim King, Bozhidar Batsov
+
+;; Author: Tim King <kingtim@gmail.com>
+;;         Bozhidar Batsov <bozhidar@batsov.dev>
+;;         Artur Malabarba <bruce.connor.am@gmail.com>
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+
+;;; Commentary:
+
+;; This file is part of CIDER
+
+;;; Code:
+
+(require 'buttercup)
+(require 'clojure-ts-mode)
+(require 'cider-util)
+
+(describe "clojure-ts-mode activation"
+  (it "test suite installs the tree-sitter-clojure grammar"
+    (with-temp-buffer
+      (clojure-ts-mode)
+      (expect (treesit-ready-p 'clojure)))))
+
+(describe "major-mode-predicates"
+  (with-temp-buffer
+    (it "matches clojure-ts-mode"
+      (clojure-ts-mode)
+      (expect (cider-clojure-major-mode-p) :to-be-truthy)
+      (expect (cider-clojurescript-major-mode-p) :not :to-be-truthy)
+      (expect (cider-clojurec-major-mode-p) :not :to-be-truthy))
+    (it "matches clojurescript-ts-mode"
+      (clojurescript-ts-mode)
+      (expect (cider-clojure-major-mode-p) :to-be-truthy)
+      (expect (cider-clojurescript-major-mode-p) :to-be-truthy)
+      (expect (cider-clojurec-major-mode-p) :not :to-be-truthy))
+    (it "matches clojurec-ts-mode"
+      (clojurec-ts-mode)
+      (expect (cider-clojure-major-mode-p) :to-be-truthy)
+      (expect (cider-clojurescript-major-mode-p) :not :to-be-truthy)
+      (expect (cider-clojurec-major-mode-p) :to-be-truthy))))
+
+(provide 'cider-ts-util-tests)
+
+;;; cider-util-ts-tests.el ends here

--- a/test/clojure-ts-mode/cider-util-ts-tests.el
+++ b/test/clojure-ts-mode/cider-util-ts-tests.el
@@ -57,5 +57,3 @@
       (expect (cider-clojurec-major-mode-p) :to-be-truthy))))
 
 (provide 'cider-ts-util-tests)
-
-;;; cider-util-ts-tests.el ends here

--- a/test/integration/integration-tests.el
+++ b/test/integration/integration-tests.el
@@ -549,5 +549,3 @@ If CLI-COMMAND is nil, then use the default."
                 ;; wait for the REPL to exit
                 (cider-itu-poll-until (not (eq (process-status nrepl-proc) 'run)) 15)
                 (expect (member (process-status nrepl-proc) '(exit signal)))))))))))
-
-;;; integration-tests.el ends here

--- a/test/utils/cider-selector-test-utils.el
+++ b/test/utils/cider-selector-test-utils.el
@@ -1,0 +1,49 @@
+;;; cider-selector-test-utils.el  -*- lexical-binding: t; -*-
+
+;; Copyright © 2012-2023 Tim King, Bozhidar Batsov
+
+;; Author: Tim King <kingtim@gmail.com>
+;;         Bozhidar Batsov <bozhidar@batsov.dev>
+;;         Artur Malabarba <bruce.connor.am@gmail.com>
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; This file is part of CIDER
+
+;;; Code:
+
+(require 'buttercup)
+(require 'cider-selector)
+
+(defun cider-invoke-selector-method-by-key (ch)
+  (let ((method (cl-find ch cider-selector-methods :key #'car)))
+    (funcall (cl-third method))))
+
+(defun cider-test-selector-method (method buffer-mode buffer-name)
+  (with-temp-buffer
+    (rename-buffer buffer-name)
+    (setq major-mode buffer-mode)
+    (let ((expected-buffer (current-buffer)))
+      ;; switch to another buffer
+      (with-temp-buffer
+        (cider-invoke-selector-method-by-key method)
+        (expect (current-buffer) :to-equal expected-buffer)))))
+
+(provide 'cider-selector-test-utils)
+
+;;; clojure-selector-test-utilss.el ends here


### PR DESCRIPTION
This does NOT intended to break the dependency from cider to clojure-mode. It is intended to make CIDER work with clojure-ts-mode.

Some functionality like clojure-find-ns, clojure-find-def, etc will still require clojure-mode in order for CIDER to get it's work done.

~I'm at a loss for how to run the tests for this project locally.~ If there are any tests I could write that make sense for these changes I am open to suggestions.

PR is in draft mode because I still need to see where it makes sense to include references to clojure-ts-mode in the documentation.

-----------------

- [X] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
