### PR TITLE
Add visual indentation of sections in ClojureDocs buffer

### DIFF
--- a/cider-clojuredocs.el
+++ b/cider-clojuredocs.el
@@ -111,13 +111,13 @@ opposite of what that option dictates."
 
 (defun cider-clojuredocs--insert-overview (dict)
   "Insert \"Overview\" section based on data from DICT."
-  (insert (format "= %s/%s\n"
+  (insert (format "%s/%s\n"
                   (nrepl-dict-get dict "ns")
                   (nrepl-dict-get dict "name")))
   (newline)
   (when-let ((arglists (nrepl-dict-get dict "arglists")))
     (dolist (arglist arglists)
-      (insert (format " [%s]\n" arglist)))
+      (insert (format "[%s]\n" arglist)))
     (newline))
   (when-let* ((doc (nrepl-dict-get dict "doc"))
               ;; As this is a literal docstring from the source code and
@@ -129,11 +129,11 @@ opposite of what that option dictates."
 
 (defun cider-clojuredocs--insert-see-also (dict)
   "Insert \"See Also\" section based on data from DICT."
-  (insert "== See Also\n")
+  (insert "See Also\n")
   (newline)
   (if-let ((see-alsos (nrepl-dict-get dict "see-alsos")))
       (dolist (see-also see-alsos)
-        (insert "* ")
+        (insert "- ")
         (insert-text-button see-also
                             'sym see-also
                             'action (lambda (btn)
@@ -145,7 +145,7 @@ opposite of what that option dictates."
 
 (defun cider-clojuredocs--insert-examples (dict)
   "Insert \"Examples\" section based on data from DICT."
-  (insert "== Examples\n")
+  (insert "Examples\n")
   (newline)
   (if-let ((examples (nrepl-dict-get dict "examples")))
       (dolist (example examples)
@@ -156,7 +156,7 @@ opposite of what that option dictates."
 
 (defun cider-clojuredocs--insert-notes (dict)
   "Insert \"Notes\" section based on data from DICT."
-  (insert "== Notes\n")
+  (insert "Notes\n")
   (newline)
   (if-let ((notes (nrepl-dict-get dict "notes")))
       (dolist (note notes)


### PR DESCRIPTION
Replace `*` with `-` for elements of the list in "See Also" section as most users are more familiar with `-` used for lists.

Remove `=` used before headings as this markup feels redundant because of the following change.

Add visual indentation of sections to improve contrast between section heading and content. This indentation is purely visual because when copying an example or note, it may be inconvenient if the indentation prefix was added before them. Also, maybe we should make it possible for users to change the indentation prefix.

This is how it looked before:
![clojuredocs-indentation-1](https://github.com/clojure-emacs/cider/assets/93549926/7f2dbe74-aea0-4d44-862c-9fe1f75e8437)

This is how it looks now:
![clojuredocs-indentation-2](https://github.com/clojure-emacs/cider/assets/93549926/39e555c4-dae2-4b8f-9fec-62e39ae6ce1c)