### PR TITLE
Refine `cider-test-run-test`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - [#3354](https://github.com/clojure-emacs/cider/issues/3354): Add new customization variable `cider-reuse-dead-repls` to control how dead REPL buffers are reused on new connections.
 - [#3364](https://github.com/clojure-emacs/cider/pull/3364): Update enrich-classpath, adding Clojure CLI compatibility, and reworking its integration into CIDER.
   * It will be progressively refined and documented, please consider this alpha software.
+- [#2958](https://github.com/clojure-emacs/cider/issues/2958), [#3279](https://github.com/clojure-emacs/cider/issues/3279): `cider-test-run-test`: support arbitrary deftest-like forms, defns with :test metadata, and search for a `-test` counterpart for a given defn (following `cider-test-infer-test-ns` logic).
+  - This also makes obsolete the `cider-test-defining-forms` customization variable.
 
 ### Bugs fixed
 

--- a/cider-test.el
+++ b/cider-test.el
@@ -875,7 +875,7 @@ or in a corresponding test namespace is searched."
          (found-ns (car found))
          (found-var (cadr found)))
     (if (not found-var)
-        (message "No test found for the function at point")
+        (message "No test found at point")
       (cider-test-update-last-test found-ns (list found-var))
       (cider-test-execute found-ns (list found-var)))))
 

--- a/doc/modules/ROOT/pages/testing/running_tests.adoc
+++ b/doc/modules/ROOT/pages/testing/running_tests.adoc
@@ -85,7 +85,8 @@ command with a prefix (kbd:[C-u C-c C-t C-s]) you can suppress
 the namespace inference logic as for kbd:[C-u C-c C-t C-n]
 
 Finally, you can execute the specific test at the point using
-kbd:[C-c C-t t] or kbd:[C-c C-t C-t].
+kbd:[C-c C-t t] or kbd:[C-c C-t C-t]. It will also work for implementation functions,
+by searching for a matching test namespace with a matching deftest name. 
 
 == Configuration
 
@@ -140,13 +141,6 @@ selectors so that tests tagged as "integration" or "flakey" don't run.
 ----
 
 TIP: You'll generally want to place default selectors in xref:config/project_config.adoc[your project configuration], as opposed to your global configuration.
-
-=== Macros Used to Define Tests
-
-If your individual tests are not defined by `deftest` or `defspec`, CIDER will
-not recognize them when searching for a test at point in `cider-test-run-test`.
-You can customize the variable `cider-test-defining-forms` to add additional
-forms for CIDER to recognize as individual test definitions.
 
 === Display Test Report on Success
 

--- a/doc/modules/ROOT/pages/usage/cider_mode.adoc
+++ b/doc/modules/ROOT/pages/usage/cider_mode.adoc
@@ -223,7 +223,7 @@ kbd:[C-c C-d C-e]
 | `cider-test-run-test`
 | kbd:[C-c C-t t] +
 kbd:[C-c C-t C-t]
-| Run test at point.
+| Run test at point. If the form under the point is a function, try to search and run a corresponding test.
 
 | `cider-test-rerun-test`
 | kbd:[C-c C-t a] +


### PR DESCRIPTION
> Fixes #2958
> Fixes #3279

Rehash of https://github.com/clojure-emacs/cider/pull/3480 with all my feedback directly applied.

Under this approach, cider-test-run-test will run the first valid test found by:

* tests marked by text properties
* deftests, and deftest-like forms (`cider-test-defining-forms` is no longer necessary)
* :test metadata that may be present in vanilla defns
* deftests, as found by `cider-test-infer-test-ns`
  * We search for a var named `foo-test`, falling back to `foo` (e.g. `deftest foo` - less idiomatic, but quite frequent)

All this lookup is very fast when cider-nrepl is present, since we use `cider-resolve--get-in`. It falls back to eval if we're on bare nrepl.

In a future, we can further search tests by leveraging `xref` functionality - but it's not as important now.

Special thanks to @tvirolai!