### PR TITLE
Remove useless bit of code from cheatsheet

### DIFF
--- a/cider-cheatsheet.el
+++ b/cider-cheatsheet.el
@@ -551,10 +551,7 @@ This list is supposed to have the following format:
   "Expand the symbols in VAR-LIST to fully-qualified var names.
 
 The list can hold one or more lists inside - one per each namespace."
-  (let ((namespaced-vars (seq-mapcat #'cider-cheatsheet--expand-vars
-                                     (seq-remove (lambda (list)
-                                                   (eq (car list) :url))
-                                                 var-list))))
+  (let ((namespaced-vars (seq-mapcat #'cider-cheatsheet--expand-vars var-list)))
     (cider-doc-lookup (completing-read "Select var: " namespaced-vars))))
 
 ;;;###autoload


### PR DESCRIPTION
When the time comes to select var in cheatsheet, we first remove var lists with `:url` as the first element. However, there are no such var lists anymore.

This bit of code comes from the initial implementation, where lists with `:url` existed (though they served no purpose) and were later removed (bfdd79c28f27e1fab6f1cd2759606ff6f4d13899).

Since this code doesn't serve any purpose anymore, we can easily remove it. In fact, we can remove the entire `cider-cheatsheet--select-var` function and replace its call, as it feels redundant, if you think that would be appropriate.