### PR TITLE
Refactor `cider-docstring.el`

### DIFF
--- a/cider-clojuredocs.el
+++ b/cider-clojuredocs.el
@@ -25,15 +25,15 @@
 
 ;;; Code:
 
+(require 'subr-x)
+(require 'url-vars)
+
 (require 'cider-client)
 (require 'cider-common)
-(require 'subr-x)
+(require 'cider-docstring)
 (require 'cider-popup)
 (require 'cider-util)
-
 (require 'nrepl-dict)
-
-(require 'url-vars)
 
 (defconst cider-clojuredocs-url "https://clojuredocs.org/")
 
@@ -120,10 +120,7 @@ opposite of what that option dictates."
       (insert (format " [%s]\n" arglist)))
     (newline))
   (when-let* ((doc (nrepl-dict-get dict "doc"))
-              ;; As this is a literal docstring from the source code and
-              ;; there are two spaces at the beginning of lines in docstrings,
-              ;; we remove them to make it align nicely in ClojureDocs buffer.
-              (doc (replace-regexp-in-string "\n  " "\n" doc)))
+              (doc (cider-docstring--format doc)))
     (insert doc "\n")
     (newline)))
 

--- a/cider-doc.el
+++ b/cider-doc.el
@@ -428,9 +428,8 @@ in a COMPACT format is specified, FOR-TOOLTIP if specified."
                                                             "doc-first-sentence-fragments" (nrepl-dict-get info "doc-first-sentence-fragments"))))
          (fetched-doc (nrepl-dict-get info "doc"))
          (doc     (or rendered-fragments
-                      (if compact
-                          (cider-docstring--dumb-trim fetched-doc)
-                        fetched-doc)
+                      (cider-docstring--format
+                       (if compact (cider-docstring--trim fetched-doc) fetched-doc))
                       (unless compact
                         "Not documented.")))
          (url     (nrepl-dict-get info "url"))
@@ -487,9 +486,7 @@ in a COMPACT format is specified, FOR-TOOLTIP if specified."
         (if (and doc class (not rendered-fragments))
             (cider-docview-render-java-doc (current-buffer) doc)
           (when doc
-            (emit (if rendered-fragments
-                      doc
-                    (concat "  " doc)))))
+            (emit doc)))
         (when url
           (insert "\n  Please see ")
           (insert-text-button url

--- a/cider-eldoc.el
+++ b/cider-eldoc.el
@@ -218,7 +218,9 @@ information."
          (symbol (lax-plist-get eldoc-info "symbol"))
          (docstring (or (cider--render-docstring-first-sentence eldoc-info)
                         (cider--render-docstring eldoc-info)
-                        (cider-docstring--dumb-trim (lax-plist-get eldoc-info "docstring"))))
+                        (cider-docstring--trim
+                         (cider-docstring--format
+                          (lax-plist-get eldoc-info "docstring")))))
          ;; if it's a single class (and not multiple class candidates), that's it
          (maybe-class (car (lax-plist-get eldoc-info "class")))
          (formatted-var (or (when maybe-class


### PR DESCRIPTION
While I was trying to clean up `cider-doc.el`, I came across `cider-docstring.el` and noticed the `cider-docstring--dumb-trim` function. I don't know why it's named that way, but it looks pretty smart to me. Maybe too smart, as it does too many things, one of which, along with trimming, is formatting. So I think it is a good idea to separate it into two functions: `cider-docstring--trim` and `cider-docstring--format`.

The main reason for this is that these two functionalities are needed in different contexts. For example, we need to format the docstring when displaying it in the Doc or ClojureDocs buffer (notice that we don't need trimming here because it's a buffer and there's plenty of space to display the docstring), and we need trimming when displaying the docstring in the minibuffer or in a popup along with completions.

Also, the current formatting of the docstring in `cider-docstring--dumb-trim` is too opinionated. For example, it moves every single paragraph (signified by ".  ") to a new line and adds an empty line after it, which totally messes up the original formatting (there are still newlines just in the middle of paragraphs, so we need to either remove all newlines and reformat the docstring from scratch, or intervene as little as possible). I guess nobody had noticed this strange formatting because not many people look for docstrings in the minibuffer or in completions, and even fewer care how it is formatted (but I do). Also, it removes a variable number of spaces from the beginning of every line. As we discussed in #3701, it will be safer to just remove 2 spaces from the beginning while performing formatting. Of course, later we can change this, and it will be much easier to do as we will need to change it in just one place (`cider-docstring--format`).

Additionally, there are a few small tweaks following this change:
- Currently, when `compact` is non-nil when the Doc buffer rendering function is called, the docstring is passed to `cider-docstring--dumb-trim` before being displayed. As I explained earlier, it does two things: formatting and trimming. I think it will be more appropriate to always format the docstring and trim it only when a compact display is needed.
- Replace the code that currently formats the docstring in the ClojureDocs buffer with a `cider-docstring--format` function call.
- Use "…" character instead of "..." if trimming of the docstring is necessary, as it is a typographic character created just for that occasion and it takes up less space.