### PR TITLE
Grab the completion prefix correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### Bugs fixed
 
+- [#3659](https://github.com/clojure-emacs/cider/pull/3659): Fixes completions when using `flex`-like completion styles.
 - [#3600](https://github.com/clojure-emacs/cider/pull/3600): Fix scittle jack-in when using `cider-jack-in-clj`.
 
 ## 1.13.1 (2024-02-01)

--- a/cider-completion.el
+++ b/cider-completion.el
@@ -299,6 +299,8 @@ Only affects the `cider' completion category.`"
     (setq completion-category-overrides (seq-remove (lambda (x)
                                                       (equal 'cider (car x)))
                                                     completion-category-overrides))
+    (unless found-styles
+      (setq found-styles '(styles)))
     (unless (member 'flex found-styles)
       (setq found-styles (append found-styles '(flex))))
     (add-to-list 'completion-category-overrides (apply #'list 'cider found-styles (when found-cycle

--- a/cider-completion.el
+++ b/cider-completion.el
@@ -219,7 +219,7 @@ has started."
     (when (and (cider-connected-p)
                (not (or (cider-in-string-p) (cider-in-comment-p))))
       (list (car bounds) (cdr bounds)
-            (lambda (pattern pred action)
+            (lambda (prefix pred action)
               ;; When the 'action is 'metadata, this lambda returns metadata about this
               ;; capf, when action is (boundaries . suffix), it returns nil. With every
               ;; other value of 'action (t, nil, or lambda), 'action is forwarded to
@@ -231,9 +231,9 @@ has started."
               (cond ((eq action 'metadata) `(metadata (category . cider))) ;; defines a completion category named 'cider, used later in our `completion-category-overrides` logic.
                     ((eq (car-safe action) 'boundaries) nil) ; boundaries
                     ((eq action 'lambda) ; test-completion
-                     (test-completion pattern (cider--complete-with-cache bounds)))
+                     (test-completion prefix (cider--complete-with-cache bounds)))
                     ((null action)  ; try-completion
-                     (try-completion pattern (cider--complete-with-cache bounds)))
+                     (try-completion prefix (cider--complete-with-cache bounds)))
                     ((eq action t)  ; all-completions
                      (all-completions "" (cider--complete-with-cache bounds)))))
             :annotation-function #'cider-annotate-symbol

--- a/cider-completion.el
+++ b/cider-completion.el
@@ -213,7 +213,8 @@ performed by `cider-annotate-completion-function'."
                 ;; '21.6.7 Programmed Completion' of the elisp manual.
                 (cond ((eq action 'metadata) `(metadata (category . cider))) ;; defines a completion category named 'cider, used later in our `completion-category-overrides` logic.
                       ((eq (car-safe action) 'boundaries) nil)
-                      (t (complete-with-action action (funcall complete) prefix pred))))
+                      (t (with-current-buffer (current-buffer)
+                           (complete-with-action action (funcall complete) prefix pred)))))
               :annotation-function #'cider-annotate-symbol
               :company-kind #'cider-company-symbol-kind
               :company-doc-buffer #'cider-create-compact-doc-buffer

--- a/cider-completion.el
+++ b/cider-completion.el
@@ -196,7 +196,7 @@ performed by `cider-annotate-completion-function'."
                 ;; defined by the bounds of the symbol at point.
                 ;;
                 ;; Caching just within the function is sufficient. Keeping it local ensures
-                ;; that it will not extend across diferent CIDER sessions.
+                ;; that it will not extend across different CIDER sessions.
                 (unless (string= bounds-string last-bounds-string)
                   (setq last-bounds-string bounds-string)
                   (setq last-result (cider-complete bounds-string)))

--- a/cider-completion.el
+++ b/cider-completion.el
@@ -294,7 +294,7 @@ Only affects the `cider' completion category.`"
                                                       (equal 'cider (car x)))
                                                     completion-category-overrides))
     (unless found-styles
-      (setq found-styles '(styles)))
+      (setq found-styles '(styles basic)))
     (unless (member 'flex found-styles)
       (setq found-styles (append found-styles '(flex))))
     (add-to-list 'completion-category-overrides (apply #'list 'cider found-styles (when found-cycle

--- a/cider-completion.el
+++ b/cider-completion.el
@@ -190,7 +190,7 @@ otherwise, call `cider-complete', set the cache, and return the completions."
   (let* ((prefix (or (buffer-substring-no-properties (car bounds) (cdr bounds)) ""))
          (completions nil))
     (when (and (consp cider--completion-cache)
-               (equal prefix (car cider--completion-cache)))
+               (string= prefix (car cider--completion-cache)))
       (setq completions (cdr cider--completion-cache)))
     (unless completions
       (let ((resp (cider-complete prefix)))

--- a/cider-completion.el
+++ b/cider-completion.el
@@ -288,19 +288,18 @@ Only affects the `cider' completion category.`"
   (when (< emacs-major-version 27)
     (user-error "`cider-enable-flex-completion' requires Emacs 27 or later"))
   (let ((found-styles (when-let ((cider (assq 'cider completion-category-overrides)))
-                        (cdr (assq 'styles cider))))
+                        (assq 'styles cider)))
         (found-cycle (when-let ((cider (assq 'cider completion-category-overrides)))
                        (assq 'cycle cider))))
     (setq completion-category-overrides (seq-remove (lambda (x)
                                                       (equal 'cider (car x)))
                                                     completion-category-overrides))
     (unless found-styles
-      (setq found-styles '(basic)))
-    (cl-pushnew 'flex found-styles)
-    (add-to-list 'completion-category-overrides (apply #'list 'cider
-                                                       (apply #'list 'styles found-styles)
-                                                       (when found-cycle
-                                                         (list found-cycle))))))
+      (setq found-styles '(styles basic)))
+    (unless (member 'flex found-styles)
+      (setq found-styles (append found-styles '(flex))))
+    (add-to-list 'completion-category-overrides (apply #'list 'cider found-styles (when found-cycle
+                                                                                    (list found-cycle))))))
 
 (provide 'cider-completion)
 ;;; cider-completion.el ends here

--- a/cider-completion.el
+++ b/cider-completion.el
@@ -192,7 +192,7 @@ otherwise, call `cider-complete', set the cache, and return the completions."
     (when (and (consp cider--completion-cache)
                (equal prefix (car cider--completion-cache)))
       (setq completions (cdr cider--completion-cache)))
-    (when (null completions)
+    (unless completions
       (let ((resp (cider-complete prefix)))
         (setq cider--completion-cache `(,prefix . ,resp)
               completions resp)))

--- a/cider-completion.el
+++ b/cider-completion.el
@@ -190,13 +190,13 @@ performed by `cider-annotate-completion-function'."
              last-result
              (complete
               (lambda ()
-                ;; Not using the prefix extracted within the (prefix pred action) lambda.
-                ;; In certain completion styles, the prefix might be an empty string,
-                ;; which is unreliable. A more dependable method is to use the string
-                ;; defined by the bounds of the symbol at point.
+                ;; We are Not using the prefix extracted within the (prefix pred action)
+                ;; lambda.  In certain completion styles, the prefix might be an empty
+                ;; string, which is unreliable. A more dependable method is to use the
+                ;; string defined by the bounds of the symbol at point.
                 ;;
-                ;; Caching just within the function is sufficient. Keeping it local ensures
-                ;; that it will not extend across different CIDER sessions.
+                ;; Caching just within the function is sufficient. Keeping it local
+                ;; ensures that it will not extend across different CIDER sessions.
                 (unless (string= bounds-string last-bounds-string)
                   (setq last-bounds-string bounds-string)
                   (setq last-result (cider-complete bounds-string)))
@@ -212,7 +212,7 @@ performed by `cider-annotate-completion-function'."
                 ;; This api is better described in the section
                 ;; '21.6.7 Programmed Completion' of the elisp manual.
                 (cond ((eq action 'metadata) `(metadata (category . cider))) ;; defines a completion category named 'cider, used later in our `completion-category-overrides` logic.
-                      ((eq (car-safe action) 'boundaries) nil) ; boundaries
+                      ((eq (car-safe action) 'boundaries) nil)
                       (t (complete-with-action action (funcall complete) prefix pred))))
               :annotation-function #'cider-annotate-symbol
               :company-kind #'cider-company-symbol-kind

--- a/cider-completion.el
+++ b/cider-completion.el
@@ -296,8 +296,7 @@ Only affects the `cider' completion category.`"
                                                     completion-category-overrides))
     (unless found-styles
       (setq found-styles '(basic)))
-    (unless (member 'flex found-styles)
-      (add-to-list 'found-styles 'flex))
+    (cl-pushnew 'flex found-styles)
     (add-to-list 'completion-category-overrides (apply #'list 'cider
                                                        (apply #'list 'styles found-styles)
                                                        (when found-cycle

--- a/cider-completion.el
+++ b/cider-completion.el
@@ -288,18 +288,20 @@ Only affects the `cider' completion category.`"
   (when (< emacs-major-version 27)
     (user-error "`cider-enable-flex-completion' requires Emacs 27 or later"))
   (let ((found-styles (when-let ((cider (assq 'cider completion-category-overrides)))
-                        (assq 'styles cider)))
+                        (cdr (assq 'styles cider))))
         (found-cycle (when-let ((cider (assq 'cider completion-category-overrides)))
                        (assq 'cycle cider))))
     (setq completion-category-overrides (seq-remove (lambda (x)
                                                       (equal 'cider (car x)))
                                                     completion-category-overrides))
     (unless found-styles
-      (setq found-styles '(styles basic)))
+      (setq found-styles '(basic)))
     (unless (member 'flex found-styles)
-      (setq found-styles (append found-styles '(flex))))
-    (add-to-list 'completion-category-overrides (apply #'list 'cider found-styles (when found-cycle
-                                                                                    (list found-cycle))))))
+      (add-to-list 'found-styles 'flex))
+    (add-to-list 'completion-category-overrides (apply #'list 'cider
+                                                       (apply #'list 'styles found-styles)
+                                                       (when found-cycle
+                                                         (list found-cycle))))))
 
 (provide 'cider-completion)
 ;;; cider-completion.el ends here

--- a/doc/modules/ROOT/pages/usage/code_completion.adoc
+++ b/doc/modules/ROOT/pages/usage/code_completion.adoc
@@ -37,17 +37,26 @@ is already properly indented.
 
 == Completion styles
 
-CIDER defines (via the `completion-styles-alist` Elisp variable) a completion category named `cider`.
+CIDER defines a specialized completion category through the `cider-complete-at-point` function,
+added to `completion-at-point-functions`, establishing a dedicated completion category named
+`cider`.
 
-The `cider` completion category currently only supports `basic` completion styles (and not `partial-completion`, `orderless`, etc),
-and `flex`, optionally (read more below).
+The CIDER completion at point function supports most completion styles, including
+`partial-completion`, `orderless` and `flex` (read more below).
 
-CIDER declares so in this fashion:
+
+Sometimes the user may want to use a different completion style just for the CIDER
+complete at point function. That can be achieved by setting
+`completion-category-overrides`, overriting the completion style of the CIDER
+complete at point function. The following snippet accomplishes that:
 
 [source,lisp]
 ----
 (add-to-list 'completion-category-overrides '(cider (styles basic)))
 ----
+
+This specifies that the `cider` completion category should employ the basic completion style by
+default.
 
 You can also enable the `flex` completion style by activating xref:usage/code_completion.adoc#fuzzy-candidate-matching[fuzzy candidate matching].
 
@@ -131,13 +140,14 @@ without needing to hit an extra key, please customize:
 
 === Fuzzy candidate matching
 
-By default, CIDER will provide completion candidates with the
-assumption that whatever you've typed so far is a prefix of what
-you're really trying to type. For example, if you type `map-` then
-you'll only get completion candidates that have `map-` as the
-beginning of their names.  Sometimes, you don't know the exact prefix
-for the item you want to type. In this case, you can get
-CIDER-specific "fuzzy completion" by setting up in your Emacs init file:
+By default, CIDER will use the completion styles defined in
+`completion-styles`, the defaults being `(basic partial-completion
+emacs22)` since Emacs 23. For a better description of how those
+completion styles operates, refer to the official Emacs manual on
+https://www.gnu.org/software/emacs/manual/html_node/emacs/Completion-Styles.html[how completion alternatives are chosen].
+
+CIDER provides a function to enable the `flex` completion style for CIDER-specific
+completions. If you wish to enable that, you can add this to your config:
 
 [source,lisp]
 ----
@@ -146,11 +156,11 @@ CIDER-specific "fuzzy completion" by setting up in your Emacs init file:
 
 This adds the `flex` completion style, as introduced in Emacs 27.
 
-Now, `company-mode` will accept certain fuzziness when matching
-candidates against the prefix. For example, typing `mi` will show you
-`map-indexed` as one of the possible completion candidates and `cji`
-will complete to `clojure.java.io`. Different completion examples are
-shown
+Now, `company-mode` (and other completion packages like `corfu`) will
+accept certain fuzziness when matching candidates against the
+prefix. For example, typing `mi` will show you `map-indexed` as one of
+the possible completion candidates and `cji` will complete to
+`clojure.java.io`. Different completion examples are shown
 https://github.com/alexander-yakushev/compliment/wiki/Examples[here].
 
 NOTE: `cider-company-enable-fuzzy-completion` (now deprecated) should be used for Emacs < 27. 
@@ -187,18 +197,6 @@ keys to cancel the prompt by customizing:
             (lambda (f a b)
               (cider--with-temporary-ido-keys "<up>" "<down>"
                 (funcall f a b))))
-----
-
-=== Changing the completion style
-
-Sometimes the user may want to use a different completion style just for the CIDER
-complete at point function. That can be achieved by setting
-`completion-category-defaults`, overriting the completion style of the CIDER
-complete at point function. The following snippet accomplishes that:
-
-[source,lisp]
-----
-(add-to-list 'completion-category-defaults '(cider (styles basic)))
 ----
 
 === Updating stale classes and methods cache

--- a/doc/modules/ROOT/pages/usage/code_completion.adoc
+++ b/doc/modules/ROOT/pages/usage/code_completion.adoc
@@ -47,7 +47,7 @@ The CIDER completion at point function supports most completion styles, includin
 
 Sometimes the user may want to use a different completion style just for the CIDER
 complete at point function. That can be achieved by setting
-`completion-category-overrides`, overriting the completion style of the CIDER
+`completion-category-overrides`, overwriting the completion style of the CIDER
 complete at point function. The following snippet accomplishes that:
 
 [source,lisp]

--- a/test/cider-completion-tests.el
+++ b/test/cider-completion-tests.el
@@ -36,13 +36,25 @@
     (let ((old-value completion-category-overrides))
       (unwind-protect
           (progn
-            (it "adds `flex'"
+            (it "adds `flex' and `basic' as a fallback"
               (cider-enable-flex-completion)
-              (expect (member 'flex (assq 'styles (assq 'cider completion-category-overrides)))
+              (expect (car (cdr (assq 'styles (assq 'cider completion-category-overrides))))
+                      :to-be 'flex)
+              (expect (member 'basic (assq 'styles (assq 'cider completion-category-overrides)))
                       :to-be-truthy))
 
             (it "doesn't add `cycle'"
               (expect (assq 'cycle (assq 'cider completion-category-overrides))
+                      :to-be nil))
+
+            (it "adds just `flex' if there is another syle present"
+              (setq completion-category-overrides '((cider (styles partial-completion))))
+              (cider-enable-flex-completion)
+              (expect (car (cdr (assq 'styles (assq 'cider completion-category-overrides))))
+                      :to-be 'flex)
+              (expect (member 'partial-completion (assq 'styles (assq 'cider completion-category-overrides)))
+                      :to-be-truthy)
+              (expect (member 'basic (assq 'styles (assq 'cider completion-category-overrides)))
                       :to-be nil))
 
             (it "doesn't re-add `flex' if already present, preserving `cycle' as well"

--- a/test/cider-completion-tests.el
+++ b/test/cider-completion-tests.el
@@ -37,11 +37,13 @@
       (unwind-protect
           (progn
             (it "adds `flex' and `basic' as a fallback"
-              (cider-enable-flex-completion)
-              (expect (member 'flex (assq 'styles (assq 'cider completion-category-overrides)))
-                      :to-be-truthy)
-              (expect (member 'basic (assq 'styles (assq 'cider completion-category-overrides)))
-                      :to-be-truthy))
+              (let ((expected-category-overrides '((cider (styles basic flex)))))
+                (cider-enable-flex-completion)
+                (expect (member 'flex (assq 'styles (assq 'cider completion-category-overrides)))
+                        :to-be-truthy)
+                (expect (member 'basic (assq 'styles (assq 'cider completion-category-overrides)))
+                        :to-be-truthy)
+                (expect completion-category-overrides :to-equal expected-category-overrides)))
 
             (it "doesn't add `cycle'"
               (expect (assq 'cycle (assq 'cider completion-category-overrides))

--- a/test/cider-completion-tests.el
+++ b/test/cider-completion-tests.el
@@ -47,7 +47,7 @@
               (expect (assq 'cycle (assq 'cider completion-category-overrides))
                       :to-be nil))
 
-            (it "adds just `flex' if there is another syle present"
+            (it "adds just `flex' if there is another style present"
               (setq completion-category-overrides '((cider (styles partial-completion))))
               (cider-enable-flex-completion)
               (expect (member 'flex (assq 'styles (assq 'cider completion-category-overrides)))

--- a/test/cider-completion-tests.el
+++ b/test/cider-completion-tests.el
@@ -47,7 +47,7 @@
               (expect (assq 'cycle (assq 'cider completion-category-overrides))
                       :to-be nil))
 
-            (it "adds just `flex' if there is another syle present"
+            (it "adds just `flex' if there is another style present"
               (setq completion-category-overrides '((cider (styles partial-completion))))
               (cider-enable-flex-completion)
               (expect (car (cdr (assq 'styles (assq 'cider completion-category-overrides))))

--- a/test/cider-completion-tests.el
+++ b/test/cider-completion-tests.el
@@ -38,8 +38,8 @@
           (progn
             (it "adds `flex' and `basic' as a fallback"
               (cider-enable-flex-completion)
-              (expect (car (cdr (assq 'styles (assq 'cider completion-category-overrides))))
-                      :to-be 'flex)
+              (expect (member 'flex (assq 'styles (assq 'cider completion-category-overrides)))
+                      :to-be-truthy)
               (expect (member 'basic (assq 'styles (assq 'cider completion-category-overrides)))
                       :to-be-truthy))
 
@@ -47,11 +47,11 @@
               (expect (assq 'cycle (assq 'cider completion-category-overrides))
                       :to-be nil))
 
-            (it "adds just `flex' if there is another style present"
+            (it "adds just `flex' if there is another syle present"
               (setq completion-category-overrides '((cider (styles partial-completion))))
               (cider-enable-flex-completion)
-              (expect (car (cdr (assq 'styles (assq 'cider completion-category-overrides))))
-                      :to-be 'flex)
+              (expect (member 'flex (assq 'styles (assq 'cider completion-category-overrides)))
+                      :to-be-truthy)
               (expect (member 'partial-completion (assq 'styles (assq 'cider completion-category-overrides)))
                       :to-be-truthy)
               (expect (member 'basic (assq 'styles (assq 'cider completion-category-overrides)))


### PR DESCRIPTION
This PR makes the CIDER completions behave correctly. Reworking the method to grab the prefix in `cider-complete-at-point`. Making it compatible with "fuzzy" completion styles.

Tested with the `flex` and `orderless` completion styles.

What should we do with `cider-company-enable-fuzzy-completion`? With
this we can remove the CIDER completion style. Should
`cider-company-enable-fuzzy-completion` just mirror the behavior of `cider-enable-flex-completion`?

This also makes CIDER use the default completion style, instead of setting `completion-category-overrides` to make CIDER use the basic completion style.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
