### PR TITLE
Address most Emacs 29 warnings

### DIFF
--- a/cider-browse-ns.el
+++ b/cider-browse-ns.el
@@ -266,12 +266,11 @@ list of items."
 (defun cider-browse-ns--render-items (items)
   "Render the nrepl-dict ITEMS to the browse-ns buffer."
   (let* ((max-length (cider-browse-ns--column-width items)))
-    (cl-labels
-        ((keys-from-pred
-          (pred items)
-          (nrepl-dict-keys (nrepl-dict-filter (lambda (_ var-meta)
-                                                (funcall pred var-meta))
-                                              items))))
+    (cl-labels ((keys-from-pred
+                 (pred items)
+                 (nrepl-dict-keys (nrepl-dict-filter (lambda (_ var-meta)
+                                                       (funcall pred var-meta))
+                                                     items))))
       (cond
        ((eql cider-browse-ns-group-by 'type)
         (let* ((func-keys (keys-from-pred #'cider-browse-ns--meta-function-p items))
@@ -453,7 +452,7 @@ var-meta map."
 
 (defun cider-browse-ns--thing-at-point ()
   "Get the thing at point.
-Return a list of the type ('ns or 'var) and the value."
+Return a list of the type (\='ns or \='var) and the value."
   (let ((ns-p (get-text-property (point) 'ns))
         (line (car (split-string (string-trim (thing-at-point 'line)) " "))))
     (if (or ns-p (string-match "\\." line))

--- a/cider-client.el
+++ b/cider-client.el
@@ -139,11 +139,10 @@ improving performance (at the possible cost of accuracy)."
 (defun cider-path-to-ns (relpath)
   "Transform RELPATH to Clojure namespace.
 Remove extension and substitute \"/\" with \".\", \"_\" with \"-\"."
-  (thread-last
-    relpath
-    (file-name-sans-extension)
-    (replace-regexp-in-string "/" ".")
-    (replace-regexp-in-string "_" "-")))
+  (thread-last relpath
+               (file-name-sans-extension)
+               (replace-regexp-in-string "/" ".")
+               (replace-regexp-in-string "_" "-")))
 
 (defun cider-expected-ns (&optional path)
   "Return the namespace string matching PATH, or nil if not found.
@@ -152,16 +151,15 @@ command falls back to `clojure-expected-ns' in the absence of an active
 nREPL connection."
   (if (cider-connected-p)
       (let* ((path (file-truename (or path buffer-file-name)))
-             (relpath (thread-last
-                        (cider-classpath-entries)
-                        (seq-filter #'file-directory-p)
-                        (seq-map (lambda (dir)
-                                   (when (file-in-directory-p path dir)
-                                     (file-relative-name path dir))))
-                        (seq-filter #'identity)
-                        (seq-sort (lambda (a b)
-                                    (< (length a) (length b))))
-                        (car))))
+             (relpath (thread-last (cider-classpath-entries)
+                                   (seq-filter #'file-directory-p)
+                                   (seq-map (lambda (dir)
+                                              (when (file-in-directory-p path dir)
+                                                (file-relative-name path dir))))
+                                   (seq-filter #'identity)
+                                   (seq-sort (lambda (a b)
+                                               (< (length a) (length b))))
+                                   (car))))
         (if relpath
             (cider-path-to-ns relpath)
           (clojure-expected-ns path)))
@@ -245,7 +243,7 @@ Assuming this is the Clojure map you want to use as `cljfmt' options:
 
 you need to encode it as the following plist:
 
-  '((\"indents\" ((\"org.me/foo\" ((\"inner\" 0))))) (\"alias-map\" ((\"me\" \"org.me\"))))"
+  \='((\"indents\" ((\"org.me/foo\" ((\"inner\" 0))))) (\"alias-map\" ((\"me\" \"org.me\"))))"
   :type 'list
   :group 'cider
   :package-version '(cider . "1.1.0"))
@@ -256,26 +254,23 @@ If non-nil, FORMAT-OPTIONS specifies the options cljfmt will use to format
 the code.  See `cider-format-code-options` for details."
   (when format-options
     (let* ((indents-dict (when (assoc "indents" format-options)
-                           (thread-last
-                             (cadr (assoc "indents" format-options))
-                             (map-pairs)
-                             (seq-mapcat #'identity)
-                             (apply #'nrepl-dict))))
+                           (thread-last (cadr (assoc "indents" format-options))
+                                        (map-pairs)
+                                        (seq-mapcat #'identity)
+                                        (apply #'nrepl-dict))))
            (alias-map-dict (when (assoc "alias-map" format-options)
-                             (thread-last
-                               (cadr (assoc "alias-map" format-options))
-                               (map-pairs)
-                               (seq-mapcat #'identity)
-                               (apply #'nrepl-dict)))))
-      (thread-last
-        (map-merge 'list
-                   (when indents-dict
-                     `(("indents" ,indents-dict)))
-                   (when alias-map-dict
-                     `(("alias-map" ,alias-map-dict))))
-        (map-pairs)
-        (seq-mapcat #'identity)
-        (apply #'nrepl-dict)))))
+                             (thread-last (cadr (assoc "alias-map" format-options))
+                                          (map-pairs)
+                                          (seq-mapcat #'identity)
+                                          (apply #'nrepl-dict)))))
+      (thread-last (map-merge 'list
+                              (when indents-dict
+                                `(("indents" ,indents-dict)))
+                              (when alias-map-dict
+                                `(("alias-map" ,alias-map-dict))))
+                   (map-pairs)
+                   (seq-mapcat #'identity)
+                   (apply #'nrepl-dict)))))
 
 (defcustom cider-print-fn 'pprint
   "Sets the function to use for printing.
@@ -316,7 +311,7 @@ nil."
   "A map of options that will be passed to `cider-print-fn'.
 Here's an example for `pprint':
 
-  '((\"length\" 50) (\"right-margin\" 70))"
+  \='((\"length\" 50) (\"right-margin\" 70))"
   :type 'list
   :group 'cider
   :package-version '(cider . "0.21.0"))
@@ -378,13 +373,12 @@ The result will be a string."
 RIGHT-MARGIN specifies the maximum column-width of the printed result, and
 is included in the request if non-nil."
   (let* ((width-option (cider--print-option "right-margin" cider-print-fn))
-         (print-options (thread-last
-                          (map-merge 'hash-table
-                                     `((,width-option ,right-margin))
-                                     cider-print-options)
-                          (map-pairs)
-                          (seq-mapcat #'identity)
-                          (apply #'nrepl-dict))))
+         (print-options (thread-last (map-merge 'hash-table
+                                                `((,width-option ,right-margin))
+                                                cider-print-options)
+                                     (map-pairs)
+                                     (seq-mapcat #'identity)
+                                     (apply #'nrepl-dict))))
     (map-merge 'list
                `(("nrepl.middleware.print/stream?" "1"))
                (when cider-print-fn
@@ -398,11 +392,10 @@ is included in the request if non-nil."
 
 (defun cider--nrepl-pr-request-map ()
   "Map to merge into requests that do not require pretty printing."
-  (let ((print-options (thread-last
-                         cider-print-options
-                         (map-pairs)
-                         (seq-mapcat #'identity)
-                         (apply #'nrepl-dict))))
+  (let ((print-options (thread-last cider-print-options
+                                    (map-pairs)
+                                    (seq-mapcat #'identity)
+                                    (apply #'nrepl-dict))))
     (map-merge 'list
                `(("nrepl.middleware.print/print" "cider.nrepl.pprint/pr")
                  ("nrepl.middleware.print/stream?" nil))
@@ -618,10 +611,9 @@ Optional arguments include SEARCH-NS, DOCS-P, PRIVATES-P, CASE-SENSITIVE-P."
 (defun cider-sync-request:classpath ()
   "Return a list of classpath entries."
   (cider-ensure-op-supported "classpath")
-  (thread-first
-    '("op" "classpath")
-    (cider-nrepl-send-sync-request)
-    (nrepl-dict-get "classpath")))
+  (thread-first '("op" "classpath")
+                (cider-nrepl-send-sync-request)
+                (nrepl-dict-get "classpath")))
 
 (defun cider--get-abs-path (path project)
   "Resolve PATH to an absolute path relative to PROJECT.
@@ -636,11 +628,10 @@ Do nothing if PATH is already absolute."
 Sometimes the classpath contains entries like src/main and we need to
 resolve those to absolute paths."
   (when (cider-runtime-clojure-p)
-    (let ((classpath (thread-first
-                       "(seq (.split (System/getProperty \"java.class.path\") \":\"))"
-                       (cider-sync-tooling-eval)
-                       (nrepl-dict-get "value")
-                       read))
+    (let ((classpath (thread-first "(seq (.split (System/getProperty \"java.class.path\") \":\"))"
+                                   (cider-sync-tooling-eval)
+                                   (nrepl-dict-get "value")
+                                   read))
           (project (clojure-project-dir)))
       (mapcar (lambda (path) (cider--get-abs-path path project)) classpath))))
 
@@ -862,12 +853,11 @@ FORMAT-OPTIONS is an optional configuration map for cljfmt."
 
 (defun cider-sync-request:format-edn (edn right-margin)
   "Perform \"format-edn\" op with EDN and RIGHT-MARGIN."
-  (let* ((request (thread-last
-                    (map-merge 'list
-                               `(("op" "format-edn")
-                                 ("edn" ,edn))
-                               (cider--nrepl-print-request-map right-margin))
-                    (seq-mapcat #'identity)))
+  (let* ((request (thread-last (map-merge 'list
+                                          `(("op" "format-edn")
+                                            ("edn" ,edn))
+                                          (cider--nrepl-print-request-map right-margin))
+                               (seq-mapcat #'identity)))
          (response (cider-nrepl-send-sync-request request))
          (err (nrepl-dict-get response "err")))
     (when err

--- a/cider-common.el
+++ b/cider-common.el
@@ -292,7 +292,7 @@ in the container, the alist would be `((\"/src\" \"~/projects/foo/src\"))."
   "Attempt to translate the PATH in the given DIRECTION, optionally RETURN-ALL.
 Looks at `cider-path-translations' for (container . host) alist of path
 prefixes and translates PATH from container to host or vice-versa depending on
-whether DIRECTION is 'from-nrepl or 'to-nrepl."
+whether DIRECTION is \='from-nrepl or \='to-nrepl."
   (seq-let [from-fn to-fn path-fn] (cond ((eq direction 'from-nrepl) '(car cdr identity))
                                          ((eq direction 'to-nrepl) '(cdr car expand-file-name)))
     (let ((f (lambda (translation)

--- a/cider-completion.el
+++ b/cider-completion.el
@@ -104,8 +104,8 @@ backend, and ABBREVIATION is a short form of that type."
 (defcustom cider-completion-annotations-include-ns 'unqualified
   "Controls passing of namespaces to `cider-annotate-completion-function'.
 
-When set to 'always, the candidate's namespace will always be passed if it
-is available.  When set to 'unqualified, the namespace will only be passed
+When set to \='always, the candidate\='s namespace will always be passed if it
+is available.  When set to \='unqualified, the namespace will only be passed
 if the candidate is not namespace-qualified."
   :type '(choice (const always)
                  (const unqualified)

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -264,7 +264,7 @@ We look only at the major and minor components.  When the major
 version is 0, only check that the minor versions match.  When the major version
 is > 0, first check that the major version matches, then that the minor
 version is >= the required minor version.
-VER the 'installed' version,
+VER the `installed' version,
 REQUIRED-VER the version required by cider."
   (let ((ver* (cider--strip-version-patch ver))
         (required-ver* (cider--strip-version-patch required-ver)))
@@ -777,7 +777,7 @@ Session name can be customized with `cider-session-name-template'."
 ;;; REPL Buffer Init
 
 (defvar-local cider-cljs-repl-type nil
-  "The type of the ClojureScript runtime ('browser, 'node, 'figwheel, etc.).")
+  "The type of the ClojureScript runtime (\='browser, \='node, \='figwheel, etc.).")
 
 (defvar-local cider-repl-type nil
   "The type of this REPL buffer, usually either clj or cljs.")

--- a/cider-debug.el
+++ b/cider-debug.el
@@ -509,7 +509,7 @@ REASON is a keyword describing why this buffer was necessary."
 COORDINATES is a list of integers that specify how to navigate into the
 sexp that is after point when this function is called.
 
-As an example, a COORDINATES list of '(1 0 2) means:
+As an example, a COORDINATES list of \='(1 0 2) means:
   - enter next sexp then `forward-sexp' once,
   - enter next sexp,
   - enter next sexp then `forward-sexp' twice.

--- a/cider-doc.el
+++ b/cider-doc.el
@@ -367,7 +367,7 @@ Tables are marked to be ignored by line wrap."
            (put-text-property (org-table-begin) (org-table-end) 'block 'table)))))))
 
 (defun cider-docview-wrap-text (buffer)
-  "For text in BUFFER not propertized as 'block', apply line wrap."
+  "For text in BUFFER not propertized as `block', apply line wrap."
   (with-current-buffer buffer
     (save-excursion
       (while (not (eobp))

--- a/cider-eldoc.el
+++ b/cider-eldoc.el
@@ -109,20 +109,18 @@ mapping `cider-eldoc-ns-function' on it returns an empty list."
      ((and cider-eldoc-max-class-names-to-display
            (> eldoc-class-names-length cider-eldoc-max-class-names-to-display))
       (format "(%s & %s more)"
-              (thread-first
-                eldoc-class-names
-                (seq-take cider-eldoc-max-class-names-to-display)
-                (string-join " ")
-                (cider-propertize 'ns))
+              (thread-first eldoc-class-names
+                            (seq-take cider-eldoc-max-class-names-to-display)
+                            (string-join " ")
+                            (cider-propertize 'ns))
               (- eldoc-class-names-length cider-eldoc-max-class-names-to-display)))
 
      ;; format the whole list but add surrounding parentheses
      ((> eldoc-class-names-length 1)
       (format "(%s)"
-              (thread-first
-                eldoc-class-names
-                (string-join " ")
-                (cider-propertize 'ns))))
+              (thread-first eldoc-class-names
+                            (string-join " ")
+                            (cider-propertize 'ns))))
 
      ;; don't add the parentheses
      (t (format "%s" (car eldoc-class-names))))))
@@ -479,13 +477,12 @@ Only useful for interop forms.  Clojure forms would be returned unchanged."
                             (cider-sync-request:eldoc-datomic-query query)
                             "inputs")))
         (if query-inputs
-            (thread-first
-              (thread-last arglists
-                           (car)
-                           (remove "&")
-                           (remove "inputs"))
-              (append (car query-inputs))
-              (list))
+            (thread-first (thread-last arglists
+                                       (car)
+                                       (remove "&")
+                                       (remove "inputs"))
+                          (append (car query-inputs))
+                          (list))
           arglists))
     arglists))
 

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -64,8 +64,8 @@
 
 (defcustom cider-show-error-buffer t
   "Control the popup behavior of cider stacktraces.
-The following values are possible t or 'always, 'except-in-repl,
-'only-in-repl.  Any other value, including nil, will cause the stacktrace
+The following values are possible t or \='always, \='except-in-repl,
+\='only-in-repl.  Any other value, including nil, will cause the stacktrace
 not to be automatically shown.
 
 Irrespective of the value of this variable, the `cider-error-buffer' is
@@ -88,7 +88,7 @@ in order to void its effect."
 (defcustom cider-auto-jump-to-error t
   "Control the cursor jump behavior in compilation error buffer.
 When non-nil automatically jump to error location during interactive
-compilation.  When set to 'errors-only, don't jump to warnings.
+compilation.  When set to \='errors-only, don\='t jump to warnings.
 When set to nil, don't jump at all."
   :type '(choice (const :tag "always" t)
                  (const errors-only)
@@ -120,7 +120,7 @@ Only applies when the *cider-inspect* buffer is currently visible."
 (defcustom cider-save-file-on-load 'prompt
   "Controls whether to prompt to save the file when loading a buffer.
 If nil, files are not saved.
-If 'prompt, the user is prompted to save the file if it's been modified.
+If \='prompt, the user is prompted to save the file if it\='s been modified.
 If t, save the file without confirmation."
   :type '(choice (const prompt :tag "Prompt to save the file if it's been modified")
                  (const nil :tag "Don't save the file")
@@ -405,13 +405,12 @@ Returns the position at which PROPERTY was found, or nil if not found."
 _ARG and _RESET are ignored, as there is only ever one compilation error.
 They exist for compatibility with `next-error'."
   (interactive)
-  (cl-labels ((goto-next-note-boundary
-               ()
-               (let ((p (or (cider-find-property 'cider-note-p)
-                            (cider-find-property 'cider-note-p t))))
-                 (when p
-                   (goto-char p)
-                   (message "%s" (get-char-property p 'cider-note))))))
+  (cl-labels ((goto-next-note-boundary ()
+                                       (let ((p (or (cider-find-property 'cider-note-p)
+                                                    (cider-find-property 'cider-note-p t))))
+                                         (when p
+                                           (goto-char p)
+                                           (message "%s" (get-char-property p 'cider-note))))))
     ;; if we're already on a compilation error, first jump to the end of
     ;; it, so that we find the next error.
     (when (get-char-property (point) 'cider-note-p)
@@ -538,11 +537,10 @@ into a new error buffer."
   ;; Causes are returned as a series of messages, which we aggregate in `causes'
   (let (causes ex-phase)
     (cider-nrepl-send-request
-     (thread-last
-       (map-merge 'list
-                  '(("op" "analyze-last-stacktrace"))
-                  (cider--nrepl-print-request-map fill-column))
-       (seq-mapcat #'identity))
+     (thread-last (map-merge 'list
+                             '(("op" "analyze-last-stacktrace"))
+                             (cider--nrepl-print-request-map fill-column))
+                  (seq-mapcat #'identity))
      (lambda (response)
        (nrepl-dbind-response response (phase)
          (when phase

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -693,7 +693,7 @@ instead of just its \"value\" entry."
 
 (defun cider-find-inspectable-object (direction limit)
   "Find the next/previous inspectable object.
-DIRECTION can be either 'next or 'prev.
+DIRECTION can be either \='next or \='prev.
 LIMIT is the maximum or minimum position in the current buffer.
 
 Return a list of two values: If an object could be found, the

--- a/cider-macroexpansion.el
+++ b/cider-macroexpansion.el
@@ -40,12 +40,12 @@
   "Determines if namespaces are displayed in the macroexpansion buffer.
 Possible values are:
 
-  'qualified ;=> Vars are fully-qualified in the expansion
-  'none      ;=> Vars are displayed without namespace qualification
-  'tidy      ;=> Vars that are :refer-ed or defined in the current namespace are
-                 displayed with their simple name, non-referred vars from other
-                 namespaces are referred using the alias for that namespace (if
-                 defined), other vars are displayed fully qualified."
+  \='qualified ;=> Vars are fully-qualified in the expansion
+  \='none      ;=> Vars are displayed without namespace qualification
+  \='tidy      ;=> Vars that are :refer-ed or defined in the current namespace are
+                   displayed with their simple name, non-referred vars from other
+                   namespaces are referred using the alias for that namespace (if
+                   defined), other vars are displayed fully qualified."
   :type '(choice (const :tag "Suppress namespaces" none)
                  (const :tag "Show fully-qualified namespaces" qualified)
                  (const :tag "Show namespace aliases" tidy))

--- a/cider-ns.el
+++ b/cider-ns.el
@@ -70,7 +70,7 @@
 (defcustom cider-ns-save-files-on-refresh 'prompt
   "Controls whether to prompt to save files before refreshing.
 If nil, files are not saved.
-If 'prompt, the user is prompted to save files if they have been modified.
+If \='prompt, the user is prompted to save files if they have been modified.
 If t, save the files without confirmation."
   :type '(choice (const prompt :tag "Prompt to save files if they have been modified")
                  (const nil :tag "Don't save the files")
@@ -188,7 +188,7 @@ Its behavior is controlled by `cider-ns-save-files-on-refresh' and
 
 ;;;###autoload
 (defun cider-ns-reload (&optional prompt)
-  "Send a (require 'ns :reload) to the REPL.
+  "Send a (require \='ns :reload) to the REPL.
 
 With an argument PROMPT, it prompts for a namespace name.  This is the
 Clojure out of the box reloading experience and does not rely on
@@ -203,7 +203,7 @@ identified libs even if they are already loaded\"."
 
 ;;;###autoload
 (defun cider-ns-reload-all (&optional prompt)
-  "Send a (require 'ns :reload-all) to the REPL.
+  "Send a (require \='ns :reload-all) to the REPL.
 
 With an argument PROMPT, it prompts for a namespace name.  This is the
 Clojure out of the box reloading experience and does not rely on
@@ -256,15 +256,14 @@ refresh functions (defined in `cider-ns-refresh-before-fn' and
           (when clear?
             (cider-nrepl-send-sync-request '("op" "refresh-clear") conn))
           (cider-nrepl-send-request
-           (thread-last
-             (map-merge 'list
-                        `(("op" ,(if refresh-all? "refresh-all" "refresh")))
-                        (cider--nrepl-print-request-map fill-column)
-                        (when (and (not inhibit-refresh-fns) cider-ns-refresh-before-fn)
-                          `(("before" ,cider-ns-refresh-before-fn)))
-                        (when (and (not inhibit-refresh-fns) cider-ns-refresh-after-fn)
-                          `(("after" ,cider-ns-refresh-after-fn))))
-             (seq-mapcat #'identity))
+           (thread-last (map-merge 'list
+                                   `(("op" ,(if refresh-all? "refresh-all" "refresh")))
+                                   (cider--nrepl-print-request-map fill-column)
+                                   (when (and (not inhibit-refresh-fns) cider-ns-refresh-before-fn)
+                                     `(("before" ,cider-ns-refresh-before-fn)))
+                                   (when (and (not inhibit-refresh-fns) cider-ns-refresh-after-fn)
+                                     `(("after" ,cider-ns-refresh-after-fn))))
+                        (seq-mapcat #'identity))
            (lambda (response)
              (cider-ns-refresh--handle-response response log-buffer))
            conn))))))

--- a/cider-overlays.el
+++ b/cider-overlays.el
@@ -85,8 +85,8 @@ see `cider-debug-use-overlays'."
 
 (defcustom cider-result-overlay-position 'at-eol
   "Where to display result overlays for inline evaluation and the debugger.
-If 'at-eol, display at the end of the line.
-If 'at-point, display at the end of the respective sexp."
+If \='at-eol, display at the end of the line.
+If \='at-point, display at the end of the respective sexp."
   :group 'cider
   :type ''(choice (const :tag "End of line" at-eol)
                   (const :tag "End of sexp" at-point))
@@ -120,9 +120,9 @@ Never throws errors, and can be used in an overlay's modification-hooks."
 
 (defun cider--make-overlay (l r type &rest props)
   "Place an overlay between L and R and return it.
-TYPE is a symbol put on the overlay's category property.  It is used to
+TYPE is a symbol put on the overlay\='s category property.  It is used to
 easily remove all overlays from a region with:
-    (remove-overlays start end 'category TYPE)
+    (remove-overlays start end \='category TYPE)
 PROPS is a plist of properties and values to add to the overlay."
   (let ((o (make-overlay l (or r l) (current-buffer))))
     (overlay-put o 'category type)

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -307,10 +307,9 @@ Run CALLBACK once the evaluation is complete."
      nil
      (line-number-at-pos (point))
      (cider-column-number-at-pos (point))
-     (thread-last
-       request
-       (map-pairs)
-       (seq-mapcat #'identity)))))
+     (thread-last request
+                  (map-pairs)
+                  (seq-mapcat #'identity)))))
 
 (defun cider-repl-init (buffer &optional callback)
   "Initialize the REPL in BUFFER.
@@ -1138,10 +1137,9 @@ If NEWLINE is true then add a newline at the end of the input."
          (cider-current-ns)
          (line-number-at-pos input-start)
          (cider-column-number-at-pos input-start)
-         (thread-last
-           (cider--repl-request-map fill-column)
-           (map-pairs)
-           (seq-mapcat #'identity)))))))
+         (thread-last (cider--repl-request-map fill-column)
+                      (map-pairs)
+                      (seq-mapcat #'identity)))))))
 
 (defun cider-repl-return (&optional end-of-input)
   "Evaluate the current input string, or insert a newline.
@@ -1365,7 +1363,7 @@ case."
   "Workhorse for getting locref at point.
 REG-LIST is an entry in `cider-locref-regexp-alist'."
   (beginning-of-line)
-  (when (re-search-forward (nth 1 reg-list) (point-at-eol) t)
+  (when (re-search-forward (nth 1 reg-list) (line-end-position) t)
     (let ((ix-highlight (or (nth 2 reg-list) 0))
           (ix-var (nth 3 reg-list))
           (ix-file (nth 4 reg-list))
@@ -1391,7 +1389,7 @@ for locref look up."
     (goto-char (or pos (point)))
     ;; Regexp lookup on long lines can result in significant hangs #2532. We
     ;; assume that lines longer than 300 don't contain source references.
-    (when (< (- (point-at-eol) (point-at-bol)) 300)
+    (when (< (- (line-end-position) (line-beginning-position)) 300)
       (seq-some (lambda (rl) (cider--locref-at-point-1 rl))
                 cider-locref-regexp-alist))))
 
@@ -1503,7 +1501,7 @@ Return -1 resp the length of the history if no item matches."
 
 (defun cider-repl--history-replace (direction &optional regexp)
   "Replace the current input with the next line in DIRECTION.
-DIRECTION is 'forward' or 'backward' (in the history list).
+DIRECTION is `forward' or `backward' (in the history list).
 If REGEXP is non-nil, only lines matching REGEXP are considered."
   (setq cider-repl-history-pattern regexp)
   (let* ((min-pos -1)

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -79,7 +79,7 @@ Pick nil if you prefer the same window as *cider-error*."
 (make-obsolete 'cider-visit-error-buffer 'cider-selector "0.18")
 
 (defcustom cider-stacktrace-suppressed-errors '()
-  "Errors that won't make the stacktrace buffer 'pop-over' your active window.
+  "Errors that won\='t make the stacktrace buffer \='pop-over\=' your active window.
 The error types are represented as strings."
   :type 'list
   :package-version '(cider . "0.12.0"))
@@ -242,9 +242,9 @@ override this and ensure that those frames are shown."
 (defun cider-stacktrace-indicate-filters (filters pos-filters)
   "Update enabled state of filter buttons.
 
-Find buttons with a 'filter property; if filter is a member of FILTERS, or
-if filter is nil ('show all') and the argument list is non-nil, fontify the
-button as disabled.  Upon finding text with a 'hidden-count property, stop
+Find buttons with a \='filter property; if filter is a member of FILTERS, or
+if filter is nil (\='show all\=') and the argument list is non-nil, fontify the
+button as disabled.  Upon finding text with a \='hidden-count property, stop
 searching and update the hidden count text.  POS-FILTERS is the list of
 positive filters to always include."
   (with-current-buffer cider-error-buffer
@@ -371,7 +371,7 @@ filters for the resulting machinery."
   "Return intersection of ERROR-TYPES and CIDER-STACKTRACE-SUPPRESSED-ERRORS.
 I.e, Return non-nil if the seq ERROR-TYPES shares any elements with
 `cider-stacktrace-suppressed-errors'.  This means that even a
-'well-behaved' (ie, promoted) error type will be 'guilty by association' if
+\='well-behaved' (ie, promoted) error type will be \='guilty by association\=' if
 grouped with a suppressed error type."
   (seq-intersection error-types cider-stacktrace-suppressed-errors))
 
@@ -768,8 +768,8 @@ the NAME.  The whole group is prefixed by string INDENT."
         (cider-stacktrace-emit-indented (concat str "\n") nil nil t)
         (when id
           (remove-from-invisibility-spec (cons id t))
-          (let ((hide-beg (save-excursion (goto-char pos) (point-at-eol)))
-                (hide-end (1- (point-at-bol))))
+          (let ((hide-beg (save-excursion (goto-char pos) (line-end-position)))
+                (hide-end (1- (line-beginning-position))))
             (overlay-put (make-overlay hide-beg hide-end) 'invisible id)))))))
 
 (defun cider-stacktrace--emit-spec-problems (spec-data indent)
@@ -898,7 +898,7 @@ make INSPECT-INDEX actionable if present."
 
 (defun cider-stacktrace-render (buffer causes &optional error-types)
   "Emit into BUFFER useful stacktrace information for the CAUSES.
-Takes an optional ERROR-TYPES list which will render a 'suppression' toggle
+Takes an optional ERROR-TYPES list which will render a \='suppression\=' toggle
 that alters the pop-over/pop-under behavorior of the stacktrace buffers
 created by these types of errors.  The suppressed errors set can be customized
 through the `cider-stacktrace-suppressed-errors' variable."
@@ -933,11 +933,10 @@ through the `cider-stacktrace-suppressed-errors' variable."
 
 (defun cider-stacktrace--stacktrace-request (stacktrace)
   "Return the Cider NREPL request to analyze STACKTRACE."
-  (thread-last
-    (map-merge 'list
-               (list (cider-stacktrace--analyze-stacktrace-op stacktrace))
-               (cider--nrepl-print-request-map fill-column))
-    (seq-mapcat #'identity)))
+  (thread-last (map-merge 'list
+                          (list (cider-stacktrace--analyze-stacktrace-op stacktrace))
+                          (cider--nrepl-print-request-map fill-column))
+               (seq-mapcat #'identity)))
 
 (defun cider-stacktrace--analyze-render (causes)
   "Render the CAUSES of the stacktrace analysis result."

--- a/cider-util.el
+++ b/cider-util.el
@@ -34,6 +34,7 @@
 ;; Built-ins
 (require 'ansi-color)
 (require 'color)
+(require 'help-mode)
 (require 'seq)
 (require 'subr-x)
 (require 'thingatpt)
@@ -80,8 +81,8 @@ Setting this to nil removes the fontification restriction."
     (nth 4 (parse-partial-sexp beg (point)))))
 
 (defun cider--tooling-file-p (file-name)
-  "Return t if FILE-NAME is not a 'real' source file.
-Currently, only check if the relative file name starts with 'form-init'
+  "Return t if FILE-NAME is not a \='real\=' source file.
+Currently, only check if the relative file name starts with \='form-init\='
 which nREPL uses for temporary evaluation file names."
   (let ((fname (file-name-nondirectory file-name)))
     (string-match-p "^form-init" fname)))
@@ -142,14 +143,13 @@ keywords."
           (if (member str '("." ".."))
               str
             ;; Remove prefix quotes, and trailing . from constructors like Record.
-            (thread-last
-              str
-              ;; constructors (Foo.)
-              (string-remove-suffix ".")
-              ;; quoted symbols ('sym)
-              (string-remove-prefix "'")
-              ;; var references (#'inc 2)
-              (string-remove-prefix "#'")))))
+            (thread-last str
+                         ;; constructors (Foo.)
+                         (string-remove-suffix ".")
+                         ;; quoted symbols ('sym)
+                         (string-remove-prefix "'")
+                         ;; var references (#'inc 2)
+                         (string-remove-prefix "#'")))))
       (when look-back
         (save-excursion
           (ignore-errors
@@ -418,13 +418,13 @@ objects."
           candidates))
 
 (defun cider-add-to-alist (symbol car cadr)
-  "Add '(CAR CADR) to the alist stored in SYMBOL.
+  "Add \='(CAR CADR) to the alist stored in SYMBOL.
 If CAR already corresponds to an entry in the alist, destructively replace
-the entry's second element with CADR.
+the entry\='s second element with CADR.
 
 This can be used, for instance, to update the version of an injected
 plugin or dependency with:
-  (cider-add-to-alist 'cider-jack-in-lein-plugins
+  (cider-add-to-alist \='cider-jack-in-lein-plugins
                   \"plugin/artifact-name\" \"THE-NEW-VERSION\")"
   (let ((alist (symbol-value symbol)))
     (if-let* ((cons (assoc car alist)))
@@ -438,7 +438,7 @@ plugin or dependency with:
 (defvar cider-version)
 
 (defconst cider-manual-url "https://docs.cider.mx/cider/%s"
-  "The URL to CIDER's manual.")
+  "The URL to CIDER\='s manual.")
 
 (defun cider-version-sans-patch ()
   "Return the version sans that patch."
@@ -451,7 +451,7 @@ plugin or dependency with:
     (concat (cider-version-sans-patch) "/")))
 
 (defun cider-manual-url ()
-  "The CIDER manual's url."
+  "The CIDER manual\='s url."
   (format cider-manual-url (cider--manual-version)))
 
 ;;;###autoload
@@ -474,7 +474,7 @@ to."
     (buffer-string)))
 
 (defconst cider-refcard-url "https://github.com/clojure-emacs/cider/raw/%s/refcard/cider-refcard.pdf"
-  "The URL to CIDER's refcard.")
+  "The URL to CIDER\='s refcard.")
 
 (defun cider--github-version ()
   "Convert the version to a GitHub-friendly version."

--- a/cider.el
+++ b/cider.el
@@ -308,7 +308,7 @@ command when there is no ambiguity."
 
 (defcustom cider-allow-jack-in-without-project 'warn
   "Controls what happens when doing `cider-jack-in' outside a project.
-When set to 'warn you'd prompted to confirm the command.
+When set to \='warn you\='d prompted to confirm the command.
 When set to t `cider-jack-in' will quietly continue.
 When set to nil `cider-jack-in' will fail."
   :type '(choice (const :tag "always" t)
@@ -377,7 +377,7 @@ The plist supports the following keys
 
 - :cmd a plist of instructions how to invoke the jack in command, with keys
 
-  - :jack-in-type 'clj to start a clj repl and 'cljs for a cljs repl.
+  - :jack-in-type \='clj to start a clj repl and \='cljs for a cljs repl.
 
   - &rest the same set of params supported by the `cider-jack-in-clj' and
     `cider-jack-in-cljs' commands.")
@@ -1374,7 +1374,7 @@ double prefix prompt for all these parameters."
 (defun cider-jack-in-cljs (params)
   "Start an nREPL server for the current project and connect to it.
 PARAMS is a plist optionally containing :project-dir, :jack-in-cmd and
-:cljs-repl-type (e.g. 'shadow, 'node, 'figwheel, etc).
+:cljs-repl-type (e.g. \='shadow, \='node, \='figwheel, etc).
 
 With the prefix argument,
 allow editing of the jack in command; with a double prefix prompt for all
@@ -1401,7 +1401,7 @@ these parameters."
 (defun cider-jack-in-clj&cljs (&optional params soft-cljs-start)
   "Start an nREPL server and connect with clj and cljs REPLs.
 PARAMS is a plist optionally containing :project-dir, :jack-in-cmd and
-:cljs-repl-type (e.g. 'shadow, 'node, 'fighweel, etc).
+:cljs-repl-type (e.g. \='shadow, \='node, \='figwheel, etc).
 
 With the prefix argument, allow for editing of the jack in command;
 with a double prefix prompt for all these parameters.
@@ -1456,8 +1456,8 @@ server is created."
 ;;;###autoload
 (defun cider-connect-sibling-cljs (params &optional other-repl)
   "Create a ClojureScript REPL with the same server as OTHER-REPL.
-PARAMS is a plist optionally containing :cljs-repl-type (e.g. 'node,
-'figwheel, 'shadow, etc).
+PARAMS is a plist optionally containing :cljs-repl-type (e.g. \='node,
+\='figwheel, \='shadow, etc).
 
 All other parameters are inferred from the OTHER-REPL.
 OTHER-REPL defaults to `cider-current-repl' but in programs can also be a
@@ -1497,7 +1497,7 @@ prefix argument, prompt for all the parameters."
 (defun cider-connect-cljs (&optional params)
   "Initialize a ClojureScript connection to an nREPL server.
 PARAMS is a plist optionally containing :host, :port, :project-dir and
-:cljs-repl-type (e.g. 'shadow, 'node, 'figwheel, etc).
+:cljs-repl-type (e.g. \='shadow, \='node, \='figwheel, etc).
 
 On prefix, prompt for all the
 parameters regardless of their supplied or default values."
@@ -1516,8 +1516,8 @@ parameters regardless of their supplied or default values."
 (defun cider-connect-clj&cljs (params &optional soft-cljs-start)
   "Initialize a Clojure and ClojureScript connection to an nREPL server.
 PARAMS is a plist optionally containing :host, :port, :project-dir and
-:cljs-repl-type (e.g. 'shadow, 'node, 'figwheel, etc).  When SOFT-CLJS-START is
-non-nil, don't start if ClojureScript requirements are not met."
+:cljs-repl-type (e.g. \='shadow, \='node, \='figwheel, etc).  When SOFT-CLJS-START is
+non-nil, don\='t start if ClojureScript requirements are not met."
   (interactive "P")
   (let* ((params (thread-first params
                                (cider--update-project-dir)

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -618,10 +618,9 @@ If NO-ERROR is non-nil, show messages instead of throwing an error."
         (error "[nREPL] SSH port forwarding failed.  Check the '%s' buffer" tunnel-buf)
       (message "[nREPL] SSH port forwarding established to localhost:%s" port)
       (let ((endpoint (nrepl--direct-connect "localhost" port)))
-        (thread-first
-          endpoint
-          (plist-put :tunnel tunnel)
-          (plist-put :remote-host host))))))
+        (thread-first endpoint
+                      (plist-put :tunnel tunnel)
+                      (plist-put :remote-host host))))))
 
 (defun nrepl--ssh-tunnel-command (ssh dir port)
   "Command string to open SSH tunnel to the host associated with DIR's PORT."
@@ -832,13 +831,13 @@ to the REPL."
                                            truncated-handler)
   "Make a response handler for connection BUFFER.
 A handler is a function that takes one argument - response received from
-the server process.  The response is an alist that contains at least 'id'
-and 'session' keys.  Other standard response keys are 'value', 'out', 'err',
-and 'status'.
+the server process.  The response is an alist that contains at least `id'
+and `session' keys.  Other standard response keys are `value', `out', `err',
+and `status'.
 
 The presence of a particular key determines the type of the response.  For
-example, if 'value' key is present, the response is of type 'value', if
-'out' key is present the response is 'stdout' etc.
+example, if `value' key is present, the response is of type `value', if
+`out' key is present the response is `stdout' etc.
 
 Depending on the type, the handler dispatches the appropriate value to one
 of the supplied handlers: VALUE-HANDLER, STDOUT-HANDLER, STDERR-HANDLER,
@@ -1148,11 +1147,10 @@ match groups:
 (defun cider--process-plist-put (proc prop val)
   "Change value in PROC's plist of PROP to VAL.
 Value is changed using `plist-put`, of which see."
-  (thread-first
-    proc
-    (process-plist)
-    (plist-put prop val)
-    (thread-last (set-process-plist proc))))
+  (thread-first proc
+                (process-plist)
+                (plist-put prop val)
+                (thread-last (set-process-plist proc))))
 
 (defun nrepl-server-filter (process output)
   "Process nREPL server output from PROCESS contained in OUTPUT.
@@ -1209,7 +1207,7 @@ up."
 (defun nrepl-server-sentinel (process event)
   "Handle nREPL server PROCESS EVENT.
 If the nREPL PROCESS failed to initiate and encountered a fatal EVENT
-signal, raise an 'error'.  Additionally, if the EVENT signal is SIGHUP,
+signal, raise an `error'.  Additionally, if the EVENT signal is SIGHUP,
 close any existing client connections."
   ;; only interested on fatal signals.
   (when (not (process-live-p process))
@@ -1392,10 +1390,9 @@ EVENT gives the button position on window."
   "Return the color to use when pretty-printing the nREPL message with ID.
 If ID is nil, return nil."
   (when id
-    (thread-first
-      (string-to-number id)
-      (mod (length nrepl-message-colors))
-      (nth nrepl-message-colors))))
+    (thread-first (string-to-number id)
+                  (mod (length nrepl-message-colors))
+                  (nth nrepl-message-colors))))
 
 (defun nrepl-log--pp-listlike (object &optional foreground button)
   "Pretty print nREPL list like OBJECT.

--- a/test/cider-error-parsing-tests.el
+++ b/test/cider-error-parsing-tests.el
@@ -35,8 +35,8 @@
 (describe "cider-extract-error-info"
   :var (file-name line-num col-num face)
   (before-all
-   ;; FIXME: Don't mess with such global names, please!
-   ;; Maybe use `cl-flet' instead?
+    ;; FIXME: Don't mess with such global names, please!
+    ;; Maybe use `cl-flet' instead?
     (fset 'file-name (lambda (info) (nth 0 info)))
     (fset 'line-num (lambda (info) (nth 1 info)))
     (fset 'col-num (lambda (info) (nth 2 info)))
@@ -125,19 +125,19 @@
                      (match-string 1 clojure-compiler-warning))
               :to-equal "warning")))
   (dolist (regexp (list cider-clojure-compilation-regexp cider-clojure-compilation-error-regexp))
-    (it "Recognizes a clojure-1.9 error message"
+    (it (format "Recognizes a clojure-1.9 error message - %s" regexp)
       (let ((clojure-1.9-compiler-error "CompilerException java.lang.RuntimeException: Unable to resolve symbol: lol in this context, compiling:(/tmp/foo/src/foo/core.clj:10:1)"))
         (expect clojure-1.9-compiler-error :to-match regexp)
         (expect (progn (string-match regexp clojure-1.9-compiler-error)
                        (match-string 2 clojure-1.9-compiler-error))
                 :to-equal "/tmp/foo/src/foo/core.clj")))
-    (it "Recognizes a clojure-1.10 error message"
+    (it (format "Recognizes a clojure-1.10 error message - %s" regexp)
       (let ((clojure-1.10-compiler-error "Syntax error compiling at (src/ardoq/service/workspace_service.clj:227:3)."))
         (expect clojure-1.10-compiler-error :to-match regexp)
         (expect (progn (string-match regexp clojure-1.10-compiler-error)
                        (match-string 2 clojure-1.10-compiler-error))
                 :to-equal "src/ardoq/service/workspace_service.clj")))
-    (it "Recognizes a clojure 'Unexpected error' message"
+    (it (format "Recognizes a clojure 'Unexpected error' message - %s" regexp)
       (let ((clojure-1.10-compiler-error "Unexpected error (ClassCastException) macroexpanding defmulti at (src/haystack/parser.cljc:21:1)."))
         (expect clojure-1.10-compiler-error :to-match regexp)
         (expect (progn (string-match regexp clojure-1.10-compiler-error)


### PR DESCRIPTION
> Fixes https://github.com/clojure-emacs/cider/issues/3606

Addresses indentation and other warnings.

Sadly we cannot immediately upgrade the CI linting, because:

* Emacs 29 deprecates lax-plist-* functions
* The alternative is based on an arity that isn't present in Emacs < 29.

Similarly, xref-go-back deprecates xref-pop-marker-stack, while the former only exists on Emacs 29, so there's no possible fix, AFAIK.

However, a great deal of warnings is now fixed, which should be less noisy to users, and pave the path future refinements.

Cheers - V