### PR TITLE
CIDER macroexpand: handle errors more gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - Improves performance for completions- and info-related functionality.
   - Updates [Orchard](https://github.com/clojure-emacs/orchard/blob/v0.18.0/CHANGELOG.md#0180-2023-10-30)
     - Improves various Inspector presentational aspects.
+- [#3554](https://github.com/clojure-emacs/cider/issues/3554): CIDER macroexpand: handle errors more gracefully. 
 
 ### Bugs fixed
 

--- a/cider-macroexpansion.el
+++ b/cider-macroexpansion.el
@@ -63,16 +63,19 @@ Possible values are:
 The default for DISPLAY-NAMESPACES is taken from
 `cider-macroexpansion-display-namespaces'."
   (cider-ensure-op-supported "macroexpand")
-  (thread-first `("op" "macroexpand"
-                  "expander" ,expander
-                  "code" ,expr
-                  "ns" ,(cider-current-ns)
-                  "display-namespaces" ,(or display-namespaces
-                                            (symbol-name cider-macroexpansion-display-namespaces)))
-                (nconc (when cider-macroexpansion-print-metadata
-                         '("print-meta" "true")))
-                (cider-nrepl-send-sync-request)
-                (nrepl-dict-get "expansion")))
+  (let ((result (thread-first `("op" "macroexpand"
+                                "expander" ,expander
+                                "code" ,expr
+                                "ns" ,(cider-current-ns)
+                                "display-namespaces" ,(or display-namespaces
+                                                          (symbol-name cider-macroexpansion-display-namespaces)))
+                              (nconc (when cider-macroexpansion-print-metadata
+                                       '("print-meta" "true")))
+                              (cider-nrepl-send-sync-request))))
+    (nrepl-dbind-response result (expansion err)
+      (if err
+          (user-error "Macroexpansion failed.  Please check *cider-error*")
+        expansion))))
 
 (defun cider-macroexpand-undo (&optional arg)
   "Undo the last macroexpansion, using `undo-only'.

--- a/cider-macroexpansion.el
+++ b/cider-macroexpansion.el
@@ -72,9 +72,9 @@ The default for DISPLAY-NAMESPACES is taken from
                               (nconc (when cider-macroexpansion-print-metadata
                                        '("print-meta" "true")))
                               (cider-nrepl-send-sync-request))))
-    (nrepl-dbind-response result (expansion err)
-      (if err
-          (user-error "Macroexpansion failed.  Please check *cider-error*")
+    (nrepl-dbind-response result (expansion status)
+      (if (member "macroexpand-error" status)
+          (user-error "Macroexpansion failed.  Check *cider-error* for more details")
         expansion))))
 
 (defun cider-macroexpand-undo (&optional arg)

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -643,7 +643,9 @@ others."
   "Emit toggle buttons for each of the ERROR-TYPES leading this stacktrace BUFFER."
   (with-current-buffer buffer
     (when error-types
-      (insert "  This is an unexpected CIDER middleware error.\n  Please submit a bug report via `")
+      (insert "  This is a CIDER middleware error.
+  It may be a due to a bug, or perhaps simply to bad user input.
+  If you believe it's a bug, please submit an issue report via `")
       (insert-text-button "M-x cider-report-bug"
                           'follow-link t
                           'action (lambda (_button) (cider-report-bug))


### PR DESCRIPTION
> Closes #3554

Bad macroexpansions ultimately caused by bad user input would (correctly) cause the nrepl middleware to return an `err`.

However that red path wasn't handled.

Cheers - V