### PR TITLE
Fix buggy special-display-buffer-names check.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 
 ### Bugs fixed
 
+- [#3673](https://github.com/clojure-emacs/cider/pull/3673): Fix buggy `special-display-buffer-names` check.
 - [#3600](https://github.com/clojure-emacs/cider/pull/3600): Fix scittle jack-in when using `cider-jack-in-clj`.
 - [#3663](https://github.com/clojure-emacs/cider/issues/3663): Fix `cider-interactive-eval-override` invocation.
 

--- a/cider-popup.el
+++ b/cider-popup.el
@@ -64,6 +64,9 @@ by adding BUFFER-NAME to the `special-display-buffer-names' list."
     ;; another time through `cider-popup-buffer-display'):
     (if (and (boundp 'special-display-buffer-names)
              (seq-find (lambda (entry)
+                         ;; Fix issue #3672 Phil Hudson 2024-05-21
+                         ;; entry can be either a list or a string
+                         ;; Previous code falsely assumed entry is always a list
                          (equal (if (listp entry) (car entry) entry) buffer-name))
                        special-display-buffer-names))
         (progn

--- a/cider-popup.el
+++ b/cider-popup.el
@@ -64,7 +64,7 @@ by adding BUFFER-NAME to the `special-display-buffer-names' list."
     ;; another time through `cider-popup-buffer-display'):
     (if (and (boundp 'special-display-buffer-names)
              (seq-find (lambda (entry)
-                         (equal (car entry) buffer-name))
+                         (equal (if (listp entry) (car entry) entry) buffer-name))
                        special-display-buffer-names))
         (progn
           (display-buffer buffer-name)


### PR DESCRIPTION
**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
