### PR TITLE
add macos aarch64 java/17 integration testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,12 @@ jobs:
           - os: macos-latest
             emacs_version: '28.2'
             java_version: '11'
+          - os: macos-latest
+            emacs_version: '29.3'
+            java_version: '17'
+          - os: macos-latest
+            emacs_version: '28.2'
+            java_version: '17'
 
     steps:
     - name: Set up Emacs

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 -----------
 [![License GPL 3][badge-license]](http://www.gnu.org/licenses/gpl-3.0.txt)
 [![CircleCI](https://circleci.com/gh/clojure-emacs/cider.svg?style=svg)](https://circleci.com/gh/clojure-emacs/cider)
+[![Integration tests](https://github.com/clojure-emacs/cider/actions/workflows/test.yml/badge.svg)](https://github.com/clojure-emacs/cider/actions/workflows/test.yml)
 [![Spell-check Status](https://github.com/clojure-emacs/cider/actions/workflows/spell_checking.yml/badge.svg)](https://github.com/clojure-emacs/cider/actions/workflows/spell_checking.yml)
 [![Discord](https://img.shields.io/badge/chat-on%20discord-7289da.svg?sanitize=true)](https://discord.com/invite/nFPpynQPME)
 [![Slack](https://img.shields.io/badge/chat-%23cider-green.svg?style=flat)](http://clojurians.net)


### PR DESCRIPTION
Hi,

could you please review follow patch up to #3669, to add integration testing for java/17 on the apple silicon on @vemv's request.

I've also added the badge for the ci integration tests on the github workflows, which was long overdue.

Thanks