### PR TITLE
Show progress when evaluating files using `cider-load-all-files`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changes
 
+- [#3714](https://github.com/clojure-emacs/cider/pull/3714): Show progress when evaluating files using `cider-load-all-files`.
+
 ### Bugs fixed
 
 ## 1.15.0 (2024-06-10)

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -1839,7 +1839,7 @@ all ns aliases and var mappings from the namespace before reloading it."
 Useful when the running nREPL on remote host.
 When UNDEF-ALL is non-nil or called with \\[universal-argument], removes
 all ns aliases and var mappings from the namespaces being reloaded"
-  (interactive "DLoad files beneath directory: \nP")
+  (interactive "DRecursively load files in directory: \nP")
   (let* ((files (directory-files-recursively directory "\\.clj[cs]?$"))
          (reporter (make-progress-reporter "Loading files" 0 (length files))))
     (seq-do-indexed (lambda (file idx)

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -1840,8 +1840,14 @@ Useful when the running nREPL on remote host.
 When UNDEF-ALL is non-nil or called with \\[universal-argument], removes
 all ns aliases and var mappings from the namespaces being reloaded"
   (interactive "DLoad files beneath directory: \nP")
-  (mapcar (lambda (file) (cider-load-file file undef-all))
-          (directory-files-recursively directory "\\.clj[cs]?$")))
+  (let* ((files (directory-files-recursively directory "\\.clj[cs]?$"))
+         (reporter (make-progress-reporter "Loading files" 0 (length files))))
+    (seq-do-indexed (lambda (file idx)
+                      (let ((inhibit-message t))
+                        (cider-load-file file undef-all))
+                      (progress-reporter-update reporter (1+ idx) file))
+                    files)
+    (progress-reporter-done reporter)))
 
 (defalias 'cider-eval-file #'cider-load-file
   "A convenience alias as some people are confused by the load-* names.")


### PR DESCRIPTION
Show progress in echo area while recursively evaluating files in directory using `cider-load-all-files`.

As I've noticed that messages from evaluations keep popping up, so it's very hard to see progress message, I've used `inhibit-message` around `cider-load-file`. One possible downside of this is that error messages are not displayed as well (though it will be really hard to notice some error message while messages pop up one after the other).

Also, I've tweaked the prompt of `cider-load-all-files` because it might not be clear how files are loaded as the word "beneath" is ambiguous (it may mean one level of depth which is not the case).

Closes #3615