### PR TITLE
Drop support for Clojure 1.9

### DIFF
--- a/cider-eval.el
+++ b/cider-eval.el
@@ -698,7 +698,7 @@ See `compilation-error-regexp-alist' for help on their format.")
       (list
        (when file
          (let ((val (match-string-no-properties file message)))
-           (unless (string= val "NO_SOURCE_PATH") val)))
+           (unless (or (string= val "REPL") (string= val "NO_SOURCE_PATH")) val)))
        (when line (string-to-number (match-string-no-properties line message)))
        (when col
          (let ((val (match-string-no-properties col message)))

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -562,11 +562,6 @@ It delegates the actual error content to the eval or op handler."
         (t (cider-default-err-eval-print-handler))))
 
 
-;; The format of the error messages emitted by Clojure's compiler changed in
-;; Clojure 1.10.  That's why we're trying to match error messages to both the
-;; old and the new format, by utilizing a combination of two different regular
-;; expressions.
-
 (defconst cider-clojure-1.10--location `((or "at ("
                                              (sequence "at "
                                                        (minimal-match (one-or-more anything)) ;; the fully-qualified name of the function that triggered the error
@@ -596,15 +591,6 @@ It delegates the actual error content to the eval or op handler."
                                                    (minimal-match (one-or-more anything)))
                                                  cider-clojure-1.10--location))
 
-(defconst cider-clojure-1.9-error `(sequence
-                                    (zero-or-more anything)
-                                    ", compiling:("
-                                    (group-n 2 (minimal-match (zero-or-more anything)))
-                                    ":"
-                                    (group-n 3 (one-or-more digit))
-                                    (optional ":" (group-n 4 (one-or-more digit)))
-                                    ")"))
-
 (defconst cider-clojure-warning `(sequence
                                   (minimal-match (zero-or-more anything))
                                   (group-n 1 "warning")
@@ -619,8 +605,7 @@ It delegates the actual error content to the eval or op handler."
 ;; which is a subset of these regexes.
 (defconst cider-clojure-compilation-regexp
   (eval
-   `(rx bol (or ,cider-clojure-1.9-error
-                ,cider-clojure-warning
+   `(rx bol (or ,cider-clojure-warning
                 ,cider-clojure-1.10-error
                 ,cider-clojure-unexpected-error))
    t)
@@ -633,8 +618,7 @@ lol in this context, compiling:(/foo/core.clj:10:1)\"
 
 (defconst cider-clojure-compilation-error-regexp
   (eval
-   `(rx bol (or ,cider-clojure-1.9-error
-                ,cider-clojure-1.10-error
+   `(rx bol (or ,cider-clojure-1.10-error
                 ,cider-clojure-unexpected-error))
    t)
   "Like `cider-clojure-compilation-regexp',

--- a/cider.el
+++ b/cider.el
@@ -141,7 +141,7 @@
            (null (executable-find "clojure")))
       "powershell"
     "clojure")
-  "The command used to execute clojure with tools.deps (requires Clojure 1.9+).
+  "The command used to execute clojure with tools.deps.
 Don't use clj here, as it doesn't work when spawned from Emacs due to it
 using rlwrap.  If on Windows and no \"clojure\" executable is found we
 default to \"powershell\"."
@@ -535,10 +535,10 @@ the artifact.")
 (defconst cider-clojure-artifact-id "org.clojure/clojure"
   "Artifact identifier for Clojure.")
 
-(defconst cider-minimum-clojure-version "1.8.0"
+(defconst cider-minimum-clojure-version "1.10.0"
   "Minimum supported version of Clojure.")
 
-(defconst cider-latest-clojure-version "1.10.1"
+(defconst cider-latest-clojure-version "1.11.3"
   "Latest supported version of Clojure.")
 
 (defconst cider-required-middleware-version "0.47.0"

--- a/doc/modules/ROOT/pages/about/compatibility.adoc
+++ b/doc/modules/ROOT/pages/about/compatibility.adoc
@@ -28,7 +28,7 @@ You can find example commands in xref:troubleshooting.adoc#navigation-to-jdk-sou
 
 == Clojure
 
-CIDER targets Clojure 1.9+. As Clojure doesn't have the concept of supported releases
+CIDER targets Clojure 1.10+. As Clojure doesn't have the concept of supported releases
 we have to get a bit creative to determine the minimum version to target.
 
 The minimum required Clojure version is currently derived using data
@@ -174,6 +174,13 @@ Below you can find the official compatibility matrix for CIDER.
 | 0.44
 | 8
 | 1.9
+
+| 1.14
+| 26.1
+| 1.0
+| 0.47
+| 8
+| 1.10
 
 |===
 

--- a/doc/modules/ROOT/pages/usage/misc_features.adoc
+++ b/doc/modules/ROOT/pages/usage/misc_features.adoc
@@ -196,8 +196,6 @@ There are a bunch of useful keybindings that are defined in browser buffers.
 
 == Browsing the Clojure Spec Registry
 
-If you are using Clojure 1.9 or newer you can browse the Clojure spec registry.
-
 If you already know which spec you're looking for, you can type
 kbd:[M-x] `cider-browse-spec` and CIDER will prompt you for a
 spec name and then drop you into the spec browser.

--- a/test/cider-error-parsing-tests.el
+++ b/test/cider-error-parsing-tests.el
@@ -45,7 +45,7 @@
   (it "extracts correct information from the error message"
 
     ;; test-cider-extract-error-info-14
-    (let* ((message "CompilerException java.lang.RuntimeException: Unable to resolve symbol: dummy in this context, compiling:(/some/test/file/core.clj:31)")
+    (let* ((message "Syntax error compiling at (/some/test/file/core.clj:31). Unable to resolve symbol: dummy in this context.")
            (info (cider-extract-error-info cider-compilation-regexp message)))
       (expect (file-name info) :to-equal "/some/test/file/core.clj")
       (expect (line-num info) :to-equal 31)
@@ -53,7 +53,7 @@
       (expect (face info) :to-equal 'cider-error-highlight-face))
 
     ;; test-cider-extract-error-info-14-windows
-    (let* ((message "CompilerException java.lang.RuntimeException: Unable to resolve symbol: dummy in this context, compiling:(c:\\some\\test\\file\\core.clj:31)")
+    (let* ((message "Syntax error compiling at (c:\\some\\test\\file\\core.clj:31). Unable to resolve symbol: dummy in this context.")
            (info (cider-extract-error-info cider-compilation-regexp message)))
       (expect (file-name info) :to-equal "c:\\some\\test\\file\\core.clj")
       (expect (line-num info) :to-equal 31)
@@ -61,7 +61,7 @@
       (expect (face info) :to-equal 'cider-error-highlight-face))
 
     ;; test-cider-extract-error-info-14-no-file
-    (let* ((message "CompilerException java.lang.RuntimeException: Unable to resolve symbol: dummy in this context, compiling:(NO_SOURCE_PATH:31)")
+    (let* ((message "Syntax error compiling at (REPL:31). Unable to resolve symbol: dummy in this context.")
            (info (cider-extract-error-info cider-compilation-regexp message)))
       (expect (file-name info) :to-equal nil)
       (expect (line-num info) :to-equal 31)
@@ -86,7 +86,7 @@
       (expect (face info) :to-equal 'cider-warning-highlight-face))
 
     ;; test-cider-extract-error-info-15
-    (let* ((message "CompilerException java.lang.RuntimeException: Unable to resolve symbol: dummy in this context, compiling:(/some/test/file/core.clj:31:3)")
+    (let* ((message "Syntax error compiling at (/some/test/file/core.clj:31:3). Unable to resolve symbol: dummy in this context.")
            (info (cider-extract-error-info cider-compilation-regexp message)))
       (expect (file-name info) :to-equal "/some/test/file/core.clj")
       (expect (line-num info) :to-equal 31)
@@ -94,7 +94,7 @@
       (expect (face info) :to-equal 'cider-error-highlight-face))
 
     ;; test-cider-extract-error-info-15-no-file
-    (let* ((message "CompilerException java.lang.RuntimeException: Unable to resolve symbol: dummy in this context, compiling:(NO_SOURCE_PATH:31:3)")
+    (let* ((message "Syntax error compiling at (REPL:31:3). Unable to resolve symbol: dummy in this context")
            (info (cider-extract-error-info cider-compilation-regexp message)))
       (expect (file-name info) :to-equal nil)
       (expect (line-num info) :to-equal 31)

--- a/test/cider-error-parsing-tests.el
+++ b/test/cider-error-parsing-tests.el
@@ -125,12 +125,6 @@
                      (match-string 1 clojure-compiler-warning))
               :to-equal "warning")))
   (dolist (regexp (list cider-clojure-compilation-regexp cider-clojure-compilation-error-regexp))
-    (it "Recognizes a clojure-1.9 error message"
-      (let ((clojure-1.9-compiler-error "CompilerException java.lang.RuntimeException: Unable to resolve symbol: lol in this context, compiling:(/tmp/foo/src/foo/core.clj:10:1)"))
-        (expect clojure-1.9-compiler-error :to-match regexp)
-        (expect (progn (string-match regexp clojure-1.9-compiler-error)
-                       (match-string 2 clojure-1.9-compiler-error))
-                :to-equal "/tmp/foo/src/foo/core.clj")))
     (it "Recognizes a clojure-1.10 error message"
       (let ((clojure-1.10-compiler-error "Syntax error compiling at (src/ardoq/service/workspace_service.clj:227:3)."))
         (expect clojure-1.10-compiler-error :to-match regexp)


### PR DESCRIPTION
We've already dropped it on the Clojure side, so I took some time to cleanup the Emacs side as well. 