### PR TITLE
Bump `parseedn`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - Improve `nrepl-dict` error reporting.
 - Bump the injected `piggieback` to [0.5.3](https://github.com/nrepl/piggieback/blob/0.5.3/CHANGES.md#053-2021-10-26).
 - Bump the `clojure-mode` required version, and use `clojure-find-ns` more safely, which fixes issues such as #[2849](https://github.com/clojure-emacs/cider/issues/2849).
+- Bump the `parseedn` require version, and wrap its usage with a more informative `user-error`.
 - Bump the injected `cider-nrepl` to [0.38.1](https://github.com/clojure-emacs/cider-nrepl/blob/v0.38.1/CHANGELOG.md#0381-2023-09-21).
   - Improves indentation, font-locking and other metadata support for ClojureScript.
   - Updates [Orchard](https://github.com/clojure-emacs/orchard/blob/v0.14.2/CHANGELOG.md)

--- a/cider.el
+++ b/cider.el
@@ -12,7 +12,7 @@
 ;; Maintainer: Bozhidar Batsov <bozhidar@batsov.dev>
 ;; URL: http://www.github.com/clojure-emacs/cider
 ;; Version: 1.8.0-snapshot
-;; Package-Requires: ((emacs "26") (clojure-mode "5.16.2") (parseedn "1.0.6") (queue "0.2") (spinner "1.7") (seq "2.22") (sesman "0.3.2") (transient "0.4.1"))
+;; Package-Requires: ((emacs "26") (clojure-mode "5.16.2") (parseedn "1.2.0") (queue "0.2") (spinner "1.7") (seq "2.22") (sesman "0.3.2") (transient "0.4.1"))
 ;; Keywords: languages, clojure, cider
 
 ;; This program is free software: you can redistribute it and/or modify

--- a/cider.el
+++ b/cider.el
@@ -1043,11 +1043,17 @@ The default options of `browser-repl' and `node-repl' are also included."
 (defun cider--shadow-get-builds ()
   "Extract build names from the shadow-cljs.edn config file in the project root."
   (let ((shadow-edn (concat (clojure-project-dir) "shadow-cljs.edn")))
-    (when (file-exists-p shadow-edn)
+    (when (file-readable-p shadow-edn)
       (with-temp-buffer
         (insert-file-contents shadow-edn)
-        (let ((hash (car (parseedn-read '((shadow/env . identity))))))
-          (cider--shadow-parse-builds hash))))))
+        (condition-case err
+            (let ((hash (car (parseedn-read '((shadow/env . identity)
+                                              (env . identity))))))
+              (cider--shadow-parse-builds hash))
+          (error
+           (user-error "Found an error while reading %s with message: %s"
+                       shadow-edn
+                       (error-message-string err))))))))
 
 (defun cider-shadow-select-cljs-init-form ()
   "Generate the init form for a shadow-cljs select-only REPL.


### PR DESCRIPTION
* Bump `parseedn`
  * https://github.com/clojure-emacs/parseedn/blob/v1.2.0/CHANGELOG.md#120-2023-09-29
* Improve the reliability of `cider--shadow-get-builds`
  * Less obstrusively than the previous attempt - we simply forward the error while adding an informative context

Build might be red until 1.2.0 is visible in MELPA - keeping it as a draft till then.

Cheers - V