### PR TITLE
Add a command to delete history item at point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+- [#3574](https://github.com/clojure-emacs/cider/issues/3574): New value `per-project` for `cider-repl-history-file` to save the history on a per-project basis.
+
 ### Bugs fixed
 
 - [#3763](https://github.com/clojure-emacs/cider/issues/3763): Fix `cider-docview-render` completion popup error when symbol being completed does not have a docstring.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+### New features
+- CIDER [History](https://docs.cider.mx/cider/repl/history.html): Add a command to delete history item at point.
+
 ### Changes
 
 - [#3574](https://github.com/clojure-emacs/cider/issues/3574): New value `per-project` for `cider-repl-history-file` to save the history on a per-project basis.

--- a/cider-repl-history.el
+++ b/cider-repl-history.el
@@ -575,6 +575,16 @@ text from the *cider-repl-history* buffer."
   (with-current-buffer cider-repl-history-repl-buffer
     (undo)))
 
+(defun cider-repl-history-delete-entry-at-point ()
+  "Delete history entry (at point)."
+  (interactive)
+  (let* ((orig (point))
+         (str (cider-repl-history-current-string orig)))
+    (with-current-buffer cider-repl-history-repl-buffer
+      (delete str cider-repl-input-history))
+    (cider-repl-history-update)
+    (goto-char orig)))
+
 (defun cider-repl-history-setup (repl-win repl-buf history-buf &optional regexp)
   "Setup.
 REPL-WIN and REPL-BUF are where to insert commands;
@@ -693,6 +703,7 @@ HISTORY-BUF is the history, and optional arg REGEXP is a filter."
     (define-key map (kbd "g")   #'cider-repl-history-update)
     (define-key map (kbd "q")   #'cider-repl-history-quit)
     (define-key map (kbd "U")   #'cider-repl-history-undo-other-window)
+    (define-key map (kbd "D")   #'cider-repl-history-delete-entry-at-point)
     (define-key map (kbd "?")   #'describe-mode)
     (define-key map (kbd "h")   #'describe-mode)
     map))

--- a/cider-repl-history.el
+++ b/cider-repl-history.el
@@ -220,7 +220,6 @@ call `cider-repl-history' again.")
 (defvar cider-repl-history-previous-overlay nil
   "Previous overlay within *cider-repl-history* buffer.")
 
-
 (defun cider-repl-history-get-history ()
   "Function to retrieve history from the REPL buffer."
   (if cider-repl-history-repl-buffer

--- a/cider-repl-history.el
+++ b/cider-repl-history.el
@@ -636,16 +636,17 @@ HISTORY-BUF is the history, and optional arg REGEXP is a filter."
                         #'cider-repl-history-update-highlighted-entry
                         nil t))
             (message
-             (let ((entry (if (= 1 (length cider-command-history))
-                              "entry"
-                            "entries")))
+             (let* ((history-length (length cider-command-history))
+                    (entry (if (= 1 history-length)
+                               "entry"
+                             "entries")))
                (concat
                 (if (and (not regexp)
                          cider-repl-history-display-duplicates)
                     (format "%s %s in the command history."
-                            (length cider-command-history) entry)
+                            history-length entry)
                   (format "%s (of %s) %s in the command history shown."
-                          (length items) (length cider-command-history) entry))
+                          (length items) history-length entry))
                 (substitute-command-keys
                  (concat "  Type \\[cider-repl-history-quit] to quit.  "
                          "\\[describe-mode] for help.")))))

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -1610,6 +1610,12 @@ It does not yet set the input history."
           (read (current-buffer))))
     '()))
 
+(defun cider-repl--find-dir-for-history ()
+  "Find the first suitable directory to store the project's history."
+  (seq-find
+   (lambda (dir) (and (not (null dir)) (not (tramp-tramp-file-p dir))))
+   (list nrepl-project-dir (clojure-project-dir) default-directory)))
+
 (defun cider-repl-history-load (&optional filename)
   "Load history from FILENAME into current session.
 FILENAME defaults to the value of `cider-repl-history-file' but user
@@ -1621,7 +1627,7 @@ The value of `cider-repl-input-history' is set by this function."
    (filename (setq cider-repl-history-file filename))
    ((equal 'per-project cider-repl-history-file)
     (make-local-variable 'cider-repl-input-history)
-    (when-let ((dir (clojure-project-dir)))
+    (when-let ((dir (cider-repl--find-dir-for-history)))
       (setq-local
        cider-repl-history-file (expand-file-name ".cider-history" dir)))))
   (when cider-repl-history-file

--- a/doc/modules/ROOT/pages/repl/configuration.adoc
+++ b/doc/modules/ROOT/pages/repl/configuration.adoc
@@ -340,12 +340,21 @@ reset automatically by the `track-state` middleware.
 (setq cider-repl-history-size 1000) ; the default is 500
 ----
 
-* To store the REPL history in a file:
+* To store the REPL history of all projects in a single file:
 
 [source,lisp]
 ----
 (setq cider-repl-history-file "path/to/file")
 ----
 
-Note that CIDER writes the history to the file when you kill the REPL
-buffer, which includes invoking `cider-quit`, or when you quit Emacs.
+* To store the REPL history per project (by creating a
+  `.cider-history` file at the root of each):
+
+[source,lisp]
+----
+(setq cider-repl-history-file 'per-project)
+----
+
+Note that CIDER writes the history to the file(s) when you kill the
+REPL buffer, which includes invoking `cider-quit`, or when you quit
+Emacs.

--- a/doc/modules/ROOT/pages/repl/history.adoc
+++ b/doc/modules/ROOT/pages/repl/history.adoc
@@ -175,4 +175,7 @@ There are a number of important keybindings in history buffers.
 
 | kbd:[U]
 | Undo in the REPL buffer.
+
+| kbd:[D]
+| Delete history item (at point).
 |===


### PR DESCRIPTION
This PR adds a command to delete an history item at point.

~The first commit is important because it makes `cider-repl-input-history` global. It was already sort of global before because the history was shared across REPLs and saved to a unique file but now it's downright a `defvar` instead of a `defvar-local`. I went in that direction because it felt like it was the simplest way of dealing with acknowledgment of deletion of an item across multiple REPLs.~

The first commit now stores histories on a per-project basis

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
