### PR TITLE
Add option to skip ssh hosts lookup on cider-connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 - [#3546](https://github.com/clojure-emacs/cider/issues/3546): Inspector: render Java items using `java-mode` syntax coloring.
+- [#3550](https://github.com/clojure-emacs/cider/pull/3550): Add option to skip ssh hosts lookup on cider-connect
 
 ### Bugs fixed
 

--- a/cider.el
+++ b/cider.el
@@ -1758,6 +1758,12 @@ canceled the action, signal quit."
         (file-remote-p buffer-file-name 'host))
       "localhost"))
 
+(defcustom cider-skip-ssh-hosts-lookup nil
+  "Skip looking up ssh hosts before connecting to a REPL."
+  :type 'boolean
+  :group 'cider
+  :package-version '(cider . "1.8.4"))
+
 (defun cider-select-endpoint ()
   "Interactively select the host and port to connect to."
   (dolist (endpoint cider-known-endpoints)
@@ -2120,11 +2126,6 @@ alternative to the default is `cider-random-tip'."
 
 (add-hook 'cider-connected-hook #'cider--maybe-inspire-on-connect)
 
-(defcustom cider-skip-ssh-hosts-lookup nil
-  "Skip looking up ssh hosts before connecting to a REPL."
-  :type 'boolean
-  :group 'cider
-  :package-version '(cider . "1.8.4"))
 
 ;;;###autoload
 (with-eval-after-load 'clojure-mode

--- a/cider.el
+++ b/cider.el
@@ -1765,7 +1765,7 @@ canceled the action, signal quit."
                          (nth 1 endpoint)))
       (user-error "The port for %s in `cider-known-endpoints' should be a string"
                   (nth 0 endpoint))))
-  (let* ((ssh-hosts (cider--ssh-hosts))
+  (let* ((ssh-hosts (unless cider-skip-ssh-hosts-lookup (cider--ssh-hosts)))
          (hosts (seq-uniq (append (when cider-host-history
                                     ;; history elements are strings of the form "host:port"
                                     (list (split-string (car cider-host-history) ":")))
@@ -2119,6 +2119,12 @@ alternative to the default is `cider-random-tip'."
     (message "Connected! %s" (funcall cider-connection-message-fn))))
 
 (add-hook 'cider-connected-hook #'cider--maybe-inspire-on-connect)
+
+(defcustom cider-skip-ssh-hosts-lookup nil
+  "Skip looking up ssh hosts before connecting to a REPL."
+  :type 'boolean
+  :group 'cider
+  :package-version '(cider . "1.8.4"))
 
 ;;;###autoload
 (with-eval-after-load 'clojure-mode


### PR DESCRIPTION
This slows down connect and causes serious annoyances if you have an `authinfo.gpg` and the pinentry path breaks for some reason (it often does)

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
