### PR TITLE
Display cheatsheet in a separate buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### New features
 
+- [#3681](https://github.com/clojure-emacs/cider/pull/3681): Add an alternative way to display cheatsheet in a buffer and make it the default.
+  - Current `cider-cheatsheet` command is renamed to `cider-cheatsheet-select`.
+  - New way to display cheatsheet in a buffer is available with `cider-cheatsheet` command.
 - [#3632](https://github.com/clojure-emacs/cider/pull/3623): Add new configuration variable `cider-clojure-cli-global-aliases`.
 - [#3366](https://github.com/clojure-emacs/cider/pull/3366): Support display of error overlays with `#dbg!` and `#break!` reader macros.
 - [#3622](https://github.com/clojure-emacs/cider/pull/3461): Basic support for using CIDER from [clojure-ts-mode](https://github.com/clojure-emacs/clojure-ts-mode).

--- a/cider-cheatsheet.el
+++ b/cider-cheatsheet.el
@@ -570,7 +570,7 @@ When you make it to a Clojure var its doc buffer gets displayed."
     (cider-cheatsheet--select-var cheatsheet-data)))
 
 (cl-defun cider-cheatsheet--insert-hierarchy (hierarchy &optional (level 0))
-  "Insert the cheatsheet hierarchy with visual indentation for each level."
+  "Insert HIERARCHY with visual indentation for LEVEL."
   (dolist (node hierarchy)
     (if (stringp (car node))
         (progn

--- a/cider-cheatsheet.el
+++ b/cider-cheatsheet.el
@@ -556,7 +556,7 @@ The list can hold one or more lists inside - one per each namespace."
     (cider-doc-lookup (completing-read "Select var: " namespaced-vars))))
 
 ;;;###autoload
-(defun cider-cheatsheet ()
+(defun cider-cheatsheet-select ()
   "Navigate `cider-cheatsheet-hierarchy' with `completing-read'.
 
 When you make it to a Clojure var its doc buffer gets displayed."
@@ -592,7 +592,7 @@ When you make it to a Clojure var its doc buffer gets displayed."
     (buffer-string)))
 
 ;;;###autoload
-(defun cider-cheatsheet-buffer ()
+(defun cider-cheatsheet ()
   "Display cheatsheet in a popup buffer."
   (interactive)
   (with-current-buffer (cider-popup-buffer "*cider-cheatsheet*")


### PR DESCRIPTION
While thinking about #3678 on how we can improve the current cheatsheet interface, I came up with the idea that we need to make it possible to display cheatsheet in a separate buffer.

The current cheatsheet is a subset of the official cheatsheet, displaying only functions using completion interface. However, by displaying cheatsheet in a buffer, we can have a richer output and make it identical to the official cheatsheet in terms of the information it provides. For example, we can make headings clickable to link to documentation, and we can display literals and other strings from the official cheatsheet that are currently omitted.

At this point, it looks like this: 
![cheatsheet-buffer](https://github.com/clojure-emacs/cider/assets/93549926/763966db-4995-4259-9fe1-12b6fd3fe466)

Following the naming pattern of `cider-apropos` and `cider-apropos-select`, I've divided this functionality into two commands: `cider-cheatsheet`, which displays cheatsheet in the `*cider-cheatsheet*` buffer, and `cider-cheatsheet-select`, which provides a completion interface (as the current `cider-cheatsheet` command does).