### PR TITLE
Fix cider-interactive-eval-override invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 ### Bugs fixed
 
 - [#3600](https://github.com/clojure-emacs/cider/pull/3600): Fix scittle jack-in when using `cider-jack-in-clj`.
+- [#3663](https://github.com/clojure-emacs/cider/issues/3663): Fix `cider-interactive-eval-override` invocation.
 
 ## 1.13.1 (2024-02-01)
 

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -1229,7 +1229,11 @@ arguments and only proceed with evaluation if it returns nil."
           (delete-overlay ov))))
     (unless (and cider-interactive-eval-override
                  (functionp cider-interactive-eval-override)
-                 (funcall cider-interactive-eval-override form callback bounds))
+                 (condition-case _
+                     (funcall cider-interactive-eval-override form callback bounds additional-params)
+                   (wrong-number-of-arguments
+                    ;; fallback for backward compatibility
+                    (funcall cider-interactive-eval-override form callback bounds))))
       (cider-map-repls :auto
         (lambda (connection)
           (cider--prep-interactive-eval form connection)


### PR DESCRIPTION
This fixes the shortcomings of `cider-interactive-eval-override` described in [#3663](https://github.com/clojure-emacs/cider/issues/3663) in a backward compatible way.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
