### PR TITLE
jack-in support for the Basilisp Clojure dialect in Python

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,7 +104,7 @@ jobs:
       with:
         python-version: '3.12'
     - run: |
-        pip install basilisp==0.1.0b1
+        pip install basilisp==0.1.0b2
 
     - name: Test integration
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,6 +100,12 @@ jobs:
     - run: npm install shadow-cljs@2.20.13 -g
     - run: npm install nbb@1.1.152 -g
 
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - run: |
+        pip install basilisp==0.1.0b1
+
     - name: Test integration
       run: |
         # The tests occasionally fail on macos&win in what is seems to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   - adds `cider-ns-code-reload-tool` defcustom, defaulting to `'tools.namespace`.
   - you can change it to `'clj-reload` to use [clj-reload](https://github.com/tonsky/clj-reload) instead of [tools.namespace](https://github.com/clojure/tools.namespace).
 
+- [#3682](https://github.com/clojure-emacs/cider/issues/3682): Add `cider-jack-in` support for [Basilisp](https://github.com/basilisp-lang/basilisp) (Python)
+
 ### Changes
 
 - [#3626](https://github.com/clojure-emacs/cider/issues/3626): `cider-ns-refresh`: jump to the relevant file/line on errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 - [#3624](https://github.com/clojure-emacs/cider/pull/3624): Support new `cider.clj-reload/reload` cider-nrepl middleware.
   - adds `cider-ns-code-reload-tool` defcustom, defaulting to `'tools.namespace`.
   - you can change it to `'clj-reload` to use [clj-reload](https://github.com/tonsky/clj-reload) instead of [tools.namespace](https://github.com/clojure/tools.namespace).
-
 - [#3682](https://github.com/clojure-emacs/cider/issues/3682): Add `cider-jack-in` support for [Basilisp](https://github.com/basilisp-lang/basilisp) (Python)
 
 ### Changes

--- a/cider.el
+++ b/cider.el
@@ -283,13 +283,6 @@ By default we favor the project-specific shadow-cljs over the system-wide."
   :safe #'stringp
   :package-version '(cider . "1.14.0"))
 
-(defcustom cider-basilisp-global-options
-  nil
-  "Command line options used to execute Basilisp."
-  :type 'string
-  :safe #'stringp
-  :package-version '(cider . "1.14.0"))
-
 (defcustom cider-basilisp-parameters
   "nrepl-server"
   "Params passed to Basilisp to start an nREPL server via `cider-jack-in'."
@@ -304,7 +297,6 @@ By default we favor the project-specific shadow-cljs over the system-wide."
 (make-obsolete-variable 'cider-gradle-global-options 'cider-gradle-parameters "1.8.0")
 (make-obsolete-variable 'cider-babashka-global-options 'cider-babashka-parameters "1.8.0")
 (make-obsolete-variable 'cider-nbb-global-options 'cider-nbb-parameters "1.8.0")
-(make-obsolete-variable 'cider-basilip-global-options 'cider-basilisp-parameters "1.8.0")
 
 (defcustom cider-jack-in-default
   (if (executable-find "clojure") 'clojure-cli 'lein)
@@ -518,7 +510,7 @@ Throws an error if PROJECT-TYPE is unknown."
     ('shadow-cljs cider-shadow-cljs-global-options)
     ('gradle      cider-gradle-global-options)
     ('nbb         cider-nbb-global-options)
-    ('basilisp    cider-basilisp-global-options)
+    ('basilisp    nil)
     (_            (user-error "Unsupported project type `%S'" project-type))))
 
 (defun cider-jack-in-params (project-type)
@@ -995,10 +987,7 @@ middleware and dependencies."
            global-opts
            (unless (seq-empty-p global-opts) " ")
            params))
-    ('basilisp (concat
-                global-opts
-                (unless (seq-empty-p global-opts) " ")
-                params))
+    ('basilisp params)
     (_ (error "Unsupported project type `%S'" project-type))))
 
 

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -152,6 +152,7 @@ The following Clojure build tools are supported so far
 - kbd:[M-2 C-c C-x j u] jack-in using leiningen.
 - kbd:[M-3 C-c C-x j u] jack-in using babashka.
 - kbd:[M-4 C-c C-x j u] jack-in using nbb.
+- kbd:[M-5 C-c C-x j u] jack-in using basilisp.
 
 Here is an example of how to bind kbd:[F12] for quickly bringing up a
 babashka REPL:

--- a/doc/modules/ROOT/pages/platforms/basilisp.adoc
+++ b/doc/modules/ROOT/pages/platforms/basilisp.adoc
@@ -1,0 +1,102 @@
+= Basilisp Integration with CIDER
+https://github.com/basilisp-lang/basilisp[basilisp]
+
+== Overview
+
+Basilisp aims to enable writing Clojure programs on Python with full Python interoperability. It is highly compatible with Clojure.
+
+To install Basilisp, run:
+
+  $ pip install basilisp
+
+== Usage
+
+There are several ways to connect to Basilisp.
+
+* kbd:[M-x cider-jack-in] and kbd:[M-5 M-x cider-jack-in-universal]
+
+If you have created a `basilisp.edn` project file at your root of your project tree, you can jack in to the project `M-x cider-jack-in`. The `basilisp.edn` is similar to `deps.edn` for clojure-cli projects. It can be left empty just to mark the root of your project.
+
+If you don't have or want a basilisp project file, you can use universal jack in with a numerical argument of 5:
+
+- kbd:[M-5 M-x cider-jack-in-universal], or
+- kbd:[M-5 C-c C-x j u], from within file in clojure-mode
+
+(Note: an alternative to kbd:[M-5] is kbd:[C-u 5])
+
+You can also bind the universal jack-in to Basilisp to a function to use as a shortcut, for example
+
+[source,lisp]
+----
+(global-set-key (kbd "<f12>") (lambda ()
+                                (interactive)
+                                (cider-jack-in-universal 5)))
+----
+
+* kbd:[M-x cider-connect]
+
+You can start its bundled nREPL server:
+
+  $ basilisp nrepl-server
+
+and connect to it afterward using `M-x cider-connect`.
+
+To see available options, type `basilisp nrepl-server -h` in a shell prompt.
+
+== Configuration
+
+The jack-in command can be configured via several defcustoms:
+
+* `cider-basilisp-command` (default is `basilisp`).
+
+If Basilisp is installed in a virtual environment, update this to the full path of the `basilisp` executable within that virtual environment.
+
+* `cider-basilisp-parameters` (default is `nrepl-server`).
+
+There at few ways to setup (custom) variables in Emacs
+
+- https://www.gnu.org/software/emacs/manual/html_node/emacs/Easy-Customization.html[Examining and Setting Variables]
+
+kbd:[C-h v cider-basilisp-command], and
+kbd:[C-h v cider-basilisp-parameters]
+
+- https://www.gnu.org/software/emacs/manual/html_node/emacs/Directory-Variables.html[Per-Diretory Local Variables]
+
+Uses `.dir-locals.el` to setup per mode variables. This file is typically stored at the root of the project.
+
+For example, to set the path to the basilisp executable within a virtual environment
+
+kbd:[M-x add-dir-local-variable]
+Mode or subdirectory: `clojure-mode`
+Add directory-local variable: `cider-basilisp-command`
+Add cider-basilisp-command with value: `"c:/dev/venvs/312/Scripts/basilisp"`
+
+This should result to updating or creating a `.dir-local.el` file like below
+
+[source,lisp]
+----
+;;; Directory Local Variables            -*- no-byte-compile: t -*-
+;;; For more information see (info "(emacs) Directory Variables")
+
+((clojure-mode . ((cider-basilisp-command . "c:/dev/venvs/312/Scripts/basilisp"))))
+----
+
+- https://www.gnu.org/software/emacs/manual/html_node/emacs/Specifying-File-Variables.html[Specifying File Variables]
+
+It is best to put this in the top of your project's `basilisp.edn` file, and always jack-in from there
+
+For example, setting `cider-basilisp-command` to start basilisp from within a virtual environment
+
+kbd:[M-x add-dir-local-variable]
+Add file-local variable: `cider-basilisp-command`
+Add cider-basilisp-command with value: `"c:/dev/venvs/312/Scripts/basilisp"`
+
+This will result in the following in `basilisp.edn`
+
+[source,clojure]
+----
+;; Local Variables:
+;; cider-basilisp-command: "c:/dev/venvs/312/Scripts/basilisp"
+;; End:
+{}
+----

--- a/doc/modules/ROOT/pages/platforms/basilisp.adoc
+++ b/doc/modules/ROOT/pages/platforms/basilisp.adoc
@@ -1,6 +1,8 @@
 = Basilisp Integration with CIDER
 https://github.com/basilisp-lang/basilisp[basilisp]
 
+since CIDER 1.14
+
 == Overview
 
 Basilisp aims to enable writing Clojure programs on Python with full Python interoperability. It is highly compatible with Clojure.

--- a/doc/modules/ROOT/pages/platforms/overview.adoc
+++ b/doc/modules/ROOT/pages/platforms/overview.adoc
@@ -30,6 +30,7 @@ Right now CIDER the supports to some extent the following:
 * xref:platforms/clojureclr.adoc[ClojureCLR]
 * Lumo (via https://github.com/djblue/nrepl-cljs)
 * xref:platforms/other_platforms.adoc[scittle, joyride & friends]
+* xref:platforms/basilisp.adoc[Basilisp]
 
 All of them are derived from Clojure, so supporting them didn't really require much work.
 

--- a/test/integration/integration-tests.el
+++ b/test/integration/integration-tests.el
@@ -184,10 +184,6 @@ If CLI-COMMAND is nil, then use the default."
                 (expect (member (process-status nrepl-proc) '(exit signal))))))))))
 
   (it "to Basilisp"
-    ;; temporarily suspended on MS-Windows until the following is released on PyPi
-    ;;
-    ;; https://github.com/basilisp-lang/basilisp/pull/866
-    (assume (not (eq system-type 'windows-nt)) "temporarily skipping on MS-Windows ...")
     (with-cider-test-sandbox
       (with-temp-dir temp-dir
         ;; Create a project in temp dir


### PR DESCRIPTION
Hi,

can you please consider merging this patch to support Basilisp jack-in in CIDER. it resolves #3682.

I have added added an integration test and updated the documentation accordingly.

Currently the integration test currently fails on MS-Windows and has been temporarily disabled. This issue is addressed by https://github.com/basilisp-lang/basilisp/issues/865 but the fix has not been released yet in PyPi. The problem is related flushing the stdout after a `println`. It only fails in CI, but works fine when invoked from a user's session.

Additionally, it requires `clojure-mode` v5.19 to support recognizing Basilisp's `.lpy` file extension

Thanks

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
