### PR TITLE
Split `cider-docstring--dumb-trim` into two single-purpose functions

### DIFF
--- a/cider-doc.el
+++ b/cider-doc.el
@@ -429,7 +429,8 @@ in a COMPACT format is specified, FOR-TOOLTIP if specified."
          (fetched-doc (nrepl-dict-get info "doc"))
          (doc     (or rendered-fragments
                       (if compact
-                          (cider-docstring--dumb-trim fetched-doc)
+                          (cider-docstring--trim
+                           (cider-docstring--format fetched-doc))
                         fetched-doc)
                       (unless compact
                         "Not documented.")))

--- a/cider-docstring.el
+++ b/cider-docstring.el
@@ -27,6 +27,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'seq)
 (require 'shr)
 (require 'subr-x)
 
@@ -140,20 +141,14 @@ Prioritize rendering as much as possible while staying within `cider-docstring-m
         second-attempt
         first-attempt)))
 
-(defun cider-docstring--trim (s &optional n)
-  "Returns up to the first N lines of string S,
+(cl-defun cider-docstring--trim (string &optional (max-lines cider-docstring-max-lines))
+  "Returns up to the first MAX-LINES lines of string STRING,
 adding \"...\" if trimming was necessary.
 
-N defaults to `cider-docstring-max-lines'."
-  (when s
-    (let* ((n (or n cider-docstring-max-lines))
-           (lines (split-string s "\n"))
-           (lines-length (length lines))
-           (selected-lines (cl-subseq lines 0 (min n lines-length)))
-           (result (string-join selected-lines "\n")))
-      (if (> lines-length n)
-          (concat result "...")
-        result))))
+MAX-LINES defaults to `cider-docstring-max-lines'."
+  (let* ((lines (split-string string "\n"))
+         (string (string-join (seq-take lines max-lines) "\n")))
+    (concat string (when (> (length lines) max-lines) "..."))))
 
 (defun cider-docstring--format (s)
   "Performs formatting of S, cleaning up some common whitespace issues."

--- a/cider-docstring.el
+++ b/cider-docstring.el
@@ -28,6 +28,7 @@
 
 (require 'cl-lib)
 (require 'shr)
+(require 'subr-x)
 
 (defsubst cider--render-pre* (dom)
   "Render DOM nodes, formatting them them as Java if they are strings."
@@ -139,27 +140,32 @@ Prioritize rendering as much as possible while staying within `cider-docstring-m
         second-attempt
         first-attempt)))
 
-(defun cider-docstring--dumb-trim (s &optional n)
+(defun cider-docstring--trim (s &optional n)
   "Returns up to the first N lines of string S,
 adding \"...\" if trimming was necessary.
 
-N defaults to `cider-docstring-max-lines'.
-
-Also performs some bare-bones formatting, cleaning up some common whitespace issues."
+N defaults to `cider-docstring-max-lines'."
   (when s
-    (let* ((s (replace-regexp-in-string "\\.  " ".\n\n" s)) ;; improve the formatting of e.g. clojure.core/reduce
-           (n (or n cider-docstring-max-lines))
+    (let* ((n (or n cider-docstring-max-lines))
            (lines (split-string s "\n"))
            (lines-length (length lines))
            (selected-lines (cl-subseq lines 0 (min n lines-length)))
-           (result (mapconcat (lambda (f)
-                                ;; Remove spaces at the beginning of each line, as it is common in many clojure.core defns:
-                                (replace-regexp-in-string "\\`[ ]+" "" f))
-                              selected-lines
-                              "\n")))
+           (result (string-join selected-lines "\n")))
       (if (> lines-length n)
           (concat result "...")
         result))))
+
+(defun cider-docstring--format (s)
+  "Performs formatting of S, cleaning up some common whitespace issues."
+  (when s
+    (let* ((s (replace-regexp-in-string "\\.  " ".\n\n" s)) ;; improve the formatting of e.g. clojure.core/reduce
+           (lines (split-string s "\n"))
+           (result (mapconcat (lambda (f)
+                                ;; Remove spaces at the beginning of each line, as it is common in many clojure.core defns:
+                                (replace-regexp-in-string "\\`[ ]+" "" f))
+                              lines
+                              "\n")))
+      result)))
 
 (provide 'cider-docstring)
 ;;; cider-docstring.el ends here

--- a/cider-docstring.el
+++ b/cider-docstring.el
@@ -142,10 +142,7 @@ Prioritize rendering as much as possible while staying within `cider-docstring-m
         first-attempt)))
 
 (cl-defun cider-docstring--trim (string &optional (max-lines cider-docstring-max-lines))
-  "Returns up to the first MAX-LINES lines of string STRING,
-adding \"...\" if trimming was necessary.
-
-MAX-LINES defaults to `cider-docstring-max-lines'."
+  "Return MAX-LINES of STRING, adding \"...\" if trimming was necessary."
   (let* ((lines (split-string string "\n"))
          (string (string-join (seq-take lines max-lines) "\n")))
     (concat string (when (> (length lines) max-lines) "..."))))

--- a/cider-docstring.el
+++ b/cider-docstring.el
@@ -148,7 +148,7 @@ Prioritize rendering as much as possible while staying within `cider-docstring-m
     (concat string (when (> (length lines) max-lines) "..."))))
 
 (defun cider-docstring--format (string)
-  "Performs formatting of STRING, cleaning up some common whitespace issues."
+  "Return a nicely formatted STRING to be displayed to the user."
   (let* ((string (replace-regexp-in-string "\\.  " ".\n\n" string)) ;; improve the formatting of e.g. clojure.core/reduce
          (string (mapconcat (lambda (line)
                               ;; Remove spaces at the beginning of each line, as it is common in many clojure.core defns:

--- a/cider-docstring.el
+++ b/cider-docstring.el
@@ -147,17 +147,15 @@ Prioritize rendering as much as possible while staying within `cider-docstring-m
          (string (string-join (seq-take lines max-lines) "\n")))
     (concat string (when (> (length lines) max-lines) "..."))))
 
-(defun cider-docstring--format (s)
-  "Performs formatting of S, cleaning up some common whitespace issues."
-  (when s
-    (let* ((s (replace-regexp-in-string "\\.  " ".\n\n" s)) ;; improve the formatting of e.g. clojure.core/reduce
-           (lines (split-string s "\n"))
-           (result (mapconcat (lambda (f)
-                                ;; Remove spaces at the beginning of each line, as it is common in many clojure.core defns:
-                                (replace-regexp-in-string "\\`[ ]+" "" f))
-                              lines
-                              "\n")))
-      result)))
+(defun cider-docstring--format (string)
+  "Performs formatting of STRING, cleaning up some common whitespace issues."
+  (let* ((string (replace-regexp-in-string "\\.  " ".\n\n" string)) ;; improve the formatting of e.g. clojure.core/reduce
+         (string (mapconcat (lambda (line)
+                              ;; Remove spaces at the beginning of each line, as it is common in many clojure.core defns:
+                              (replace-regexp-in-string "\\`[ ]+" "" line))
+                            (split-string string "\n")
+                            "\n")))
+    string))
 
 (provide 'cider-docstring)
 ;;; cider-docstring.el ends here

--- a/cider-eldoc.el
+++ b/cider-eldoc.el
@@ -218,7 +218,9 @@ information."
          (symbol (lax-plist-get eldoc-info "symbol"))
          (docstring (or (cider--render-docstring-first-sentence eldoc-info)
                         (cider--render-docstring eldoc-info)
-                        (cider-docstring--dumb-trim (lax-plist-get eldoc-info "docstring"))))
+                        (cider-docstring--trim
+                         (cider-docstring--format
+                          (lax-plist-get eldoc-info "docstring")))))
          ;; if it's a single class (and not multiple class candidates), that's it
          (maybe-class (car (lax-plist-get eldoc-info "class")))
          (formatted-var (or (when maybe-class


### PR DESCRIPTION
The function `cider-docstring--dumb-trim` performs both formatting and trimming. I propose splitting it into two separate functions: `cider-docstring--trim` and `cider-docstring--format` because these two functionalities are needed in different contexts. For example, we need to format the docstring when displaying it in the documentation buffer, and we need to trim the docstring when displaying it in the minibuffer or in a popup along with completions.