### PR TITLE
clean duplicate define-key at cider-sesman-browser-map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [#3714](https://github.com/clojure-emacs/cider/pull/3714): Show progress when evaluating files using `cider-load-all-files`.
 - [#3713](https://github.com/clojure-emacs/cider/pull/3713): Optimize `nrepl-dict-get` and deprecate its 3-argument arity.
+- [#3719](https://github.com/clojure-emacs/cider/pull/3719): Clean duplicate define-key
 
 ### Bugs fixed
 

--- a/cider-connection.el
+++ b/cider-connection.el
@@ -631,7 +631,6 @@ REPL defaults to the current REPL."
     (define-key map (kbd "j d") #'cider-describe-connection)
     (define-key map (kbd "j i") #'cider-describe-connection)
     (define-key map (kbd "C-c C-q") #'cider-quit)
-    (define-key map (kbd "C-c C-q") #'cider-quit)
     (define-key map (kbd "C-c C-r") #'cider-restart)
     (define-key map (kbd "C-c M-r") #'cider-restart)
     (define-key map (kbd "C-c C-d") #'cider-describe-connection)


### PR DESCRIPTION
This keybind first introduced in [the commit](https://github.com/clojure-emacs/cider/commit/6a9bc1cc05a4e393b31c5dfb79c70179fb3233f4).  There are two lines of key bindings to `C-c C-q`, probably due to a simple mistake.

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x]All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
