### PR TITLE
add new inspector function to tap current value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Changes
 
 - [#3546](https://github.com/clojure-emacs/cider/issues/3546): Inspector: render Java items using `java-mode` syntax coloring.
+- [#3548](https://github.com/clojure-emacs/cider/issues/3548)
+Inspector: add function to tap> the current inspector value
 
 ### Bugs fixed
 

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -308,7 +308,7 @@ current-namespace."
     (message "%s#'%s/%s = %s" cider-eval-result-prefix ns var-name value)))
 
 (defun cider-inspector-tap-current-val ()
-  "Sends current value to tap>"
+  "Sends current value to tap>."
   (interactive)
   (setq cider-inspector--current-repl (cider-current-repl))
   (when-let* ((value (cider-sync-request:inspect-tap-current-val)))
@@ -378,7 +378,7 @@ MAX-SIZE is the new value."
                 (nrepl-dict-get "value")))
 
 (defun cider-sync-request:inspect-tap-current-val ()
-  "Sends current inspector value to tap>"
+  "Sends current inspector value to tap>."
   (thread-first `("op" "inspect-tap-current-value")
                 (cider-nrepl-send-sync-request cider-inspector--current-repl)
                 (nrepl-dict-get "value")))

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -307,6 +307,14 @@ current-namespace."
     (cider-inspector--render-value value)
     (message "%s#'%s/%s = %s" cider-eval-result-prefix ns var-name value)))
 
+(defun cider-inspector-tap-current-val ()
+  "Sends current value to tap>"
+  (interactive)
+  (setq cider-inspector--current-repl (cider-current-repl))
+  (when-let* ((value (cider-sync-request:inspect-tap-current-val)))
+    (cider-inspector--render-value value)
+    (message "%s# tapped %s" cider-eval-result-prefix value)))
+
 ;; nREPL interactions
 (defun cider-sync-request:inspect-pop ()
   "Move one level up in the inspector stack."
@@ -366,6 +374,12 @@ MAX-SIZE is the new value."
   (thread-first `("op" "inspect-def-current-value"
                   "ns" ,ns
                   "var-name" ,var-name)
+                (cider-nrepl-send-sync-request cider-inspector--current-repl)
+                (nrepl-dict-get "value")))
+
+(defun cider-sync-request:inspect-tap-current-val ()
+  "Sends current inspector value to tap>"
+  (thread-first `("op" "inspect-tap-current-value")
                 (cider-nrepl-send-sync-request cider-inspector--current-repl)
                 (nrepl-dict-get "value")))
 

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -106,6 +106,7 @@ by clicking or navigating to them by other means."
     (define-key map "a" #'cider-inspector-set-max-atom-length)
     (define-key map "c" #'cider-inspector-set-max-coll-size)
     (define-key map "d" #'cider-inspector-def-current-val)
+    (define-key map "t" #'cider-inspector-tap-current-val)
     (define-key map [tab] #'cider-inspector-next-inspectable-object)
     (define-key map "\C-i" #'cider-inspector-next-inspectable-object)
     (define-key map "n" #'cider-inspector-next-inspectable-object)

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -312,9 +312,16 @@ current-namespace."
   "Sends current value to tap>."
   (interactive)
   (setq cider-inspector--current-repl (cider-current-repl))
-  (when-let* ((value (cider-sync-request:inspect-tap-current-val)))
+
+  (let* ((value (cider-sync-request:inspect-tap-current-val))
+         (elements (car (read-from-string value)))
+         (path-present (equal "--- Path:" (nth  (- (length elements) 4) elements  )))
+         (path-str (if path-present
+                       (car (last elements))
+                     "TOP-LEVEL")))
     (cider-inspector--render-value value)
-    (message "%s# tapped %s" cider-eval-result-prefix value)))
+    (message "%s# tapped element '%s'" cider-eval-result-prefix path-str)))
+
 
 ;; nREPL interactions
 (defun cider-sync-request:inspect-pop ()

--- a/doc/modules/ROOT/pages/debugging/inspector.adoc
+++ b/doc/modules/ROOT/pages/debugging/inspector.adoc
@@ -60,6 +60,10 @@ You'll have access to additional keybindings in the inspector buffer
 
 | kbd:[d]
 | Defines a var in the REPL namespace with current inspector value. If you tend to always choose the same name(s), you may want to set the `cider-inspector-preferred-var-names` customization option.
+
+| kbd:[t]
+| Sends the current inspector value to Clojure's tap>.
+
 |===
 
 == Configuration

--- a/doc/modules/ROOT/pages/debugging/inspector.adoc
+++ b/doc/modules/ROOT/pages/debugging/inspector.adoc
@@ -22,7 +22,7 @@ the last result. This behavior can be controlled with the variable
 TIP: The inspector can also be invoked in the middle of a debugging
 session, see xref:debugging/debugger.adoc[here] for more details.
 
-TIP: The curent value of the debugger can be as send as well to Clojure's
+TIP: The current value of the debugger can be as send as well to Clojure's
 tap> facility. This can be used to integrate CIDER with various external
 tools which render tapped values in a Web Browser for example.
 

--- a/doc/modules/ROOT/pages/debugging/inspector.adoc
+++ b/doc/modules/ROOT/pages/debugging/inspector.adoc
@@ -22,6 +22,10 @@ the last result. This behavior can be controlled with the variable
 TIP: The inspector can also be invoked in the middle of a debugging
 session, see xref:debugging/debugger.adoc[here] for more details.
 
+TIP: The curent value of the debugger can be as send as well to Clojure's
+tap> facility. This can be used to integrate CIDER with various external
+tools which render tapped values in a Web Browser for example.
+
 You'll have access to additional keybindings in the inspector buffer
 (which is internally using `cider-inspector-mode`):
 


### PR DESCRIPTION
> Fixes https://github.com/clojure-emacs/cider/issues/3548

add new interactive function  `cider-inspector-tap-current-val` to inspector.

It sends the current inspector value to the tap>.
It uses a new middleware op,  `inspect-tap-current-value` which has been added recently to cider-nrepl.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

