### PR TITLE
Update Clojure CLI aliases examples to not include leading -A or -M

### DIFF
--- a/doc/modules/ROOT/pages/cljs/figwheel.adoc
+++ b/doc/modules/ROOT/pages/cljs/figwheel.adoc
@@ -78,7 +78,7 @@ use `revert-buffer`.)
 +
 [source,lisp]
 ----
-((clojurescript-mode . ((cider-clojure-cli-aliases . "-M:fig:build"))))
+((clojurescript-mode . ((cider-clojure-cli-aliases . ":fig:build"))))
 ----
 
 TIP: If you didn't setup `.dir-locals.el` you can edit the command-line

--- a/doc/modules/ROOT/pages/cljs/shadow-cljs.adoc
+++ b/doc/modules/ROOT/pages/cljs/shadow-cljs.adoc
@@ -112,7 +112,7 @@ Create a `:dev` alias with an extra source path of "dev" and add the following n
 
 Supposing your build-id is `:app`, add the following to your `.dir-locals.el`
 ```elisp
-((nil . ((cider-clojure-cli-aliases        . "-M:dev")
+((nil . ((cider-clojure-cli-aliases        . ":dev")
          (cider-preferred-build-tool       . clojure-cli)
          (cider-default-cljs-repl          . custom)
          (cider-custom-cljs-repl-init-form . "(do (user/cljs-repl))")

--- a/doc/modules/ROOT/pages/config/project_config.adoc
+++ b/doc/modules/ROOT/pages/config/project_config.adoc
@@ -22,7 +22,7 @@ Very simply put, all you need to do is to create in the root of your project a f
 [source,emacs-lisp]
 ----
 ((clojurescript-mode
-  (cider-clojure-cli-aliases . "-A:fig")
+  (cider-clojure-cli-aliases . ":fig")
   (eval . (cider-register-cljs-repl-type 'super-cljs "(do (foo) (bar))"))
   (cider-default-cljs-repl . super-cljs)))
 ----

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -465,7 +465,7 @@
                                      " -M:dev:test:cider/nrepl")
                                    "")))
         (setq-local cider-jack-in-dependencies nil)
-        (setq-local cider-clojure-cli-aliases "-A:dev:test")
+        (setq-local cider-clojure-cli-aliases ":dev:test")
         (setq-local cider-allow-jack-in-without-project t)
         (setq-local cider-clojure-cli-command "clojure")
         (setq-local cider-inject-dependencies-at-jack-in t)


### PR DESCRIPTION
The docs and a test didn't always show the intended usage for `cider-clojure-cli-aliases`.