### PR TITLE
`cider-popup-buffer-display`: honor `special-display-buffer-names` if customized for a given CIDER buffer name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+- `cider-popup-buffer-display`: honor `special-display-buffer-names` if customized for a given CIDER buffer name (e.g. `*cider-inspect*`), avoiding the double-rendering of the given buffer.
+
 ## 1.10.0 (2023-10-31)
 
 ### New features

--- a/cider-popup.el
+++ b/cider-popup.el
@@ -46,29 +46,53 @@ If major MODE is non-nil, enable it for the popup buffer.
 If ANCILLARY is non-nil, the buffer is added to `cider-ancillary-buffers'
 and automatically removed when killed."
   (thread-first (cider-make-popup-buffer name mode ancillary)
+                (buffer-name)
                 (cider-popup-buffer-display select)))
 
-(defun cider-popup-buffer-display (buffer &optional select)
-  "Display BUFFER.
-If SELECT is non-nil, select the BUFFER."
-  (let ((window (get-buffer-window buffer 'visible)))
-    (when window
-      (with-current-buffer buffer
-        (set-window-point window (point))))
-    ;; If the buffer we are popping up is already displayed in the selected
-    ;; window, the below `inhibit-same-window' logic will cause it to be
-    ;; displayed twice - so we early out in this case. Note that we must check
-    ;; `selected-window', as async request handlers are executed in the context
-    ;; of the current connection buffer (i.e. `current-buffer' is dynamically
-    ;; bound to that).
-    (unless (eq window (selected-window))
-      ;; Non nil `inhibit-same-window' ensures that current window is not covered
-      ;; Non nil `inhibit-switch-frame' ensures that the other frame is not selected
-      ;; if that's where the buffer is being shown.
-      (funcall (if select #'pop-to-buffer #'display-buffer)
-               buffer `(nil . ((inhibit-same-window . ,pop-up-windows)
-                               (reusable-frames . visible))))))
-  buffer)
+(defun cider-popup-buffer-display (buffer-name &optional select)
+  "Display the buffer identified by BUFFER-NAME.
+If SELECT is non-nil, select the buffer.
+
+You can customize how the window will be chosen/created
+by adding BUFFER-NAME to the `special-display-buffer-names' list."
+  (let ((buffer-name (if (bufferp buffer-name) ;; ensure buffer-name is a string
+                         (buffer-name buffer-name)
+                       buffer-name)))
+    ;; if `buffer-name' belongs to `special-display-buffer-names',
+    ;; delegate to that mechanism the displaying of the buffer,
+    ;; otherwise the displaying would happen twice (ance through `special-display-buffer-names',
+    ;; another time through `cider-popup-buffer-display'):
+    (if (and (boundp 'special-display-buffer-names)
+             (seq-find (lambda (entry)
+                         (equal (car entry) buffer-name))
+                       special-display-buffer-names))
+        (progn
+          (display-buffer buffer-name)
+          (when select
+            (when-let ((window (get-buffer-window buffer-name)))
+              (select-window window))))
+      (let ((window (get-buffer-window buffer-name 'visible)))
+        (when window
+          (with-current-buffer buffer-name
+            (set-window-point window (point))))
+        ;; If the buffer we are popping up is already displayed in the selected
+        ;; window, the below `inhibit-same-window' logic will cause it to be
+        ;; displayed twice - so we early out in this case. Note that we must check
+        ;; `selected-window', as async request handlers are executed in the context
+        ;; of the current connection buffer (i.e. `current-buffer' is dynamically
+        ;; bound to that).
+        (unless (eq window (selected-window))
+          ;; Non nil `inhibit-same-window' ensures that current window is not covered
+          ;; Non nil `inhibit-switch-frame' ensures that the other frame is not selected
+          ;; if that's where the buffer is being shown.
+          (funcall (if select #'pop-to-buffer #'display-buffer)
+                   buffer-name `(nil . ((inhibit-same-window .
+                                                             ;; A non-nil value prevents the same window from being used for display:
+                                                             ,pop-up-windows)
+                                        (reusable-frames .
+                                                         ;; choose any visible frame
+                                                         visible)))))))
+    buffer-name))
 
 (defun cider-popup-buffer-quit (&optional kill)
   "Quit the current (temp) window.


### PR DESCRIPTION
Before this PR, if I `(add-to-list 'special-display-buffer-names '("*cider-inspect*" my/display-fn))`, the buffer would be rendered twice - once through one's custom function, and once again through CIDER.

I verified it works as intended.

Cheers - V