### PR TITLE
Refactor code used to insert sections into ClojureDocs buffer

### DIFF
--- a/cider-clojuredocs.el
+++ b/cider-clojuredocs.el
@@ -109,42 +109,69 @@ opposite of what that option dictates."
     (goto-char (point-min))
     (current-buffer)))
 
+(defun cider-clojuredocs--insert-overview (dict)
+  "Insert \"Overview\" section based on data from DICT."
+  (insert (format "= %s/%s\n"
+                  (nrepl-dict-get dict "ns")
+                  (nrepl-dict-get dict "name")))
+  (newline)
+  (when-let ((arglists (nrepl-dict-get dict "arglists")))
+    (dolist (arglist arglists)
+      (insert (format " [%s]\n" arglist)))
+    (newline))
+  (when-let* ((doc (nrepl-dict-get dict "doc"))
+              ;; As this is a literal docstring from the source code and
+              ;; there are two spaces at the beginning of lines in docstrings,
+              ;; we remove them to make it align nicely in ClojureDocs buffer.
+              (doc (replace-regexp-in-string "\n  " "\n" doc)))
+    (insert doc "\n")
+    (newline)))
+
+(defun cider-clojuredocs--insert-see-also (dict)
+  "Insert \"See Also\" section based on data from DICT."
+  (insert "== See Also\n")
+  (newline)
+  (if-let ((see-alsos (nrepl-dict-get dict "see-alsos")))
+      (dolist (see-also see-alsos)
+        (insert "* ")
+        (insert-text-button see-also
+                            'sym see-also
+                            'action (lambda (btn)
+                                      (cider-clojuredocs-lookup (button-get btn 'sym)))
+                            'help-echo (format "Press Enter or middle click to jump to %s" see-also))
+        (insert "\n"))
+    (insert "Not available\n"))
+  (newline))
+
+(defun cider-clojuredocs--insert-examples (dict)
+  "Insert \"Examples\" section based on data from DICT."
+  (insert "== Examples\n")
+  (newline)
+  (if-let ((examples (nrepl-dict-get dict "examples")))
+      (dolist (example examples)
+        (insert (cider-font-lock-as-clojure example) "\n")
+        (insert "-------------------------------------------------\n"))
+    (insert "Not available\n"))
+  (newline))
+
+(defun cider-clojuredocs--insert-notes (dict)
+  "Insert \"Notes\" section based on data from DICT."
+  (insert "== Notes\n")
+  (newline)
+  (if-let ((notes (nrepl-dict-get dict "notes")))
+      (dolist (note notes)
+        (insert note "\n")
+        (insert "-------------------------------------------------\n"))
+    (insert "Not available\n"))
+  (newline))
+
 (defun cider-clojuredocs--content (dict)
   "Generate a nice string from DICT."
   (with-temp-buffer
-    (insert "= " (nrepl-dict-get dict "ns") "/" (nrepl-dict-get dict "name") "\n\n")
-    (let ((arglists (nrepl-dict-get dict "arglists")))
-      (dolist (arglist arglists)
-        (insert (format " [%s]\n" arglist)))
-      (when-let* ((doc (nrepl-dict-get dict "doc"))
-                  ;; As this is a literal docstring from the source code and
-                  ;; there are two spaces at the beginning of lines in docstrings,
-                  ;; we remove them to make it align nicely in ClojureDocs buffer.
-                  (doc (replace-regexp-in-string "\n  " "\n" doc)))
-        (insert "\n" doc "\n")))
-    (insert "\n== See Also\n\n")
-    (if-let ((see-alsos (nrepl-dict-get dict "see-alsos")))
-        (dolist (see-also see-alsos)
-          (insert "* ")
-          (insert-text-button see-also
-                              'sym see-also
-                              'action (lambda (btn)
-                                        (cider-clojuredocs-lookup (button-get btn 'sym)))
-                              'help-echo (format "Press Enter or middle click to jump to %s" see-also))
-          (insert "\n"))
-      (insert "Not available\n"))
-    (insert "\n== Examples\n\n")
-    (if-let ((examples (nrepl-dict-get dict "examples")))
-        (dolist (example examples)
-          (insert (cider-font-lock-as-clojure example))
-          (insert "\n-------------------------------------------------\n"))
-      (insert "Not available\n"))
-    (insert "\n== Notes\n\n")
-    (if-let ((notes (nrepl-dict-get dict "notes")))
-        (dolist (note notes)
-          (insert note)
-          (insert "\n-------------------------------------------------\n"))
-      (insert "Not available\n"))
+    (cider-clojuredocs--insert-overview dict)
+    (cider-clojuredocs--insert-see-also dict)
+    (cider-clojuredocs--insert-examples dict)
+    (cider-clojuredocs--insert-notes dict)
     (buffer-string)))
 
 (defun cider-clojuredocs-lookup (sym)


### PR DESCRIPTION
I've moved the code used to insert sections into separate functions, as it is easier to modify sections that way. Maybe, in the future, I will also create a generic function to insert sections, so we can reduce boilerplate.

In places where we need to insert an empty line, I've used `newline` explicitly instead of the previously used additional `\n` in content insertions. This way, it will be more obvious where we are inserting actual content and where we are inserting just empty lines.