### PR TITLE
Possibly display error overlays on `cider-load-buffer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - CIDER [Inspector](https://docs.cider.mx/cider/debugging/inspector.html): display Java class/method/field info when available.
   - This info is available when [enrich-classpath](https://docs.cider.mx/cider/config/basic_config.html#use-enrich-classpath) is active.
+- [#3495](https://github.com/clojure-emacs/cider/issues/3495): possibly display error overlays on [`cider-load-buffer`](https://docs.cider.mx/cider/usage/code_evaluation.html#basic-evaluation).
 - `cider-popup-buffer-display`: honor `special-display-buffer-names` if customized for a given CIDER buffer name (e.g. `*cider-inspect*`), avoiding the double-rendering of the given buffer.
 - [#3572](https://github.com/clojure-emacs/cider/issues/3572): `lein.sh`: honor `XDG_CACHE_HOME`. 
 - Bump the injected `cider-nrepl` to [0.43.0](https://github.com/clojure-emacs/cider-nrepl/blob/v0.43.0/CHANGELOG.md#0430-2023-11-04).

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -951,7 +951,16 @@ Optional argument DONE-HANDLER lambda will be run once load is complete."
                                    (cider-emit-interactive-eval-output value))
                                  (lambda (_buffer err)
                                    (cider-emit-interactive-eval-err-output err)
-                                   (cider-handle-compilation-errors err eval-buffer))
+                                   ;; 1.- Jump to the error line:
+                                   (cider-handle-compilation-errors err eval-buffer)
+                                   (with-current-buffer eval-buffer
+                                     (let* ((phase (cider--error-phase-of-last-exception buffer))
+                                            ;; 2.- Calculate the overlay position, which is the point (per the previous jump),
+                                            ;;     and then end-of-line (for ensuring the overlay will be rendered properly):
+                                            (end (save-excursion
+                                                   (end-of-line)
+                                                   (point))))
+                                       (cider--maybe-display-error-as-overlay phase err end))))
                                  (lambda (buffer)
                                    (when cider-eval-register
                                      (set-register cider-eval-register res))

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -958,7 +958,8 @@ Optional argument DONE-HANDLER lambda will be run once load is complete."
                                             ;; 2.- Calculate the overlay position, which is the point (per the previous jump),
                                             ;;     and then end-of-line (for ensuring the overlay will be rendered properly):
                                             (end (save-excursion
-                                                   (end-of-line)
+                                                   (when (equal cider-result-overlay-position 'at-eol)
+                                                     (end-of-line))
                                                    (point))))
                                        (cider--maybe-display-error-as-overlay phase err end))))
                                  (lambda (buffer)


### PR DESCRIPTION
> Part of https://github.com/clojure-emacs/cider/issues/3495

I verified locally that it works nicely.

Cheers - V