### PR TITLE
Don't require `cider-log` eagerly

### DIFF
--- a/cider-log.el
+++ b/cider-log.el
@@ -792,6 +792,7 @@ The KEYS are used to lookup the values and are joined by SEPARATOR."
   "Return the log event at point."
   (get-text-property (point) :cider-log-event))
 
+;;;###autoload (autoload 'cider-log-info "cider-log-info" "Show the Cider log current log buffer, framework, appender and consumer." t)
 (defun cider-log-info ()
   "Show the current log buffer, framework, appender and consumer."
   (interactive)

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -33,7 +33,6 @@
 
 (require 'clojure-mode)
 (require 'cider-eval)
-(require 'cider-log)
 (require 'cider-test) ; required only for the menu
 (require 'cider-eldoc)
 (require 'cider-resolve)
@@ -531,6 +530,7 @@ higher precedence."
     (define-key map (kbd "C-c C-? C-d") #'cider-xref-fn-deps-select)
     (define-key map (kbd "C-c C-q") #'cider-quit)
     (define-key map (kbd "C-c M-r") #'cider-restart)
+    ;; NOTE: all cider-log* vars are autoloaded. Please do not add a require.
     (define-key map (kbd "C-c M-l a") #'cider-log-appender)
     (define-key map (kbd "C-c M-l c") #'cider-log-consumer)
     (define-key map (kbd "C-c M-l e") #'cider-log-event)


### PR DESCRIPTION
The now-removed `require` was adding some startup performance overhead (as it has transitive dependencies), and most importantly, its https://github.com/magit/transient dep appears to have an issue under Emacs 29 (I'm currently investigating it prior to reporting it).

cider-log.el has autoloads in place - only one was missing so the `require` removal seems safe. Still, I'd be much thankful you could try it out - I still haven't gotten to try out cider-log as I'm busy with misc features.

Cheers - V