### PR TITLE
Restore `cider--display-interactive-eval-result` overlays for compilation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,10 @@
 - [#3331](https://github.com/clojure-emacs/cider/issues/3331): `cider-eval`: never jump to spurious locations, as sometimes conveyed by nREPL.  
 - [#3112](https://github.com/clojure-emacs/cider/issues/3112): Fix the CIDER `xref-find-references` backend to return correct filenames.
 - [#3393](https://github.com/clojure-emacs/cider/issues/3393): recompute namespace info on each shadow-cljs recompilation or evaluation.
-- [#3402](https://github.com/clojure-emacs/cider/issues/3402): fix `cider-format-connection-params` edge case for Emacs 29.
+- [#3402](https://github.com/clojure-emacs/cider/issues/3402): Fix `cider-format-connection-params` edge case for Emacs 29.
 - [#3393](https://github.com/clojure-emacs/cider/issues/3393): Recompute namespace info on each shadow-cljs recompilation or evaluation.
 - Recompute namespace info on each fighweel-main recompilation.
-- [#3250](https://github.com/clojure-emacs/cider/issues/3250): don't lose the CIDER session over TRAMP files. 
+- [#3250](https://github.com/clojure-emacs/cider/issues/3250): Don't lose the CIDER session over TRAMP files. 
 - [#3413](https://github.com/clojure-emacs/cider/issues/3413): Make jump-to-definition work in projects needing `cider-path-translations` (i.e. Dockerized projects). 
 - [#2436](https://github.com/clojure-emacs/cider/issues/2436): Prevent malformed `cider-repl-history-file`s from failing `cider-jack-in`.
 - [#3456](https://github.com/clojure-emacs/cider/issues/3456): restore xref-based jump-to-definition in Babashka (and any nREPL clients not having cider-nrepl).

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -775,7 +775,7 @@ REPL buffer.  This is controlled via
             (cider--make-fringe-overlay (point)))
         (scan-error nil)))))
 
-(defun cider--error-phase-of-latest-exception (buffer)
+(defun cider--error-phase-of-last-exception (buffer)
   "Returns the :phase of the latest exception associated to BUFFER, if any."
   (when cider-clojure-compilation-error-phases
     (when-let ((conn (with-current-buffer buffer
@@ -813,7 +813,7 @@ when `cider-auto-inspect-after-eval' is non-nil."
                                  (lambda (buffer err)
                                    (cider-emit-interactive-eval-err-output err)
 
-                                   (let ((phase (cider--error-phase-of-latest-exception buffer)))
+                                   (let ((phase (cider--error-phase-of-last-exception buffer)))
                                      (when (or
                                             ;; if we won't show *cider-error*, because of configuration, the overlay is adequate because it compensates for the lack of info in a compact manner:
                                             (not cider-show-error-buffer)


### PR DESCRIPTION
Fixes https://github.com/clojure-emacs/cider/issues/3487

* `cider-interactive-eval-handler`: Check if the given exception's phase is ignored, and if so, display the overlay.
  * The general idea is, we either display the overlay or `*cider-error*` (not both, not none)
* Reuse the same computation ("is the phase ignored?") and if truthy, we avoid jumping to the compilation line (because for compilation errors, it's always the current one, while nrepl while tell us 0:0, which we cannot detect as spurious, client-side)

I've tested this out locally for all cases, and it works nicely.

No changelog is needed.

Cheers - V