### PR TITLE
Introduce `custom-face-1`/`custom-face-2` facility

### DIFF
--- a/cider-mode.el
+++ b/cider-mode.el
@@ -622,8 +622,9 @@ re-visited."
 
 (defcustom cider-custom-symbol-categorizer-1
   nil
-  "A function that receives `var-sym' and `metadata-map'.
-Determines is a given symbol should be rendered using
+  "A function that receives `var' (type: string),
+and `metadata-map' (type: nrepl dict).
+Determines if a given symbol should be rendered using
 `cider-custom-face-1'.
 
 See also: `cider-custom-face-1', `cider-font-lock-dynamically'."
@@ -633,8 +634,9 @@ See also: `cider-custom-face-1', `cider-font-lock-dynamically'."
 
 (defcustom cider-custom-symbol-categorizer-2
   nil
-  "A function that receives `var-sym' and `metadata-map'.
-Determines is a given symbol should be rendered using
+  "A function that receives `var' (type: string),
+and `metadata-map' (type: nrepl dict).
+Determines if a given symbol should be rendered using
 `cider-custom-face-2'.
 
 See also: `cider-custom-face-2', `cider-font-lock-dynamically'."

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -881,7 +881,10 @@ with the given LIMIT."
                                 (push sym macros))
                                ((and do-function is-function)
                                 (push sym functions))
-                               ((and do-var (not is-function) (not is-macro))
+                               ((and do-var
+                                     (not is-any-custom)
+                                     (not is-function)
+                                     (not is-macro))
                                 (push sym vars))
                                (is-custom-1
                                 (push sym custom-1))

--- a/doc/modules/ROOT/pages/usage/code_reloading.adoc
+++ b/doc/modules/ROOT/pages/usage/code_reloading.adoc
@@ -112,7 +112,7 @@ and `cider-ns-reload-all` (kbd:[C-c M-n M-l]) commands can be used instead. Thes
 invoke Clojure's `+(require ... :reload)+` and `+(require
 ... :reload-all)+` commands at the REPL.
 
-TIP: Theses commands don't depend on `cider-nrepl`, so they are always available.
+TIP: These commands don't depend on `cider-nrepl`, so they are always available.
 
 == Keybindings
 


### PR DESCRIPTION
## Context

DSLs and libraries with special semantics aren't uncommon in the Clojure world.

Users of those may want some extra highlighting rules, with different faces, that apply to just those DSLs.

Those extra faces allow to:

* distinguish "normal" Clojure from DSL code
  * note that both can be interleaved
* make that DSL simply nicer to read in itself

CIDER by default gives a relatively small palette of faces to be possibly applied, so stuff either won't get any particular font-locking, or the applied font-locking will overlap with Clojure font-locking (e.g. N different things all use `font-lock-variable-name-face`), hindering the desired distinction.

## Changes

Introduce two new faces and two customizable 'categorizers' that when set, decide whether a given symbol should use one of the custom faces.

## Example

The user would simply use something like:

```lisp
(setq cider-custom-symbol-categorizer-1 (lambda (sym meta)
                                          (member (nrepl-dict-get meta "ns")
                                                  '("com.rpl.ramaspecter"))))

(setq cider-custom-symbol-categorizer-2 (lambda (sym meta)
                                          (member sym
                                                  '("<<sources"
                                                    "<<if"
                                                    "<<subsource"
                                                    "<<cond"
                                                    "<<ramaop"
                                                    "<<ramafn"
                                                    "or>"
                                                    "and>"
                                                    "else>"
                                                    "case>"
                                                    "<<shadowif"))))
```

And then one's theme can be customized to use the produced faces:

```lisp
(custom-theme-set-faces
 'my-theme
 `(cider-custom-face-1 ((t (:foreground "blue"))))
 `(cider-custom-face-2 ((t (:foreground "red")))))
```

## Status

Generally ready and functional, except for the addition of a user manual + changelog entry.

I also plan to provide a little more metadata from cider-nrepl (in an efficient manner).

Tweaks welcome.

Cheers - V