### PR TITLE
cider--sesman-friendly-session-p: check for `ns-list` op availability

### DIFF
--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1778,11 +1778,12 @@ The checking is done as follows:
                                             (cider-classpath-entries))))
                                   (process-put proc :cached-classpath cp)
                                   cp)))
-                 (ns-list (or (process-get proc :all-namespaces)
-                              (let ((ns-list (with-current-buffer repl
-                                               (cider-sync-request:ns-list))))
-                                (process-put proc :all-namespaces ns-list)
-                                ns-list)))
+                 (ns-list (when (nrepl-op-supported-p "ns-list" repl)
+                            (or (process-get proc :all-namespaces)
+                                (let ((ns-list (with-current-buffer repl
+                                                 (cider-sync-request:ns-list))))
+                                  (process-put proc :all-namespaces ns-list)
+                                  ns-list))))
                  (classpath-roots (or (process-get proc :cached-classpath-roots)
                                       (let ((cp (thread-last classpath
                                                              (seq-filter (lambda (path) (not (string-match-p "\\.jar$" path))))


### PR DESCRIPTION
This speeds up `(cider-current-repl)` performance in non-linked buffers from to 0.01s to 0.0001s.

Because `(cider-current-repl)` can be repeatedly invoked by e.g. `electric-indent-mode`, the numbers make a difference.

No changelog is needed because the ns-list logic was introduced recently.

Fixes https://github.com/clojure-emacs/clojure-mode/issues/665 (which mostly affects Babashka users, or users using bare nrepl without cider-nrepl)

Cheers - V
