### PR TITLE
`cider-ns` - refinements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 - [#3626](https://github.com/clojure-emacs/cider/issues/3626): `cider-ns-refresh`: jump to the relevant file/line on errors.
 - [#3628](https://github.com/clojure-emacs/cider/issues/3628): `cider-ns-refresh`: summarize errors as an overlay.
+- [#3628](https://github.com/clojure-emacs/cider/issues/3628): `cider-ns-refresh`: accept `clear-and-inhibit` mode.
+  - It often makes sense not to run the before/after functions around the `clear`ing.
 - Bump the injected nREPL to [1.1.1](https://github.com/nrepl/nrepl/blob/v1.1.1/CHANGELOG.md#111-2024-02-20).
 - Bump the injected `cider-nrepl` to [0.47.0](https://github.com/clojure-emacs/cider-nrepl/blob/v0.47.0/CHANGELOG.md#0470-2024-03-10).
   - Updates [Orchard](https://github.com/clojure-emacs/orchard/blob/v0.23.2/CHANGELOG.md#0232-2024-03-10).

--- a/cider-ns.el
+++ b/cider-ns.el
@@ -137,8 +137,9 @@ presenting the error message as an overlay."
                                              ;; jars are unlikely sources of user errors, so we favor the next `cause-dict':
                                              (not (string-prefix-p "jar:" file-url))
                                              line)
-                                    (setq buf (cider--find-buffer-for-file file-url))
-                                    (list buf (cons line column)))))
+                                    (when-let ((found (cider--find-buffer-for-file file-url)))
+                                      (setq buf found)
+                                      (list buf (cons line column))))))
                               error)))
     (when jump-args
       (apply #'cider-jump-to jump-args)

--- a/cider-ns.el
+++ b/cider-ns.el
@@ -153,7 +153,7 @@ presenting the error message as an overlay."
             (cider--display-interactive-eval-result trimmed-err
                                                     'error
                                                     (save-excursion
-                                                      (end-of-defun)
+                                                      (end-of-sexp)
                                                       (point))
                                                     'cider-error-overlay-face)))))
     (cider--render-stacktrace-causes error)

--- a/cider-ns.el
+++ b/cider-ns.el
@@ -286,24 +286,27 @@ Uses the configured 'refresh dirs' \(defaults to the classpath dirs).
 With a single prefix argument, or if MODE is `refresh-all', reload all
 namespaces on the classpath dirs unconditionally.
 
-With a double prefix argument, or if MODE is `clear', clear the state of
-the namespace tracker before reloading.  This is useful for recovering from
+With a double prefix argument, or if MODE is `clear' (or `clear-and-inhibit'),
+clear the state of the namespace tracker before reloading.
+
+This is useful for recovering from
 some classes of error (for example, those caused by circular dependencies)
 that a normal reload would not otherwise recover from.  The trade-off of
 clearing is that stale code from any deleted files may not be completely
 unloaded.
 
-With a negative prefix argument, or if MODE is `inhibit-fns', prevent any
-refresh functions (defined in `cider-ns-refresh-before-fn' and
+With a negative prefix argument,
+or if MODE is `inhibit-fns' (or `clear-and-inhibit'),
+ prevent any refresh functions (defined in `cider-ns-refresh-before-fn' and
 `cider-ns-refresh-after-fn') from being invoked."
   (interactive "p")
   (cider-ensure-connected)
   (cider-ensure-op-supported "refresh")
   (cider-ensure-op-supported "cider.clj-reload/reload")
   (cider-ns-refresh--save-modified-buffers)
-  (let ((clear? (member mode '(clear 16)))
+  (let ((clear? (member mode '(clear clear-and-inhibit 16)))
         (all? (member mode '(refresh-all 4)))
-        (inhibit-refresh-fns (member mode '(inhibit-fns -1))))
+        (inhibit-refresh-fns (member mode '(inhibit-fns clear-and-inhibit -1))))
     (cider-map-repls :clj
       (lambda (conn)
         ;; Inside the lambda, so the buffer is not created if we error out.


### PR DESCRIPTION
- Strengthen `cider-ns--present-error`
- `cider-ns--present-error`: prefer `end-of-sexp`
  -  One has to use structural movements in order to present the overlay without errors.
  - By using this finer-grained function, it's more likely that the overlay will be rendered at the right place (and not too far away at the bottom).
- `cider-ns-refresh`: accept `clear-and-inhibit` mode
  - It often makes sense not to run the before/after functions around the `clear`ing.

Cheers - V