### PR TITLE
Add an alternative way to display `cider-cheatsheet-select`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#3681](https://github.com/clojure-emacs/cider/pull/3681): Add an alternative way to display cheatsheet in a buffer and make it the default.
   - Current `cider-cheatsheet` command is renamed to `cider-cheatsheet-select`.
   - New way to display cheatsheet in a buffer is available with `cider-cheatsheet` command.
+- [#3686](https://github.com/clojure-emacs/cider/pull/3686): Add an alternative way to display `cider-cheatsheet-select` when called with a prefix argument.
 - [#3632](https://github.com/clojure-emacs/cider/pull/3623): Add new configuration variable `cider-clojure-cli-global-aliases`.
 - [#3366](https://github.com/clojure-emacs/cider/pull/3366): Support display of error overlays with `#dbg!` and `#break!` reader macros.
 - [#3622](https://github.com/clojure-emacs/cider/pull/3461): Basic support for using CIDER from [clojure-ts-mode](https://github.com/clojure-emacs/clojure-ts-mode).


### PR DESCRIPTION
Instead of having the multi-step selection process, which is the default `cider-cheatsheet-select` behavior, we represent each candidate as a full path to a var when `cider-cheatsheet-select` is called with a prefix argument. This can be handy with fuzzy completion style and vertical candidates display, as discussed in #3678.

Here's how the default multi-step selection process looks when you need to select every single section before choosing a var:
![cider-cheatsheet-select-default](https://github.com/clojure-emacs/cider/assets/93549926/0fe96d7c-bae5-47cb-8ed9-f451196f2beb)

In contrast, when `cider-cheatsheet-select` is called with a prefix argument, each candidate is a full path to a var:
![cider-cheatsheet-select-flat](https://github.com/clojure-emacs/cider/assets/93549926/d5e2656e-9803-4d9b-bee4-89666b795b8f)
