### PR TITLE
Minor adjustments to docstrings

### DIFF
--- a/cider-client.el
+++ b/cider-client.el
@@ -548,7 +548,7 @@ Used only when the info nREPL middleware is not available."
     var-info))
 
 (defun cider-var-info (var &optional all)
-  "Return VAR's info as an alist with list cdrs.
+  "Return info for VAR as an nREPL dict.
 When multiple matching vars are returned you'll be prompted to select one,
 unless ALL is truthy."
   (when (and var (not (string= var "")))
@@ -559,7 +559,7 @@ unless ALL is truthy."
       (if all var-info (cider--var-choice var-info)))))
 
 (defun cider-member-info (class member)
-  "Return the CLASS MEMBER's info as an alist with list cdrs."
+  "Return info for MEMBER of CLASS as an nREPL dict."
   (when (and class member)
     (cider-sync-request:info nil class member (cider-completion-get-context t))))
 

--- a/cider-clojuredocs.el
+++ b/cider-clojuredocs.el
@@ -40,7 +40,7 @@
 (defconst cider-clojuredocs-buffer "*cider-clojuredocs*")
 
 (defun cider-sync-request:clojuredocs-lookup (ns sym)
-  "Perform nREPL \"resource\" op with NS and SYM."
+  "Perform nREPL \"clojuredocs-lookup\" op with NS and SYM."
   (thread-first `("op" "clojuredocs-lookup"
                   "ns" ,ns
                   "sym" ,sym)


### PR DESCRIPTION
Tweak docstring of `cider-sync-request:clojuredocs-lookup` as it actually performs `clojuredocs-lookup` op and not `resource` op.

Tweak docstrings of `cider-var-info` and `cider-member-info` as it seems that what these functions actually return is an nREPL dict and not an alist. Also, I'm not sure what "with list cdrs" means.