### PR TITLE
`cider-jump-to-locref-at-point`: don't jump to non-existing files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 - [#2903](https://github.com/clojure-emacs/cider/issues/2903): Avoid `No comment syntax is defined` prompts.
 - Bump the `clojure-mode` required version to [5.18.0](https://github.com/clojure-emacs/clojure-mode/blob/v5.18.0/CHANGELOG.md#5180-2023-10-18)
 
+### Bugs fixed
+
+- [#3539](https://github.com/clojure-emacs/cider/issues/3539): `cider-jump-to-locref-at-point`: don't jump to non-existing files.
+
 ## 1.8.2 (2023-10-15)
 
 ### Changes

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1401,21 +1401,20 @@ regexes from `cider-locref-regexp-alist' to infer locations at point."
                           (nrepl-dict-get (cider-sync-request:info var) "file")))
                     (when-let* ((file (plist-get loc :file)))
                       ;; 2) file detected by the regexp
-                      (or
-                       (if (file-name-absolute-p file)
-                           file
-                         ;; when not absolute, expand within the current project
-                         (when-let* ((proj (clojure-project-dir)))
-                           (let ((path (expand-file-name file proj)))
-                             (when (file-exists-p path)
-                               path))))
-                       ;; 3) infer ns from the abbreviated path (common in
-                       ;; reflection warnings)
-                       (let ((ns (cider-path-to-ns file)))
-                         (cider-sync-request:ns-path ns)))))))
+                      (let ((file-from-regexp (if (file-name-absolute-p file)
+                                                  file
+                                                ;; when not absolute, expand within the current project
+                                                (when-let* ((proj (clojure-project-dir)))
+                                                  (expand-file-name file proj)))))
+                        (or (when (file-readable-p file-from-regexp)
+                              file-from-regexp)
+                            ;; 3) infer ns from the abbreviated path
+                            ;;    (common in reflection warnings)
+                            (let ((ns (cider-path-to-ns file)))
+                              (cider-sync-request:ns-path ns))))))))
         (if file
             (cider--jump-to-loc-from-info (nrepl-dict "file" file "line" line) t)
-          (error "No source location for %s" var)))
+          (error "No source location for %s - you may need to adjust `cider-locref-regexp-alist' to match your logging format" var)))
     (user-error "No location reference at point")))
 
 (defvar cider-locref-hoover-overlay

--- a/doc/modules/ROOT/pages/usage/dealing_with_errors.adoc
+++ b/doc/modules/ROOT/pages/usage/dealing_with_errors.adoc
@@ -243,7 +243,7 @@ To open this stacktrace in the Cider stacktrace inspector, move point
 somewhere over the exception and run `M-x
 cider-stacktrace-analyze-at-point`.
 
-This also works to some extend for exceptions that are buried inside a
+This also works to some extent for exceptions that are buried inside a
 string like the following exception:
 
 [source,text]


### PR DESCRIPTION
Fixes https://github.com/clojure-emacs/cider/issues/3539