### PR TITLE
Preserve the font size as one navigates through the CIDER inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - Example string that is now trimmed away: `(java.lang.Long is in module java.base of loader 'bootstrap'; clojure.lang.IObj is in unnamed module of loader 'app')`
 - [#3522](https://github.com/clojure-emacs/cider/issues/3522): Introduce a new possible value for [`cider-use-overlays`](https://docs.cider.mx/cider/usage/code_evaluation.html#overlays): `errors-only`.
   - If specified, only errors will result in an overlay being shown.
+- [#3527](https://github.com/clojure-emacs/cider/issues/3527): Preserve the font size as one navigates through the CIDER inspector.
 
 ## 1.8.2 (2023-10-15)
 

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -389,6 +389,9 @@ MAX-COLL-SIZE if non nil."
 (defun cider-inspector--render-value (value)
   "Render VALUE."
   (let ((font-size (when-let ((b (get-buffer cider-inspector-buffer)))
+                     ;; The font size is lost between inspector 'screens',
+                     ;; because on each re-rendering, we wipe everything, including the mode.
+                     ;; Enabling cider-inspector-mode is the specific step that loses the font size.
                      (buffer-local-value 'text-scale-mode-amount b))))
     (cider-make-popup-buffer cider-inspector-buffer 'cider-inspector-mode 'ancillary)
     (cider-inspector-render cider-inspector-buffer value font-size))

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -388,8 +388,10 @@ MAX-COLL-SIZE if non nil."
 ;; Render Inspector from Structured Values
 (defun cider-inspector--render-value (value)
   "Render VALUE."
-  (cider-make-popup-buffer cider-inspector-buffer 'cider-inspector-mode 'ancillary)
-  (cider-inspector-render cider-inspector-buffer value)
+  (let ((font-size (when-let ((b (get-buffer cider-inspector-buffer)))
+                     (buffer-local-value 'text-scale-mode-amount b))))
+    (cider-make-popup-buffer cider-inspector-buffer 'cider-inspector-mode 'ancillary)
+    (cider-inspector-render cider-inspector-buffer value font-size))
   (cider-popup-buffer-display cider-inspector-buffer cider-inspector-auto-select-buffer)
   (when cider-inspector-fill-frame (delete-other-windows))
   (ignore-errors (cider-inspector-next-inspectable-object 1))
@@ -408,10 +410,12 @@ MAX-COLL-SIZE if non nil."
       (when cider-inspector-page-location-stack
         (goto-char (pop cider-inspector-page-location-stack))))))
 
-(defun cider-inspector-render (buffer str)
+(defun cider-inspector-render (buffer str &optional font-size)
   "Render STR in BUFFER."
   (with-current-buffer buffer
     (cider-inspector-mode)
+    (when font-size
+      (text-scale-set font-size))
     (let ((inhibit-read-only t))
       (condition-case nil
           (cider-inspector-render* (car (read-from-string str)))


### PR DESCRIPTION
Fixes #3527 