### PR TITLE
Use clojure-mode 5.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@
 - Ensure there's a leading `:` when using `cider-clojure-cli-aliases`.
 - Improve `nrepl-dict` error reporting.
 - Bump the injected `piggieback` to [0.5.3](https://github.com/nrepl/piggieback/blob/0.5.3/CHANGES.md#053-2021-10-26).
-- Bump the `clojure-mode` required version, and use `clojure-find-ns` more safely, which fixes issues such as #[2849](https://github.com/clojure-emacs/cider/issues/2849).
+- Bump the `clojure-mode` required version to [5.17.0](https://github.com/clojure-emacs/clojure-mode/blob/v5.17.0/CHANGELOG.md#5170-2023-09-11), and use `clojure-find-ns` more safely, which fixes issues such as #[2849](https://github.com/clojure-emacs/cider/issues/2849).
 - Bump the `parseedn` require version, and wrap its usage with a more informative `user-error`.
 - Bump the injected `cider-nrepl` to [0.38.1](https://github.com/clojure-emacs/cider-nrepl/blob/v0.38.1/CHANGELOG.md#0381-2023-09-21).
   - Improves indentation, font-locking and other metadata support for ClojureScript.

--- a/cider.el
+++ b/cider.el
@@ -12,7 +12,7 @@
 ;; Maintainer: Bozhidar Batsov <bozhidar@batsov.dev>
 ;; URL: http://www.github.com/clojure-emacs/cider
 ;; Version: 1.8.0-snapshot
-;; Package-Requires: ((emacs "26") (clojure-mode "5.16.2") (parseedn "1.2.0") (queue "0.2") (spinner "1.7") (seq "2.22") (sesman "0.3.2") (transient "0.4.1"))
+;; Package-Requires: ((emacs "26") (clojure-mode "5.17.0") (parseedn "1.2.0") (queue "0.2") (spinner "1.7") (seq "2.22") (sesman "0.3.2") (transient "0.4.1"))
 ;; Keywords: languages, clojure, cider
 
 ;; This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
https://github.com/clojure-emacs/clojure-mode/blob/v5.17.0/CHANGELOG.md#5170-2023-09-11
https://stable.melpa.org/#/clojure-mode

I've used it for the last 3 weeks without issue.