### PR TITLE
Fix cider-inspector-def-current-val

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - [#3626](https://github.com/clojure-emacs/cider/issues/3626): `cider-ns-refresh`: jump to the relevant file/line on errors.
 - [#3628](https://github.com/clojure-emacs/cider/issues/3628): `cider-ns-refresh`: summarize errors as an overlay.
+- [#3660](https://github.com/clojure-emacs/cider/issues/3660): Fix `cider-inspector-def-current-val` always defining in `user` namespace.
 - Bump the injected `enrich-classpath` to [1.19.3](https://github.com/clojure-emacs/enrich-classpath/compare/v1.19.0...v1.19.3).
 - Bump the injected nREPL to [1.1.1](https://github.com/nrepl/nrepl/blob/v1.1.1/CHANGELOG.md#111-2024-02-20).
 - Bump the injected `cider-nrepl` to [0.47.0](https://github.com/clojure-emacs/cider-nrepl/blob/v0.47.0/CHANGELOG.md#0470-2024-03-10).

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -369,10 +369,9 @@ current-namespace."
                  (list (cider-inspector--read-var-name-from-user ns)
                        ns)))
   (setq cider-inspector--current-repl (cider-current-repl))
-  (when-let* ((result (cider-sync-request:inspect-def-current-val ns var-name 'v2))
-              (value (nrepl-dict-get result "value")))
+  (when-let* ((result (cider-sync-request:inspect-def-current-val ns var-name 'v2)))
     (cider-inspector--render-value result 'v2)
-    (message "%s#'%s/%s = %s" cider-eval-result-prefix ns var-name value)))
+    (message "Defined current inspector value as #'%s/%s" ns var-name)))
 
 (defun cider-inspector-tap-current-val ()
   "Sends the current Inspector current value to `tap>'."


### PR DESCRIPTION
Two issues with it:

1. The message in the minibuffer after `d` is used is ugly. 
2. The namespace where the values are defined is always `user`, because `*cider-inspect*` buffer is not associated with the code buffer where it was called from.

Before:
<img width="1278" alt="Screenshot 2024-05-13 at 11 09 31" src="https://github.com/clojure-emacs/cider/assets/468477/63b18359-38b8-4687-868c-19dc7fc07d7d">
After:
<img width="571" alt="Screenshot 2024-05-13 at 11 14 58" src="https://github.com/clojure-emacs/cider/assets/468477/7d86ab59-c066-4aa8-a038-298a48f95787">