### PR TITLE
Add buffer-local caching to friendly-session calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - Improve the presentation of `xref` data.
 - [#3419](https://github.com/clojure-emacs/cider/issues/3419): Also match friendly sessions based on the buffer's ns form.
 - Always match friendly sessions for `cider-ancillary-buffers` (like `*cider-error*`, `*cider-result*`, etc).
+- Add buffer-local caching to friendly-session calculation.
 - `cider-test`: only show diffs for collections.
 - [#3375](https://github.com/clojure-emacs/cider/pull/3375): `cider-test`: don't render a newline between expected and actual, most times.
 - Ensure there's a leading `:` when using `cider-clojure-cli-aliases`.

--- a/cider-common.el
+++ b/cider-common.el
@@ -309,11 +309,8 @@ whether DIRECTION is 'from-nrepl or 'to-nrepl."
   "Returns the Unix time."
   (float-time))
 
-(defvar cider--all-path-translations-calculated-at nil)
-
 (defun cider--all-path-translations ()
   "Returns `cider-path-translations' if non-empty, else seeks a present value."
-  (setq cider--all-path-translations-calculated-at (cider--unix-time))
   (or cider-path-translations
       ;; cider-path-translations often is defined as a directory-local variable,
       ;; so after jumping to a .jar file, its value can be lost,

--- a/cider-common.el
+++ b/cider-common.el
@@ -306,8 +306,8 @@ whether DIRECTION is 'from-nrepl or 'to-nrepl."
         (seq-some f cider-path-translations)))))
 
 (defun cider--unix-time ()
-  "Returns the Unix time in seconds."
-  (floor (float-time)))
+  "Returns the Unix time."
+  (float-time))
 
 (defvar cider--all-path-translations-calculated-at nil)
 

--- a/cider-common.el
+++ b/cider-common.el
@@ -305,8 +305,15 @@ whether DIRECTION is 'from-nrepl or 'to-nrepl."
           (seq-filter #'identity (mapcar f cider-path-translations))
         (seq-some f cider-path-translations)))))
 
+(defun cider--unix-time ()
+  "Returns the Unix time in seconds."
+  (floor (float-time)))
+
+(defvar cider--all-path-translations-calculated-at nil)
+
 (defun cider--all-path-translations ()
   "Returns `cider-path-translations' if non-empty, else seeks a present value."
+  (setq cider--all-path-translations-calculated-at (cider--unix-time))
   (or cider-path-translations
       ;; cider-path-translations often is defined as a directory-local variable,
       ;; so after jumping to a .jar file, its value can be lost,

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -230,7 +230,7 @@ Currently its only purpose is to facilitate `cider-repl-clear-buffer'.")
 This cache is stored in the connection buffer.")
 
 (defvar-local cider-repl-ns-cached-at nil
-  "As Unix time in seconds.")
+  "As Unix time.")
 
 (defvar cider-mode)
 (declare-function cider-refresh-dynamic-font-lock "cider-mode")

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1762,6 +1762,11 @@ constructs."
   nil
   "A <repl buffer> -> <latest 'friendly' calculation unix time> hashmap.")
 
+(defvar-local cider--sesman-friendly-session-last-path-translations
+  nil
+  "The latest perceived value of (cider--all-path-translations)
+in this buffer.")
+
 (defun cider--sesman-friendly-session-p (session &optional debug)
   "Check if SESSION is a friendly session, DEBUG optionally.
 
@@ -1816,11 +1821,11 @@ The checking is done as follows:
               (setq cider--sesman-friendly-session-result (nrepl-dict)))
 
             (let ((calculated-at (nrepl-dict-get cider--sesman-friendly-session-calculated-at repl))
-                  (cider-path-translations (cider--all-path-translations)))
+                  (cider-path-translations (cider--all-path-translations))
+                  (cider-repl-ns-cached-at (buffer-local-value 'cider-repl-ns-cached-at repl)))
               (if (and calculated-at
-                       (or (not cider--all-path-translations-calculated-at)
-                           (> calculated-at
-                              cider--all-path-translations-calculated-at))
+                       (equal cider--sesman-friendly-session-last-path-translations
+                              cider-path-translations)
                        (or (not cider-repl-ns-cached-at)
                            (> calculated-at
                               cider-repl-ns-cached-at))
@@ -1859,6 +1864,8 @@ The checking is done as follows:
                                      (member ns ns-list))))
                              (when debug
                                (list file "was not determined to belong to classpath:" classpath "or classpath-roots:" classpath-roots)))))
+
+                  (setq cider--sesman-friendly-session-last-path-translations cider-path-translations)
 
                   (nrepl-dict-put cider--sesman-friendly-session-calculated-at repl (cider--unix-time))
 


### PR DESCRIPTION
Friendly session calculation has always be at least a touch slow ([ref](https://github.com/clojure-emacs/cider/issues/3344), [ref](https://github.com/clojure-emacs/clojure-mode/issues/665#issuecomment-1716440552)), and even more so following recent additions to it.

All slow paths have in common that they run `seq-find` over a series of sequences (the classpath, classpath roots, the ns list). Those can be arbitrarily large.

We may do relatively expensive stuff for each element, like trying to match a string.

So, this PR adds buffer-local caching.

The buffer-local caching is essentially this map:

`<repl buffer>` -> `<is this buffer considered friendly to it?>`

There are timestamps to ensure that we're not basing the caching on stale data.

---

From a quick test, it appears to work. Anyway I'll keep this as a draft to give it at least a couple days of QAing. Review welcome!