### PR TITLE
Introduce `cider-enable-flex-completion`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 
 - Ensure that `cider` completion isn't used with completion styles that are currently unsupported (`initials`, `partial-completion`, `orderless`, etc).
   - This restores completions for users that favor those styles - otherwise the would see bad or no completions.
+  - Relatedly `cider-company-enable-fuzzy-completion` is now deprecated in favor of `cider-company-enable-fuzzy-completion-globally` (which enables the `flex` completion style).
 - Improve support for multiple forms in the same line by replacing `beginning-of-defun` fn.
 - [#3390](https://github.com/clojure-emacs/cider/issues/3390): Enhance `cider-connect` to show all nREPLs available ports, instead of only Leiningen ones.
 - [#3408](https://github.com/clojure-emacs/cider/issues/3408): `cider-connect`: check `.nrepl-port`-like files for liveness, hiding them if they don't reflect an active port.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 
 - Ensure that `cider` completion isn't used with completion styles that are currently unsupported (`initials`, `partial-completion`, `orderless`, etc).
   - This restores completions for users that favor those styles - otherwise the would see bad or no completions.
-  - Relatedly `cider-company-enable-fuzzy-completion` is now deprecated in favor of `cider-company-enable-fuzzy-completion-globally` (which enables the `flex` completion style).
+  - Relatedly `cider-company-enable-fuzzy-completion` is now deprecated in favor of `cider-enable-flex-completion` (which enables the `flex` completion style).
 - Improve support for multiple forms in the same line by replacing `beginning-of-defun` fn.
 - [#3390](https://github.com/clojure-emacs/cider/issues/3390): Enhance `cider-connect` to show all nREPLs available ports, instead of only Leiningen ones.
 - [#3408](https://github.com/clojure-emacs/cider/issues/3408): `cider-connect`: check `.nrepl-port`-like files for liveness, hiding them if they don't reflect an active port.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 
 - Ensure that `cider` completion isn't used with completion styles that are currently unsupported (`initials`, `partial-completion`, `orderless`, etc).
   - This restores completions for users that favor those styles - otherwise the would see bad or no completions.
-  - Relatedly `cider-company-enable-fuzzy-completion` is now deprecated in favor of `cider-enable-flex-completion` (which enables the `flex` completion style).
+  - Relatedly, `cider-company-enable-fuzzy-completion` is now deprecated in favor of `cider-enable-flex-completion`.
 - Improve support for multiple forms in the same line by replacing `beginning-of-defun` fn.
 - [#3390](https://github.com/clojure-emacs/cider/issues/3390): Enhance `cider-connect` to show all nREPLs available ports, instead of only Leiningen ones.
 - [#3408](https://github.com/clojure-emacs/cider/issues/3408): `cider-connect`: check `.nrepl-port`-like files for liveness, hiding them if they don't reflect an active port.

--- a/cider-completion.el
+++ b/cider-completion.el
@@ -259,22 +259,22 @@ in the buffer."
 ;; Currently CIDER completions only work for `basic`, and not `initials`, `partial-completion`, `orderless`, etc.
 ;; So we ensure that those other styles aren't used with CIDER, otherwise one would see bad or no completions at all.
 ;; This `add-to-list` call can be removed once we implement the other completion styles.
-;; (When doing that, please refactor `cider-company-enable-fuzzy-completion-globally' as well)
+;; (When doing that, please refactor `cider-enable-flex-completion' as well)
 (add-to-list 'completion-category-overrides '(cider (styles basic)))
 
 (defun cider-company-enable-fuzzy-completion ()
   "Enable backend-driven fuzzy completion in the current buffer.
 
-DEPRECATED: please use `cider-company-enable-fuzzy-completion-globally' instead."
+DEPRECATED: please use `cider-enable-flex-completion' instead."
   (setq-local completion-styles '(cider)))
 
-(make-obsolete 'cider-company-enable-fuzzy-completion 'cider-company-enable-fuzzy-completion-globally "1.8.0")
+(make-obsolete 'cider-company-enable-fuzzy-completion 'cider-enable-flex-completion "1.8.0")
 
-(defun cider-company-enable-fuzzy-completion-globally ()
+(defun cider-enable-flex-completion ()
   "Enables `flex' (fuzzy) completion for CIDER in all buffers."
   (interactive)
   (when (< emacs-major-version 27)
-    (user-error "`cider-company-enable-fuzzy-completion-globally' requires Emacs 27 or later"))
+    (user-error "`cider-enable-flex-completion' requires Emacs 27 or later"))
   (let ((found-styles (when-let ((cider (assq 'cider completion-category-overrides)))
                         (assq 'styles cider)))
         (found-cycle (when-let ((cider (assq 'cider completion-category-overrides)))

--- a/cider-completion.el
+++ b/cider-completion.el
@@ -271,7 +271,9 @@ DEPRECATED: please use `cider-enable-flex-completion' instead."
 (make-obsolete 'cider-company-enable-fuzzy-completion 'cider-enable-flex-completion "1.8.0")
 
 (defun cider-enable-flex-completion ()
-  "Enables `flex' (fuzzy) completion for CIDER in all buffers."
+  "Enables `flex' (fuzzy) completion for CIDER in all buffers.
+
+Only affects the `cider' comlpetion category.`"
   (interactive)
   (when (< emacs-major-version 27)
     (user-error "`cider-enable-flex-completion' requires Emacs 27 or later"))

--- a/cider-completion.el
+++ b/cider-completion.el
@@ -248,7 +248,8 @@ in the buffer."
 ;; note that there's already a completion category named `cider' (grep for `(metadata (category . cider))` in this file),
 ;; which can be confusing given the identical name.
 ;; The `cider' completion style should be removed because the `flex' style is essentially equivalent.
-;; (`flex' was introduced 3 years later, to be fair)
+;; (`flex' was introduced in Emacs 27, 3 years in after our commit 04e428b
+;;   which introduced `cider-company-enable-fuzzy-completion', to be fair)
 (add-to-list 'completion-styles-alist
              '(cider
                cider-company-unfiltered-candidates

--- a/cider-completion.el
+++ b/cider-completion.el
@@ -248,8 +248,8 @@ in the buffer."
 ;; note that there's already a completion category named `cider' (grep for `(metadata (category . cider))` in this file),
 ;; which can be confusing given the identical name.
 ;; The `cider' completion style should be removed because the `flex' style is essentially equivalent.
-;; (`flex' was introduced in Emacs 27, 3 years in after our commit 04e428b
-;;   which introduced `cider-company-enable-fuzzy-completion', to be fair)
+;; (To be fair, `flex' was introduced in Emacs 27, 3 years in after our commit 04e428b
+;;  which introduced `cider-company-enable-fuzzy-completion')
 (add-to-list 'completion-styles-alist
              '(cider
                cider-company-unfiltered-candidates
@@ -273,7 +273,7 @@ DEPRECATED: please use `cider-enable-flex-completion' instead."
 (defun cider-enable-flex-completion ()
   "Enables `flex' (fuzzy) completion for CIDER in all buffers.
 
-Only affects the `cider' comlpetion category.`"
+Only affects the `cider' completion category.`"
   (interactive)
   (when (< emacs-major-version 27)
     (user-error "`cider-enable-flex-completion' requires Emacs 27 or later"))

--- a/doc/modules/ROOT/pages/usage/code_completion.adoc
+++ b/doc/modules/ROOT/pages/usage/code_completion.adoc
@@ -137,12 +137,11 @@ you're really trying to type. For example, if you type `map-` then
 you'll only get completion candidates that have `map-` as the
 beginning of their names.  Sometimes, you don't know the exact prefix
 for the item you want to type. In this case, you can get
-CIDER-specific "fuzzy completion" by adding:
+CIDER-specific "fuzzy completion" by setting up in your Emacs init file:
 
 [source,lisp]
 ----
-(add-hook 'cider-repl-mode-hook #'cider-enable-flex-completion)
-(add-hook 'cider-mode-hook #'cider-enable-flex-completion)
+(cider-enable-flex-completion)
 ----
 
 This adds the `flex` completion style, as introduced in Emacs 27.

--- a/doc/modules/ROOT/pages/usage/code_completion.adoc
+++ b/doc/modules/ROOT/pages/usage/code_completion.adoc
@@ -154,7 +154,7 @@ will complete to `clojure.java.io`. Different completion examples are
 shown
 https://github.com/alexander-yakushev/compliment/wiki/Examples[here].
 
-NOTE: `cider-company-enable-fuzzy-completion` (now depreecated) should be used for Emacs < 27. 
+NOTE: `cider-company-enable-fuzzy-completion` (now deprecated) should be used for Emacs < 27. 
 
 === Completion annotations
 

--- a/doc/modules/ROOT/pages/usage/code_completion.adoc
+++ b/doc/modules/ROOT/pages/usage/code_completion.adoc
@@ -39,16 +39,17 @@ is already properly indented.
 
 CIDER defines (via the `completion-styles-alist` Elisp variable) a completion category named `cider`.
 
-The `cider` completion category currently only supports `basic` and `flex` completion styles (and not `partial-completion`, `orderless`, etc).
+The `cider` completion category currently only supports `basic` completion styles (and not `partial-completion`, `orderless`, etc),
+and `flex`, optionally (read more below).
 
 CIDER declares so in this fashion:
 
 [source,lisp]
 ----
-(add-to-list 'completion-category-overrides '(cider (styles basic flex)))
+(add-to-list 'completion-category-overrides '(cider (styles basic)))
 ----
 
-Note that `flex` will only work if you also enabled xref:usage/code_completion.adoc#fuzzy-candidate-matching[fuzzy candidate matching].
+You can also enable the `flex` completion style by activating xref:usage/code_completion.adoc#fuzzy-candidate-matching[fuzzy candidate matching].
 
 == Auto-completion
 
@@ -130,7 +131,7 @@ without needing to hit an extra key, please customize:
 
 === Fuzzy candidate matching
 
-By default `company-mode` will provide completion candidates with the
+By default, CIDER will provide completion candidates with the
 assumption that whatever you've typed so far is a prefix of what
 you're really trying to type. For example, if you type `map-` then
 you'll only get completion candidates that have `map-` as the
@@ -140,9 +141,11 @@ CIDER-specific "fuzzy completion" by adding:
 
 [source,lisp]
 ----
-(add-hook 'cider-repl-mode-hook #'cider-company-enable-fuzzy-completion)
-(add-hook 'cider-mode-hook #'cider-company-enable-fuzzy-completion)
+(add-hook 'cider-repl-mode-hook #'cider-company-enable-fuzzy-completion-globally)
+(add-hook 'cider-mode-hook #'cider-company-enable-fuzzy-completion-globally)
 ----
+
+This adds the `flex` completion style, as introduced in Emacs 27.
 
 Now, `company-mode` will accept certain fuzziness when matching
 candidates against the prefix. For example, typing `mi` will show you
@@ -150,6 +153,8 @@ candidates against the prefix. For example, typing `mi` will show you
 will complete to `clojure.java.io`. Different completion examples are
 shown
 https://github.com/alexander-yakushev/compliment/wiki/Examples[here].
+
+NOTE: `cider-company-enable-fuzzy-completion` (now depreecated) should be used for Emacs < 27. 
 
 === Completion annotations
 

--- a/doc/modules/ROOT/pages/usage/code_completion.adoc
+++ b/doc/modules/ROOT/pages/usage/code_completion.adoc
@@ -141,8 +141,8 @@ CIDER-specific "fuzzy completion" by adding:
 
 [source,lisp]
 ----
-(add-hook 'cider-repl-mode-hook #'cider-company-enable-fuzzy-completion-globally)
-(add-hook 'cider-mode-hook #'cider-company-enable-fuzzy-completion-globally)
+(add-hook 'cider-repl-mode-hook #'cider-enable-flex-completion)
+(add-hook 'cider-mode-hook #'cider-enable-flex-completion)
 ----
 
 This adds the `flex` completion style, as introduced in Emacs 27.

--- a/test/cider-completion-tests.el
+++ b/test/cider-completion-tests.el
@@ -1,0 +1,55 @@
+;;; cider-completion-tests.el  -*- lexical-binding: t; -*-
+
+;; Copyright © 2012-2023 Bozhidar Batsov
+
+;; Author: Bozhidar Batsov <bozhidar@batsov.dev>
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; This file is part of CIDER
+
+;;; Code:
+
+(require 'buttercup)
+(require 'cider-completion)
+
+;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
+
+(describe "cider-company-enable-fuzzy-completion-globally"
+  (when (>= emacs-major-version 27)
+    (cl-assert (not (member 'flex (assq 'styles (assq 'cider completion-category-overrides)))))
+    (let ((old-value completion-category-overrides))
+      (unwind-protect
+          (progn
+            (it "adds `flex'"
+              (cider-company-enable-fuzzy-completion-globally)
+              (expect (member 'flex (assq 'styles (assq 'cider completion-category-overrides)))
+                      :to-be-truthy))
+
+            (it "doesn't add `cycle'"
+              (expect (assq 'cycle (assq 'cider completion-category-overrides))
+                      :to-be nil))
+
+            (it "doesn't re-add `flex' if already present, preserving `cycle' as well"
+              (let ((with-flex-and-cycle '((cider (styles basic flex)
+                                                  (cycle t)))))
+                (setq completion-category-overrides with-flex-and-cycle)
+                (cider-company-enable-fuzzy-completion-globally)
+                (expect completion-category-overrides
+                        :to-equal with-flex-and-cycle))))
+        (setq completion-category-overrides old-value)))))

--- a/test/cider-completion-tests.el
+++ b/test/cider-completion-tests.el
@@ -30,14 +30,14 @@
 
 ;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
 
-(describe "cider-company-enable-fuzzy-completion-globally"
+(describe "cider-enable-flex-completion"
   (when (>= emacs-major-version 27)
     (cl-assert (not (member 'flex (assq 'styles (assq 'cider completion-category-overrides)))))
     (let ((old-value completion-category-overrides))
       (unwind-protect
           (progn
             (it "adds `flex'"
-              (cider-company-enable-fuzzy-completion-globally)
+              (cider-enable-flex-completion)
               (expect (member 'flex (assq 'styles (assq 'cider completion-category-overrides)))
                       :to-be-truthy))
 
@@ -49,7 +49,7 @@
               (let ((with-flex-and-cycle '((cider (styles basic flex)
                                                   (cycle t)))))
                 (setq completion-category-overrides with-flex-and-cycle)
-                (cider-company-enable-fuzzy-completion-globally)
+                (cider-enable-flex-completion)
                 (expect completion-category-overrides
                         :to-equal with-flex-and-cycle))))
         (setq completion-category-overrides old-value)))))


### PR DESCRIPTION
Replaces `cider-company-enable-fuzzy-completion`, which is now deprecated.

This way, the `flex` completion style becomes opt-in ([7e68df](https://github.com/clojure-emacs/cider/commit/7e68df2bf930f9ea577ffa76172a0b00ff391fe3) had inadvertently enabled it unconditionally).

I have QAd this and it works as intended:

* `iteatn<TAB>` will complete nothing by default
* after `M-x cider-enable-flex-completion`, `iteatn<TAB>` will complete `iteration`.

I also added comments so that we better understand things in a future.

Cheers - V