### PR TITLE
Discover nbb through nrepl describe #3466

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
   * It will be progressively refined and documented, please consider this alpha software.
 
 ### Bugs fixed
-
+- [#3466](https://github.com/clojure-emacs/cider/issues/3466): Fix jvm nrepl startup performance (36% improvement).
 - [#3341](https://github.com/clojure-emacs/cider/issues/3341): Escape clojure-cli args on MS-Windows on non powershell invocations.
 - [#3353](https://github.com/clojure-emacs/cider/issues/3353): Fix regression which caused new connections to prompt for reusing dead REPLs.
 - [#3355](https://github.com/clojure-emacs/cider/pull/3355): Fix `cider-mode` disabling itself after a disconnect when `cider-auto-mode` is set to nil.

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -453,7 +453,10 @@ process buffer."
       (nrepl-dict-get nrepl-versions "babashka.nrepl"))))
 
 (defun cider--nbb-nrepl-version ()
-  "Retrieve the underlying connection's babashka.nrepl version."
+  "Retrieve the underlying connection's nbb version.
+
+Note that this is currently not a real version number.
+But helps us know if this is a nbb repl, or not."
   (with-current-buffer (cider-current-repl)
     (when nrepl-versions
       (nrepl-dict-get nrepl-versions "nbb-nrepl"))))

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -399,6 +399,8 @@ buffer."
        (when cider-auto-mode
          (cider-enable-on-existing-clojure-buffers))
 
+       (cider-nrepl-request:eval "warm-up" #'ignore)
+
        (run-hooks 'cider-connected-hook)))))
 
 (defun cider--disconnected-handler ()

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -358,6 +358,7 @@ See `cider-connection-capabilities'."
 (declare-function cider--debug-init-connection "cider-debug")
 (declare-function cider-repl-init "cider-repl")
 (declare-function cider-nrepl-op-supported-p "cider-client")
+(declare-function cider-nrepl-request:eval "cider-client")
 (defun cider--connected-handler ()
   "Handle CIDER initialization after nREPL connection has been established.
 This function is appended to `nrepl-connected-hook' in the client process

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -349,15 +349,10 @@ See `cider-connection-capabilities'."
            (pcase (cider-runtime)
              ('clojure '(clojure jvm-compilation-errors))
              ('babashka '(babashka jvm-compilation-errors))
+             ('nbb '(cljs))
              (_ '()))
            (when
-               (or
-                (eq cider-repl-type 'cljs)
-                ;; This check is currently basically for nbb.
-                ;; See `cider-sync-tooling-eval', but it is defined on a higher layer
-                (nrepl-dict-get
-                 (nrepl-sync-request:eval "cljs.core/demunge" (current-buffer) nil 'tooling)
-                 "value"))
+               (eq cider-repl-type 'cljs)
              '(cljs))))))
 
 (declare-function cider--debug-init-connection "cider-debug")
@@ -457,11 +452,18 @@ process buffer."
     (when nrepl-versions
       (nrepl-dict-get nrepl-versions "babashka.nrepl"))))
 
+(defun cider--nbb-nrepl-version ()
+  "Retrieve the underlying connection's babashka.nrepl version."
+  (with-current-buffer (cider-current-repl)
+    (when nrepl-versions
+      (nrepl-dict-get nrepl-versions "nbb-nrepl"))))
+
 (defun cider-runtime ()
   "Return the runtime of the nREPl server."
   (cond
    ((cider--clojure-version) 'clojure)
    ((cider--babashka-version) 'babashka)
+   ((cider--nbb-nrepl-version) 'nbb)
    (t 'generic)))
 
 (defun cider-runtime-clojure-p ()


### PR DESCRIPTION
> Fixes https://github.com/clojure-emacs/cider/issues/3466

See issue.

The main idea for the dynamic discovery of the nrepl server capabilities was that you start out with a blank repl
and it augments itself by discovering the server.

The eval during startup was a hit of 1.6 seconds on my machine and 2 for vemv.

1. This check was currently only done for nbb connections (when connecting with cider-connect-clj)
2. For nbb, we do have a version from the describe op, so we already can say if it is nbb, or not

So the current change is to rely on the nrepl descibe op.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [X] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
