### PR TITLE
[complete] Prioritize flex style if flex style is requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs fixed
 
+- [#3696](https://github.com/clojure-emacs/cider/pull/3696): Don't eagerly complete a candidate if there are other candidates matching `flex` style.
+
 ## 1.14.0 (2024-05-30)
 
 ### New features

--- a/cider-completion.el
+++ b/cider-completion.el
@@ -297,7 +297,7 @@ Only affects the `cider' completion category.`"
     (unless found-styles
       (setq found-styles '(styles basic)))
     (unless (member 'flex found-styles)
-      (setq found-styles (append found-styles '(flex))))
+      (setq found-styles (apply #'list 'styles 'flex (cdr found-styles))))
     (add-to-list 'completion-category-overrides (apply #'list 'cider found-styles (when found-cycle
                                                                                     (list found-cycle))))))
 

--- a/test/cider-completion-tests.el
+++ b/test/cider-completion-tests.el
@@ -37,7 +37,7 @@
       (unwind-protect
           (progn
             (it "adds `flex' and `basic' as a fallback"
-              (let ((expected-category-overrides '((cider (styles basic flex)))))
+              (let ((expected-category-overrides '((cider (styles flex basic)))))
                 (cider-enable-flex-completion)
                 (expect (member 'flex (assq 'styles (assq 'cider completion-category-overrides)))
                         :to-be-truthy)


### PR DESCRIPTION
This has been briefly discussed here https://github.com/clojure-emacs/cider/pull/3659#discussion_r1602166071 before making `basic` the prioritized one.

The current setup produces a bug when Compliment returns a list of candidates that matches `flex` style, but only one of the items on that list matches `basic` style. In that case, Emacs will eagerly complete that single candidate without presenting a list.

Example:

`Unsa` instantly completes to `UnsatisfiedLinkError` (because that's a class that is always imported to all namespaces).

Desired behavior:

<img width="484" alt="image" src="https://github.com/clojure-emacs/cider/assets/468477/c4d3c4d1-241b-4cb3-8e1c-06a2931fe1d8">
