### PR TITLE
ClojureDocs formatting tweaks

### DIFF
--- a/cider-clojuredocs.el
+++ b/cider-clojuredocs.el
@@ -116,9 +116,12 @@ opposite of what that option dictates."
     (let ((arglists (nrepl-dict-get dict "arglists")))
       (dolist (arglist arglists)
         (insert (format " [%s]\n" arglist)))
-      (insert "\n")
-      (insert (nrepl-dict-get dict "doc"))
-      (insert "\n"))
+      (when-let* ((doc (nrepl-dict-get dict "doc"))
+                  ;; As this is a literal docstring from the source code and
+                  ;; there are two spaces at the beginning of lines in docstrings,
+                  ;; we remove them to make it align nicely in ClojureDocs buffer.
+                  (doc (replace-regexp-in-string "\n  " "\n" doc)))
+        (insert "\n" doc "\n")))
     (insert "\n== See Also\n\n")
     (if-let ((see-alsos (nrepl-dict-get dict "see-alsos")))
         (dolist (see-also see-alsos)

--- a/cider-clojuredocs.el
+++ b/cider-clojuredocs.el
@@ -125,11 +125,13 @@ opposite of what that option dictates."
     (insert "\n== See Also\n\n")
     (if-let ((see-alsos (nrepl-dict-get dict "see-alsos")))
         (dolist (see-also see-alsos)
-          (insert-text-button (format "* %s\n" see-also)
+          (insert "* ")
+          (insert-text-button see-also
                               'sym see-also
                               'action (lambda (btn)
                                         (cider-clojuredocs-lookup (button-get btn 'sym)))
-                              'help-echo (format "Press Enter or middle click to jump to %s" see-also)))
+                              'help-echo (format "Press Enter or middle click to jump to %s" see-also))
+          (insert "\n"))
       (insert "Not available\n"))
     (insert "\n== Examples\n\n")
     (if-let ((examples (nrepl-dict-get dict "examples")))


### PR DESCRIPTION
I plan to rework how ClojureDocs buffer is displayed (improve some formatting, make it more modular and customizable) and want to start with some small improvements.

This particular change:
- Removes annoying whitespace that appears before every line (after the first one) of the docstring.
- Changes how buttons are displayed so that `*` and newline are no longer part of the button.

This is how it looked before:
![cider-cheatsheet-formatting-tweaks-old](https://github.com/clojure-emacs/cider/assets/93549926/af2c28d9-8415-4f0a-8de5-13f275f3f582)

This is how it looks now:
![cider-cheatsheet-formatting-tweaks-new](https://github.com/clojure-emacs/cider/assets/93549926/a64cf82c-972d-4800-ba7a-5033db6d2e1f)