### PR TITLE
[completion] Don't pass :same if context string hasn't changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs fixed
 
 - [#3605](https://github.com/clojure-emacs/cider/issues/3605): avoid `cider--error-phase-of-last-exception` recursive loop.  
+- [#3613](https://github.com/clojure-emacs/cider/issues/3613): adapt `cider-completion-context.el` to upstream changes in Compliment.  
 
 ## 1.13.0 (2024-01-14)
 

--- a/cider-completion-context.el
+++ b/cider-completion-context.el
@@ -96,27 +96,21 @@ form, with symbol at point replaced by __prefix__."
                 "__prefix__"
                 (substring context (- pref-end expr-start)))))))
 
-(defvar cider-completion-last-context nil)
-
 (defun cider-completion-get-context (&optional info)
   "Extract context depending (maybe of INFO type).
 
 Output depends on `cider-completion-use-context' and the current major mode."
-  (let ((context (if cider-completion-use-context
-                     ;; We use ignore-errors here since grabbing the context
-                     ;; might fail because of unbalanced parens, or other
-                     ;; technical reasons, yet we don't want to lose all
-                     ;; completions and throw error to user because of that.
-                     (or (ignore-errors
-                           (if info
-                               (cider-completion-get-info-context-at-point)
-                             (cider-completion-get-context-at-point)))
-                         "nil")
-                   "nil")))
-    (if (string= cider-completion-last-context context)
-        ":same"
-      (setq cider-completion-last-context context)
-      context)))
+  (if cider-completion-use-context
+      ;; We use ignore-errors here since grabbing the context
+      ;; might fail because of unbalanced parens, or other
+      ;; technical reasons, yet we don't want to lose all
+      ;; completions and throw error to user because of that.
+      (or (ignore-errors
+            (if info
+                (cider-completion-get-info-context-at-point)
+              (cider-completion-get-context-at-point)))
+          "nil")
+    "nil"))
 
 (provide 'cider-completion-context)
 ;;; cider-completion-context.el ends here

--- a/test/cider-completion-context-tests.el
+++ b/test/cider-completion-context-tests.el
@@ -45,4 +45,11 @@
       (it "Returns different things depending on the :info param"
         (with-clojure-buffer "user> (.foo|bar \"\")"
           (expect (cider-completion-get-context) :to-equal "(__prefix__bar \"\")")
-          (expect (cider-completion-get-info-context-at-point) :to-equal "(__prefix__ \"\")"))))))
+          (expect (cider-completion-get-info-context-at-point) :to-equal "(__prefix__ \"\")")))))
+
+  (it "Returns the same context when invoked twice at the same place"
+    (with-clojure-buffer "(ns foo)
+
+(.foo| \"\")"
+      (expect (cider-completion-get-context) :to-equal "(__prefix__ \"\")")
+      (expect (cider-completion-get-context) :to-equal "(__prefix__ \"\")"))))


### PR DESCRIPTION
> Fixes https://github.com/clojure-emacs/cider/issues/3613

This has been a quite awkward premature optimization that turned up to be unnecessary. The support for it has been broken in Compliment 0.5.1.
