### PR TITLE
Show friendly error message if symbol is not found on ClojureDocs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 
 ### Bugs fixed
 
+- [#3689](https://github.com/clojure-emacs/cider/pull/3689): Fix `cider-clojuredocs-lookup` to show friendly error message if symbol is not found on ClojureDocs.
 - [#3673](https://github.com/clojure-emacs/cider/pull/3673): Fix buggy `special-display-buffer-names` check.
 - [#3659](https://github.com/clojure-emacs/cider/pull/3659): Fixes completions when using `flex`-like completion styles.
 - [#3600](https://github.com/clojure-emacs/cider/pull/3600): Fix scittle jack-in when using `cider-jack-in-clj`.

--- a/cider-clojuredocs.el
+++ b/cider-clojuredocs.el
@@ -144,14 +144,16 @@ opposite of what that option dictates."
 
 (defun cider-clojuredocs-lookup (sym)
   "Look up the ClojureDocs documentation for SYM."
-  (let ((docs (cider-sync-request:clojuredocs-lookup (cider-current-ns) sym)))
-    (pop-to-buffer (cider-create-clojuredocs-buffer (cider-clojuredocs--content docs)))
-    ;; highlight the symbol in question in the docs buffer
-    (highlight-regexp
-     (regexp-quote
-      (or (cadr (split-string sym "/"))
-          sym))
-     'bold)))
+  (if-let ((docs (cider-sync-request:clojuredocs-lookup (cider-current-ns) sym)))
+      (progn
+        (pop-to-buffer (cider-create-clojuredocs-buffer (cider-clojuredocs--content docs)))
+        ;; highlight the symbol in question in the docs buffer
+        (highlight-regexp
+         (regexp-quote
+          (or (cadr (split-string sym "/"))
+              sym))
+         'bold))
+    (user-error "ClojureDocs documentation for %s is not found" sym)))
 
 ;;;###autoload
 (defun cider-clojuredocs (&optional arg)


### PR DESCRIPTION
When we use `cider-clojuredocs`, it shows the error message `Wrong type argument: char-or-string-p, nil` if a symbol we are looking for is not found. It will be nice if it will show something more meaningful instead.