### PR TITLE
Inspector: retain `truncate-lines` values across screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 - [#3576](https://github.com/clojure-emacs/cider/issues/3576): CIDER [Inspector](https://docs.cider.mx/cider/debugging/inspector.html): display Java class/method/field block tags (Returns/Throws/Params info) when available.
+- CIDER [Inspector](https://docs.cider.mx/cider/debugging/inspector.html): retain [`truncate-lines`](https://www.gnu.org/software/emacs/manual/html_node/emacs/Line-Truncation.html) values across screens. 
 
 ## 1.11.1 (2023-11-11)
 

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -537,14 +537,18 @@ instead of just its \"value\" entry."
                       ;; because on each re-rendering, we wipe everything, including the mode.
                       ;; Enabling cider-inspector-mode is the specific step that loses the font size.
                       (buffer-local-value variable b)))
-         (truncate-lines-variable 'truncate-lines)
          (truncate-lines-defined (when-let* ((b (get-buffer cider-inspector-buffer)))
-                                   (local-variable-p truncate-lines-variable b)))
+                                   (local-variable-p 'truncate-lines b)))
          (truncate-lines-p (when-let* ((b (get-buffer cider-inspector-buffer))
                                        (continue truncate-lines-defined))
-                             (buffer-local-value truncate-lines-variable b))))
+                             (buffer-local-value 'truncate-lines b))))
     (cider-make-popup-buffer cider-inspector-buffer 'cider-inspector-mode 'ancillary)
-    (cider-inspector-render cider-inspector-buffer value font-size truncate-lines-defined truncate-lines-p fragments block-tags))
+    (cider-inspector-render cider-inspector-buffer value
+                            :font-size font-size
+                            :truncate-lines-defined truncate-lines-defined
+                            :truncate-lines-p truncate-lines-p
+                            :fragments fragments
+                            :block-tags block-tags))
   (cider-popup-buffer-display cider-inspector-buffer cider-inspector-auto-select-buffer)
   (when cider-inspector-fill-frame (delete-other-windows))
   (ignore-errors (cider-inspector-next-inspectable-object 1))
@@ -563,7 +567,7 @@ instead of just its \"value\" entry."
       (when cider-inspector-page-location-stack
         (goto-char (pop cider-inspector-page-location-stack))))))
 
-(defun cider-inspector-render (buffer str &optional font-size truncate-lines-defined truncate-lines-p fragments block-tags)
+(cl-defun cider-inspector-render (buffer str &key font-size truncate-lines-defined truncate-lines-p fragments block-tags)
   "Render STR in BUFFER."
   (with-current-buffer buffer
     (cider-inspector-mode)


### PR DESCRIPTION
Retains the user's t/nil preference across Inspector screens.

This is particularly important now that we render Java doc, which can be quite lengthy.