### PR TITLE
introduced variable `cider-clojure-cli-global-aliases`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## master (unreleased)
 
-- new configuration variable `cider-clojure-cli-global-aliases`
+
 
 ### New features
-
+- [#3632](https://github.com/clojure-emacs/cider/pull/3623): new configuration variable `cider-clojure-cli-global-aliases`
 - [#3366](https://github.com/clojure-emacs/cider/pull/3366): Support display of error overlays with #dbg! and #break! reader macros.
 - [#3622](https://github.com/clojure-emacs/cider/pull/3461): Basic support for using CIDER from [clojure-ts-mode](https://github.com/clojure-emacs/clojure-ts-mode).
   - The `clojure-mode` dependency is still required for CIDER to function.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- new configuration variable `cider-clojure-cli-global-aliases`
+
 ### New features
 
 - [#3622](https://github.com/clojure-emacs/cider/pull/3461): Basic support for using CIDER from [clojure-ts-mode](https://github.com/clojure-emacs/clojure-ts-mode)

--- a/cider.el
+++ b/cider.el
@@ -833,7 +833,7 @@ rules to quote it."
 
 
 (defun cider--combined-aliases ()
-  "Creates the combined ailases as stringe seperated by ':'."
+  "Creates the combined ailases as stringe separated by ':'."
   (let ((final-cider-clojure-cli-aliases
          (cond ((and cider-clojure-cli-global-aliases cider-clojure-cli-aliases)
                 (concat cider-clojure-cli-global-aliases ":" cider-clojure-cli-aliases))

--- a/cider.el
+++ b/cider.el
@@ -864,9 +864,10 @@ your aliases contain any mains, the cider/nrepl one will be the one used."
             (if global-options (format "%s " global-options) "")
             deps-quoted
             (let ((final-cider-clojure-cli-aliases
-                   (if cider-clojure-cli-global-aliases
-                       (concat cider-clojure-cli-global-aliases ":" cider-clojure-cli-aliases)
-                     cider-clojure-cli-aliases)))
+                   (cond ((and cider-clojure-cli-global-aliases cider-clojure-cli-aliases)
+                          (concat cider-clojure-cli-global-aliases ":" cider-clojure-cli-aliases))
+                         (cider-clojure-cli-global-aliases cider-clojure-cli-global-aliases)
+                         (t cider-clojure-cli-aliases))))
               (if final-cider-clojure-cli-aliases
                   ;; remove exec-opts flags -A -M -T or -X from cider-clojure-cli-aliases
                   ;; concatenated with :cider/nrepl to ensure :cider/nrepl comes last

--- a/cider.el
+++ b/cider.el
@@ -173,6 +173,19 @@ then concatenated into the \"-M[your-aliases]:cider/nrepl\" form."
   :safe #'stringp
   :package-version '(cider . "1.1"))
 
+
+(defcustom cider-clojure-cli-global-aliases
+  nil
+  "A list of global aliases to include when using the clojure cli.
+It's value will be prepended to the value of `cider-clojure-cli-aliases`
+Alias names should be of the form \":foo:bar\".
+Leading \"-A\" \"-M\" \"-T\" or \"-X\" are stripped from aliases
+then concatenated into the \"-M[your-aliases]:cider/nrepl\" form."
+  :type 'string
+  :safe #'stringp
+  :package-version '(cider . "1.1"))
+
+
 (defcustom cider-shadow-cljs-command
   "npx shadow-cljs"
   "The command used to execute shadow-cljs.
@@ -850,14 +863,18 @@ your aliases contain any mains, the cider/nrepl one will be the one used."
             ;; TODO: global-options are deprecated and should be removed in CIDER 2.0
             (if global-options (format "%s " global-options) "")
             deps-quoted
-            (if cider-clojure-cli-aliases
-                ;; remove exec-opts flags -A -M -T or -X from cider-clojure-cli-aliases
-                ;; concatenated with :cider/nrepl to ensure :cider/nrepl comes last
-                (let ((aliases (format "%s" (replace-regexp-in-string "^-\\(A\\|M\\|T\\|X\\)" "" cider-clojure-cli-aliases))))
-                  (if (string-prefix-p ":" aliases)
-                      aliases
-                    (concat ":" aliases)))
-              "")
+            (let ((final-cider-clojure-cli-aliases
+                   (if cider-clojure-cli-global-aliases
+                       (concat cider-clojure-cli-global-aliases ":" cider-clojure-cli-aliases)
+                     cider-clojure-cli-aliases)))
+              (if final-cider-clojure-cli-aliases
+                  ;; remove exec-opts flags -A -M -T or -X from cider-clojure-cli-aliases
+                  ;; concatenated with :cider/nrepl to ensure :cider/nrepl comes last
+                  (let ((aliases (format "%s" (replace-regexp-in-string "^-\\(A\\|M\\|T\\|X\\)" "" final-cider-clojure-cli-aliases))))
+                    (if (string-prefix-p ":" aliases)
+                        aliases
+                      (concat ":" aliases)))
+                ""))
             (if params (format " %s" params) ""))))
 
 (defun cider-shadow-cljs-jack-in-dependencies (global-opts params dependencies)


### PR DESCRIPTION
This PR introduces a variable `cider-clojure-cli-global-aliases`
Discussed here: https://clojurians.slack.com/archives/C0617A8PQ/p1708857780583699

It allows a user to have a "global" system wide set of aliases, which get added by cider to each repl start.
It allows to combine "project specific aliases" and" global aliases"
