### PR TITLE
[completion] Cache last result of `cider-complete`

### DIFF
--- a/cider-completion.el
+++ b/cider-completion.el
@@ -184,26 +184,34 @@ performed by `cider-annotate-completion-function'."
   (when-let* ((bounds (bounds-of-thing-at-point 'symbol)))
     (when (and (cider-connected-p)
                (not (or (cider-in-string-p) (cider-in-comment-p))))
-      (list (car bounds) (cdr bounds)
-            (lambda (prefix pred action)
-              ;; When the 'action is 'metadata, this lambda returns metadata about this
-              ;; capf, when action is (boundaries . suffix), it returns nil. With every
-              ;; other value of 'action (t, nil, or lambda), 'action is forwarded to
-              ;; (complete-with-action), together with (cider-complete), prefix and pred.
-              ;; And that function performs the completion based on those arguments.
-              ;;
-              ;; This api is better described in the section
-              ;; '21.6.7 Programmed Completion' of the elisp manual.
-              (cond ((eq action 'metadata) `(metadata (category . cider))) ;; defines a completion category named 'cider, used later in our `completion-category-overrides` logic.
-                    ((eq (car-safe action) 'boundaries) nil)
-                    (t (with-current-buffer (current-buffer)
-                         (complete-with-action action
-                                               (cider-complete prefix) prefix pred)))))
-            :annotation-function #'cider-annotate-symbol
-            :company-kind #'cider-company-symbol-kind
-            :company-doc-buffer #'cider-create-compact-doc-buffer
-            :company-location #'cider-company-location
-            :company-docsig #'cider-company-docsig))))
+      (let* (last-prefix
+             last-result
+             (complete
+              (lambda (prefix)
+                (unless (string-equal last-prefix prefix)
+                  (setq last-prefix prefix)
+                  (setq last-result (cider-complete prefix)))
+                last-result)))
+        (list (car bounds) (cdr bounds)
+              (lambda (prefix pred action)
+                ;; When the 'action is 'metadata, this lambda returns metadata about this
+                ;; capf, when action is (boundaries . suffix), it returns nil. With every
+                ;; other value of 'action (t, nil, or lambda), 'action is forwarded to
+                ;; (complete-with-action), together with (cider-complete), prefix and pred.
+                ;; And that function performs the completion based on those arguments.
+                ;;
+                ;; This api is better described in the section
+                ;; '21.6.7 Programmed Completion' of the elisp manual.
+                (cond ((eq action 'metadata) `(metadata (category . cider))) ;; defines a completion category named 'cider, used later in our `completion-category-overrides` logic.
+                      ((eq (car-safe action) 'boundaries) nil)
+                      (t (with-current-buffer (current-buffer)
+                           (complete-with-action action
+                                                 (funcall complete prefix) prefix pred)))))
+              :annotation-function #'cider-annotate-symbol
+              :company-kind #'cider-company-symbol-kind
+              :company-doc-buffer #'cider-create-compact-doc-buffer
+              :company-location #'cider-company-location
+              :company-docsig #'cider-company-docsig)))))
 
 (defun cider-completion-flush-caches ()
   "Force Compliment to refill its caches.


### PR DESCRIPTION
I've been spending much more time making sense of Emacs completion machinery than it is worth, but at this point it's too late for me to abandon it. Apart from other findings, I discovered that Emacs' `completion-at-point` can call its `completion-at-point-functions` multiple times during a single invocation. I've never noticed it before because Company is smarter about that and usually issues a single call to the backend. But with the default settings (three completion styles – `(basic partial-completion emacs22)`), on a prefix that yields no completion candidates, `completion-at-point` can yank the "complete" op 4-6 times. As much as I tried to fight it by reducing the number of enabled styles, I could only drop it down to 2. Emacs itself recognizes that this API can call backend many times and encourages caching the response, hence the existence of this function: https://www.gnu.org/software/emacs/manual/html_node/elisp/Programmed-Completion.html#index-completion_002dtable_002dwith_002dcache.

This PR proposes a simple cached `cider-complete` implementation that remembers the last result and can give it back without touching the backend. The "key" of the cache includes the prefix, the buffer where the completion was initiated, and the point in the buffer. I also thought about adding `nrepl-request-counter` to the key, so that the cache is properly invalidated if user evaluated something that might change the completion results. But I noticed that `eldoc` ops often like to squeeze between the calls to `complete`, rendering the cache useless. So I need advice on this.

I have a feeling that a stale incorrect cache may be quite annoying, so maybe adding an expiration time to the mix could help?

Overall, when the completion is triggered on a large list of candidates (e.g. the prefix`com.`), it feels significantly snappier with the cache. Let alone if you call it manually the second time. This would be doubly true when connecting to a remote REPL.