### PR TITLE
JVMTI followup

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -910,13 +910,16 @@ your aliases contain any mains, the cider/nrepl one will be the one used."
                       (cider-jack-in-normalized-nrepl-middlewares)
                       ","))
          (main-opts (format "\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[%s]\"" middleware))
-         (deps (format "{:deps {%s} :aliases {:cider/nrepl {:main-opts [%s]}}}"
-                       (string-join all-deps " ") main-opts))
+         (deps (format "{:deps {%s} :aliases {:cider/nrepl {%s:main-opts [%s]}}}"
+                       (string-join all-deps " ")
+                       (if cider-enable-nrepl-jvmti-agent
+                           ":jvm-opts [\"-Djdk.attach.allowAttachSelf\"], "
+                         "")
+                       main-opts))
          (deps-quoted (cider--shell-quote-argument deps command)))
-    (format "%s%s-Sdeps %s -M%s:cider/nrepl%s"
+    (format "%s-Sdeps %s -M%s:cider/nrepl%s"
             ;; TODO: global-options are deprecated and should be removed in CIDER 2.0
             (if global-options (format "%s " global-options) "")
-            (if cider-enable-nrepl-jvmti-agent "-J-Djdk.attach.allowAttachSelf " "")
             deps-quoted
             (cider--combined-aliases)
             (if params (format " %s" params) ""))))

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -206,11 +206,33 @@ so we'll examine them tool by tool.
 
 ==== Enabling nREPL JVMTI agent
 
-Since version 1.2.0, nREPL ships together with a native JVMTI agent, so that the
-eval interrupts properly work on Java 21 and later. To enable the agent, the
-Java process should be launched with `-Djdk.attach.allowAttachSelf`. CIDER will
-do it automatically during jack-in if `cider-enable-nrepl-jvmti-agent` is set to
-`t`.
+Since version 1.2.0, nREPL includes a native JVMTI agent which makes the eval
+interrupts work properly on Java 21 and later. To enable the agent, the Java
+process should be launched with `-Djdk.attach.allowAttachSelf`. CIDER will do it
+automatically during jack-in if `cider-enable-nrepl-jvmti-agent` variable is set
+to `t`.
+
+[IMPORTANT]
+====
+`cider-enable-nrepl-jvmti-agent` has no effect if you start a REPL
+process outside of Emacs and connect to it with `cider-connect`. In that
+scenario, you have to add `-Djdk.attach.allowAttachSelf` Java property manually
+through the means of the build tool. In Leiningen, add this to `project.clj`:
+
+[source,lisp]
+----
+:jvm-opts ["-Djdk.attach.allowAttachSelf"]
+----
+
+In tools.deps, add this to one of the aliases that you enable with the REPL:
+
+[source,lisp]
+----
+:aliases {:dev
+          {:jvm-opts ["-Djdk.attach.allowAttachSelf"]
+           ...}}
+----
+====
 
 ==== Leiningen Options
 

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -455,8 +455,8 @@
     (it "uses main opts in an alias to prevent other mains from winning"
       (setq-local cider-jack-in-dependencies nil)
       (setq-local cider-jack-in-nrepl-middlewares '("cider.nrepl/cider-middleware"))
-      (let ((expected (string-join `("clojure -J-Djdk.attach.allowAttachSelf -Sdeps "
-                                     ,(shell-quote-argument "{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} cider/cider-nrepl {:mvn/version \"0.49.0\"}} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
+      (let ((expected (string-join `("clojure -Sdeps "
+                                     ,(shell-quote-argument "{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} cider/cider-nrepl {:mvn/version \"0.49.0\"}} :aliases {:cider/nrepl {:jvm-opts [\"-Djdk.attach.allowAttachSelf\"], :main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
                                      " -M:cider/nrepl")
                                    "")))
         (setq-local cider-allow-jack-in-without-project t)
@@ -470,8 +470,8 @@
                 :to-equal expected)))
 
     (it "allows specifying custom aliases with `cider-clojure-cli-aliases`"
-      (let ((expected (string-join `("clojure -J-Djdk.attach.allowAttachSelf -Sdeps "
-                                     ,(shell-quote-argument "{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} cider/cider-nrepl {:mvn/version \"0.49.0\"}} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
+      (let ((expected (string-join `("clojure -Sdeps "
+                                     ,(shell-quote-argument "{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} cider/cider-nrepl {:mvn/version \"0.49.0\"}} :aliases {:cider/nrepl {:jvm-opts [\"-Djdk.attach.allowAttachSelf\"], :main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
                                      " -M:dev:test:cider/nrepl")
                                    "")))
         (setq-local cider-jack-in-dependencies nil)
@@ -488,9 +488,8 @@
     (dolist (command '("clojure" "powershell"))
       (it (format "should remove duplicates, yielding the same result (for %S command invocation)" command)
         ;; repeat the same test for PowerShell too
-        (let ((expected (string-join `("-J-Djdk.attach.allowAttachSelf "
-                                       "-Sdeps "
-                                       ,(cider--shell-quote-argument "{:deps {cider/cider-nrepl {:mvn/version \"0.49.0\"} nrepl/nrepl {:mvn/version \"0.9.0\"}} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}"
+        (let ((expected (string-join `("-Sdeps "
+                                       ,(cider--shell-quote-argument "{:deps {cider/cider-nrepl {:mvn/version \"0.49.0\"} nrepl/nrepl {:mvn/version \"0.9.0\"}} :aliases {:cider/nrepl {:jvm-opts [\"-Djdk.attach.allowAttachSelf\"], :main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}"
                                                                      command)
                                        " -M:dev:test:cider/nrepl")
                                      "")))
@@ -499,9 +498,8 @@
                                                           command)
                   :to-equal expected))))
     (it "handles aliases correctly"
-      (let ((expected (string-join `("-J-Djdk.attach.allowAttachSelf "
-                                     "-Sdeps "
-                                     ,(shell-quote-argument "{:deps {cider/cider-nrepl {:mvn/version \"0.49.0\"} nrepl/nrepl {:mvn/version \"0.9.0\"}} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
+      (let ((expected (string-join `("-Sdeps "
+                                     ,(shell-quote-argument "{:deps {cider/cider-nrepl {:mvn/version \"0.49.0\"} nrepl/nrepl {:mvn/version \"0.9.0\"}} :aliases {:cider/nrepl {:jvm-opts [\"-Djdk.attach.allowAttachSelf\"], :main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
                                      " -M:test:cider/nrepl")
                                    ""))
             (deps '(("nrepl/nrepl" "0.9.0"))))
@@ -528,8 +526,8 @@
             (expect (cider-clojure-cli-jack-in-dependencies nil nil deps)
                     :to-equal expected)))))
     (it "allows for global options"
-        (let ((expected (string-join `("-J-Xverify:none -J-Djdk.attach.allowAttachSelf -Sdeps "
-                                     ,(shell-quote-argument "{:deps {cider/cider-nrepl {:mvn/version \"0.49.0\"} nrepl/nrepl {:mvn/version \"0.9.0\"}} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
+        (let ((expected (string-join `("-J-Xverify:none -Sdeps "
+                                       ,(shell-quote-argument "{:deps {cider/cider-nrepl {:mvn/version \"0.49.0\"} nrepl/nrepl {:mvn/version \"0.9.0\"}} :aliases {:cider/nrepl {:jvm-opts [\"-Djdk.attach.allowAttachSelf\"], :main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
                                      " -M:test:cider/nrepl")
                                    ""))
             (deps '(("nrepl/nrepl" "0.9.0"))))
@@ -539,8 +537,8 @@
     (it "allows to specify git coordinate as cider-jack-in-dependency"
       (setq-local cider-jack-in-dependencies '(("org.clojure/tools.deps" (("git/sha" . "6ae2b6f71773de7549d7f22759e8b09fec27f0d9")
                                                                           ("git/url" . "https://github.com/clojure/tools.deps/")))))
-      (let ((expected (string-join `("clojure -J-Djdk.attach.allowAttachSelf -Sdeps "
-                                     ,(shell-quote-argument "{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} cider/cider-nrepl {:mvn/version \"0.49.0\"} org.clojure/tools.deps { :git/sha \"6ae2b6f71773de7549d7f22759e8b09fec27f0d9\"  :git/url \"https://github.com/clojure/tools.deps/\" }} :aliases {:cider/nrepl {:main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
+      (let ((expected (string-join `("clojure -Sdeps "
+                                     ,(shell-quote-argument "{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} cider/cider-nrepl {:mvn/version \"0.49.0\"} org.clojure/tools.deps { :git/sha \"6ae2b6f71773de7549d7f22759e8b09fec27f0d9\"  :git/url \"https://github.com/clojure/tools.deps/\" }} :aliases {:cider/nrepl {:jvm-opts [\"-Djdk.attach.allowAttachSelf\"], :main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
                                      " -M:cider/nrepl")
                                    "")))
         (setq-local cider-allow-jack-in-without-project t)


### PR DESCRIPTION
1. Per @yuhan0 suggestion, I've changed the way how allowAttachSelf property is injected for tools.deps. It looks marginally cleaner this way.
2. Updated the docs clarifying that allowAttachSelf can (and should) be specified manually when the REPL is not started through jack-in.