### PR TITLE
Limit the maximum string size to be displayed in echo area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#3626](https://github.com/clojure-emacs/cider/issues/3626): `cider-ns-refresh`: jump to the relevant file/line on errors.
 - [#3628](https://github.com/clojure-emacs/cider/issues/3628): `cider-ns-refresh`: summarize errors as an overlay.
 - [#3660](https://github.com/clojure-emacs/cider/issues/3660): Fix `cider-inspector-def-current-val` always defining in `user` namespace.
+- [#3661](https://github.com/clojure-emacs/cider/issues/3661): Truncate echo area output ahead of time.
 - Bump the injected `enrich-classpath` to [1.19.3](https://github.com/clojure-emacs/enrich-classpath/compare/v1.19.0...v1.19.3).
 - Bump the injected nREPL to [1.1.1](https://github.com/nrepl/nrepl/blob/v1.1.1/CHANGELOG.md#111-2024-02-20).
 - Bump the injected `cider-nrepl` to [0.47.0](https://github.com/clojure-emacs/cider-nrepl/blob/v0.47.0/CHANGELOG.md#0470-2024-03-10).

--- a/cider-overlays.el
+++ b/cider-overlays.el
@@ -304,10 +304,10 @@ Note that, while POINT can be a number, it's preferable to be a marker, as
 that will better handle some corner cases where the original buffer is not
 focused."
   (cl-assert (symbolp value-type)) ;; We assert because for avoiding confusion with the optional args.
-  (let* ((font-value (if cider-result-use-clojure-font-lock
+  (let* ((value (string-trim-right value))
+         (font-value (if cider-result-use-clojure-font-lock
                          (cider-font-lock-as-clojure value)
                        value))
-         (font-value (string-trim-right font-value))
          (used-overlay (when (and point
                                   cider-use-overlays
                                   (if (equal 'error value-type)
@@ -316,10 +316,15 @@ focused."
                          (cider--make-result-overlay font-value
                            :where point
                            :duration cider-eval-result-duration
-                           :prepend-face (or overlay-face 'cider-result-overlay-face)))))
+                           :prepend-face (or overlay-face 'cider-result-overlay-face))))
+         (msg (format "%s%s" cider-eval-result-prefix value))
+         (max-msg-length (* (floor (max-mini-window-lines)) (frame-width)))
+         (msg (if (> (string-width msg) max-msg-length)
+                  (format "%s..." (substring msg 0 (- max-msg-length 3)))
+                msg)))
     (message
      "%s"
-     (propertize (format "%s%s" cider-eval-result-prefix font-value)
+     (propertize msg
                  ;; The following hides the message from the echo-area, but
                  ;; displays it in the Messages buffer. We only hide the message
                  ;; if the user wants to AND if the overlay succeeded.


### PR DESCRIPTION
Although there is still work to be done (and thoughts to be thought) in cider-nrepl or nREPL regarding how much we want to print, it makes sense to solve such an issue on CIDER side too. Currently, if `cider-use-overlays` is not `t`, the standard `cider-interactive-eval-handler` will try to display the whole printed result in the minibuffer (echo area). For some reason, pushing huge strings through the echo area is much slower than printing it to the REPL. E.g., doing `(println (range 200000))` is almost instant while evaluating `(range 200000)` in the source buffer takes ~3 seconds on my machine to display the truncated result. Emacs would obviously still truncate the echo area output but not before printing the whole response to `*Messages*`.

This PR proposes to truncate the long output ahead of time. We can also add the similar message that we currently show in overlays, something like `"Result truncated. Type M-x cider-inspect-last-result to inspect it.` if it is deemed necessary.

Example of how the truncated result would look like:
<img width="1279" alt="image" src="https://github.com/clojure-emacs/cider/assets/468477/5a558f28-ea84-4153-97ab-eadae085292c">
