### PR TITLE
Don't void `nrepl-err-handler`

### DIFF
--- a/cider-eval.el
+++ b/cider-eval.el
@@ -849,8 +849,7 @@ REPL buffer.  This is controlled via
     (when-let ((conn (with-current-buffer buffer
                        (cider-current-repl))))
       (when (cider-nrepl-op-supported-p "analyze-last-stacktrace" conn)
-        (let ((nrepl-err-handler (lambda (&rest _))) ;; ignore any errors during this request to avoid any recursion
-              (nrepl-sync-request-timeout 4)) ;; ensure that this feature cannot possibly create an overly laggy UX
+        (let ((nrepl-sync-request-timeout 4)) ;; ensure that this feature cannot possibly create an overly laggy UX
           (when-let* ((result (nrepl-send-sync-request (thread-last (map-merge 'list
                                                                                '(("op" "analyze-last-stacktrace"))
                                                                                (cider--nrepl-print-request-map fill-column))


### PR DESCRIPTION
This was an extra measure included as part of https://github.com/clojure-emacs/cider/pull/3607

It resulted in `*cider-error*` not being shown, in certain scenarios.

That particular measure wasn't critical in avoiding the issue tackled in that PR.