### PR TITLE
Fix another error regex bug, limit check to JVM runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Bugs fixed
 
 - [#3696](https://github.com/clojure-emacs/cider/pull/3696): Don't eagerly complete a candidate if there are other candidates matching `flex` style.
+- [#3698](https://github.com/clojure-emacs/cider/pull/3698): Fix error messages in non-JVM runtimes being suppressed when `cider-show-error-buffer` is set to `nil`.
 
 ## 1.14.0 (2024-05-30)
 

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -594,7 +594,8 @@ It delegates the actual error content to the eval or op handler."
     ":" (group-n 3 (one-or-more (any "-" digit)))
     (optional
      ":" (group-n 4 (one-or-more (any "-" digit))))
-    " - "))
+    " - ")
+  "Regexp matching various non-error messages, e.g. reflection warnings.")
 
 ;; Please keep this in sync with `cider-clojure-compilation-error-regexp',
 ;; which is a subset of these regexes.
@@ -605,8 +606,6 @@ It delegates the actual error content to the eval or op handler."
    'nogroup)
   "A few example values that will match:
 \"Reflection warning, /tmp/foo/src/foo/core.clj:14:1 - \"
-\"CompilerException java.lang.RuntimeException: Unable to resolve symbol: \\
-lol in this context, compiling:(/foo/core.clj:10:1)\"
 \"Syntax error compiling at (src/workspace_service.clj:227:3).\"
 \"Unexpected error (ClassCastException) macroexpanding defmulti at (src/haystack/parser.cljc:21:1).\"")
 
@@ -618,8 +617,6 @@ lol in this context, compiling:(/foo/core.clj:10:1)\"
 but excluding warnings such as reflection warnings.
 
 A few example values that will match:
-\"CompilerException java.lang.RuntimeException: Unable to resolve symbol: \\
-lol in this context, compiling:(/foo/core.clj:10:1)\"
 \"Syntax error compiling at (src/workspace_service.clj:227:3).\"
 \"Unexpected error (ClassCastException) macroexpanding defmulti at (src/haystack/parser.cljc:21:1).\"")
 

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -925,8 +925,11 @@ depending on the PHASE."
               (and cider-show-error-buffer
                    (member phase (cider-clojure-compilation-error-phases))))
              ;; Only show overlays for things that do look like an exception (#3587):
-             (or (string-match-p cider-clojure-runtime-error-regexp err)
-                 (string-match-p cider-clojure-compilation-error-regexp err)))
+             ;; Note: only applicable to JVM Clojure error messages (#3687)
+             (if (cider-runtime-clojure-p)
+                 (or (string-match-p cider-clojure-runtime-error-regexp err)
+                     (string-match-p cider-clojure-compilation-error-regexp err))
+               t))
     ;; Display errors as temporary overlays
     (let ((cider-result-use-clojure-font-lock nil)
           (trimmed-err (funcall cider-inline-error-message-function err)))

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -564,7 +564,7 @@ It delegates the actual error content to the eval or op handler."
 ;; Reference:
 ;; https://github.com/clojure/clojure/blob/clojure-1.10.0/src/clj/clojure/main.clj#L251
 ;; See `cider-compilation-regexp' for interpretation of match groups.
-(defconst cider-clojure-1.10--location
+(defconst cider--clojure-1.10-location
   '(sequence
     "at " (minimal-match (zero-or-more anything)) ;; the fully-qualified name of the function that triggered the error
     "("
@@ -574,7 +574,7 @@ It delegates the actual error content to the eval or op handler."
      ":" (group-n 4 (one-or-more (any "-" digit)))) ; column number
     ")."))
 
-(defconst cider-clojure-1.10-error
+(defconst cider--clojure-1.10-error
   `(sequence
     (or "Syntax error reading source " ; phase = :read-source
         (sequence
@@ -583,10 +583,10 @@ It delegates the actual error content to the eval or op handler."
          (or "macroexpanding " ; phase = :macro-syntax-check / :macroexpansion
              "compiling ")     ; phase = :compile-syntax-check / :compilation
          (minimal-match (zero-or-more anything)))) ; optional symbol, eg. foo/bar
-    ,cider-clojure-1.10--location)
+    ,cider--clojure-1.10-location)
   "Regexp matching error messages triggered in compilation / read / print phases.")
 
-(defconst cider-clojure-warning
+(defconst cider--clojure-warning
   `(sequence
     (minimal-match (zero-or-more anything))
     (group-n 1 "warning")
@@ -601,8 +601,8 @@ It delegates the actual error content to the eval or op handler."
 ;; which is a subset of these regexes.
 (defconst cider-clojure-compilation-regexp
   (rx-to-string
-   `(seq bol (or ,cider-clojure-warning
-                 ,cider-clojure-1.10-error))
+   `(seq bol (or ,cider--clojure-warning
+                 ,cider--clojure-1.10-error))
    'nogroup)
   "A few example values that will match:
 \"Reflection warning, /tmp/foo/src/foo/core.clj:14:1 - \"
@@ -611,7 +611,7 @@ It delegates the actual error content to the eval or op handler."
 
 (defconst cider-clojure-compilation-error-regexp
   (rx-to-string
-   `(seq bol ,cider-clojure-1.10-error)
+   `(seq bol ,cider--clojure-1.10-error)
    'nogroup)
   "Like `cider-clojure-compilation-regexp',
 but excluding warnings such as reflection warnings.
@@ -620,25 +620,25 @@ A few example values that will match:
 \"Syntax error compiling at (src/workspace_service.clj:227:3).\"
 \"Unexpected error (ClassCastException) macroexpanding defmulti at (src/haystack/parser.cljc:21:1).\"")
 
-(defconst cider--clojure-execution-error-regexp
+(defconst cider--clojure-execution-error
   `(sequence
     (or "Error reading eval result "   ; phase = :read-eval-result
         "Error printing return value " ; phase = :print-eval-result
         "Execution error ")            ; phase = :execution
     (minimal-match (zero-or-more anything)) ; optional class, eg. (ArithmeticException)
-    ,cider-clojure-1.10--location))
+    ,cider--clojure-1.10-location))
 
-(defconst cider--clojure-spec-execution-error-regexp
+(defconst cider--clojure-spec-execution-error
   `(sequence
     "Execution error - invalid arguments to "
     (minimal-match (one-or-more anything))
     " "
-    ,cider-clojure-1.10--location))
+    ,cider--clojure-1.10-location))
 
 (defconst cider-clojure-runtime-error-regexp
   (rx-to-string
-   `(seq bol (or ,cider--clojure-execution-error-regexp
-                 ,cider--clojure-spec-execution-error-regexp))
+   `(seq bol (or ,cider--clojure-execution-error
+                 ,cider--clojure-spec-execution-error))
    'nogroup)
   "Matches runtime errors, as oppsed to compile-time/macroexpansion-time errors.
 

--- a/test/cider-error-parsing-tests.el
+++ b/test/cider-error-parsing-tests.el
@@ -124,6 +124,7 @@
       (expect (progn (string-match cider-clojure-compilation-regexp clojure-compiler-warning)
                      (match-string 1 clojure-compiler-warning))
               :to-equal "warning")))
+  ;; FIXME: duplicate spec names
   (dolist (regexp (list cider-clojure-compilation-regexp cider-clojure-compilation-error-regexp))
     (it "Recognizes a clojure-1.10 error message"
       (let ((clojure-1.10-compiler-error "Syntax error compiling at (src/ardoq/service/workspace_service.clj:227:3)."))
@@ -156,7 +157,7 @@
                 (match-string 2 specimen))
               :to-equal "src/haystack/parser.cljc"))
 
-    ;; without foo/foo symbol
+    ;; without exception class cause-type
     (let ((specimen "Execution error at (src/haystack/parser.cljc:4)."))
       (expect specimen :to-match cider-clojure-runtime-error-regexp)
       (expect (progn
@@ -187,7 +188,15 @@
       (expect (progn
                 (string-match cider-clojure-runtime-error-regexp specimen)
                 (match-string 2 specimen))
-              :to-equal "FileInputStream.java"))))
+              :to-equal "FileInputStream.java")))
+
+  (it "Recognizes errors thrown during the result printing phase"
+    (let ((specimen "Error printing return value (ClassCastException) at clojure.core/file-seq$fn (core.clj:4997)."))
+      (expect specimen :to-match cider-clojure-runtime-error-regexp)
+      (expect (progn
+                (string-match cider-clojure-runtime-error-regexp specimen)
+                (match-string 2 specimen))
+              :to-equal "core.clj"))))
 
 (describe "cider-module-info-regexp"
   (it "Matches module info provided by Java"


### PR DESCRIPTION
Fixes #3687

Not sure if the last commit is technically a breaking change.. the inconsistent var naming was bugging me, and these were introduced recently so it's unlikely that other packages depend on them. 

Side note: `eldev lint` produces lots of linter errors unrelated to the changes here, it seems like the CI isn't flagging them so they've been accumulating from other PRs.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
