### PR TITLE
Update up_and_running.adoc

### DIFF
--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -41,6 +41,12 @@ CIDER figures out this by parsing the output from the command and waiting for a 
 TIP: You can see the exact command that `cider-jack-in` invoked in your minibuffer, while
 waiting for nREPL to start. You can also find this command in Emacs's `+*Messages*+` buffer.
 
+IMPORTANT: `cider-jack-in` is mainly designed for local development with files on a local machine and 
+the nREPL process running on the same machine. It has as well features to support various remote / container
+scenarious, see below. Due to the large variation of remote scenarious it cannot support all of them, 
+so in some cases a manual nREPL start and usage of `cider-connect` is needed.
+
+
 In some cases one project might have multiple project markers in it - e.g. `project.clj` and `deps.edn`.
 When this happens CIDER will prompt you to select the build tool to use. You can override this behavior
 by setting the variable `cider-preferred-build-tool`. While you can set it globally in your Emacs config,


### PR DESCRIPTION
mention `local` in the cider-jack-in introduction

I think we  should a bit more express that `cider-jack-in`  works always for "local" situation and "often" for "remote" (but not always, even when setting the configurations CIDER has correctly).
