### PR TITLE
Update cheatsheet to v55

### DIFF
--- a/cider-cheatsheet.el
+++ b/cider-cheatsheet.el
@@ -32,56 +32,40 @@
 (require 'seq)
 
 (defconst cider-cheatsheet-hierarchy
-  '(("Primitives"
+  '(("Documentation"
+     ("REPL"
+      (clojure.repl doc find-doc apropos dir source pst)
+      (clojure.java.javadoc javadoc)))
+    ("Primitives"
      ("Numbers"
       ("Arithmetic"
-       (clojure.core + - * / quot rem mod dec inc max min))
-      ("Compare"
-       (clojure.core = == not= < > <= >= compare))
-      ("Bitwise"
-       (clojure.core bit-and bit-and-not bit-clear bit-flip bit-not bit-or bit-set bit-shift-left bit-shift-right bit-test bit-xor unsigned-bit-shift-right))
-      ("Cast"
-       (clojure.core byte short long int float double bigdec bigint biginteger num rationalize))
-      ("Test"
-       (clojure.core nil? some? identical? zero? pos? neg? even? odd?))
-      ("Random"
-       (clojure.core rand rand-int))
-      ("BigDecimal"
-       (clojure.core with-precision))
-      ("Ratios"
-       (clojure.core numerator denominator ratio?))
+       (clojure.core + - * / quot rem mod inc dec max min abs)
+       (clojure.math floor-div floor-mod ceil floor rint round pow sqrt cbrt E exp expm1 log log10 log1p PI sin cos tan asin acos atan atan2))
       ("Arbitrary Precision Arithmetic"
        (clojure.core +\' -\' *\' inc\' dec\'))
+      ("Compare"
+       (clojure.core == < > <= >= compare))
+      ("Bitwise"
+       (clojure.core bit-and bit-or bit-xor bit-not bit-flip bit-set bit-shift-right bit-shift-left bit-and-not bit-clear bit-test unsigned-bit-shift-right))
+      ("Cast"
+       (clojure.core byte short int long float double bigdec bigint num rationalize biginteger))
+      ("Test"
+       (clojure.core zero? pos? neg? even? odd? number? rational? integer? ratio? decimal? float? double? int? nat-int? neg-int? pos-int? NaN? infinite?))
+      ("Random"
+       (clojure.core rand rand-int)
+       (clojure.math random))
+      ("BigDecimal"
+       (clojure.core with-precision))
       ("Unchecked"
-       (clojure.core *unchecked-math*
-                     unchecked-add
-                     unchecked-add-int
-                     unchecked-byte
-                     unchecked-char
-                     unchecked-dec
-                     unchecked-dec-int
-                     unchecked-divide-int
-                     unchecked-double
-                     unchecked-float
-                     unchecked-inc
-                     unchecked-inc-int
-                     unchecked-int
-                     unchecked-long
-                     unchecked-multiply
-                     unchecked-multiply-int
-                     unchecked-negate
-                     unchecked-negate-int
-                     unchecked-remainder-int
-                     unchecked-short
-                     unchecked-subtract
-                     unchecked-subtract-int)))
-
+       (clojure.core *unchecked-math* unchecked-add unchecked-dec unchecked-inc unchecked-multiply unchecked-negate unchecked-subtract))
+      ("Ratios"
+       (clojure.core numerator denominator ratio?)))
      ("Strings"
       ("Create"
        (clojure.core str format))
       ("Use"
-       (clojure.core count get subs compare)
-       (clojure.string join escape split split-lines replace replace-first reverse re-quote-replacement index-of last-index-of starts-with? ends-with? includes?))
+       (clojure.core count get subs compare parse-boolean parse-double parse-long parse-uuid)
+       (clojure.string join escape split split-lines replace replace-first reverse index-of last-index-of))
       ("Regex"
        (clojure.core re-find re-seq re-matches re-pattern re-matcher re-groups)
        (clojure.string replace replace-first re-quote-replacement))
@@ -90,32 +74,26 @@
       ("Trim"
        (clojure.string trim trim-newline triml trimr))
       ("Test"
-       (clojure.core char char? string?)
-       (clojure.string blank?)))
-
+       (clojure.core string?)
+       (clojure.string blank? starts-with? ends-with? includes?)))
      ("Other"
       ("Characters"
-       (clojure.core char char-name-string char-escape-string))
+       (clojure.core char char? char-name-string char-escape-string))
       ("Keywords"
        (clojure.core keyword keyword? find-keyword))
       ("Symbols"
-       (clojure.core symbol symbol? gensym))
-      ("Data Readers"
-       (clojure.core *data-readers* default-data-readers *default-data-reader-fn*))))
-
+       (clojure.core symbol symbol? gensym))))
     ("Collections"
-     ("Generic Ops"
-      (clojure.core count bounded-count empty not-empty into conj))
-     ("Tree Walking"
+     ("Generic ops"
+      (clojure.core count empty not-empty into conj bounded-count))
+     ("Tree walking"
       (clojure.walk walk prewalk prewalk-demo prewalk-replace postwalk postwalk-demo postwalk-replace keywordize-keys stringify-keys))
      ("Content tests"
       (clojure.core distinct? empty? every? not-every? some not-any?))
      ("Capabilities"
       (clojure.core sequential? associative? sorted? counted? reversible?))
      ("Type tests"
-      (clojure.core type class coll? list? vector? set? map? seq?
-                    number? integer? float? decimal? class? rational? ratio?
-                    chunked-seq? reduced? special-symbol? record?))
+      (clojure.core coll? list? vector? set? map? seq? record? map-entry?))
      ("Lists"
       ("Create"
        (clojure.core list list*))
@@ -123,72 +101,126 @@
        (clojure.core first nth peek))
       ("Change"
        (clojure.core cons conj rest pop)))
-
      ("Vectors"
       ("Create"
-       (clojure.core vec vector vector-of))
+       (clojure.core vector vec vector-of mapv filterv))
       ("Examine"
-       (clojure.core get peek))
-
+       (clojure.core nth get peek))
       ("Change"
-       (clojure.core assoc pop subvec replace conj rseq))
+       (clojure.core assoc assoc-in pop subvec replace conj rseq update update-in))
       ("Ops"
-       (clojure.core mapv filterv reduce-kv)))
-
+       (clojure.core reduce-kv)))
      ("Sets"
-      ("Create"
-       (clojure.core set hash-set sorted-set sorted-set-by))
+      ("Create unsorted"
+       (clojure.core set hash-set))
+      ("Create sorted"
+       (clojure.core sorted-set sorted-set-by)
+       (clojure.data.avl sorted-set sorted-set-by)
+       (clojure.data.int-map int-set dense-int-set))
       ("Examine"
        (clojure.core get contains?))
       ("Change"
        (clojure.core conj disj))
-      ("Relational Algebra"
-       (clojure.set join select project union difference intersection))
-      ("Get map"
-       (clojure.set index rename-keys rename map-invert))
+      ("Set ops"
+       (clojure.set union difference intersection select))
       ("Test"
        (clojure.set subset? superset?))
-      ("Sorted Sets"
+      ("Sorted sets"
        (clojure.core rseq subseq rsubseq)))
-
      ("Maps"
-      ("Create"
-       (clojure.core hash-map array-map zipmap sorted-map sorted-map-by bean frequencies group-by))
+      ("Create unsorted"
+       (clojure.core hash-map array-map zipmap bean frequencies group-by)
+       (clojure.set index))
+      ("Create sorted"
+       (clojure.core sorted-map sorted-map-by)
+       (clojure.data.avl sorted-map sorted-map-by)
+       (clojure.data.priority-map priority-map)
+       (clojure.data.int-map int-map))
       ("Examine"
-       (clojure.core get get-in contains? find keys vals map-entry?))
+       (clojure.core get get get-in contains? find keys vals))
       ("Change"
-       (clojure.core assoc assoc-in dissoc merge merge-with select-keys update update-in))
+       (clojure.core assoc assoc-in dissoc merge merge-with select-keys update update-in update-keys update-vals)
+       (clojure.set rename-keys map-invert))
+      ("Ops"
+       (clojure.core reduce-kv))
       ("Entry"
        (clojure.core key val))
-      ("Sorted Maps"
+      ("Sorted maps"
        (clojure.core rseq subseq rsubseq)))
-
+     ("Queues"
+      ("Examine"
+       (clojure.core peek))
+      ("Change"
+       (clojure.core conj pop)))
+     ("Relations"
+      ("Relational algebra"
+       (clojure.set join select project union difference intersection index rename)))
+     ("Transients"
+      ("Create"
+       (clojure.core transient persistent!))
+      ("Change"
+       (clojure.core conj! pop! assoc! dissoc! disj!)))
+     ("Misc"
+      ("Compare"
+       (clojure.core = identical? not= not compare)
+       (clojure.data diff))
+      ("Test"
+       (clojure.core true? false? instance? nil? some?)))
      ("Hashes"
-      (clojure.core hash hash-ordered-coll hash-unordered-coll mix-collection-hash))
-
-     ("Volatiles"
-      (clojure.core volatile! volatile? vreset! vswap!)))
-
-    ("Functions"
-     ("Create"
-      (clojure.core fn defn defn- definline identity constantly comp complement partial juxt memfn memoize fnil every-pred some-fn trampoline))
-     ("Call"
-      (clojure.core -> ->> some-> some->> as-> cond-> cond->>))
-     ("Test"
-      (clojure.core fn? ifn?)))
-
+      (clojure.core hash hash-ordered-coll hash-unordered-coll mix-collection-hash)))
+    ("Sequences"
+     ("Creating a Lazy Seq"
+      ("From collection"
+       (clojure.core seq vals keys rseq subseq rsubseq sequence))
+      ("From producer fn"
+       (clojure.core lazy-seq repeatedly iterate iteration))
+      ("From constant"
+       (clojure.core repeat range))
+      ("From other"
+       (clojure.core file-seq line-seq resultset-seq re-seq tree-seq xml-seq iterator-seq enumeration-seq))
+      ("From seq"
+       (clojure.core keep keep-indexed)))
+     ("Seq in, Seq out"
+      ("Get shorter"
+       (clojure.core distinct filter remove take-nth for dedupe random-sample))
+      ("Get longer"
+       (clojure.core cons conj concat lazy-cat mapcat cycle interleave interpose))
+      ("Tail-items"
+       (clojure.core rest nthrest next fnext nnext drop drop-while take-last for))
+      ("Head-items"
+       (clojure.core take take-while butlast drop-last for))
+      ("Change"
+       (clojure.core conj concat distinct flatten group-by partition partition-all partition-by split-at split-with filter remove replace shuffle))
+      ("Rearrange"
+       (clojure.core reverse sort sort-by compare))
+      ("Process items"
+       (clojure.core map pmap map-indexed mapcat for replace seque)))
+     ("Using a Seq"
+      ("Extract item"
+       (clojure.core first second last rest next ffirst nfirst fnext nnext nth nthnext rand-nth when-first max-key min-key))
+      ("Construct coll"
+       (clojure.core zipmap into reduce reductions set vec into-array to-array-2d mapv filterv))
+      ("Pass to fn"
+       (clojure.core apply))
+      ("Search"
+       (clojure.core some filter))
+      ("Force evaluation"
+       (clojure.core doseq dorun doall run!))
+      ("Check for forced"
+       (clojure.core realized?))))
     ("Transducers"
-     ("Create"
-      (clojure.core cat dedupe distinct drop drop-while filter halt-when interpose keep keep-indexed map map-indexed mapcat partition-all partition-by random-sample remove replace take take-nth take-while))
-     ("Call"
-      (clojure.core ->Eduction eduction into sequence transduce completing run!))
-     ("Early Termination"
-      (clojure.core deref reduced reduced? ensure-reduced unreduced)))
-
+     ("Off the shelf"
+      (clojure.core map mapcat filter remove take take-while take-nth drop drop-while replace partition-by partition-all keep keep-indexed map-indexed distinct interpose cat dedupe random-sample halt-when))
+     ("Create your own"
+      (clojure.core completing ensure-reduced unreduced))
+     ("Use"
+      (clojure.core into sequence transduce eduction))
+     ("Early termination"
+      (clojure.core reduced reduced? deref)))
     ("Spec"
      ("Operations"
       (clojure.spec.alpha valid? conform unform explain explain-data explain-str explain-out form describe assert check-asserts check-asserts?))
-     ("Generator Ops"
+     ("Generator ops"
       (clojure.spec.alpha gen exercise exercise-fn))
      ("Defn & Registry"
       (clojure.spec.alpha def fdef registry get-spec spec? spec with-gen))
@@ -196,19 +228,18 @@
       (clojure.spec.alpha and or))
      ("Collection"
       (clojure.spec.alpha coll-of map-of every every-kv keys merge))
-     ("Regex "
+     ("Regex"
       (clojure.spec.alpha cat alt * + \? & keys*))
      ("Range"
       (clojure.spec.alpha int-in inst-in double-in int-in-range? inst-in-range?))
-     ("Custom Explain"
-      (clojure.spec.alpha explain-printer *explain-out*))
      ("Other"
       (clojure.spec.alpha nilable multi-spec fspec conformer))
-
+     ("Custom explain"
+      (clojure.spec.alpha explain-printer *explain-out*))
      ("Predicates with test.check generators"
       ("Numbers"
        (clojure.core number? rational? integer? ratio? decimal? float? zero? double? int? nat-int? neg-int? pos-int?))
-      ("Symbols & Keywords"
+      ("Symbols, keywords"
        (clojure.core keyword? symbol? ident? qualified-ident? qualified-keyword? qualified-symbol? simple-ident? simple-keyword? simple-symbol?))
       ("Scalars"
        (clojure.core string? true? false? nil? some? boolean? bytes? inst? uri? uuid?))
@@ -216,245 +247,6 @@
        (clojure.core list? map? set? vector? associative? coll? sequential? seq? empty? indexed? seqable?))
       ("Other"
        (clojure.core any?))))
-
-    ("Other"
-     ("XML"
-      (clojure.core xml-seq)
-      (clojure.xml parse))
-     ("REPL"
-      (clojure.core *1 *2 *3 *e *print-dup* *print-length* *print-level* *print-meta* *print-readably*))
-     ("EDN"
-      (clojure.edn read read-string))
-     ("Compiling Code & Class Generation"
-      (clojure.core *compile-files* *compile-path* *file* *warn-on-reflection* compile gen-class gen-interface loaded-libs test))
-     ("Misc"
-      (clojure.core eval force name *clojure-version* clojure-version *command-line-args*))
-     ("Pretty Printing"
-      (clojure.pprint pprint print-table pp *print-right-margin*))
-     ("Browser / Shell"
-      (clojure.java.browse browse-url)
-      (clojure.java.shell sh with-sh-dir with-sh-env)))
-
-    ("Vars & Global Environment"
-     ("Def Variants"
-      (:special def)
-      (clojure.core defn defn- definline defmacro defmethod defmulti defonce defrecord))
-     ("Interned Vars"
-      (:special var)
-      (clojure.core declare intern binding find-var))
-     ("Var Objects"
-      (clojure.core with-local-vars var-get var-set alter-var-root var?))
-     ("Var Validators"
-      (clojure.core set-validator! get-validator)))
-
-    ("Reader Conditionals"
-     (clojure.core reader-conditional reader-conditional? tagged-literal tagged-literal?))
-
-    ("Abstractions"
-     ("Protocols"
-      (clojure.core defprotocol extend extend-type extend-protocol reify extends? satisfies? extenders))
-     ("Records & Types"
-      (clojure.core defrecord deftype))
-     ("Multimethods"
-      ("Define"
-       (clojure.core defmulti defmethod))
-      ("Dispatch"
-       (clojure.core get-method methods))
-      ("Remove"
-       (clojure.core remove-method remove-all-methods))
-      ("Prefer"
-       (clojure.core prefer-method prefers))
-      ("Relation"
-       (clojure.core derive isa? parents ancestors descendants make-hierarchy))))
-
-    ("Macros"
-     ("Create"
-      (clojure.core defmacro definline))
-     ("Debug"
-      (clojure.core macroexpand-1 macroexpand)
-      (clojure.walk macroexpand-all))
-     ("Branch"
-      (clojure.core and or when when-not when-let when-first if-not if-let cond condp case))
-     ("Loop"
-      (clojure.core for doseq dotimes while))
-     ("Arrange"
-      (clojure.core .. doto ->))
-     ("Scope"
-      (clojure.core binding locking time)
-      (clojure.core with-in-str with-local-vars with-open with-out-str with-precision with-redefs with-redefs-fn))
-     ("Lazy"
-      (clojure.core lazy-cat lazy-seq delay delay?))
-     ("Doc"
-      (clojure.core assert comment)
-      (clojure.repl doc dir dir-fn source-fn)))
-
-    ("Java Interop"
-     ("General"
-      (:special new set!)
-      (clojure.core .. doto bean comparator enumeration-seq import iterator-seq memfn definterface supers bases))
-     ("Cast"
-      (clojure.core boolean byte short char int long float double bigdec bigint num cast biginteger))
-     ("Exceptions"
-      (:special throw try catch finally)
-      (clojure.core ex-info ex-data Throwable->map StackTraceElement->vec)
-      (clojure.repl pst))
-     ("Arrays"
-      ("Create"
-       (clojure.core boolean-array byte-array double-array char-array float-array int-array long-array make-array object-array short-array to-array))
-      ("Manipulate"
-       (clojure.core aclone aget aset alength amap areduce aset-int aset-long aset-short aset-boolean aset-byte aset-char aset-double aset-float))
-      ("Cast"
-       (clojure.core booleans bytes chars doubles floats ints longs shorts)))
-     ("Proxy"
-      ("Create"
-       (clojure.core proxy get-proxy-class construct-proxy init-proxy))
-      ("Misc"
-       (clojure.core proxy-mappings proxy-super update-proxy))))
-
-    ("Namespaces"
-     ("Current"
-      (clojure.core *ns*))
-     ("Create Switch"
-      (clojure.core ns in-ns create-ns))
-     ("Add"
-      (clojure.core alias import intern refer refer-clojure))
-     ("Find"
-      (clojure.core all-ns find-ns))
-     ("Examine"
-      (clojure.core ns-aliases ns-imports ns-interns ns-map ns-name ns-publics ns-refers))
-     ("From symbol"
-      (clojure.core resolve namespace ns-resolve the-ns))
-     ("Remove"
-      (clojure.core ns-unalias ns-unmap remove-ns)))
-    ("Loading"
-     ("Load libs"
-      (clojure.core require use import refer))
-     ("List Loaded"
-      (clojure.core loaded-libs))
-     ("Load Misc"
-      (clojure.core load load-file load-reader load-string)))
-
-    ("Concurrency"
-     ("Atoms"
-      (clojure.core atom swap! swap-vals! reset! reset-vals! compare-and-set!))
-     ("Futures"
-      (clojure.core future future-call future-cancel future-cancelled? future-done? future?))
-     ("Threads"
-      (clojure.core bound-fn bound-fn* get-thread-bindings pop-thread-bindings push-thread-bindings))
-
-     ("Misc"
-      (clojure.core locking pcalls pvalues pmap seque promise deliver))
-
-     ("Refs & Transactions"
-      ("Create"
-       (clojure.core ref))
-      ("Examine"
-       (clojure.core deref))
-      ("Transaction"
-       (clojure.core sync dosync io!))
-      ("In Transaction"
-       (clojure.core ensure ref-set alter commute))
-      ("Validators"
-       (clojure.core get-validator set-validator!))
-      ("History"
-       (clojure.core ref-history-count ref-max-history ref-min-history)))
-
-     ("Agents & Asynchronous Actions"
-      ("Create"
-       (clojure.core agent))
-      ("Examine"
-       (clojure.core agent-error))
-      ("Change State"
-       (clojure.core send send-off restart-agent send-via set-agent-send-executor! set-agent-send-off-executor!))
-      ("Block Waiting"
-       (clojure.core await await-for))
-      ("Ref Validators"
-       (clojure.core get-validator set-validator!))
-      ("Watchers"
-       (clojure.core add-watch remove-watch))
-      ("Thread Handling"
-       (clojure.core shutdown-agents))
-      ("Error"
-       (clojure.core error-handler set-error-handler! error-mode set-error-mode!))
-      ("Misc"
-       (clojure.core *agent* release-pending-sends))))
-
-    ("Sequences"
-     ("Creating a Lazy Seq"
-      ("From Collection"
-       (clojure.core seq sequence keys vals rseq subseq rsubseq))
-      ("From Producer Fn"
-       (clojure.core lazy-seq repeatedly iterate))
-      ("From Constant"
-       (clojure.core repeat range))
-      ("From Other"
-       (clojure.core file-seq line-seq resultset-seq re-seq tree-seq xml-seq iterator-seq enumeration-seq))
-      ("From Seq"
-       (clojure.core keep keep-indexed)))
-
-     ("Seq in, Seq out"
-      ("Get shorter"
-       (clojure.core distinct dedupe filter remove for))
-      ("Get longer"
-       (clojure.core cons conj concat lazy-cat mapcat cycle interleave interpose)))
-     ("Tail-items"
-      (clojure.core rest nthrest fnext nnext drop drop-while take-last for))
-     ("Head-items"
-      (clojure.core take take-nth take-while butlast drop-last for))
-     ("Change"
-      (clojure.core conj concat distinct flatten group-by partition partition-all partition-by split-at split-with filter remove replace shuffle random-sample))
-     ("Rearrange"
-      (clojure.core reverse sort sort-by compare))
-     ("Process items"
-      (clojure.core map pmap map-indexed mapcat for replace seque))
-
-     ("Using a Seq"
-      ("Extract item"
-       (clojure.core first second last rest next ffirst nfirst fnext nnext nth nthnext rand-nth when-first max-key min-key))
-      ("Construct coll"
-       (clojure.core zipmap into reduce reductions set vec into-array to-array-2d))
-      ("Pass to fn"
-       (clojure.core apply))
-      ("Search"
-       (clojure.core some filter))
-      ("Force evaluation"
-       (clojure.core doseq dorun doall))
-      ("Check for forced"
-       (clojure.core realized?))))
-
-    ("Zippers"
-     ("Create"
-      (clojure.zip zipper seq-zip vector-zip xml-zip))
-     ("Get loc"
-      (clojure.zip up down left right leftmost rightmost))
-     ("Get seq"
-      (clojure.zip lefts rights path children))
-     ("Change"
-      (clojure.zip make-node replace edit insert-child insert-left insert-right append-child remove))
-     ("Move"
-      (clojure.zip next prev))
-     ("XML"
-      (clojure.data.zip.xml attr attr= seq-test tag= text text= xml-> xml1->))
-     ("Misc"
-      (clojure.zip root node branch? end?)))
-
-    ("Documentation"
-     ("REPL"
-      (clojure.repl doc find-doc apropos source pst)
-      (clojure.java.javadoc javadoc)))
-
-    ("Transients"
-     ("Create"
-      (clojure.core transient persistent!))
-     ("Change"
-      (clojure.core conj! pop! assoc! dissoc! disj!)))
-    ("Misc"
-     ("Compare"
-      (clojure.core = == identical? not= not compare)
-      (clojure.data diff))
-     ("Test"
-      (clojure.core true? false? nil? instance?)))
-
     ("IO"
      ("To/from ..."
       (clojure.core spit slurp))
@@ -466,29 +258,243 @@
      ("To string"
       (clojure.core format with-out-str pr-str prn-str print-str println-str))
      ("From *in*"
-      (clojure.core read-line read))
+      (clojure.core read-line)
+      (clojure.edn read)
+      (clojure.tools.reader.edn read))
      ("From reader"
-      (clojure.core line-seq read))
+      (clojure.core line-seq)
+      (clojure.edn read)
+      (clojure.tools.reader.edn read))
      ("From string"
-      (clojure.core read-string with-in-str))
+      (clojure.core with-in-str)
+      (clojure.edn read-string)
+      (clojure.tools.reader.edn read-string))
      ("Open"
       (clojure.core with-open)
       (clojure.java.io reader writer input-stream output-stream))
-     ("Interop"
-      (clojure.java.io make-writer make-reader make-output-stream make-input-stream))
      ("Misc"
       (clojure.core flush file-seq *in* *out* *err*)
-      (clojure.java.io file copy delete-file resource as-file as-url as-relative-path make-parents)))
-
+      (clojure.java.io file copy delete-file resource as-file as-url as-relative-path make-parents))
+     ("Data readers"
+      (clojure.core *data-readers* default-data-readers *default-data-reader-fn*))
+     ("Tap"
+      (clojure.core tap> add-tap remove-tap))
+     ("Interop"
+      (clojure.java.io make-writer make-reader make-output-stream make-input-stream)))
+    ("Functions"
+     ("Create"
+      (:special fn)
+      (clojure.core defn defn- definline identity constantly memfn comp complement partial juxt memoize fnil every-pred some-fn))
+     ("Call"
+      (clojure.core apply -> ->> trampoline as-> cond-> cond->> some-> some->>))
+     ("Test"
+      (clojure.core fn? ifn?)))
+    ("Abstractions"
+     ("Protocols"
+      ("Define"
+       (clojure.core defprotocol))
+      ("Extend"
+       (clojure.core extend-type))
+      ("Reify"
+       (clojure.core reify))
+      ("Test"
+       (clojure.core satisfies? extends?))
+      ("Other"
+       (clojure.core extend extend-protocol extenders)))
+     ("Records"
+      ("Define"
+       (clojure.core defrecord))
+      ("Test"
+       (clojure.core record?)))
+     ("Types"
+      ("Define"
+       (clojure.core deftype))
+      ("With methods"
+       (clojure.core deftype)))
+     ("Multimethods"
+      ("Define"
+       (clojure.core defmulti))
+      ("Method define"
+       (clojure.core defmethod))
+      ("Dispatch"
+       (clojure.core get-method methods))
+      ("Remove"
+       (clojure.core remove-method remove-all-methods))
+      ("Prefer"
+       (clojure.core prefer-method prefers))
+      ("Relation"
+       (clojure.core derive underive isa? parents ancestors descendants make-hierarchy))))
+    ("Macros"
+     ("Create"
+      (clojure.core defmacro definline))
+     ("Debug"
+      (clojure.core macroexpand-1 macroexpand)
+      (clojure.walk macroexpand-all))
+     ("Branch"
+      (clojure.core and or when when-not when-let when-first if-not if-let cond condp case when-some if-some))
+     ("Loop"
+      (clojure.core for doseq dotimes while))
+     ("Arrange"
+      (clojure.core .. doto -> ->> as-> cond-> cond->> some-> some->>))
+     ("Scope"
+      (clojure.core binding locking time with-in-str with-local-vars with-open with-out-str with-precision with-redefs with-redefs-fn))
+     ("Lazy"
+      (clojure.core lazy-cat lazy-seq delay))
+     ("Doc"
+      (clojure.core assert comment)
+      (clojure.repl doc)))
     ("Metadata"
-     (clojure.core meta with-meta alter-meta! reset-meta! vary-meta))
-
+     (clojure.core meta with-meta vary-meta alter-meta! reset-meta! test)
+     (clojure.repl doc find-doc))
     ("Special Forms"
-     (:special def if do quote var recur throw try monitor-enter monitor-exit)
-     (clojure.core fn loop)
-     ("Binding / Destructuring"
-      (clojure.core let fn letfn defn defmacro loop for doseq if-let if-some when-let when-some)))
-
+     ("General"
+      (:special def if do let letfn quote var fn loop recur set! throw try monitor-enter monitor-exit))
+     ("Binding Forms / Destructuring"
+      (:special let fn loop)
+      (clojure.core defn defmacro for doseq if-let when-let if-some when-some)))
+    ("Vars and global environment"
+     ("Def variants"
+      (:special def)
+      (clojure.core defn defn- definline defmacro defmethod defmulti defonce defrecord))
+     ("Interned vars"
+      (clojure.core declare intern binding find-var)
+      (:special var))
+     ("Var objects"
+      (clojure.core with-local-vars var-get var-set alter-var-root var? bound? thread-bound?))
+     ("Var validators"
+      (clojure.core set-validator! get-validator)))
+    ("Namespaces"
+     ("Current"
+      (clojure.core *ns*))
+     ("Create/Switch"
+      (clojure.core ns in-ns create-ns))
+     ("Add"
+      (clojure.core alias import intern refer)
+      (:special def))
+     ("Find"
+      (clojure.core all-ns find-ns))
+     ("Examine"
+      (clojure.core ns-name ns-aliases ns-map ns-interns ns-publics ns-refers ns-imports))
+     ("From symbol"
+      (clojure.core resolve ns-resolve namespace the-ns requiring-resolve))
+     ("Remove"
+      (clojure.core ns-unalias ns-unmap remove-ns)))
+    ("Loading"
+     ("Load libs"
+      (clojure.core require use import refer))
+     ("List loaded"
+      (clojure.core loaded-libs))
+     ("Load misc"
+      (clojure.core load load-file load-reader load-string)))
+    ("Concurrency"
+     ("Atoms"
+      (clojure.core atom swap! reset! compare-and-set! swap-vals! reset-vals!))
+     ("Futures"
+      (clojure.core future future-call future-done? future-cancel future-cancelled? future?))
+     ("Threads"
+      (clojure.core bound-fn bound-fn* get-thread-bindings push-thread-bindings pop-thread-bindings thread-bound?))
+     ("Volatiles"
+      (clojure.core volatile! vreset! vswap! volatile?))
+     ("Misc"
+      (clojure.core locking pcalls pvalues pmap seque promise deliver))
+     ("Refs and Transactions"
+      ("Create"
+       (clojure.core ref))
+      ("Examine"
+       (clojure.core deref))
+      ("Transaction"
+       (clojure.core sync dosync io!))
+      ("In transaction"
+       (clojure.core ensure ref-set alter commute))
+      ("Validators"
+       (clojure.core set-validator! get-validator))
+      ("History"
+       (clojure.core ref-history-count ref-min-history ref-max-history)))
+     ("Agents and Asynchronous Actions"
+      ("Create"
+       (clojure.core agent))
+      ("Examine"
+       (clojure.core agent-error))
+      ("Change state"
+       (clojure.core send send-off restart-agent send-via set-agent-send-executor! set-agent-send-off-executor!))
+      ("Block waiting"
+       (clojure.core await await-for))
+      ("Ref validators"
+       (clojure.core set-validator! get-validator))
+      ("Watchers"
+       (clojure.core add-watch remove-watch))
+      ("Thread handling"
+       (clojure.core shutdown-agents))
+      ("Error"
+       (clojure.core error-handler set-error-handler! error-mode set-error-mode!))
+      ("Misc"
+       (clojure.core *agent* release-pending-sends))))
+    ("Java Interoperation"
+     ("General"
+      (clojure.core .. doto bean comparator enumeration-seq import iterator-seq memfn class class? bases supers type gen-class gen-interface definterface)
+      (:special new set!))
+     ("Cast"
+      (clojure.core boolean byte short char int long float double bigdec bigint num cast biginteger))
+     ("Exceptions"
+      (:special throw try catch finally)
+      (clojure.repl pst)
+      (clojure.core ex-info ex-data Throwable->map StackTraceElement->vec ex-cause ex-message)
+      (clojure.main ex-triage ex-str err->msg report-error))
+     ("Arrays"
+      ("Create"
+       (clojure.core make-array object-array boolean-array byte-array short-array char-array int-array long-array float-array double-array aclone to-array to-array-2d into-array))
+      ("Use"
+       (clojure.core aget aset aset-boolean aset-byte aset-short aset-char aset-int aset-long aset-float aset-double alength amap areduce))
+      ("Cast"
+       (clojure.core booleans bytes shorts chars ints longs floats doubles)))
+     ("Proxy"
+      ("Create"
+       (clojure.core proxy get-proxy-class construct-proxy init-proxy))
+      ("Misc"
+       (clojure.core proxy-mappings proxy-super update-proxy))))
+    ("Zippers"
+     ("Create"
+      (clojure.zip zipper seq-zip vector-zip xml-zip))
+     ("Get loc"
+      (clojure.zip up down left right leftmost rightmost))
+     ("Get seq"
+      (clojure.zip lefts rights path children))
+     ("Change"
+      (clojure.zip make-node replace edit insert-child insert-left insert-right append-child remove))
+     ("Move"
+      (clojure.zip next prev))
+     ("Misc"
+      (clojure.zip root node branch? end?))
+     ("XML"
+      (clojure.data.zip.xml attr attr= seq-test tag= text text= xml-> xml1->)))
+    ("Other"
+     ("XML"
+      (clojure.xml parse)
+      (clojure.core xml-seq))
+     ("REPL"
+      (clojure.core *1 *2 *3 *e *print-dup* *print-length* *print-level* *print-meta* *print-readably*))
+     ("Code"
+      (clojure.core *compile-files* *compile-path* *file* *warn-on-reflection* compile loaded-libs test))
+     ("Misc"
+      (clojure.core eval force hash *clojure-version* clojure-version *command-line-args* random-uuid))
+     ("Browser / Shell"
+      (clojure.java.browse browse-url)
+      (clojure.java.shell sh with-sh-dir with-sh-env))
+     ("EDN"
+      (clojure.edn read read-string))
+     ("Pretty Printing"
+      (clojure.pprint pprint print-table pp *print-right-margin*))
+     ("Compiling Code & Class Generation"
+      (clojure.core *compile-files* *compile-path* *file* *warn-on-reflection* compile gen-class gen-interface loaded-libs test)))
+    ("Reader Conditionals"
+     (clojure.core reader-conditional reader-conditional? tagged-literal tagged-literal?))
+    ("Unit Tests"
+     ("Defining"
+      (clojure.test deftest deftest- testing is are))
+     ("Running"
+      (clojure.test run-tests run-all-tests test-vars))
+     ("Fixtures"
+      (clojure.test use-fixtures join-fixtures compose-fixtures)))
     ("Async"
      ("Main"
       (clojure.core.async go go-loop <! <!! >! >!! chan put! take take! close! timeout offer! poll! promise-chan))
@@ -509,14 +515,7 @@
      ("Higher Order"
       (clojure.core.async filter< filter> map map< map> mapcat< mapcat> partition partition-by reduce remove< remove> split))
      ("Pre-Populate"
-      (clojure.core.async into onto-chan to-chan)))
-    ("Unit Tests"
-     ("Defining"
-      (clojure.test deftest deftest- testing is are))
-     ("Running"
-      (clojure.test run-tests run-all-tests test-vars))
-     ("Fixtures"
-      (clojure.test use-fixtures join-fixtures compose-fixtures))))
+      (clojure.core.async into onto-chan to-chan))))
   "A data structure for Clojure cheatsheet information.
 
 It's a tree, where the head of each list determines the context of the rest


### PR DESCRIPTION
Update cheatsheet to match v55 of the official cheatsheet. Also, reorder sections as they are ordered in the official cheatsheet and move additional sections, which are not in the official cheatsheet, to the end.

Closes #3674