### PR TITLE
Introduce `cider-inspector-preferred-var-names`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@
 - [#3419](https://github.com/clojure-emacs/cider/issues/3419): Also match friendly sessions based on the buffer's ns form.
 - Always match friendly sessions for `cider-ancillary-buffers` (like `*cider-error*`, `*cider-result*`, etc).
 - `cider-test`: only show diffs for collections.
-- `cider-inspector-def-current-val` now suggests a var name, which can be customized via `cider-inspector-preferred-var-names`.
+- `cider-inspector-def-current-val` now can suggest a var name (default none), which can be customized via `cider-inspector-preferred-var-names`.
 - [#3375](https://github.com/clojure-emacs/cider/pull/3375): `cider-test`: don't render a newline between expected and actual, most times.
 - Ensure there's a leading `:` when using `cider-clojure-cli-aliases`.
 - Improve `nrepl-dict` error reporting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - [#3419](https://github.com/clojure-emacs/cider/issues/3419): Also match friendly sessions based on the buffer's ns form.
 - Always match friendly sessions for `cider-ancillary-buffers` (like `*cider-error*`, `*cider-result*`, etc).
 - `cider-test`: only show diffs for collections.
+- `cider-inspector-def-current-val` now suggests a var name, which can be customized via `cider-inspector-preferred-var-names`.
 - [#3375](https://github.com/clojure-emacs/cider/pull/3375): `cider-test`: don't render a newline between expected and actual, most times.
 - Ensure there's a leading `:` when using `cider-clojure-cli-aliases`.
 - Improve `nrepl-dict` error reporting.

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -274,7 +274,7 @@ MAX-SIZE is the new value."
   (when-let ((value (cider-sync-request:inspect-set-max-coll-size max-size)))
     (cider-inspector--render-value value)))
 
-(defcustom cider-inspector-preferred-var-names '("X")
+(defcustom cider-inspector-preferred-var-names nil
   "The preferred var names to be suggested by `cider-inspector-def-current-val'.
 
 If you choose a different one while completing interactively,

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -274,13 +274,33 @@ MAX-SIZE is the new value."
   (when-let ((value (cider-sync-request:inspect-set-max-coll-size max-size)))
     (cider-inspector--render-value value)))
 
+(defcustom cider-inspector-preferred-var-names '("X")
+  "The preferred var names to be suggested by `cider-inspector-def-current-val'.
+
+If you choose a different one while completing interactively,
+it will be included (in the first position) the next time
+you use `cider-inspector-def-current-val'."
+  :type '(repeat string)
+  :group 'cider
+  :package-version '(cider . "1.8.0"))
+
+(defun cider-inspector--read-var-name-from-user (ns)
+  "Reads a var name from the user, to be defined within NS.
+Grows `cider-inspector-preferred-var-names' if the user chose a new name,
+making that new name take precedence for subsequent usages."
+  (let ((v (completing-read (format "Name of the var to be defined in ns %s: " ns)
+                            cider-inspector-preferred-var-names)))
+    (unless (member v cider-inspector-preferred-var-names)
+      (setq cider-inspector-preferred-var-names (cons v cider-inspector-preferred-var-names)))
+    v))
+
 (defun cider-inspector-def-current-val (var-name ns)
   "Defines a var with VAR-NAME in current namespace.
 
 Doesn't modify current page.  When called interactively NS defaults to
 current-namespace."
   (interactive (let ((ns (cider-current-ns)))
-                 (list (read-from-minibuffer (concat "Var name: " ns "/"))
+                 (list (cider-inspector--read-var-name-from-user ns)
                        ns)))
   (setq cider-inspector--current-repl (cider-current-repl))
   (when-let* ((value (cider-sync-request:inspect-def-current-val ns var-name)))

--- a/doc/modules/ROOT/pages/debugging/inspector.adoc
+++ b/doc/modules/ROOT/pages/debugging/inspector.adoc
@@ -60,7 +60,8 @@ You'll have access to additional keybindings in the inspector buffer
 
 | kbd:[d]
 | Defines a var in the REPL namespace with current inspector value.
-| The name `X` will be suggested. You can choose another one, which will take priority.
+| If you tend to always choose the same name,
+| you way want to set the `cider-inspector-preferred-var-names` customization option.
 |===
 
 == Configuration
@@ -82,8 +83,10 @@ If you enable `cider-inspector-fill-frame`, the inspector window fills its
 frame.
 
 Starting from CIDER 1.8.0, when you define a var using kbd:[d],
-the var name `X` will be suggested. You can customize this value
+a var name can be suggested (default none). You can customize this value
 via the `cider-inspector-preferred-var-names` configuration option.  
+Even after setting it, you are free to choose new names on the fly,
+as you type. Most recent names will take priority in subsequent usages.
 
 == Additional Resources
 

--- a/doc/modules/ROOT/pages/debugging/inspector.adoc
+++ b/doc/modules/ROOT/pages/debugging/inspector.adoc
@@ -59,7 +59,8 @@ You'll have access to additional keybindings in the inspector buffer
 | Set a new maximum length above which nested atoms (non-collections) are truncated
 
 | kbd:[d]
-| Defines a var in the REPL namespace with current inspector value
+| Defines a var in the REPL namespace with current inspector value.
+| The name `X` will be suggested. You can choose another one, which will take priority.
 |===
 
 == Configuration
@@ -79,6 +80,10 @@ inspector buffer using the `s`, `c`, and `a` keybindings.
 
 If you enable `cider-inspector-fill-frame`, the inspector window fills its
 frame.
+
+Starting from CIDER 1.8.0, when you define a var using kbd:[d],
+the var name `X` will be suggested. You can customize this value
+via the `cider-inspector-preferred-var-names` configuration option.  
 
 == Additional Resources
 


### PR DESCRIPTION
I found that the `cider-inspector-def-current-val` prompt makes me think excessively.

90% of the times I want to use the same var name. So I propose CIDER suggests the name `X`, customizable.

(capital `X` to prevent clashes with locally-scoped `x` variables - very common)

The user can always customize it to something else, or choose something else on the fly.

(On-the-fly choices will take precedence in subsequent usages)

After implementing this, I found an interesting usage pattern: maybe I want to repeatedly re-define X and Y - each slot for a different kind of thing. It's really handy to have a `completing-read` for those, so that I don't forget/mistype those two names (which may be longer names if the case calls for it).

Cheers - V