### PR TITLE
Use lower nREPL print quotas for interactive evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Changes
 
+- [#3633](https://github.com/clojure-emacs/cider/issues/3633): Use lower nREPL [print quotas](https://nrepl.org/nrepl/1.1/design/middleware.html#pretty-printing) for interactive evaluation.
+  - This can improve responsiveness for large outputs, with no tradeoffs.
 - [#3626](https://github.com/clojure-emacs/cider/issues/3626): `cider-ns-refresh`: jump to the relevant file/line on errors.
 - [#3628](https://github.com/clojure-emacs/cider/issues/3628): `cider-ns-refresh`: summarize errors as an overlay.
 - Bump the injected nREPL to [1.1.1](https://github.com/nrepl/nrepl/blob/v1.1.1/CHANGELOG.md#111-2024-02-20).

--- a/cider-client.el
+++ b/cider-client.el
@@ -411,6 +411,34 @@ is included in the request if non-nil."
                (when cider-print-quota
                  `(("nrepl.middleware.print/quota" ,cider-print-quota))))))
 
+(defun cider--make-interactive-quota ()
+  "Returns a value `nrepl.middleware.print/quota',
+that is suitable for interactive evaluation.
+
+These should be lower than `cider-print-quota',
+which is a good default for other use cases
+\(repls, logs, stacktraces, tests, etc),
+because by definition large values don't fit in the screen
+and can slow down performance."
+  (min (max (round (* (frame-width) (frame-height) 1.5))
+            10000)
+       30000))
+
+(defun cider--nrepl-interactive-pr-request-map ()
+  "Map to merge into requests that do not require pretty printing.
+
+Like `cider--nrepl-pr-request-map', but has a more apt
+`nrepl.middleware.print/quota' for interactive evaluation."
+  (let ((cider-print-quota (cider--make-interactive-quota)))
+    (cider--nrepl-pr-request-map)))
+
+(defun cider--nrepl-interactive-print-request-map (&optional right-margin)
+  "Map to merge into requests that require pretty-printing.
+RIGHT-MARGIN specifies the maximum column-width of the printed result, and
+is included in the request if non-nil."
+  (let ((cider-print-quota (cider--make-interactive-quota)))
+    (cider--nrepl-print-request-map right-margin)))
+
 (defun cider--nrepl-content-type-map ()
   "Map to be merged into an eval request to make it use content-types."
   '(("content-type" "true")))

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -1266,7 +1266,7 @@ arguments and only proceed with evaluation if it returns nil."
   (cider-interactive-eval nil
                           nil
                           (list start end)
-                          (cider--nrepl-pr-request-map)))
+                          (cider--nrepl-interactive-pr-request-map)))
 
 (defun cider-eval-last-sexp (&optional output-to-current-buffer)
   "Evaluate the expression preceding point.
@@ -1276,7 +1276,7 @@ buffer."
   (cider-interactive-eval nil
                           (when output-to-current-buffer (cider-eval-print-handler))
                           (cider-last-sexp 'bounds)
-                          (cider--nrepl-pr-request-map)))
+                          (cider--nrepl-interactive-pr-request-map)))
 
 (defun cider-eval-last-sexp-and-replace ()
   "Evaluate the expression preceding point and replace it with its result."
@@ -1291,7 +1291,7 @@ buffer."
     (cider-interactive-eval last-sexp
                             (cider-eval-print-handler)
                             nil
-                            (cider--nrepl-pr-request-map))))
+                            (cider--nrepl-interactive-pr-request-map))))
 
 (defun cider-eval-list-at-point (&optional output-to-current-buffer)
   "Evaluate the list (eg.  a function call, surrounded by parens) around point.
@@ -1318,7 +1318,7 @@ buffer."
     (cider-interactive-eval tapped-form
                             (when output-to-current-buffer (cider-eval-print-handler))
                             nil
-                            (cider--nrepl-pr-request-map))))
+                            (cider--nrepl-interactive-pr-request-map))))
 
 (defun cider-tap-sexp-at-point (&optional output-to-current-buffer)
   "Evaluate and tap the expression around point.
@@ -1367,7 +1367,7 @@ When GUESS is non-nil, attempt to extract the context from parent let-bindings."
     (cider-interactive-eval code
                             nil
                             bounds
-                            (cider--nrepl-pr-request-map))))
+                            (cider--nrepl-interactive-pr-request-map))))
 
 (defun cider-eval-last-sexp-in-context (guess)
   "Evaluate the preceding sexp in user-supplied context.
@@ -1406,7 +1406,7 @@ With the prefix arg INSERT-BEFORE, insert before the form, otherwise afterwards.
                              (set-marker (make-marker) insertion-point)
                              cider-comment-prefix)
                             bounds
-                            (cider--nrepl-pr-request-map))))
+                            (cider--nrepl-interactive-pr-request-map))))
 
 (defun cider-pprint-form-to-comment (form-fn insert-before)
   "Evaluate the form selected by FORM-FN and insert result as comment.
@@ -1436,7 +1436,7 @@ If INSERT-BEFORE is non-nil, insert before the form, otherwise afterwards."
                              cider-comment-continued-prefix
                              comment-postfix)
                             bounds
-                            (cider--nrepl-print-request-map fill-column))))
+                            (cider--nrepl-interactive-print-request-map fill-column))))
 
 (defun cider-pprint-eval-last-sexp-to-comment (&optional insert-before)
   "Evaluate the last sexp and insert result as comment.
@@ -1490,13 +1490,13 @@ honoring SWITCH-TO-REPL, REQUEST-MAP."
   "Evaluate the expression preceding point and insert its result in the REPL.
 If invoked with a PREFIX argument, switch to the REPL buffer."
   (interactive "P")
-  (cider--eval-last-sexp-to-repl prefix (cider--nrepl-pr-request-map)))
+  (cider--eval-last-sexp-to-repl prefix (cider--nrepl-interactive-pr-request-map)))
 
 (defun cider-pprint-eval-last-sexp-to-repl (&optional prefix)
   "Evaluate expr before point and insert its pretty-printed result in the REPL.
 If invoked with a PREFIX argument, switch to the REPL buffer."
   (interactive "P")
-  (cider--eval-last-sexp-to-repl prefix (cider--nrepl-print-request-map fill-column)))
+  (cider--eval-last-sexp-to-repl prefix (cider--nrepl-interactive-print-request-map fill-column)))
 
 (defun cider-eval-print-last-sexp (&optional pretty-print)
   "Evaluate the expression preceding point.
@@ -1507,8 +1507,8 @@ With an optional PRETTY-PRINT prefix it pretty-prints the result."
                           (cider-eval-print-handler)
                           (cider-last-sexp 'bounds)
                           (if pretty-print
-                              (cider--nrepl-print-request-map fill-column)
-                            (cider--nrepl-pr-request-map))))
+                              (cider--nrepl-interactive-print-request-map fill-column)
+                            (cider--nrepl-interactive-pr-request-map))))
 
 (defun cider--pprint-eval-form (form)
   "Pretty print FORM in popup buffer."
@@ -1519,7 +1519,7 @@ With an optional PRETTY-PRINT prefix it pretty-prints the result."
       (cider-interactive-eval (when (stringp form) form)
                               handler
                               (when (consp form) form)
-                              (cider--nrepl-print-request-map fill-column)))))
+                              (cider--nrepl-interactive-print-request-map fill-column)))))
 
 (defun cider-pprint-eval-last-sexp (&optional output-to-current-buffer)
   "Evaluate the sexp preceding point and pprint its value.
@@ -1583,7 +1583,7 @@ command `cider-debug-defun-at-point'."
                               (concat "#dbg\n" (cider-defun-at-point)))
                             nil
                             (cider-defun-at-point 'bounds)
-                            (cider--nrepl-pr-request-map))))
+                            (cider--nrepl-interactive-pr-request-map))))
 
 (defun cider--insert-closing-delimiters (code)
   "Closes all open parenthesized or bracketed expressions of CODE."
@@ -1615,7 +1615,7 @@ buffer.  It constructs an expression to eval in the following manner:
                             (when output-to-current-buffer
                               (cider-eval-print-handler))
                             (list beg-of-defun (point))
-                            (cider--nrepl-pr-request-map))))
+                            (cider--nrepl-interactive-pr-request-map))))
 
 (defun cider--matching-delimiter (delimiter)
   "Get the matching (opening/closing) delimiter for DELIMITER."
@@ -1646,7 +1646,7 @@ buffer.  It constructs an expression to eval in the following manner:
                             (when output-to-current-buffer
                               (cider-eval-print-handler))
                             (list beg-of-sexp (point))
-                            (cider--nrepl-pr-request-map))))
+                            (cider--nrepl-interactive-pr-request-map))))
 
 (defun cider-pprint-eval-defun-at-point (&optional output-to-current-buffer)
   "Evaluate the \"top-level\" form at point and pprint its value.
@@ -1685,7 +1685,7 @@ If VALUE is non-nil, it is inserted into the minibuffer as initial input."
         (cider-interactive-eval form
                                 nil
                                 nil
-                                (cider--nrepl-pr-request-map))))))
+                                (cider--nrepl-interactive-pr-request-map))))))
 
 (defun cider-read-and-eval-defun-at-point ()
   "Insert the toplevel form at point in the minibuffer and output its result.


### PR DESCRIPTION
> Fixes https://github.com/clojure-emacs/cider/issues/3633

Seems to work nicely (per the nrepl logs, and evaluating some huge objects).

Marking the PR as draft as I'll want to test out the defuns one by one.

Although many are affected, a good variety of defuns are unchanged - we still use the larger quota for repls, stacktraces, logs, tests, etc - basically whenever the nREPL output is printed to a buffer (vs. to an overlay).

I based the quota size on the frame, as definitionally one cannot display an overlay larger than the current frame.

Cheers - V