### PR TITLE
Interactive evaluation: show a shorter overlay when rendering compilation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@
 - `cider-test`: only show diffs for collections.
 - `cider-inspector-def-current-val` now can suggest a var name (default none), which can be customized via `cider-inspector-preferred-var-names`.
 - [#3375](https://github.com/clojure-emacs/cider/pull/3375): `cider-test`: don't render a newline between expected and actual, most times.
+- Interactive evaluation: show a shorter overlay when rendering compilation errors.
+  - e.g., the `Syntax error compiling clojure.core/let at (foo/bar.clj:10:1)` prefix is now removed. 
 - Ensure there's a leading `:` when using `cider-clojure-cli-aliases`.
 - Improve `nrepl-dict` error reporting.
 - Bump the injected `piggieback` to [0.5.3](https://github.com/nrepl/piggieback/blob/0.5.3/CHANGES.md#053-2021-10-26).

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -822,9 +822,15 @@ when `cider-auto-inspect-after-eval' is non-nil."
                                             (and cider-show-error-buffer
                                                  (member phase cider-clojure-compilation-error-phases)))
                                        ;; Display errors as temporary overlays
-                                       (let ((cider-result-use-clojure-font-lock nil))
+                                       (let ((cider-result-use-clojure-font-lock nil)
+                                             (trimmed-err (thread-last err
+                                                                       (replace-regexp-in-string cider-clojure-compilation-regexp
+                                                                                                 "")
+                                                                       (string-trim))))
                                          (cider--display-interactive-eval-result
-                                          err end 'cider-error-overlay-face)))
+                                          trimmed-err
+                                          end
+                                          'cider-error-overlay-face)))
 
                                      (cider-handle-compilation-errors err
                                                                       eval-buffer

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -596,7 +596,16 @@ It delegates the actual error content to the eval or op handler."
    `(rx bol (or ,cider-clojure-1.9-error
                 ,cider-clojure-warning
                 ,cider-clojure-1.10-error))
-   t))
+   t)
+  "A few example values that will match:
+\"Reflection warning, /tmp/foo/src/foo/core.clj:14:1 - \"
+\"CompilerException java.lang.RuntimeException: Unable to resolve symbol: \\
+lol in this context, compiling:(/foo/core.clj:10:1)\"
+\"Syntax error compiling at (src/workspace_service.clj:227:3).\"")
+
+(replace-regexp-in-string cider-clojure-compilation-regexp
+                          ""
+                          "Reflection warning, /tmp/foo/src/foo/core.clj:14:1 - call to java.lang.Integer ctor can't be resolved.")
 
 
 (defvar cider-compilation-regexp


### PR DESCRIPTION
e.g., the `Syntax error compiling clojure.core/let at (foo/bar.clj:10:1)` prefix is now removed.

Samples:

<img width="779" alt="image" src="https://github.com/clojure-emacs/cider/assets/1162994/2f53d3d5-4394-4a49-8e46-1ace9a378daa">

<img width="549" alt="Screen Shot 2023-09-30 at 15 44 01" src="https://github.com/clojure-emacs/cider/assets/1162994/a261c08b-cdb9-4f80-95c7-e4de46de0bd0">


Cheers - V