### PR TITLE
Bump parseedn, enrich-classpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 - [#3588](https://github.com/clojure-emacs/cider/issues/3588): Compatibility with pwsh 7.3 quoting rules.
+- Bump the `parseedn` required version to 1.2.1.
 
 ## 1.12.0 (2023-11-24)
 
@@ -186,7 +187,7 @@ but without connecting to the started nREPL server.
 - Improve `nrepl-dict` error reporting.
 - Bump the injected `piggieback` to [0.5.3](https://github.com/nrepl/piggieback/blob/0.5.3/CHANGES.md#053-2021-10-26).
 - Bump the `clojure-mode` required version to [5.17.1](https://github.com/clojure-emacs/clojure-mode/blob/v5.17.1/CHANGELOG.md#5171-2023-09-12), and use `clojure-find-ns` more safely, which fixes issues such as #[2849](https://github.com/clojure-emacs/cider/issues/2849).
-- Bump the `parseedn` require version, and wrap its usage with a more informative `user-error`.
+- Bump the `parseedn` required version, and wrap its usage with a more informative `user-error`.
 - Bump the injected `cider-nrepl` to [0.39.1](https://github.com/clojure-emacs/cider-nrepl/blob/v0.39.1/CHANGELOG.md#0391-2023-10-12).
   - Improves indentation, font-locking and other metadata support for ClojureScript.
   - Updates [Orchard](https://github.com/clojure-emacs/orchard/blob/v0.16.1/CHANGELOG.md#0161-2023-10-05)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 - [#3588](https://github.com/clojure-emacs/cider/issues/3588): Compatibility with pwsh 7.3 quoting rules.
+- Bump the injected `enrich-classpath` to [1.19.0](https://github.com/clojure-emacs/enrich-classpath/compare/v1.18.6...v1.19.0).
 - Bump the `parseedn` required version to 1.2.1.
 
 ## 1.12.0 (2023-11-24)

--- a/cider.el
+++ b/cider.el
@@ -12,7 +12,7 @@
 ;; Maintainer: Bozhidar Batsov <bozhidar@batsov.dev>
 ;; URL: https://www.github.com/clojure-emacs/cider
 ;; Version: 1.13.0-snapshot
-;; Package-Requires: ((emacs "26") (clojure-mode "5.18.1") (parseedn "1.2.0") (queue "0.2") (spinner "1.7") (seq "2.22") (sesman "0.3.2") (transient "0.4.1"))
+;; Package-Requires: ((emacs "26") (clojure-mode "5.18.1") (parseedn "1.2.1") (queue "0.2") (spinner "1.7") (seq "2.22") (sesman "0.3.2") (transient "0.4.1"))
 ;; Keywords: languages, clojure, cider
 
 ;; This program is free software: you can redistribute it and/or modify

--- a/cider.el
+++ b/cider.el
@@ -598,7 +598,7 @@ returned by this function does not include keyword arguments."
   (let ((plugins (if cider-enrich-classpath
                      (append cider-jack-in-lein-plugins
                              `(("cider/cider-nrepl" ,cider-injected-middleware-version)
-                               ("mx.cider/lein-enrich-classpath" "1.18.6")))
+                               ("mx.cider/lein-enrich-classpath" "1.19.0")))
                    (append cider-jack-in-lein-plugins
                            `(("cider/cider-nrepl" ,cider-injected-middleware-version))))))
     (thread-last plugins

--- a/clojure.sh
+++ b/clojure.sh
@@ -37,7 +37,7 @@ else
   cd "$there"
 
   # enrich-classpath will emit a command starting by "clojure", or print a stacktrace:
-  output=$(2>&1 "$clojure" -Sforce -Srepro -J-XX:-OmitStackTraceInFastThrow -J-Dclojure.main.report=stderr -Sdeps '{:deps {mx.cider/tools.deps.enrich-classpath {:mvn/version "1.18.6"}}}' -M -m cider.enrich-classpath.clojure "$clojure" "$here" "true" "$@")
+  output=$(2>&1 "$clojure" -Sforce -Srepro -J-XX:-OmitStackTraceInFastThrow -J-Dclojure.main.report=stderr -Sdeps '{:deps {mx.cider/tools.deps.enrich-classpath {:mvn/version "1.19.0"}}}' -M -m cider.enrich-classpath.clojure "$clojure" "$here" "true" "$@")
   cmd=$(tail -n1 <(echo "$output"))
 
   cd "$here"

--- a/doc/modules/ROOT/pages/config/basic_config.adoc
+++ b/doc/modules/ROOT/pages/config/basic_config.adoc
@@ -44,7 +44,7 @@ With it enabled, `cider-jack-in` will activate enrich-classpath, given the follo
 * You are on macOS/Linux
 * You are launching a vanilla JVM repl (and not a cljs repl, or a clj+cljs repl)
 * You are using `cider-jack-in` / `cider-jack-in-clj` (and not `cider-connect`)
- ** For `cider-connect`, please follow enrich-classpath's https://github.com/clojure-emacs/enrich-classpath/tree/v1.18.6#emacs-cider-connect[own instructions].
+ ** For `cider-connect`, please follow enrich-classpath's https://github.com/clojure-emacs/enrich-classpath/tree/v1.19.0#emacs-cider-connect[own instructions].
 
 ...these conditions will be progressively relaxed.
 

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -156,7 +156,7 @@
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[cider/cider-nrepl \"0.44.0\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[mx.cider/lein-enrich-classpath \"1.18.6\"]")
+                                (shell-quote-argument "[mx.cider/lein-enrich-classpath \"1.19.0\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath.plugin-v2/middleware"
                                 " -- repl :headless")))
 
@@ -169,7 +169,7 @@
                          " -- update-in :plugins conj "
                          (shell-quote-argument "[cider/cider-nrepl \"0.44.0\"]")
                          " -- update-in :plugins conj "
-                         (shell-quote-argument "[mx.cider/lein-enrich-classpath \"1.18.6\"]")
+                         (shell-quote-argument "[mx.cider/lein-enrich-classpath \"1.19.0\"]")
                          " -- update-in :middleware conj cider.enrich-classpath.plugin-v2/middleware"
                          " -- repl :headless")))
 
@@ -181,7 +181,7 @@
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[cider/cider-nrepl \"0.44.0\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[mx.cider/lein-enrich-classpath \"1.18.6\"]")
+                                (shell-quote-argument "[mx.cider/lein-enrich-classpath \"1.19.0\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath.plugin-v2/middleware"
                                 " -- repl :headless")))
 
@@ -220,7 +220,7 @@
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[cider/cider-nrepl \"0.44.0\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[mx.cider/lein-enrich-classpath \"1.18.6\"]")
+                                (shell-quote-argument "[mx.cider/lein-enrich-classpath \"1.19.0\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath.plugin-v2/middleware"
                                 " -- repl :headless")))
 
@@ -255,7 +255,7 @@
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[cider/cider-nrepl \"0.44.0\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[mx.cider/lein-enrich-classpath \"1.18.6\"]")
+                                (shell-quote-argument "[mx.cider/lein-enrich-classpath \"1.19.0\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath.plugin-v2/middleware"
                                 " -- repl :headless")))
     (it "can concat in a boot project"
@@ -324,7 +324,7 @@
       (spy-on 'cider-jack-in-normalized-lein-plugins
               :and-return-value '(("refactor-nrepl" "2.0.0")
                                   ("cider/cider-nrepl" "0.44.0")
-                                  ("mx.cider/lein-enrich-classpath" "1.18.6")))
+                                  ("mx.cider/lein-enrich-classpath" "1.19.0")))
       (setq-local cider-jack-in-dependencies-exclusions '())
       (setq-local cider-enrich-classpath t))
     (it "uses them in a lein project"
@@ -336,7 +336,7 @@
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[cider/cider-nrepl \"0.44.0\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[mx.cider/lein-enrich-classpath \"1.18.6\"]")
+                                (shell-quote-argument "[mx.cider/lein-enrich-classpath \"1.19.0\"]")
                                 " -- update-in :middleware conj cider.enrich-classpath.plugin-v2/middleware"
                                 " -- repl :headless"))))
 


### PR DESCRIPTION
* Bump the `parseedn` required version to [1.2.1](https://github.com/clojure-emacs/parseedn/blob/v1.2.1/CHANGELOG.md#121-2023-12-03)
* Bump the injected `enrich-classpath` to 1.19.0
  * https://github.com/clojure-emacs/enrich-classpath/compare/v1.18.6...v1.19.0