### PR TITLE
Avoid overlays and `message`s on stderr that is unrelated to exception handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [#3605](https://github.com/clojure-emacs/cider/issues/3605): avoid `cider--error-phase-of-last-exception` recursive loop.  
 - [#3613](https://github.com/clojure-emacs/cider/issues/3613): adapt `cider-completion-context.el` to upstream changes in Compliment.  
+- [#3587](https://github.com/clojure-emacs/cider/issues/3587): avoid overlays and `message`s on stderr that is unrelated to exception handling.
 
 ## 1.13.0 (2024-01-14)
 

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -615,6 +615,8 @@ It delegates the actual error content to the eval or op handler."
                                   (optional ":" (group-n 4 (one-or-more digit)))
                                   " - "))
 
+;; Please keep this in sync with `cider-clojure-compilation-error-regexp',
+;; which is a subset of these regexes.
 (defconst cider-clojure-compilation-regexp
   (eval
    `(rx bol (or ,cider-clojure-1.9-error
@@ -624,6 +626,21 @@ It delegates the actual error content to the eval or op handler."
    t)
   "A few example values that will match:
 \"Reflection warning, /tmp/foo/src/foo/core.clj:14:1 - \"
+\"CompilerException java.lang.RuntimeException: Unable to resolve symbol: \\
+lol in this context, compiling:(/foo/core.clj:10:1)\"
+\"Syntax error compiling at (src/workspace_service.clj:227:3).\"
+\"Unexpected error (ClassCastException) macroexpanding defmulti at (src/haystack/parser.cljc:21:1).\"")
+
+(defconst cider-clojure-compilation-error-regexp
+  (eval
+   `(rx bol (or ,cider-clojure-1.9-error
+                ,cider-clojure-1.10-error
+                ,cider-clojure-unexpected-error))
+   t)
+  "Like `cider-clojure-compilation-regexp',
+but excluding warnings such as reflection warnings.
+
+A few example values that will match:
 \"CompilerException java.lang.RuntimeException: Unable to resolve symbol: \\
 lol in this context, compiling:(/foo/core.clj:10:1)\"
 \"Syntax error compiling at (src/workspace_service.clj:227:3).\"
@@ -922,7 +939,7 @@ depending on the PHASE."
                    (member phase (cider-clojure-compilation-error-phases))))
              ;; Only show overlays for things that do look like an exception (#3587):
              (or (string-match-p cider-clojure-runtime-error-regexp err)
-                 (string-match-p cider-clojure-compilation-regexp err)))
+                 (string-match-p cider-clojure-compilation-error-regexp err)))
     ;; Display errors as temporary overlays
     (let ((cider-result-use-clojure-font-lock nil)
           (trimmed-err (funcall cider-inline-error-message-function err)))

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -913,13 +913,16 @@ and the suffix matched by `cider-module-info-regexp'."
 (defun cider--maybe-display-error-as-overlay (phase err end)
   "Possibly display ERR as an overlay honoring END,
 depending on the PHASE."
-  (when (or
-         ;; if we won't show *cider-error*, because of configuration, the overlay is adequate because it compensates for the lack of info in a compact manner:
-         (not cider-show-error-buffer)
-         (not (cider-connection-has-capability-p 'jvm-compilation-errors))
-         ;; if we won't show *cider-error*, because of an ignored phase, the overlay is adequate:
-         (and cider-show-error-buffer
-              (member phase (cider-clojure-compilation-error-phases))))
+  (when (and (or
+              ;; if we won't show *cider-error*, because of configuration, the overlay is adequate because it compensates for the lack of info in a compact manner:
+              (not cider-show-error-buffer)
+              (not (cider-connection-has-capability-p 'jvm-compilation-errors))
+              ;; if we won't show *cider-error*, because of an ignored phase, the overlay is adequate:
+              (and cider-show-error-buffer
+                   (member phase (cider-clojure-compilation-error-phases))))
+             ;; Only show overlays for things that do look like an exception (#3587):
+             (or (string-match-p cider-clojure-runtime-error-regexp err)
+                 (string-match-p cider-clojure-compilation-regexp err)))
     ;; Display errors as temporary overlays
     (let ((cider-result-use-clojure-font-lock nil)
           (trimmed-err (funcall cider-inline-error-message-function err)))

--- a/test/cider-error-parsing-tests.el
+++ b/test/cider-error-parsing-tests.el
@@ -117,31 +117,32 @@
       (expect (col-num info) :to-equal 43)
       (expect (face info) :to-equal 'cider-warning-highlight-face))))
 
-(describe "The cider compilation regex"
+(describe "The cider compilation regexes"
   (it "Recognizes a clojure warning message"
     (let ((clojure-compiler-warning "Reflection warning, /tmp/foo/src/foo/core.clj:14:1 - call to java.lang.Integer ctor can't be resolved."))
       (expect clojure-compiler-warning :to-match cider-clojure-compilation-regexp)
       (expect (progn (string-match cider-clojure-compilation-regexp clojure-compiler-warning)
                      (match-string 1 clojure-compiler-warning))
               :to-equal "warning")))
-  (it "Recognizes a clojure-1.9 error message"
-    (let ((clojure-1.9-compiler-error "CompilerException java.lang.RuntimeException: Unable to resolve symbol: lol in this context, compiling:(/tmp/foo/src/foo/core.clj:10:1)"))
-      (expect clojure-1.9-compiler-error :to-match cider-clojure-compilation-regexp)
-      (expect (progn (string-match cider-clojure-compilation-regexp clojure-1.9-compiler-error)
-                     (match-string 2 clojure-1.9-compiler-error))
-              :to-equal "/tmp/foo/src/foo/core.clj")))
-  (it "Recognizes a clojure-1.10 error message"
-    (let ((clojure-1.10-compiler-error "Syntax error compiling at (src/ardoq/service/workspace_service.clj:227:3)."))
-      (expect clojure-1.10-compiler-error :to-match cider-clojure-compilation-regexp)
-      (expect (progn (string-match cider-clojure-compilation-regexp clojure-1.10-compiler-error)
-                     (match-string 2 clojure-1.10-compiler-error))
-              :to-equal "src/ardoq/service/workspace_service.clj")))
-  (it "Recognizes a clojure 'Unexpected error' message"
-    (let ((clojure-1.10-compiler-error "Unexpected error (ClassCastException) macroexpanding defmulti at (src/haystack/parser.cljc:21:1)."))
-      (expect clojure-1.10-compiler-error :to-match cider-clojure-compilation-regexp)
-      (expect (progn (string-match cider-clojure-compilation-regexp clojure-1.10-compiler-error)
-                     (match-string 2 clojure-1.10-compiler-error))
-              :to-equal "src/haystack/parser.cljc"))))
+  (dolist (regexp (list cider-clojure-compilation-regexp cider-clojure-compilation-error-regexp))
+    (it "Recognizes a clojure-1.9 error message"
+      (let ((clojure-1.9-compiler-error "CompilerException java.lang.RuntimeException: Unable to resolve symbol: lol in this context, compiling:(/tmp/foo/src/foo/core.clj:10:1)"))
+        (expect clojure-1.9-compiler-error :to-match regexp)
+        (expect (progn (string-match regexp clojure-1.9-compiler-error)
+                       (match-string 2 clojure-1.9-compiler-error))
+                :to-equal "/tmp/foo/src/foo/core.clj")))
+    (it "Recognizes a clojure-1.10 error message"
+      (let ((clojure-1.10-compiler-error "Syntax error compiling at (src/ardoq/service/workspace_service.clj:227:3)."))
+        (expect clojure-1.10-compiler-error :to-match regexp)
+        (expect (progn (string-match regexp clojure-1.10-compiler-error)
+                       (match-string 2 clojure-1.10-compiler-error))
+                :to-equal "src/ardoq/service/workspace_service.clj")))
+    (it "Recognizes a clojure 'Unexpected error' message"
+      (let ((clojure-1.10-compiler-error "Unexpected error (ClassCastException) macroexpanding defmulti at (src/haystack/parser.cljc:21:1)."))
+        (expect clojure-1.10-compiler-error :to-match regexp)
+        (expect (progn (string-match regexp clojure-1.10-compiler-error)
+                       (match-string 2 clojure-1.10-compiler-error))
+                :to-equal "src/haystack/parser.cljc")))))
 
 (describe "cider-clojure-runtime-error-regexp"
   (it "Recognizes a clojure-1.10 runtime error message"

--- a/test/cider-error-parsing-tests.el
+++ b/test/cider-error-parsing-tests.el
@@ -143,6 +143,48 @@
                      (match-string 2 clojure-1.10-compiler-error))
               :to-equal "src/haystack/parser.cljc"))))
 
+(describe "cider-clojure-runtime-error-regexp"
+  (it "Recognizes a clojure-1.10 runtime error message"
+
+    ;; Something like "(ArithmeticException)" will be absent for Exception and RuntimeException in particular
+    (let ((specimen "Execution error at foo/foo (src/haystack/parser.cljc:4)."))
+      (expect specimen :to-match cider-clojure-runtime-error-regexp)
+      (expect (progn
+                (string-match cider-clojure-runtime-error-regexp specimen)
+                (match-string 2 specimen))
+              :to-equal "src/haystack/parser.cljc"))
+
+    (let ((specimen "Execution error (ArithmeticException) at foo/foo (src/haystack/parser.cljc:4)."))
+      (expect specimen :to-match cider-clojure-runtime-error-regexp)
+      (expect (progn
+                (string-match cider-clojure-runtime-error-regexp specimen)
+                (match-string 2 specimen))
+              :to-equal "src/haystack/parser.cljc"))
+
+    ;; without foo/foo symbol
+    (let ((specimen "Execution error at (src/haystack/parser.cljc:4)."))
+      (expect specimen :to-match cider-clojure-runtime-error-regexp)
+      (expect (progn
+                (string-match cider-clojure-runtime-error-regexp specimen)
+                (match-string 2 specimen))
+              :to-equal "src/haystack/parser.cljc"))
+
+    ;; without foo/foo symbol
+    (let ((specimen "Execution error (ArithmeticException) at (src/haystack/parser.cljc:4)."))
+      (expect specimen :to-match cider-clojure-runtime-error-regexp)
+      (expect (progn
+                (string-match cider-clojure-runtime-error-regexp specimen)
+                (match-string 2 specimen))
+              :to-equal "src/haystack/parser.cljc")))
+
+  (it "Recognizes a clojure-1.10 runtime spec validation error message"
+    (let ((specimen "Execution error - invalid arguments to foo/bar at (src/haystack/parser.cljc:4)."))
+      (expect specimen :to-match cider-clojure-runtime-error-regexp)
+      (expect (progn
+                (string-match cider-clojure-runtime-error-regexp specimen)
+                (match-string 2 specimen))
+              :to-equal "src/haystack/parser.cljc"))))
+
 (describe "cider-module-info-regexp"
   (it "Matches module info provided by Java"
     (expect " (java.lang.Long is in module java.base of loader 'bootstrap'; clojure.lang.IObj is in unnamed module of loader 'app')"


### PR DESCRIPTION
* Introduce `cider-clojure-runtime-error-regexp`
  * Similar to our compilation errors regex - we didn't need runtime-oriented ones till now
  * [Ref](https://github.com/clojure/clojure/blob/08a2d9bdd013143a87e50fa82e9740e2ab4ee2c2/src/clj/clojure/main.clj#L326-L340)
* Avoid overlays and `message`s on stderr that is unrelated to exception handling
  * Fixes #3587

After https://github.com/clojure-emacs/cider/pull/3608 and other attempts I'm finally confident about this solution - it's simple, robust and aligned with other similar solutions.

@rrudakov QAing would be most welcome.

Cheers - V