### PR TITLE
Eldev: enable slightly longer docstring first sentences

### DIFF
--- a/Eldev
+++ b/Eldev
@@ -33,6 +33,9 @@
     (signal 'eldev-wrong-option-usage `("unknown test type `%s'" ,type)))
   (setf cider-test-type (intern type)))
 
+(setq byte-compile-docstring-max-column 100) ;; slightly increase the maximum (applies to checkdoc and the byte compiler alike)
+(setq checkdoc-permit-comma-termination-flag t) ;; allow commas to indicate that the first sentence continues, which enables longer first sentences
+
 (add-hook 'eldev-test-hook
           (lambda ()
             (eldev-verbose "Using cider tests of type `%s'" cider-test-type)))


### PR DESCRIPTION
A frequent pain I perceive is that when adding new parameters to an Elisp defun, I can hardly document them in a way that:

* satisfies Eldev; and
* makes sense / is fully informative to maintainers _at the same time_.

By enabling `checkdoc-permit-comma-termination-flag`, we allow a comma to indicate that the docstring continues. Any character other than a comma or a period will not pass the linter, as usual.

An example of a would-be refactoring that would be allowed:

```diff
-  "Emit into BUFFER formatted INFO for the Clojure or Java symbol."
+  "Emit into BUFFER formatted INFO for the Clojure or Java symbol,
+in a SHORTER format is specified."
```

I also tentatively increased the limit to 100 - logically, in English a comma cannot be placed anywhere, so the more headroom we have the better.

I verified these work as intended (clj-refactor.el is using them).

Cheers - V