### PR TITLE
Issue/gh action macos aarch64

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,17 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
-        emacs_version: ['26.3', '27.2', '28.2', '29.1']
+        os: [macos-13, ubuntu-latest, windows-latest]
+        emacs_version: ['26.3', '27.2', '28.2', '29.3']
         java_version: ['11', '17']
+        include:
+          # aarch64 (macos-13 is Intel)
+          - os: macos-latest
+            emacs_version: '29.3'
+            java_version: '11'
+          - os: macos-latest
+            emacs_version: '28.2'
+            java_version: '11'
 
     steps:
     - name: Set up Emacs


### PR DESCRIPTION
Hi,

Could you please review the patch to add a separate flow in the CI for macOS on Apple Silicon? It fixes #3668 

The macos-latest runner now targets Apple Silicon, and nix-emacs-ci supports version 28.x and above on this platform. I don't see this as an issue since I've also restored the old flow on the Intel macos 13.

By the way, as I've mentioned on other occasions, my personal opinion is that it is sufficient to only run/support the latest Emacs version on non-Unix platforms. :)

https://github.com/actions/runner-images/issues/9741

https://github.com/purcell/nix-emacs-ci/commit/ff5333aa28f65844da04fe6d81a404cff75f4f33#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5

Thanks
 
-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

