### PR TITLE
Inspector - improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+- [#3529](https://github.com/clojure-emacs/cider/issues/3529): CIDER inspector: introduce `cider-inspector-previous-sibling`, `cider-inspector-next-sibling` commands ([doc](https://docs.cider.mx/cider/debugging/inspector.html#usage)).
+
 ### Changes
 
 - [#3546](https://github.com/clojure-emacs/cider/issues/3546): Inspector: render Java items using `java-mode` syntax coloring.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Changes
 
 - [#3546](https://github.com/clojure-emacs/cider/issues/3546): Inspector: render Java items using `java-mode` syntax coloring.
+- [#3528](https://github.com/clojure-emacs/cider/issues/3528): Bump the injected `cider-nrepl` to [0.41.0](https://github.com/clojure-emacs/cider-nrepl/blob/v0.41.0/CHANGELOG.md#0410-2023-10-24).
+  - Updates [Orchard](https://github.com/clojure-emacs/orchard/blob/v0.17.0/CHANGELOG.md#0170-2023-10-24), providing misc presentational improvements for the CIDER Inspector.
 
 ### Bugs fixed
 

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -436,7 +436,13 @@ MAX-COLL-SIZE if non nil."
     (cider-inspector-render-el* el)))
 
 (defconst cider--inspector-java-headers
-  '("--- Interfaces:" "--- Constructors:" "--- Fields:" "--- Methods:" "--- Imports:"))
+  ;; NOTE "--- Static fields:" "--- Instance fields:" are for objects,
+  ;; and don't deserve Java syntax highlighting (they can contain a Clojure value like `:foo/bar`, for instance)
+  '("--- Interfaces:"
+    "--- Fields:" ;; rendered only for Class objects (and not other objects) - see previous comment
+    "--- Constructors:"
+    "--- Methods:"
+    "--- Imports:"))
 
 (defun cider-inspector-render-el* (el)
   "Render EL."

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -456,9 +456,12 @@ MAX-COLL-SIZE if non nil."
     (cond ((symbolp el) (insert (symbol-name el)))
           ((stringp el) (insert (if cider-inspector-looking-at-java-p
                                     (cider-font-lock-as 'java-mode el)
-                                  (propertize el 'font-lock-face (if header-p
-                                                                     'font-lock-comment-face
-                                                                   'font-lock-keyword-face)))))
+                                  (let ((trimmed-el (replace-regexp-in-string (regexp-quote "<non-inspectable value>")
+                                                                              ""
+                                                                              el)))
+                                    (propertize trimmed-el 'font-lock-face (if header-p
+                                                                               'font-lock-comment-face
+                                                                             'font-lock-keyword-face))))))
           ((and (consp el) (eq (car el) :newline))
            (insert "\n"))
           ((and (consp el) (eq (car el) :value))

--- a/cider.el
+++ b/cider.el
@@ -527,7 +527,7 @@ the artifact.")
 (defconst cider-latest-clojure-version "1.10.1"
   "Latest supported version of Clojure.")
 
-(defconst cider-required-middleware-version "0.40.0"
+(defconst cider-required-middleware-version "0.41.0"
   "The CIDER nREPL version that's known to work properly with CIDER.")
 
 (defcustom cider-injected-middleware-version cider-required-middleware-version

--- a/dev/docker-sample-project/project.clj
+++ b/dev/docker-sample-project/project.clj
@@ -2,4 +2,4 @@
   :dependencies [[org.clojure/clojure "1.11.1"]
                  [clj-http "3.12.3"]]
   :source-paths ["src"]
-  :plugins [[cider/cider-nrepl "0.40.0"]])
+  :plugins [[cider/cider-nrepl "0.41.0"]])

--- a/dev/tramp-sample-project/project.clj
+++ b/dev/tramp-sample-project/project.clj
@@ -2,5 +2,5 @@
   :dependencies [[org.clojure/clojure "1.11.1"]
                  [clj-http "3.12.3"]]
   :source-paths ["src"]
-  :plugins [[cider/cider-nrepl "0.40.0"]
+  :plugins [[cider/cider-nrepl "0.41.0"]
             [refactor-nrepl "3.9.0"]])

--- a/doc/modules/ROOT/pages/basics/middleware_setup.adoc
+++ b/doc/modules/ROOT/pages/basics/middleware_setup.adoc
@@ -32,14 +32,14 @@ Use the convenient plugin for defaults, either in your project's
 
 [source,clojure]
 ----
-:plugins [[cider/cider-nrepl "0.40.0"]]
+:plugins [[cider/cider-nrepl "0.41.0"]]
 ----
 
 A minimal `profiles.clj` for CIDER would be:
 
 [source,clojure]
 ----
-{:repl {:plugins [[cider/cider-nrepl "0.40.0"]]}}
+{:repl {:plugins [[cider/cider-nrepl "0.41.0"]]}}
 ----
 
 WARNING: Be careful not to place this in the `:user` profile, as this way CIDER's
@@ -59,7 +59,7 @@ all of their projects using a `~/.boot/profile.boot` file like so:
 (require 'boot.repl)
 
 (swap! boot.repl/*default-dependencies*
-       concat '[[cider/cider-nrepl "0.40.0"]])
+       concat '[[cider/cider-nrepl "0.41.0"]])
 
 (swap! boot.repl/*default-middleware*
        conj 'cider.nrepl/cider-middleware)
@@ -76,11 +76,11 @@ run `cider-connect` or `cider-connect-cljs`.
 
 [source,clojure]
 ----
-  :cider-clj {:extra-deps {cider/cider-nrepl {:mvn/version "0.40.0"}}
+  :cider-clj {:extra-deps {cider/cider-nrepl {:mvn/version "0.41.0"}}
               :main-opts ["-m" "nrepl.cmdline" "--middleware" "[cider.nrepl/cider-middleware]"]}
 
   :cider-cljs {:extra-deps {org.clojure/clojurescript {:mvn/version "1.10.339"}
-                            cider/cider-nrepl {:mvn/version "0.40.0"}
+                            cider/cider-nrepl {:mvn/version "0.41.0"}
                             cider/piggieback {:mvn/version "0.5.3"}}
                :main-opts ["-m" "nrepl.cmdline" "--middleware"
                            "[cider.nrepl/cider-middleware,cider.piggieback/wrap-cljs-repl]"]}

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -67,7 +67,7 @@ simple - CIDER simply passes the extra dependencies and nREPL configuration to
 your build tool in the command it runs to start the nREPL server. Here's how
 this looks for `tools.deps`:
 
-  $ clojure -Sdeps '{:deps {nrepl {:mvn/version "0.6.0"} cider/cider-nrepl {:mvn/version "0.40.0"}}}' -m nrepl.cmdline --middleware '["cider.nrepl/cider-middleware"]'
+  $ clojure -Sdeps '{:deps {nrepl {:mvn/version "0.6.0"} cider/cider-nrepl {:mvn/version "0.41.0"}}}' -m nrepl.cmdline --middleware '["cider.nrepl/cider-middleware"]'
 
 TIP: If you don't want `cider-jack-in` to inject dependencies automatically, set
 `cider-inject-dependencies-at-jack-in` to `nil`. Note that you'll have to setup
@@ -292,7 +292,7 @@ It is also possible for plain `clj`, although the command is somewhat longer:
 
 [source,sh]
 ----
-$ clj -Sdeps '{:deps {cider/cider-nrepl {:mvn/version "0.40.0"}}}' -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"
+$ clj -Sdeps '{:deps {cider/cider-nrepl {:mvn/version "0.41.0"}}}' -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"
 ----
 
 Alternatively, you can start nREPL either manually or using the facilities

--- a/doc/modules/ROOT/pages/cljs/shadow-cljs.adoc
+++ b/doc/modules/ROOT/pages/cljs/shadow-cljs.adoc
@@ -62,7 +62,7 @@ And connect to it with `cider-connect`.
 ...For that to work, `shadow-cljs.edn` contents like the following are assumed:
 
 ```clj
- :dependencies [[cider/cider-nrepl "0.40.0"] ;; mandatory (unless it's inherited from deps.edn or otherwise present in the classpath of shadow-cljs's JVM process)
+ :dependencies [[cider/cider-nrepl "0.41.0"] ;; mandatory (unless it's inherited from deps.edn or otherwise present in the classpath of shadow-cljs's JVM process)
                 [refactor-nrepl/refactor-nrepl "3.9.0"]] ;; refactor-nrepl is optional
 
  :nrepl {:middleware [cider.nrepl/cider-middleware ;; it's advisable to explicitly add this middleware. It's automatically added by shadow-cljs (if available in the classpath), unless `:nrepl {:cider false}`

--- a/doc/modules/ROOT/pages/debugging/inspector.adoc
+++ b/doc/modules/ROOT/pages/debugging/inspector.adoc
@@ -26,40 +26,59 @@ You'll have access to additional keybindings in the inspector buffer
 (which is internally using `cider-inspector-mode`):
 
 |===
-| Keyboard shortcut | Description
+| Keyboard shortcut | Command | Description
 
-| kbd:[Tab] and kbd:[Shift-Tab] / kdb:[n] and kbd:[p]
+| kbd:[Tab] and kbd:[Shift-Tab] / kbd:[n] and kbd:[p]
+| `cider-inspector-next-inspectable-object`
 | Navigate inspectable sub-objects
 
 | kbd:[f] and kbd:[b]
+| `forward-char`, `backward-char`
 | Navigate across characters on a line
 
 | kbd:[Return]
+| `cider-inspector-operate-on-point`
 | Inspect sub-objects
 
 | kbd:[l]
+| `cider-inspector-pop`
 | Pop to the parent object
 
 | kbd:[g]
+| `cider-inspector-refresh`
 | Refresh the inspector (e.g. if viewing an atom/ref/agent)
 
 | kbd:[SPC]
+| `cider-inspector-next-page`
 | Jump to next page in paginated view
 
 | kbd:[M-SPC]
+| `cider-inspector-prev-page`
 | Jump to previous page in paginated view
 
 | kbd:[s]
+| `cider-inspector-set-page-size`
 | Set a new page size in paginated view
 
 | kbd:[c]
+| `cider-inspector-set-max-coll-size`
 | Set a new maximum size above which nested collections are truncated
 
 | kbd:[a]
+| `cider-inspector-set-max-atom-length`
 | Set a new maximum length above which nested atoms (non-collections) are truncated
 
 | kbd:[d]
+| `cider-inspector-def-current-val`
 | Defines a var in the REPL namespace with current inspector value. If you tend to always choose the same name(s), you may want to set the `cider-inspector-preferred-var-names` customization option.
+
+| kbd:[9]
+| `cider-inspector-previous-sibling`
+| Navigates to the previous sibling, within a sequential collection.
+
+| kbd:[0]
+| `cider-inspector-next-sibling`
+| Navigates to the next sibling, within a sequential collection.
 |===
 
 == Configuration

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -144,7 +144,7 @@
   (describe "when there is a single dependency"
     (before-each
       (setq-local cider-injected-nrepl-version "0.9.0")
-      (setq-local cider-injected-middleware-version "0.40.0")
+      (setq-local cider-injected-middleware-version "0.41.0")
       (setq-local cider-jack-in-nrepl-middlewares '("cider.nrepl/cider-middleware"))
       (setq-local cider-jack-in-dependencies-exclusions '())
       (setq-local cider-enrich-classpath t))
@@ -154,7 +154,7 @@
               :to-equal (concat "update-in :dependencies conj "
                                 (shell-quote-argument "[nrepl/nrepl \"0.9.0\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[cider/cider-nrepl \"0.40.0\"]")
+                                (shell-quote-argument "[cider/cider-nrepl \"0.41.0\"]")
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[mx.cider/lein-enrich-classpath \"1.18.2\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath.plugin-v2/middleware"
@@ -167,7 +167,7 @@
                          "update-in :dependencies conj "
                          (shell-quote-argument "[nrepl/nrepl \"0.9.0\" :exclusions [org.clojure/clojure]]")
                          " -- update-in :plugins conj "
-                         (shell-quote-argument "[cider/cider-nrepl \"0.40.0\"]")
+                         (shell-quote-argument "[cider/cider-nrepl \"0.41.0\"]")
                          " -- update-in :plugins conj "
                          (shell-quote-argument "[mx.cider/lein-enrich-classpath \"1.18.2\"]")
                          " -- update-in :middleware conj cider.enrich-classpath.plugin-v2/middleware"
@@ -179,7 +179,7 @@
               :to-equal (concat "update-in :dependencies conj "
                                 (shell-quote-argument "[nrepl/nrepl \"0.9.0\" :exclusions [org.clojure/clojure foo.bar/baz]]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[cider/cider-nrepl \"0.40.0\"]")
+                                (shell-quote-argument "[cider/cider-nrepl \"0.41.0\"]")
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[mx.cider/lein-enrich-classpath \"1.18.2\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath.plugin-v2/middleware"
@@ -192,7 +192,7 @@
                          " -d "
                          (shell-quote-argument "nrepl/nrepl:0.9.0")
                          " -d "
-                         (shell-quote-argument "cider/cider-nrepl:0.40.0")
+                         (shell-quote-argument "cider/cider-nrepl:0.41.0")
                          " cider.tasks/add-middleware"
                          " -m "
                          (shell-quote-argument "cider.nrepl/cider-middleware")
@@ -201,7 +201,7 @@
     (it "can inject dependencies in a gradle project"
       (expect (cider-inject-jack-in-dependencies "--no-daemon" ":clojureRepl" 'gradle)
               :to-equal (concat "--no-daemon "
-                                (shell-quote-argument "-Pdev.clojurephant.jack-in.nrepl=nrepl:nrepl:0.9.0,cider:cider-nrepl:0.40.0")
+                                (shell-quote-argument "-Pdev.clojurephant.jack-in.nrepl=nrepl:nrepl:0.9.0,cider:cider-nrepl:0.41.0")
                                 " :clojureRepl "
                                 (shell-quote-argument "--middleware=cider.nrepl/cider-middleware")))))
 
@@ -218,7 +218,7 @@
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[refactor-nrepl \"2.0.0\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[cider/cider-nrepl \"0.40.0\"]")
+                                (shell-quote-argument "[cider/cider-nrepl \"0.41.0\"]")
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[mx.cider/lein-enrich-classpath \"1.18.2\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath.plugin-v2/middleware"
@@ -231,7 +231,7 @@
                                 " -d "
                                 (shell-quote-argument "nrepl/nrepl:0.9.0")
                                 " -d "
-                                (shell-quote-argument "cider/cider-nrepl:0.40.0")
+                                (shell-quote-argument "cider/cider-nrepl:0.41.0")
                                 " -d "
                                 (shell-quote-argument "refactor-nrepl:2.0.0")
                                 " cider.tasks/add-middleware"
@@ -253,7 +253,7 @@
               :to-equal (concat "-o -U update-in :dependencies conj "
                                 (shell-quote-argument "[nrepl/nrepl \"0.9.0\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[cider/cider-nrepl \"0.40.0\"]")
+                                (shell-quote-argument "[cider/cider-nrepl \"0.41.0\"]")
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[mx.cider/lein-enrich-classpath \"1.18.2\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath.plugin-v2/middleware"
@@ -264,7 +264,7 @@
                                 " -d "
                                 (shell-quote-argument "nrepl/nrepl:0.9.0")
                                 " -d "
-                                (shell-quote-argument "cider/cider-nrepl:0.40.0")
+                                (shell-quote-argument "cider/cider-nrepl:0.41.0")
                                 " cider.tasks/add-middleware"
                                 " -m "
                                 (shell-quote-argument "cider.nrepl/cider-middleware")
@@ -272,7 +272,7 @@
     (it "can concat in a gradle project"
       (expect (cider-inject-jack-in-dependencies "--no-daemon" ":clojureRepl" 'gradle)
               :to-equal (concat "--no-daemon "
-                                (shell-quote-argument "-Pdev.clojurephant.jack-in.nrepl=nrepl:nrepl:0.9.0,cider:cider-nrepl:0.40.0")
+                                (shell-quote-argument "-Pdev.clojurephant.jack-in.nrepl=nrepl:nrepl:0.9.0,cider:cider-nrepl:0.41.0")
                                 " :clojureRepl "
                                 (shell-quote-argument "--middleware=cider.nrepl/cider-middleware")))))
 
@@ -287,14 +287,14 @@
       (setq-local cider-jack-in-nrepl-middlewares '(("refactor-nrepl.middleware/wrap-refactor" :predicate middlewares-predicate) "cider.nrepl/cider-middleware" ("another/middleware"))))
     (it "includes plugins whose predicates return true"
       (expect (cider-jack-in-normalized-lein-plugins)
-              :to-equal '(("refactor-nrepl" "2.0.0") ("cider/cider-nrepl" "0.40.0"))))
+              :to-equal '(("refactor-nrepl" "2.0.0") ("cider/cider-nrepl" "0.41.0"))))
     (it "includes middlewares whose predicates return true"
       (expect (cider-jack-in-normalized-nrepl-middlewares)
               :to-equal '("refactor-nrepl.middleware/wrap-refactor" "cider.nrepl/cider-middleware" "another/middleware")))
     (it "ignores plugins whose predicates return false"
       (spy-on 'plugins-predicate :and-return-value nil)
       (expect (cider-jack-in-normalized-lein-plugins)
-              :to-equal '(("cider/cider-nrepl" "0.40.0")))
+              :to-equal '(("cider/cider-nrepl" "0.41.0")))
       (spy-on 'middlewares-predicate :and-return-value nil)
       (expect (cider-jack-in-normalized-nrepl-middlewares)
               :to-equal '("cider.nrepl/cider-middleware" "another/middleware")))
@@ -323,7 +323,7 @@
               :and-return-value '("refactor-nrepl.middleware/wrap-refactor" "cider.nrepl/cider-middleware"))
       (spy-on 'cider-jack-in-normalized-lein-plugins
               :and-return-value '(("refactor-nrepl" "2.0.0")
-                                  ("cider/cider-nrepl" "0.40.0")
+                                  ("cider/cider-nrepl" "0.41.0")
                                   ("mx.cider/lein-enrich-classpath" "1.18.2")))
       (setq-local cider-jack-in-dependencies-exclusions '())
       (setq-local cider-enrich-classpath t))
@@ -334,7 +334,7 @@
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[refactor-nrepl \"2.0.0\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[cider/cider-nrepl \"0.40.0\"]")
+                                (shell-quote-argument "[cider/cider-nrepl \"0.41.0\"]")
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[mx.cider/lein-enrich-classpath \"1.18.2\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath.plugin-v2/middleware"
@@ -352,7 +352,7 @@
                                 " -d "
                                 (shell-quote-argument "nrepl/nrepl:0.9.0")
                                 " -d "
-                                (shell-quote-argument "cider/cider-nrepl:0.40.0")
+                                (shell-quote-argument "cider/cider-nrepl:0.41.0")
                                 " -d "
                                 (shell-quote-argument "refactor-nrepl:2.0.0")
                                 " cider.tasks/add-middleware"
@@ -447,7 +447,7 @@
       (setq-local cider-jack-in-dependencies nil)
       (setq-local cider-jack-in-nrepl-middlewares '("cider.nrepl/cider-middleware"))
       (let ((expected (string-join `("clojure -Sdeps "
-                                     ,(shell-quote-argument "{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} cider/cider-nrepl {:mvn/version \"0.40.0\"}} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
+                                     ,(shell-quote-argument "{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} cider/cider-nrepl {:mvn/version \"0.41.0\"}} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
                                      " -M:cider/nrepl")
                                    "")))
         (setq-local cider-allow-jack-in-without-project t)
@@ -461,7 +461,7 @@
 
     (it "allows specifying custom aliases with `cider-clojure-cli-aliases`"
       (let ((expected (string-join `("clojure -Sdeps "
-                                     ,(shell-quote-argument "{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} cider/cider-nrepl {:mvn/version \"0.40.0\"}} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
+                                     ,(shell-quote-argument "{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} cider/cider-nrepl {:mvn/version \"0.41.0\"}} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
                                      " -M:dev:test:cider/nrepl")
                                    "")))
         (setq-local cider-jack-in-dependencies nil)
@@ -478,7 +478,7 @@
       (it (format "should remove duplicates, yielding the same result (for %S command invocation)" command)
         ;; repeat the same test for PowerShell too
         (let ((expected (string-join `("-Sdeps "
-                                       ,(cider--shell-quote-argument "{:deps {cider/cider-nrepl {:mvn/version \"0.40.0\"} nrepl/nrepl {:mvn/version \"0.9.0\"}} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}"
+                                       ,(cider--shell-quote-argument "{:deps {cider/cider-nrepl {:mvn/version \"0.41.0\"} nrepl/nrepl {:mvn/version \"0.9.0\"}} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}"
                                                                      command)
                                        " -M:dev:test:cider/nrepl")
                                      "")))
@@ -488,7 +488,7 @@
                   :to-equal expected))))
     (it "handles aliases correctly"
       (let ((expected (string-join `("-Sdeps "
-                                     ,(shell-quote-argument "{:deps {cider/cider-nrepl {:mvn/version \"0.40.0\"} nrepl/nrepl {:mvn/version \"0.9.0\"}} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
+                                     ,(shell-quote-argument "{:deps {cider/cider-nrepl {:mvn/version \"0.41.0\"} nrepl/nrepl {:mvn/version \"0.9.0\"}} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
                                      " -M:test:cider/nrepl")
                                    ""))
             (deps '(("nrepl/nrepl" "0.9.0"))))
@@ -516,7 +516,7 @@
                     :to-equal expected)))))
     (it "allows for global options"
       (let ((expected (string-join `("-J-Djdk.attach.allowAttachSelf -Sdeps "
-                                     ,(shell-quote-argument "{:deps {cider/cider-nrepl {:mvn/version \"0.40.0\"} nrepl/nrepl {:mvn/version \"0.9.0\"}} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
+                                     ,(shell-quote-argument "{:deps {cider/cider-nrepl {:mvn/version \"0.41.0\"} nrepl/nrepl {:mvn/version \"0.9.0\"}} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
                                      " -M:test:cider/nrepl")
                                    ""))
             (deps '(("nrepl/nrepl" "0.9.0"))))
@@ -527,7 +527,7 @@
       (setq-local cider-jack-in-dependencies '(("org.clojure/tools.deps" (("git/sha" . "6ae2b6f71773de7549d7f22759e8b09fec27f0d9")
                                                                           ("git/url" . "https://github.com/clojure/tools.deps/")))))
       (let ((expected (string-join `("clojure -Sdeps "
-                                     ,(shell-quote-argument "{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} cider/cider-nrepl {:mvn/version \"0.40.0\"} org.clojure/tools.deps { :git/sha \"6ae2b6f71773de7549d7f22759e8b09fec27f0d9\"  :git/url \"https://github.com/clojure/tools.deps/\" }} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
+                                     ,(shell-quote-argument "{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} cider/cider-nrepl {:mvn/version \"0.41.0\"} org.clojure/tools.deps { :git/sha \"6ae2b6f71773de7549d7f22759e8b09fec27f0d9\"  :git/url \"https://github.com/clojure/tools.deps/\" }} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
                                      " -M:cider/nrepl")
                                    "")))
         (setq-local cider-allow-jack-in-without-project t)


### PR DESCRIPTION
* Use cider-nrepl 0.41.0
  * Fixes https://github.com/clojure-emacs/cider/issues/3528
* Adapt `cider--inspector-java-headers` to the changes introduced in Orchard
  * See https://github.com/clojure-emacs/orchard/pull/197
* Inspector: don't render non-inspectable values
  * Those are conveyed by Orchard/cider-nrepl for representing values that cannot be inspected (i.e. private, inaccessible fields).
  * See https://github.com/clojure-emacs/orchard/pull/197
  * Fixes https://github.com/clojure-emacs/cider/issues/3542
* Inspector: Introduce jump to previous/next sibling commands
  * Fixes https://github.com/clojure-emacs/cider/issues/3529

Cheers - V