### PR TITLE
call cider-docstring--format after checking argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [#3719](https://github.com/clojure-emacs/cider/pull/3719): Remove duplicated keybinding.
 - Bump the injected `cider-nrepl` to [0.49.1](https://github.com/clojure-emacs/cider-nrepl/blob/master/CHANGELOG.md#0491-2024-06-30).
   - Reduces the minimal supported Clojure version to 1.10.0 (from 1.10.3).
+- [#3722](https://github.com/clojure-emacs/cider/pull/3722): Call `cider-docstring--format` after checking argument
 
 ### Bugs fixed
 

--- a/cider-eldoc.el
+++ b/cider-eldoc.el
@@ -218,9 +218,10 @@ information."
          (symbol (lax-plist-get eldoc-info "symbol"))
          (docstring (or (cider--render-docstring-first-sentence eldoc-info)
                         (cider--render-docstring eldoc-info)
-                        (cider-docstring--trim
-                         (cider-docstring--format
-                          (lax-plist-get eldoc-info "docstring")))))
+                        (when (lax-plist-get eldoc-info "docstring")
+                          (cider-docstring--trim
+                           (cider-docstring--format
+                            (lax-plist-get eldoc-info "docstring"))))))
          ;; if it's a single class (and not multiple class candidates), that's it
          (maybe-class (car (lax-plist-get eldoc-info "class")))
          (formatted-var (or (when maybe-class

--- a/cider-eldoc.el
+++ b/cider-eldoc.el
@@ -218,10 +218,9 @@ information."
          (symbol (lax-plist-get eldoc-info "symbol"))
          (docstring (or (cider--render-docstring-first-sentence eldoc-info)
                         (cider--render-docstring eldoc-info)
-                        (when (lax-plist-get eldoc-info "docstring")
+                        (when-let (docstring (lax-plist-get eldoc-info "docstring"))
                           (cider-docstring--trim
-                           (cider-docstring--format
-                            (lax-plist-get eldoc-info "docstring"))))))
+                           (cider-docstring--format docstring)))))
          ;; if it's a single class (and not multiple class candidates), that's it
          (maybe-class (car (lax-plist-get eldoc-info "class")))
          (formatted-var (or (when maybe-class


### PR DESCRIPTION
I see below error when write some functions which doesn't have docstring.
`cider-docstring--format` cannot call with `nil`, so checking argument before function call.

## Backtrace
```
Debugger entered--Lisp error: (wrong-type-argument arrayp nil)
  substring(nil 0 0)
  (cons (substring string start l) matches)
  (setq matches (cons (substring string start l) matches))
  (progn (while (and (< start l) (string-match regexp string start)) (progn (setq mb (match-beginning 0)) (setq me (match-end 0))) (if (= me mb) (progn (setq me (min l (1+ mb))))) (match-data--translate (- mb)) (setq str (substring string mb me)) (setq matches (cons (replace-match (if (stringp rep) rep (funcall rep (match-string 0 str))) fixedcase literal str subexp) (cons (substring string start mb) matches))) (setq start me)) (setq matches (cons (substring string start l) matches)) (apply #'concat (nreverse matches)))
  (unwind-protect (progn (while (and (< start l) (string-match regexp string start)) (progn (setq mb (match-beginning 0)) (setq me (match-end 0))) (if (= me mb) (progn (setq me (min l (1+ mb))))) (match-data--translate (- mb)) (setq str (substring string mb me)) (setq matches (cons (replace-match (if (stringp rep) rep (funcall rep ...)) fixedcase literal str subexp) (cons (substring string start mb) matches))) (setq start me)) (setq matches (cons (substring string start l) matches)) (apply #'concat (nreverse matches))) (set-match-data saved-match-data t))
  (let ((saved-match-data (match-data))) (unwind-protect (progn (while (and (< start l) (string-match regexp string start)) (progn (setq mb (match-beginning 0)) (setq me (match-end 0))) (if (= me mb) (progn (setq me (min l ...)))) (match-data--translate (- mb)) (setq str (substring string mb me)) (setq matches (cons (replace-match (if ... rep ...) fixedcase literal str subexp) (cons (substring string start mb) matches))) (setq start me)) (setq matches (cons (substring string start l) matches)) (apply #'concat (nreverse matches))) (set-match-data saved-match-data t)))
  (let ((l (length string)) (start (or start 0)) matches str mb me) (let ((saved-match-data (match-data))) (unwind-protect (progn (while (and (< start l) (string-match regexp string start)) (progn (setq mb (match-beginning 0)) (setq me (match-end 0))) (if (= me mb) (progn (setq me ...))) (match-data--translate (- mb)) (setq str (substring string mb me)) (setq matches (cons (replace-match ... fixedcase literal str subexp) (cons ... matches))) (setq start me)) (setq matches (cons (substring string start l) matches)) (apply #'concat (nreverse matches))) (set-match-data saved-match-data t))))
  replace-regexp-in-string("\n  " "\n" nil)
  cider-docstring--format(nil)
  (cider-docstring--trim (cider-docstring--format (lax-plist-get eldoc-info "docstring")))
  (progn (lax-plist-get eldoc-info "docstring") (cider-docstring--trim (cider-docstring--format (lax-plist-get eldoc-info "docstring"))))
  (if t (progn (lax-plist-get eldoc-info "docstring") (cider-docstring--trim (cider-docstring--format (lax-plist-get eldoc-info "docstring")))))
  (or (cider--render-docstring-first-sentence eldoc-info) (cider--render-docstring eldoc-info) (if t (progn (lax-plist-get eldoc-info "docstring") (cider-docstring--trim (cider-docstring--format (lax-plist-get eldoc-info "docstring"))))))
  (let* ((ns (lax-plist-get eldoc-info "ns")) (symbol (lax-plist-get eldoc-info "symbol")) (docstring (or (cider--render-docstring-first-sentence eldoc-info) (cider--render-docstring eldoc-info) (if t (progn (lax-plist-get eldoc-info "docstring") (cider-docstring--trim (cider-docstring--format ...)))))) (maybe-class (car (lax-plist-get eldoc-info "class"))) (formatted-var (or (if maybe-class (progn (cider-propertize maybe-class 'var))) (cider-eldoc-format-thing ns symbol thing 'var)))) (if docstring (progn (cider-eldoc-format-sym-doc formatted-var ns docstring))))
  cider-eldoc-format-variable("m.primitive" ("ns" "cljdebbugs.primitive" "class" nil "symbol" "cljdebbugs.primitive" "arglists" nil "docstring" nil "doc-fragments" nil "doc-first-sentence-fragments" nil "doc-block-tags-fragments" nil "type" "variable"))
  (cond ((eq (cider-eldoc-thing-type eldoc-info) 'var) (cider-eldoc-format-variable thing eldoc-info)) ((eq (cider-eldoc-thing-type eldoc-info) 'special-form) (cider-eldoc-format-special-form thing pos eldoc-info)) (t (cider-eldoc-format-function thing pos eldoc-info)))
  (progn (cond ((eq (cider-eldoc-thing-type eldoc-info) 'var) (cider-eldoc-format-variable thing eldoc-info)) ((eq (cider-eldoc-thing-type eldoc-info) 'special-form) (cider-eldoc-format-special-form thing pos eldoc-info)) (t (cider-eldoc-format-function thing pos eldoc-info))))
  (if eldoc-info (progn (cond ((eq (cider-eldoc-thing-type eldoc-info) 'var) (cider-eldoc-format-variable thing eldoc-info)) ((eq (cider-eldoc-thing-type eldoc-info) 'special-form) (cider-eldoc-format-special-form thing pos eldoc-info)) (t (cider-eldoc-format-function thing pos eldoc-info)))))
  (let* ((sexp-eldoc-info (cider-eldoc-info-in-current-sexp)) (eldoc-info (lax-plist-get sexp-eldoc-info "eldoc-info")) (pos (lax-plist-get sexp-eldoc-info "pos")) (thing (lax-plist-get sexp-eldoc-info "thing"))) (if eldoc-info (progn (cond ((eq (cider-eldoc-thing-type eldoc-info) 'var) (cider-eldoc-format-variable thing eldoc-info)) ((eq (cider-eldoc-thing-type eldoc-info) 'special-form) (cider-eldoc-format-special-form thing pos eldoc-info)) (t (cider-eldoc-format-function thing pos eldoc-info))))))
  (progn (let* ((sexp-eldoc-info (cider-eldoc-info-in-current-sexp)) (eldoc-info (lax-plist-get sexp-eldoc-info "eldoc-info")) (pos (lax-plist-get sexp-eldoc-info "pos")) (thing (lax-plist-get sexp-eldoc-info "thing"))) (if eldoc-info (progn (cond ((eq (cider-eldoc-thing-type eldoc-info) 'var) (cider-eldoc-format-variable thing eldoc-info)) ((eq (cider-eldoc-thing-type eldoc-info) 'special-form) (cider-eldoc-format-special-form thing pos eldoc-info)) (t (cider-eldoc-format-function thing pos eldoc-info)))))))
  (if (and (cider-connected-p) (not (member last-command '(next-error previous-error))) (not (cider--eldoc-edn-file-p buffer-file-name))) (progn (let* ((sexp-eldoc-info (cider-eldoc-info-in-current-sexp)) (eldoc-info (lax-plist-get sexp-eldoc-info "eldoc-info")) (pos (lax-plist-get sexp-eldoc-info "pos")) (thing (lax-plist-get sexp-eldoc-info "thing"))) (if eldoc-info (progn (cond ((eq ... ...) (cider-eldoc-format-variable thing eldoc-info)) ((eq ... ...) (cider-eldoc-format-special-form thing pos eldoc-info)) (t (cider-eldoc-format-function thing pos eldoc-info))))))))
  cider-eldoc(#f(compiled-function (string &rest plist) #<bytecode 0x16bf3f5f25637d8>))
  #<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_17>(cider-eldoc)
  eldoc-documentation-default()
  eldoc--invoke-strategy(nil)
  eldoc-print-current-symbol-info()
  #<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_12>()
  apply(#<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_12> nil)
  timer-event-handler([t 0 0 500000 nil #<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_12> nil idle 0 nil])
```


-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
