### PR TITLE
Refactor `cider-cheatsheet-select`

### DIFF
--- a/cider-cheatsheet.el
+++ b/cider-cheatsheet.el
@@ -557,9 +557,7 @@ The list can hold one or more lists inside - one per each namespace."
 
 ;;;###autoload
 (defun cider-cheatsheet-select ()
-  "Navigate `cider-cheatsheet-hierarchy' with `completing-read'.
-
-When you make it to a Clojure var its doc buffer gets displayed."
+  "Navigate cheatsheet sections and show documentation for selected var."
   (interactive)
   (let ((cheatsheet-data cider-cheatsheet-hierarchy))
     (while (stringp (caar cheatsheet-data))


### PR DESCRIPTION
I've updated the docstring to be more concise and refactored `cider-cheatsheet-select` command, including the removal of the redundant `cider-cheatsheet--select-var` function.