### PR TITLE
Avoid `No comment syntax is defined` prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   - If specified, only errors will result in an overlay being shown.
 - [#3527](https://github.com/clojure-emacs/cider/issues/3527): Preserve the font size as one navigates through the CIDER inspector.
 - [#3525](https://github.com/clojure-emacs/cider/issues/3525): Introduce [`cider-inline-error-message-function`](https://docs.cider.mx/cider/usage/code_evaluation.html#overlays) customization option.
+- [#2903](https://github.com/clojure-emacs/cider/issues/2903): Avoid `No comment syntax is defined` prompts.
+- Bump the `clojure-mode` required version to [5.18.0](https://github.com/clojure-emacs/clojure-mode/blob/v5.18.0/CHANGELOG.md#5180-2023-10-18)
 
 ## 1.8.2 (2023-10-15)
 

--- a/cider-debug.el
+++ b/cider-debug.el
@@ -770,7 +770,7 @@ The boolean value of FORCE will be sent in the reply."
                   (> here (point))))
         (user-error "Point is outside the sexp being debugged"))
       ;; Move forward until start of sexp.
-      (comment-normalize-vars)
+      (comment-normalize-vars t)
       (comment-forward (point-max))
       ;; Find the coordinate and send it.
       (cider-debug-mode-send-reply

--- a/cider.el
+++ b/cider.el
@@ -12,7 +12,7 @@
 ;; Maintainer: Bozhidar Batsov <bozhidar@batsov.dev>
 ;; URL: http://www.github.com/clojure-emacs/cider
 ;; Version: 1.8.2
-;; Package-Requires: ((emacs "26") (clojure-mode "5.17.1") (parseedn "1.2.0") (queue "0.2") (spinner "1.7") (seq "2.22") (sesman "0.3.2") (transient "0.4.1"))
+;; Package-Requires: ((emacs "26") (clojure-mode "5.18.0") (parseedn "1.2.0") (queue "0.2") (spinner "1.7") (seq "2.22") (sesman "0.3.2") (transient "0.4.1"))
 ;; Keywords: languages, clojure, cider
 
 ;; This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
Fixes #2903

Kudos go to @rrudakov!