### PR TITLE
Inspector: introduce `o`, `:` keybindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 - [#3576](https://github.com/clojure-emacs/cider/issues/3576): CIDER [Inspector](https://docs.cider.mx/cider/debugging/inspector.html): display Java class/method/field block tags (Returns/Throws/Params info) when available.
+- CIDER [Inspector](https://docs.cider.mx/cider/debugging/inspector.html#usage): introduce `u` keybinding which performs `cider-open-url-at-point`.
 - CIDER [Inspector](https://docs.cider.mx/cider/debugging/inspector.html): retain [`truncate-lines`](https://www.gnu.org/software/emacs/manual/html_node/emacs/Line-Truncation.html) values across screens. 
 - [#3580](https://github.com/clojure-emacs/cider/issues/3580): `cider-test`: make test vars in [test results reports](https://docs.cider.mx/cider/testing/test_reports.html) clickable.
   - As defined in the newly introduced `cider-test-var-keymap` var.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 ### Changes
 
 - [#3576](https://github.com/clojure-emacs/cider/issues/3576): CIDER [Inspector](https://docs.cider.mx/cider/debugging/inspector.html): display Java class/method/field block tags (Returns/Throws/Params info) when available.
-- CIDER [Inspector](https://docs.cider.mx/cider/debugging/inspector.html#usage): introduce `u` keybinding which performs `cider-open-url-at-point`.
-- CIDER [Inspector](https://docs.cider.mx/cider/debugging/inspector.html#usage): introduce `r` keybinding which performs `cider-inspect-expr`.
+- CIDER [Inspector](https://docs.cider.mx/cider/debugging/inspector.html#usage): introduce `o` keybinding which performs `cider-inspector-open-thing-at-point`.
+- CIDER [Inspector](https://docs.cider.mx/cider/debugging/inspector.html#usage): introduce `:` keybinding which performs `cider-inspect-expr`.
 - CIDER [Inspector](https://docs.cider.mx/cider/debugging/inspector.html): retain [`truncate-lines`](https://www.gnu.org/software/emacs/manual/html_node/emacs/Line-Truncation.html) values across screens. 
 - [#3580](https://github.com/clojure-emacs/cider/issues/3580): `cider-test`: make test vars in [test results reports](https://docs.cider.mx/cider/testing/test_reports.html) clickable.
   - As defined in the newly introduced `cider-test-var-keymap` var.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - [#3576](https://github.com/clojure-emacs/cider/issues/3576): CIDER [Inspector](https://docs.cider.mx/cider/debugging/inspector.html): display Java class/method/field block tags (Returns/Throws/Params info) when available.
 - CIDER [Inspector](https://docs.cider.mx/cider/debugging/inspector.html#usage): introduce `o` keybinding which performs `cider-inspector-open-thing-at-point`.
-- CIDER [Inspector](https://docs.cider.mx/cider/debugging/inspector.html#usage): introduce `:` keybinding which performs `cider-inspect-expr`.
+- CIDER [Inspector](https://docs.cider.mx/cider/debugging/inspector.html#usage): introduce `:` keybinding which performs `cider-inspect-expr-from-inspector`.
 - CIDER [Inspector](https://docs.cider.mx/cider/debugging/inspector.html): retain [`truncate-lines`](https://www.gnu.org/software/emacs/manual/html_node/emacs/Line-Truncation.html) values across screens. 
 - [#3580](https://github.com/clojure-emacs/cider/issues/3580): `cider-test`: make test vars in [test results reports](https://docs.cider.mx/cider/testing/test_reports.html) clickable.
   - As defined in the newly introduced `cider-test-var-keymap` var.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [#3576](https://github.com/clojure-emacs/cider/issues/3576): CIDER [Inspector](https://docs.cider.mx/cider/debugging/inspector.html): display Java class/method/field block tags (Returns/Throws/Params info) when available.
 - CIDER [Inspector](https://docs.cider.mx/cider/debugging/inspector.html#usage): introduce `u` keybinding which performs `cider-open-url-at-point`.
+- CIDER [Inspector](https://docs.cider.mx/cider/debugging/inspector.html#usage): introduce `r` keybinding which performs `cider-inspect-expr`.
 - CIDER [Inspector](https://docs.cider.mx/cider/debugging/inspector.html): retain [`truncate-lines`](https://www.gnu.org/software/emacs/manual/html_node/emacs/Line-Truncation.html) values across screens. 
 - [#3580](https://github.com/clojure-emacs/cider/issues/3580): `cider-test`: make test vars in [test results reports](https://docs.cider.mx/cider/testing/test_reports.html) clickable.
   - As defined in the newly introduced `cider-test-var-keymap` var.

--- a/cider-common.el
+++ b/cider-common.el
@@ -84,12 +84,13 @@ INVERT inverts the semantics of the function `cider--should-prompt-for-symbol'."
 
 (declare-function cider-complete-at-point "cider-completion")
 (declare-function cider-eldoc "cider-eldoc")
-(defun cider-read-from-minibuffer (prompt &optional value)
+(defun cider-read-from-minibuffer (prompt &optional value skip-colon)
   "Read a string from the minibuffer, prompting with PROMPT.
 If VALUE is non-nil, it is inserted into the minibuffer as initial-input.
-PROMPT need not end with \": \". If it doesn't, VALUE is displayed on the
+PROMPT need not end with \": \".  If it doesn't, VALUE is displayed on the
 prompt as a default value (used if the user doesn't type anything) and is
-not used as initial input (input is left empty)."
+not used as initial input (input is left empty).
+If SKIP-COLON is non-nil, no \": \" is forced at the end of the prompt."
   (minibuffer-with-setup-hook
       (lambda ()
         (set-syntax-table clojure-mode-syntax-table)
@@ -100,6 +101,7 @@ not used as initial input (input is left empty)."
     (let* ((has-colon (string-match ": \\'" prompt))
            (input (read-from-minibuffer (cond
                                          (has-colon prompt)
+                                         (skip-colon prompt)
                                          (value (format "%s (default %s): " prompt value))
                                          (t (format "%s: " prompt)))
                                         (when has-colon value) ; initial-input

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -89,11 +89,13 @@ by clicking or navigating to them by other means."
           "\\|[+-.0-9]+")            ; nor numbers. Note: BigInts, ratios etc. are interesting
   "Regexp of uninteresting and skippable values.")
 
-(defun cider-open-url-at-point ()
-  "Opens the url at point if found, without prompting."
+(defun cider-inspector-open-thing-at-point ()
+  "Opens the thing at point if found, without prompting."
   (interactive)
-  (when-let ((url (thing-at-point 'url)))
-    (browse-url url)))
+  (if-let ((url (thing-at-point 'url)))
+      (browse-url url)
+    (if-let ((filename (thing-at-point 'filename)))
+        (find-file filename))))
 
 (defvar cider-inspector-mode-map
   (let ((map (make-sparse-keymap)))
@@ -102,7 +104,7 @@ by clicking or navigating to them by other means."
     (define-key map [mouse-1] #'cider-inspector-operate-on-click)
     (define-key map "l" #'cider-inspector-pop)
     (define-key map "g" #'cider-inspector-refresh)
-    (define-key map "u" #'cider-open-url-at-point)
+    (define-key map "o" #'cider-inspector-open-thing-at-point)
     ;; Page-up/down
     (define-key map [next] #'cider-inspector-next-page)
     (define-key map [prior] #'cider-inspector-prev-page)
@@ -119,7 +121,7 @@ by clicking or navigating to them by other means."
     (define-key map "n" #'cider-inspector-next-inspectable-object)
     (define-key map [(shift tab)] #'cider-inspector-previous-inspectable-object)
     (define-key map "p" #'cider-inspector-previous-inspectable-object)
-    (define-key map "r" #'cider-inspect-expr)
+    (define-key map ":" #'cider-inspect-expr)
     (define-key map "f" #'forward-char)
     (define-key map "b" #'backward-char)
     (define-key map "9" #'cider-inspector-previous-sibling)

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -121,7 +121,7 @@ by clicking or navigating to them by other means."
     (define-key map "n" #'cider-inspector-next-inspectable-object)
     (define-key map [(shift tab)] #'cider-inspector-previous-inspectable-object)
     (define-key map "p" #'cider-inspector-previous-inspectable-object)
-    (define-key map ":" #'cider-inspect-expr)
+    (define-key map ":" #'cider-inspect-expr-from-inspector)
     (define-key map "f" #'forward-char)
     (define-key map "b" #'backward-char)
     (define-key map "9" #'cider-inspector-previous-sibling)
@@ -226,6 +226,16 @@ current buffer's namespace."
                  'v2)))
     (when (nrepl-dict-get result "value")
       (cider-inspector--render-value result 'v2))))
+
+(defun cider-inspect-expr-from-inspector ()
+  "Performs `cider-inspect-expr' in a way that is suitable from the Inspector itself.
+In particular, it does not read `cider-sexp-at-point'."
+  (interactive)
+  (let* ((ns (cider-current-ns))
+         (prompt (format "Inspect expression in %s"
+                         (substring-no-properties (funcall cider-repl-prompt-function ns)))))
+    (cider-inspect-expr (cider-read-from-minibuffer prompt nil 'skip-colon)
+                        ns)))
 
 (defun cider-inspector-pop ()
   "Pop the last value off the inspector stack and render it.

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -119,6 +119,7 @@ by clicking or navigating to them by other means."
     (define-key map "n" #'cider-inspector-next-inspectable-object)
     (define-key map [(shift tab)] #'cider-inspector-previous-inspectable-object)
     (define-key map "p" #'cider-inspector-previous-inspectable-object)
+    (define-key map "r" #'cider-inspect-expr)
     (define-key map "f" #'forward-char)
     (define-key map "b" #'backward-char)
     (define-key map "9" #'cider-inspector-previous-sibling)

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -89,6 +89,12 @@ by clicking or navigating to them by other means."
           "\\|[+-.0-9]+")            ; nor numbers. Note: BigInts, ratios etc. are interesting
   "Regexp of uninteresting and skippable values.")
 
+(defun cider-open-url-at-point ()
+  "Opens the url at point if found, without prompting."
+  (interactive)
+  (when-let ((url (thing-at-point 'url)))
+    (browse-url url)))
+
 (defvar cider-inspector-mode-map
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map cider-popup-buffer-mode-map)
@@ -96,6 +102,7 @@ by clicking or navigating to them by other means."
     (define-key map [mouse-1] #'cider-inspector-operate-on-click)
     (define-key map "l" #'cider-inspector-pop)
     (define-key map "g" #'cider-inspector-refresh)
+    (define-key map "u" #'cider-open-url-at-point)
     ;; Page-up/down
     (define-key map [next] #'cider-inspector-next-page)
     (define-key map [prior] #'cider-inspector-prev-page)

--- a/doc/modules/ROOT/pages/debugging/inspector.adoc
+++ b/doc/modules/ROOT/pages/debugging/inspector.adoc
@@ -84,6 +84,10 @@ You'll have access to additional keybindings in the inspector buffer
 | `cider-inspector-next-sibling`
 | Navigates to the next sibling, within a sequential collection.
 
+| kbd:[u]
+| `cider-open-url-at-point`
+| Opens the url at point if found.
+
 | kbd:[t]
 | `cider-inspector-tap-current-val`
 | Performs `tap>` using the inspector's current value as it argument.

--- a/doc/modules/ROOT/pages/debugging/inspector.adoc
+++ b/doc/modules/ROOT/pages/debugging/inspector.adoc
@@ -88,6 +88,10 @@ You'll have access to additional keybindings in the inspector buffer
 | `cider-open-url-at-point`
 | Opens the url at point if found.
 
+| kbd:[r]
+| `cider-inspect-expr`
+| Prompts for a new value, rendering it in the Inspector.
+
 | kbd:[t]
 | `cider-inspector-tap-current-val`
 | Performs `tap>` using the inspector's current value as it argument.

--- a/doc/modules/ROOT/pages/debugging/inspector.adoc
+++ b/doc/modules/ROOT/pages/debugging/inspector.adoc
@@ -89,7 +89,7 @@ You'll have access to additional keybindings in the inspector buffer
 | Opens the url or file at point, if found.
 
 | kbd:[:]
-| `cider-inspect-expr`
+| `cider-inspect-expr-from-inspector`
 | Prompts for a new value, rendering it in the Inspector.
 
 | kbd:[t]

--- a/doc/modules/ROOT/pages/debugging/inspector.adoc
+++ b/doc/modules/ROOT/pages/debugging/inspector.adoc
@@ -84,11 +84,11 @@ You'll have access to additional keybindings in the inspector buffer
 | `cider-inspector-next-sibling`
 | Navigates to the next sibling, within a sequential collection.
 
-| kbd:[u]
-| `cider-open-url-at-point`
-| Opens the url at point if found.
+| kbd:[o]
+| `cider-inspector-open-thing-at-point`
+| Opens the url or file at point, if found.
 
-| kbd:[r]
+| kbd:[:]
 | `cider-inspect-expr`
 | Prompts for a new value, rendering it in the Inspector.
 


### PR DESCRIPTION
* Inspector: introduce `:` keybinding which performs `cider-inspect-expr`

Now the inspector can also double as a REPL 😄

* Inspector: introduce `o` keybinding which performs `cider-open-url-at-point`

It's relatively common to inspect objects that contain a URL in it.

`u` now can open those in the browser.

