### PR TITLE
Fix `cider-test-rerun-failed-tests`

### DIFF
--- a/cider-test.el
+++ b/cider-test.el
@@ -710,11 +710,11 @@ running them."
               ;; we generate a different message when running individual tests
               (cider-test-echo-running ns (car tests))
             (cider-test-echo-running ns)))
-        (let ((retest? (eq :non-passing ns))
-              (request `("op" ,(cond ((stringp ns)         "test")
-                                     ((eq :project ns)     "test-all")
-                                     ((eq :loaded ns)      "test-all")
-                                     (retest?              "retest")))))
+        (let* ((retest? (eq :non-passing ns))
+               (request `("op" ,(cond ((stringp ns)         "test")
+                                      ((eq :project ns)     "test-all")
+                                      ((eq :loaded ns)      "test-all")
+                                      (retest?              "retest")))))
           ;; we add optional parts of the request only when relevant
           (when (and (listp include-selectors) include-selectors)
             (setq request (append request `("include" ,include-selectors))))


### PR DESCRIPTION
Fixes https://github.com/clojure-emacs/cider/issues/3484

This was a bug introduced in 74be055295c92252a62f1d6647f75352d69c166c , so no changelog is needed.