### PR TITLE
Fix `cider-insert-commands-map` variable initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Fix the `cider-xref-fn-deps` buttons to direct to the right file.
 - Fix the `cider-find-keyword` overall reliability and correctness, particularly for ClojureScript.
 - Make TRAMP functionality work when using non-standard ports.
+- Fix the `cider-insert-commands-map` variable initialization.
 
 ### Changes
 

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -204,7 +204,8 @@ With a prefix argument, prompt for function to run instead of -main."
     (define-key map (kbd "C-e") #'cider-insert-last-sexp-in-repl)
     (define-key map (kbd "C-d") #'cider-insert-defun-in-repl)
     (define-key map (kbd "C-r") #'cider-insert-region-in-repl)
-    (define-key map (kbd "C-n") #'cider-insert-ns-form-in-repl)))
+    (define-key map (kbd "C-n") #'cider-insert-ns-form-in-repl)
+    map))
 
 (defcustom cider-switch-to-repl-on-insert t
   "Whether to switch to the REPL when inserting a form into the REPL."


### PR DESCRIPTION
Let form must return sparse map instead of result of define-key function.