### PR TITLE
pwsh 7.3 quoting rules compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+- [#3588](https://github.com/clojure-emacs/cider/issues/3588): Compatibility with pwsh 7.3 quoting rules.
+
 ## 1.12.0 (2023-11-24)
 
 ### Changes

--- a/cider.el
+++ b/cider.el
@@ -810,7 +810,10 @@ rules to quote it."
 (defun cider--powershell-encode-command (cmd-params)
   "Base64 encode the powershell command and jack-in CMD-PARAMS for clojure-cli."
   (let* ((quoted-params cmd-params)
-         (command (format "clojure %s" quoted-params))
+         ;; Also ensure compatibility with pwsh 7.3 quoting rules
+         ;;
+         ;; https://stackoverflow.com/a/59036879
+         (command (format "$PSNativeCommandArgumentPassing = 'Legacy'; clojure %s" quoted-params))
          (utf-16le-command (encode-coding-string command 'utf-16le)))
     (format "-encodedCommand %s" (base64-encode-string utf-16le-command t))))
 

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -208,11 +208,20 @@ so we'll examine them tool by tool.
 * `cider-clojure-cli-parameters` - the command-line parameters to start a REPL
 * `cider-clojure-cli-aliases` - a list of aliases to be used at jack-in time
 
-To use `cider-jack-in` with `tools.deps` on Windows set the
-`cider-clojure-cli-command` to `"powershell"`. This happens by default
-if you are on Windows and no `clojure` executable is found. Using
-`"powershell"` will Base64 encode the clojure launch command before
-passing it to PowerShell and avoids shell-escaping issues.
+On MS-Windows, CIDER will employ `PowerShell` to execute Clojure if no
+`clojure` executable is found in the PATH (e.g. like the one supplied
+by https://github.com/borkdude/deps.clj[deps.clj]). The default
+executable used is `powershell` which is available on all Windows
+platforms. Using `PowerShell` will Base64 encode the clojure launch
+command before passing it to PowerShell and avoids shell-escaping
+issues.
+
+The functionality of `cider-clojure-cli-command` has been verified
+with the following alternatives
+
+* `pwsh`: This option proves beneficial when the user has installed the https://github.com/clojure/tools.deps.alpha/wiki/clj-on-Windows[ClojureTools] module on pwsh in a directory not accessible by the system's PowerShell installation.
+* `deps.exe`: This executable is part of the tools provided by
+  https://github.com/borkdude/deps.clj[deps.clj] as an alternative name for `clojure.exe`.
 
 NOTE: Alternatively you can use WSL (e.g. to run nREPL and Emacs there), which
 will likely result in a better overall development experience.

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -420,12 +420,12 @@
     (expect (cider--powershell-encode-command "cmd-params")
             :to-equal (concat "-encodedCommand "
                               ;; Eval to reproduce reference string below: (base64-encode-string (encode-coding-string "clojure cmd-params" 'utf-16le) t)
-                              "YwBsAG8AagB1AHIAZQAgAGMAbQBkAC0AcABhAHIAYQBtAHMA")))
+                              "JABQAFMATgBhAHQAaQB2AGUAQwBvAG0AbQBhAG4AZABBAHIAZwB1AG0AZQBuAHQAUABhAHMAcwBpAG4AZwAgAD0AIAAnAEwAZQBnAGEAYwB5ACcAOwAgAGMAbABvAGoAdQByAGUAIABjAG0AZAAtAHAAYQByAGEAbQBzAA==")))
   (it "escapes double quotes by repeating them"
     (expect (cider--powershell-encode-command "\"cmd-params\"")
             :to-equal (concat "-encodedCommand "
                               ;; Eval to reproduce reference string below: (base64-encode-string (encode-coding-string "clojure "\"cmd-params\""" 'utf-16le) t)
-                              "YwBsAG8AagB1AHIAZQAgACIAYwBtAGQALQBwAGEAcgBhAG0AcwAiAA=="))))
+                              "JABQAFMATgBhAHQAaQB2AGUAQwBvAG0AbQBhAG4AZABBAHIAZwB1AG0AZQBuAHQAUABhAHMAcwBpAG4AZwAgAD0AIAAnAEwAZQBnAGEAYwB5ACcAOwAgAGMAbABvAGoAdQByAGUAIAAiAGMAbQBkAC0AcABhAHIAYQBtAHMAIgA="))))
 
 (describe "cider--update-jack-in-cmd"
   (describe "when 'clojure-cli project type and \"powershell\" command"
@@ -441,7 +441,7 @@
       (expect (plist-get (cider--update-jack-in-cmd nil) :jack-in-cmd)
               :to-equal (concat "resolved-powershell -encodedCommand "
                                 ;; Eval to reproduce reference string below: (base64-encode-string (encode-coding-string "clojure "\"cmd-params"\"" 'utf-16le) t)
-                                "YwBsAG8AagB1AHIAZQAgACIAYwBtAGQALQBwAGEAcgBhAG0AcwAiAA=="))))
+                                "JABQAFMATgBhAHQAaQB2AGUAQwBvAG0AbQBhAG4AZABBAHIAZwB1AG0AZQBuAHQAUABhAHMAcwBpAG4AZwAgAD0AIAAnAEwAZQBnAGEAYwB5ACcAOwAgAGMAbABvAGoAdQByAGUAIAAiAGMAbQBkAC0AcABhAHIAYQBtAHMAIgA="))))
   (describe "when 'clojure-cli project type"
     (it "uses main opts in an alias to prevent other mains from winning"
       (setq-local cider-jack-in-dependencies nil)

--- a/test/integration/integration-tests.el
+++ b/test/integration/integration-tests.el
@@ -187,7 +187,11 @@ If CLI-COMMAND is nil, then use the default."
     (jack-in-clojure-cli-test nil))
 
   (when (eq system-type 'windows-nt)
-    (it "to clojure tools cli (alternative deps.exe)"
+    (it "to clojure tools cli (alternative pwsh)"
+      (jack-in-clojure-cli-test "pwsh")))
+
+(when (eq system-type 'windows-nt)
+  (it "to clojure tools cli (alternative deps.exe)"
       (jack-in-clojure-cli-test "deps.exe")))
 
   (it "to leiningen"


### PR DESCRIPTION
Hi,

could you please review patch to maintain compatibility with pwsh 7.3. It fixes #3588 based on #3590 by @shishini.

It uses the `PSNativeCommandArgumentPassing = 'Legacy'` flag as explained at https://stackoverflow.com/a/59036879.

A integration test was added for the same,  powershell quoting tests updated to accommodate the above var,  docs updated.

Thanks

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)


