### PR TITLE
Fix keybindings in cider scratch buffer with newer versions of paredit

### DIFF
--- a/cider-scratch.el
+++ b/cider-scratch.el
@@ -48,6 +48,7 @@
     (set-keymap-parent map clojure-mode-map)
     (define-key map (kbd "C-j") #'cider-eval-print-last-sexp)
     (define-key map [remap paredit-newline] #'cider-eval-print-last-sexp)
+    (define-key map [remap paredit-C-j] #'cider-eval-print-last-sexp)
     (easy-menu-define cider-clojure-interaction-mode-menu map
       "Menu for Clojure Interaction mode"
       '("Clojure Interaction"


### PR DESCRIPTION

 - `C-j` is bound to a different function in newer versions of paredit.
 https://github.com/emacsmirror/paredit/commit/5615023023aea50683f5725284fb9bc6cbbd64ec
