### PR TITLE
Fix `cider-jack-in` failing in remote ssh buffers and adapt the tramp example project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Bugs fixed
 
-- [#3544](https://github.com/clojure-emacs/cider/pull/3544): Fix cider-jack-in failing with ssh-remotes #3541 #3303
+- [#3541](https://github.com/clojure-emacs/cider/issues/3541): Fix `cider-jack-in` failing with SSH remotes.
 - [#3559](https://github.com/clojure-emacs/cider/issues/3559): Don't apply [dynamic syntax highlighting](https://docs.cider.mx/cider/config/syntax_highlighting.html) over buffers belonging to unrelated Sesman sessions.
 
 ## 1.9.0 (2023-10-24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Bugs fixed
 
+- [#3544](https://github.com/clojure-emacs/cider/pull/3544): Fix cider-jack-in failing with ssh-remotes #3541 #3303
 - [#3559](https://github.com/clojure-emacs/cider/issues/3559): Don't apply [dynamic syntax highlighting](https://docs.cider.mx/cider/config/syntax_highlighting.html) over buffers belonging to unrelated Sesman sessions.
 
 ## 1.9.0 (2023-10-24)

--- a/dev/tramp-sample-project/Dockerfile
+++ b/dev/tramp-sample-project/Dockerfile
@@ -36,6 +36,7 @@ COPY . /usr/src/app
 RUN lein deps
 
 RUN echo "export JAVA_HOME=${JAVA_HOME}" >> /root/.bashrc
+RUN echo "export JAVA_CMD=${JAVA_HOME}/bin/java" >> /root/.bashrc
 RUN echo "export LEIN_HOME=${LEIN_HOME}" >> /root/.bashrc
 RUN echo "export LEIN_JAVA_CMD=${LEIN_JAVA_CMD}" >> /root/.bashrc
 RUN echo "export LEIN_JVM_OPTS=${LEIN_JVM_OPTS}" >> /root/.bashrc

--- a/dev/tramp-sample-project/README.md
+++ b/dev/tramp-sample-project/README.md
@@ -4,8 +4,15 @@ The Docker image exposes a SSH server.
 
 This way, for development purposes, we can SSH into it with TRAMP and exercise CIDER's TRAMP-related capabilities.
 
-To get started:
+## Some ways to get started:
 
+### `cider-jack-in` from a tramp buffer
+* `M-:` `(async-shell-command "make run")` to run the Docker image
+* `M-:` `(find-file "/sshx:root@localhost#8022:/usr/src/app/src/foo.clj")`
+* `M-x` `cider-jack-in`
+* Enter password: `cider`
+
+###  Manually create a remote repl and connect to it
 * In one terminal tab, run `make run` to run the Docker image
 * Once it's ready, from another tab, run `make ssh` and start a repl manually from there
   * The password is `cider`

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -271,6 +271,12 @@ Discards it if it can be determined that the port is not active."
                           (shell-command-to-string (format "lsof -i:%s" port-number))))
           port-string)))))
 
+(defun nrepl--ssh-file-name-matches-host-p (file-name host)
+  "Return t, if FILE-NAME is a tramp-file-name on HOST via ssh."
+  (when (tramp-tramp-file-p file-name)
+    (with-parsed-tramp-file-name file-name v
+      (and (member v-method '("ssh" "sshx" "sshfs"))
+           (member host (list v-host (concat v-host "#" v-port)))))))
 
 ;;; Bencode
 
@@ -587,14 +593,12 @@ If NO-ERROR is non-nil, show messages instead of throwing an error."
 (defun nrepl--ssh-tunnel-connect (host port)
   "Connect to a remote machine identified by HOST and PORT through SSH tunnel."
   (message "[nREPL] Establishing SSH tunneled connection to %s:%s ..." host port)
-  (let* ((current-buf (buffer-file-name))
-         (tramp-file-regexp "/ssh:\\(.+@\\)?\\(.+?\\)\\(:\\|#\\).+")
+  (let* ((file-name (or (buffer-file-name) nrepl-project-dir))
          (remote-dir (cond
                       ;; If current buffer is a TRAMP buffer and its host is
                       ;; the same as HOST, reuse its connection parameters for
                       ;; SSH tunnel.
-                      ((and (string-match tramp-file-regexp current-buf)
-                            (string= host (match-string 2 current-buf))) current-buf)
+                      ((nrepl--ssh-file-name-matches-host-p file-name host) file-name)
                       ;; Otherwise, if HOST was provided, use it for connection.
                       (host (format "/ssh:%s:" host))
                       ;; Use default directory as fallback.

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -275,7 +275,7 @@ Discards it if it can be determined that the port is not active."
   "Return t, if FILE-NAME is a tramp-file-name on HOST via ssh."
   (when (tramp-tramp-file-p file-name)
     (with-parsed-tramp-file-name file-name v
-      (and (member v-method '("ssh" "sshx" "sshfs"))
+      (and (member v-method '("ssh" "sshx"))
            (member host (list v-host (concat v-host "#" v-port)))))))
 
 ;;; Bencode

--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -158,6 +158,30 @@
         (expect (match-string 1 msg)
                 :to-equal "nrepl.sock"))))
 
+(describe "nrepl--ssh-file-name-matches-host-p"
+  (it "works in the most basic case"
+    (expect (nrepl--ssh-file-name-matches-host-p "/ssh:host:~/test/" "host")
+            :to-be-truthy)
+    (expect (nrepl--ssh-file-name-matches-host-p "/ssh:host:~/test/" "other-host")
+            :to-be nil))
+  (it "understands non-standart ssh ports and distinguishes between them"
+    (expect (nrepl--ssh-file-name-matches-host-p
+             "/ssh:tester@host#8022:~/test/" "host#8022")
+            :to-be-truthy)
+    (expect (nrepl--ssh-file-name-matches-host-p
+             "/ssh:tester@host#8022:~/test/" "host#7777")
+            :to-be nil))
+  (it "works with tramps other ssh methods"
+    (expect (nrepl--ssh-file-name-matches-host-p
+             "/sshx:tester@host:~/test/" "host")
+            :to-be-truthy)
+    (expect (nrepl--ssh-file-name-matches-host-p
+             "/sshfs:tester@host:~/test/" "host")
+            :to-be-truthy))
+  (it "can handle nil"
+    (expect (nrepl--ssh-file-name-matches-host-p nil nil)
+            :to-be nil)))
+
 (describe "nrepl-client-lifecycle"
   (it "start and stop nrepl client process"
 

--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -174,9 +174,6 @@
   (it "works with tramps other ssh methods"
     (expect (nrepl--ssh-file-name-matches-host-p
              "/sshx:tester@host:~/test/" "host")
-            :to-be-truthy)
-    (expect (nrepl--ssh-file-name-matches-host-p
-             "/sshfs:tester@host:~/test/" "host")
             :to-be-truthy))
   (it "can handle nil"
     (expect (nrepl--ssh-file-name-matches-host-p nil nil)


### PR DESCRIPTION
> Fixes https://github.com/clojure-emacs/cider/issues/3541

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) 
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)

## Fix `cider-jack-in` failing in remote ssh buffers

[Updated]
cca3e3651e5e3c4a1d455dd5f6e2f3ea062f0c1c
```
Calling cider-jack-in from a tramp buffer on a ssh-remote would throw:
"error in process filter: Wrong type argument: stringp, nil"

This happens because nrepl--ssh-tunnel-connect is trying to infer the
hostname from the current filename: It string-matches
on (buffer-file-name) which returns nil in
the *cider-uninitialized-repl* buffer.

For the jack-in use-case, the local var nrepl-project-dir will
always be bound when connecting the client, so we can use
it as a fallback.

Fixes:
https://github.com/clojure-emacs/cider/issues/3541
https://github.com/clojure-emacs/cider/issues/3303 (partially)
```

## Additional Issues

Trying `cider-jack-in` with the [tramp-sample-project](https://github.com/clojure-emacs/cider/tree/master/dev/tramp-sample-project) uncovered some issues.

I followed the [README](https://github.com/clojure-emacs/cider/blob/master/dev/tramp-sample-project/README.md), was able to start a repl and connect to it as described:
```
* In one terminal tab, run `make run` to run the Docker image
* Once it's ready, from another tab, run `make ssh` and start a repl manually from there
...
```

but had no luck with `M-x cider-jack-in` from `(dired "/sshx:root@localhost#8022:/usr/src/app")`:

### `M-x cider-jack-in` in `/usr/src/app` failed at server creation: `java` not in `PATH`
```
Tramp: Opening connection nrepl-server for root@localhost using sshx...done
[nREPL] Starting server via lein update-in :dependencies conj \[nrepl/nrepl\ \"1.0.0\"\] -- update-in :plugins conj \[cider/cider-nrepl\ \"0.40.0\"\] -- repl :headless :host localhost
error in process sentinel: let: Could not start nREPL server: /usr/local/bin/lein: line 224: type: java: not found
Leiningen couldn't find 'java' executable, which is required.
Please either set JAVA_CMD or put java (>=1.6) in your $PATH (/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin).
 ("exited abnormally with code 1")
```

But when manually connecting through `make ssh`, `java` is available (and there's some duplication going on):

```
make ssh
...
root@747a04bdfcfa:~# echo $PATH
/opt/java/openjdk/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/
```

When shelling out in the remote dired buffer, the envars that are written to `.bashrc` at the bottom of the [Dockerfile](https://github.com/clojure-emacs/cider/blob/master/dev/tramp-sample-project/Dockerfile) (e.g. `LEIN_ROOT`) seem to be picked up correctly, but `PATH` is different:
```
(dired "/sshx:root@localhost#8022:/usr/src/app")
(async-shell-command "echo $LEIN_ROOT")
;; => 1
(async-shell-command "echo $PATH")
;; => /bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
```

Where are the extra `PATH` elements coming from when using `make ssh`? It's just
```
ssh:
	ssh-keygen -R "[localhost]:8022"
	echo "Password is: cider"
	ssh root@localhost -p 8022

```
#### Wild guess
I stumbled over a comment in `start-file-process-shell-command` (used by `nrepl-start-server-process`):
 ```
 ;; On remote hosts, the local `shell-file-name' might be useless.
 ```
Maybe some `sh` vs `bash` thing going on here? But why are the `.bashrc` envars working then...?
Giving  up for now, because my Docker experience is limited.

#### Workaround
Adding `$JAVA_CMD` - as suggested by `lein` - made it work and the remote repl would spin up,
see: 442bdc353783a851c6bb7ad20a101465c9989979

### The remote filename was not detected properly by `nrepl--ssh-tunnel-connect`

With `"/sshx:root@localhost#8022:/usr/src/app"`, the `tramp-file-regex`
- did not match "sshx"
- and its host capture group ("`localhost`") did not match the `host` arg (`"localhost#8022"`)

**DANGER**: These are corrected in e3c933df722316db37e9e14b598e0a18cba4233d, but I am unsure if including the `#...` part in the host capture group is the right thing to do here and not breaking anything?

#### Cosmetics and Documentation

5e41923e76cebd280c5536db60bfd91aefb052d7
cc2ae8d978b77090a83808d4b920896f5e4fe5ff
