### PR TITLE
Fix breaks with running current set of unit tests on GH

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,10 +86,6 @@ jobs:
     - run: npm install shadow-cljs@2.20.13 -g
     - run: npm install nbb@1.1.152 -g
 
-    - name: Test the project
-      run: |
-        eldev -p -dtTC test || eldev -p -dtTC test
-
     - name: Test integration
       run: |
         # The tests occasionally fail on macos&win in what is seems to

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,10 @@ jobs:
     - run: npm install shadow-cljs@2.20.13 -g
     - run: npm install nbb@1.1.152 -g
 
+    - name: Test the project
+      run: |
+        eldev -p -dtTC test || eldev -p -dtTC test
+
     - name: Test integration
       run: |
         # The tests occasionally fail on macos&win in what is seems to

--- a/test/cider-client-tests.el
+++ b/test/cider-client-tests.el
@@ -136,7 +136,7 @@
   (before-each
     (spy-on 'cider-connected-p :and-return-value t)
     (spy-on 'cider-classpath-entries :and-return-value
-            '("/a" "/b" "/c" "/c/inner" "/base/clj" "/base/clj-dev"))
+            '("/cider--a" "/cider--b" "/cider--c" "/cider--c/inner" "/cider--base/clj" "/cider--base/clj-dev"))
     (spy-on 'file-directory-p :and-return-value t)
     (spy-on 'file-in-directory-p :and-call-fake (lambda (file dir)
                                                   (string-prefix-p dir file)))
@@ -144,22 +144,22 @@
                                                  (substring file (+ 1 (length dir))))))
 
   (it "returns the namespace matching the given string path"
-    (expect (cider-expected-ns "/a/foo/bar/baz_utils.clj") :to-equal
+    (expect (cider-expected-ns "/cider--a/foo/bar/baz_utils.clj") :to-equal
             "foo.bar.baz-utils")
-    (expect (cider-expected-ns "/b/foo.clj") :to-equal
+    (expect (cider-expected-ns "/cider--b/foo.clj") :to-equal
             "foo")
-    (expect (cider-expected-ns "/c/inner/foo/bar.clj") :to-equal
+    (expect (cider-expected-ns "/cider--c/inner/foo/bar.clj") :to-equal
             ;; NOT inner.foo.bar
             "foo.bar")
-    (expect (cider-expected-ns "/c/foo/bar/baz") :to-equal
+    (expect (cider-expected-ns "/cider--c/foo/bar/baz") :to-equal
             "foo.bar.baz")
-    (expect (cider-expected-ns "/base/clj-dev/foo/bar.clj") :to-equal
+    (expect (cider-expected-ns "/cider--base/clj-dev/foo/bar.clj") :to-equal
             "foo.bar")
-    (expect (cider-expected-ns "/not/in/classpath.clj") :to-equal
-            (clojure-expected-ns "/not/in/classpath.clj")))
+    (expect (cider-expected-ns "/cider--not/in/classpath.clj") :to-equal
+            (clojure-expected-ns "/cider--not/in/classpath.clj")))
 
   (it "returns nil if it cannot find the namespace"
-    (expect (cider-expected-ns "/z/abc/def") :to-equal ""))
+    (expect (cider-expected-ns "/cider--z/abc/def") :to-equal ""))
 
   (it "falls back on `clojure-expected-ns' in the absence of an active nREPL connection"
     (spy-on 'cider-connected-p :and-return-value nil)

--- a/test/cider-eval-tests.el
+++ b/test/cider-eval-tests.el
@@ -31,23 +31,24 @@
 ;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
 
 (describe "cider-provide-file"
-  (it "returns an empty string when the file is not found"
-    (expect (cider-provide-file "abc.clj") :to-equal ""))
-  (it "base64 encodes without newlines"
-    (let ((cider-sideloader-path (list "/tmp"))
-          (default-directory "/tmp")
-          (filename (make-temp-file "abc.clj")))
-      (with-temp-file filename
-        (dotimes (_ 60) (insert "x")))
-      (expect (cider-provide-file filename) :not :to-match "\n")))
-  (it "can handle multibyte characters"
-    (let ((cider-sideloader-path (list "/tmp"))
-          (default-directory "/tmp")
-          (filename (make-temp-file "abc.clj"))
-          (coding-system-for-write 'utf-8-unix))
-      (with-temp-file filename
-        (insert "🍻"))
-      (expect (cider-provide-file filename) :to-equal "8J+Nuw=="))))
+  (let ((tmp-dir (temporary-file-directory)))
+    (it "returns an empty string when the file is not found"
+        (expect (cider-provide-file "abc.clj") :to-equal ""))
+    (it "base64 encodes without newlines"
+        (let ((cider-sideloader-path (list tmp-dir))
+              (default-directory tmp-dir)
+              (filename (make-temp-file "abc.clj")))
+          (with-temp-file filename
+            (dotimes (_ 60) (insert "x")))
+          (expect (cider-provide-file filename) :not :to-match "\n")))
+    (it "can handle multibyte characters"
+        (let ((cider-sideloader-path (list tmp-dir))
+              (default-directory tmp-dir)
+              (filename (make-temp-file "abc.clj"))
+              (coding-system-for-write 'utf-8-unix))
+          (with-temp-file filename
+            (insert "🍻"))
+          (expect (cider-provide-file filename) :to-equal "8J+Nuw==")))))
 
 (describe "cider-extract-error-info"
   (it "Matches Clojure compilation exceptions"


### PR DESCRIPTION
Hi, 

as discussed in https://github.com/clojure-emacs/cider/pull/3461, there are a couple of unit tests that fail if ran on GH MS-Windows, which will of benefit to the `clojure-ts-mode` PR

The purpose of this PR is to fix them. We start by having a run of the tests on GH, observe their failures and fix them in a follow up commit

Thanks