### PR TITLE
Expand `cider-clojure-compilation-regexp`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Changes
 
 - [#3521](https://github.com/clojure-emacs/cider/issues/3521): Expand `cider-clojure-compilation-regexp` to also match e.g. `Unexpected error (ExceptionInfo) macroexpanding defmulti at (src/ns.clj:1:1).`.
+- Remove module info from the [CIDER error overlay](https://docs.cider.mx/cider/usage/dealing_with_errors.html#configuration).
+  - Example string that is now trimmed away: `(java.lang.Long is in module java.base of loader 'bootstrap'; clojure.lang.IObj is in unnamed module of loader 'app')`
 
 ## 1.8.2 (2023-10-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+- [#3521](https://github.com/clojure-emacs/cider/issues/3521): Expand `cider-clojure-compilation-regexp` to also match e.g. `Unexpected error (ExceptionInfo) macroexpanding defmulti at (src/ns.clj:1:1).`.
+
 ## 1.8.2 (2023-10-15)
 
 ### Changes

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -617,6 +617,21 @@ lol in this context, compiling:(/foo/core.clj:10:1)\"
 \"Syntax error compiling at (src/workspace_service.clj:227:3).\"
 \"Unexpected error (ClassCastException) macroexpanding defmulti at (src/haystack/parser.cljc:21:1).\"")
 
+(defconst cider-module-info-regexp
+  (rx " ("
+      (minimal-match (one-or-more anything))
+      " is in"
+      (minimal-match (one-or-more anything)) ;; module or unnamed module
+      " of loader "
+      (minimal-match (one-or-more anything))
+      "; "
+      (minimal-match (one-or-more anything))
+      " is in "
+      (minimal-match (one-or-more anything)) ;; module or unnamed module
+      " of loader "
+      (minimal-match (one-or-more anything))
+      ")"))
+
 (defvar cider-compilation-regexp
   (list cider-clojure-compilation-regexp  2 3 4 '(1))
   "Specifications for matching errors and warnings in Clojure stacktraces.
@@ -843,6 +858,8 @@ when `cider-auto-inspect-after-eval' is non-nil."
                                        (let ((cider-result-use-clojure-font-lock nil)
                                              (trimmed-err (thread-last err
                                                                        (replace-regexp-in-string cider-clojure-compilation-regexp
+                                                                                                 "")
+                                                                       (replace-regexp-in-string cider-module-info-regexp
                                                                                                  "")
                                                                        (string-trim))))
                                          (cider--display-interactive-eval-result

--- a/doc/modules/ROOT/pages/usage/dealing_with_errors.adoc
+++ b/doc/modules/ROOT/pages/usage/dealing_with_errors.adoc
@@ -23,6 +23,8 @@ temporary overlay or in the echo area:
 (setq cider-show-error-buffer nil)
 ----
 
+NOTE: you will only see the overlay if `cider-use-overlays` is non-nil.
+
 Starting from CIDER 1.8.0, only runtime exceptions (and not compilation errors)
 will cause a stacktrace buffer to be shown. This better follows Clojure 1.10's
 https://clojure.org/reference/repl_and_main#_at_repl[intended semantics].

--- a/test/cider-error-parsing-tests.el
+++ b/test/cider-error-parsing-tests.el
@@ -142,3 +142,14 @@
       (expect (progn (string-match cider-clojure-compilation-regexp clojure-1.10-compiler-error)
                      (match-string 2 clojure-1.10-compiler-error))
               :to-equal "src/haystack/parser.cljc"))))
+
+(describe "cider-module-info-regexp"
+  (it "Matches module info provided by Java"
+    (expect " (java.lang.Long is in module java.base of loader 'bootstrap'; clojure.lang.IObj is in unnamed module of loader 'app')"
+            :to-match cider-module-info-regexp)
+    (expect " (java.lang.Long is in module java.base of loader 'bootstrap'; clojure.lang.IObj is in module java.base of loader 'bootstrap')"
+            :to-match cider-module-info-regexp)
+    (expect " (java.lang.Long is in unnamed module of loader 'app'; clojure.lang.IObj is in module java.base of loader 'bootstrap')"
+            :to-match cider-module-info-regexp)
+    (expect " (java.lang.Long is in unnamed module of loader 'app'; clojure.lang.IObj is in unnamed module of loader 'app')"
+            :to-match cider-module-info-regexp)))

--- a/test/cider-error-parsing-tests.el
+++ b/test/cider-error-parsing-tests.el
@@ -135,4 +135,10 @@
       (expect clojure-1.10-compiler-error :to-match cider-clojure-compilation-regexp)
       (expect (progn (string-match cider-clojure-compilation-regexp clojure-1.10-compiler-error)
                      (match-string 2 clojure-1.10-compiler-error))
-              :to-equal "src/ardoq/service/workspace_service.clj"))))
+              :to-equal "src/ardoq/service/workspace_service.clj")))
+  (it "Recognizes a clojure 'Unexpected error' message"
+    (let ((clojure-1.10-compiler-error "Unexpected error (ClassCastException) macroexpanding defmulti at (src/haystack/parser.cljc:21:1)."))
+      (expect clojure-1.10-compiler-error :to-match cider-clojure-compilation-regexp)
+      (expect (progn (string-match cider-clojure-compilation-regexp clojure-1.10-compiler-error)
+                     (match-string 2 clojure-1.10-compiler-error))
+              :to-equal "src/haystack/parser.cljc"))))


### PR DESCRIPTION
* Expand cider-clojure-compilation-regexp
  * Fixes https://github.com/clojure-emacs/cider/issues/3521
* Remove module info from the error overlay

i.e. we remove the prefix and suffix, leaving a clean result:

<img width="766" alt="Screen Shot 2023-10-15 at 20 59 04" src="https://github.com/clojure-emacs/cider/assets/1162994/93119131-f261-44bb-91b1-9d882fe1be8c">
