### PR TITLE
reindent

### DIFF
--- a/cider-browse-ns.el
+++ b/cider-browse-ns.el
@@ -268,10 +268,10 @@ list of items."
   (let* ((max-length (cider-browse-ns--column-width items)))
     (cl-labels
         ((keys-from-pred
-          (pred items)
-          (nrepl-dict-keys (nrepl-dict-filter (lambda (_ var-meta)
-                                                (funcall pred var-meta))
-                                              items))))
+           (pred items)
+           (nrepl-dict-keys (nrepl-dict-filter (lambda (_ var-meta)
+                                                 (funcall pred var-meta))
+                                               items))))
       (cond
        ((eql cider-browse-ns-group-by 'type)
         (let* ((func-keys (keys-from-pred #'cider-browse-ns--meta-function-p items))

--- a/cider-doc.el
+++ b/cider-doc.el
@@ -447,10 +447,10 @@ in a COMPACT format is specified, FOR-TOOLTIP if specified."
     (cider--help-setup-xref (list #'cider-doc-lookup (format "%s/%s" ns name)) nil buffer)
     (with-current-buffer buffer
       (cl-flet ((emit (text &optional face sep)
-                      (insert (if face
-                                  (propertize text 'font-lock-face face)
-                                text)
-                              (or sep "\n"))))
+                  (insert (if face
+                              (propertize text 'font-lock-face face)
+                            text)
+                          (or sep "\n"))))
         (emit (if class java-name clj-name) 'font-lock-function-name-face)
         (when super
           (emit (concat "Extends: " (cider-font-lock-as 'java-mode super))))

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -406,12 +406,12 @@ _ARG and _RESET are ignored, as there is only ever one compilation error.
 They exist for compatibility with `next-error'."
   (interactive)
   (cl-labels ((goto-next-note-boundary
-               ()
-               (let ((p (or (cider-find-property 'cider-note-p)
-                            (cider-find-property 'cider-note-p t))))
-                 (when p
-                   (goto-char p)
-                   (message "%s" (get-char-property p 'cider-note))))))
+                ()
+                (let ((p (or (cider-find-property 'cider-note-p)
+                             (cider-find-property 'cider-note-p t))))
+                  (when p
+                    (goto-char p)
+                    (message "%s" (get-char-property p 'cider-note))))))
     ;; if we're already on a compilation error, first jump to the end of
     ;; it, so that we find the next error.
     (when (get-char-property (point) 'cider-note-p)

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -789,40 +789,40 @@ with the given LIMIT."
         deprecated enlightened
         macros functions vars instrumented traced)
     (cl-labels ((handle-plist
-                 (plist)
-                 ;; Note that (memq 'function cider-font-lock-dynamically) and similar statements are evaluated differently
-                 ;; for `core' - they're always truthy for `core' (see related core-handling code some lines below):
-                 (let ((do-function (memq 'function cider-font-lock-dynamically))
-                       (do-var (memq 'var cider-font-lock-dynamically))
-                       (do-macro (memq 'macro cider-font-lock-dynamically))
-                       (do-deprecated (memq 'deprecated cider-font-lock-dynamically)))
-                   (while plist
-                     (let ((sym (pop plist))
-                           (meta (pop plist)))
-                       (pcase (nrepl-dict-get meta "cider/instrumented")
-                         (`nil nil)
-                         (`"\"breakpoint-if-interesting\""
-                          (push sym instrumented))
-                         (`"\"light-form\""
-                          (push sym enlightened)))
-                       ;; The ::traced keywords can be inlined by MrAnderson, so
-                       ;; we catch that case too.
-                       ;; FIXME: This matches values too, not just keys.
-                       (when (seq-find (lambda (k) (and (stringp k)
-                                                        (string-match (rx "clojure.tools.trace/traced" eos) k)))
-                                       meta)
-                         (push sym traced))
-                       (when (and do-deprecated (nrepl-dict-get meta "deprecated"))
-                         (push sym deprecated))
-                       (let ((is-macro (nrepl-dict-get meta "macro"))
-                             (is-function (or (nrepl-dict-get meta "fn")
-                                              (nrepl-dict-get meta "arglists"))))
-                         (cond ((and do-macro is-macro)
-                                (push sym macros))
-                               ((and do-function is-function)
-                                (push sym functions))
-                               ((and do-var (not is-function) (not is-macro))
-                                (push sym vars)))))))))
+                  (plist)
+                  ;; Note that (memq 'function cider-font-lock-dynamically) and similar statements are evaluated differently
+                  ;; for `core' - they're always truthy for `core' (see related core-handling code some lines below):
+                  (let ((do-function (memq 'function cider-font-lock-dynamically))
+                        (do-var (memq 'var cider-font-lock-dynamically))
+                        (do-macro (memq 'macro cider-font-lock-dynamically))
+                        (do-deprecated (memq 'deprecated cider-font-lock-dynamically)))
+                    (while plist
+                      (let ((sym (pop plist))
+                            (meta (pop plist)))
+                        (pcase (nrepl-dict-get meta "cider/instrumented")
+                          (`nil nil)
+                          (`"\"breakpoint-if-interesting\""
+                           (push sym instrumented))
+                          (`"\"light-form\""
+                           (push sym enlightened)))
+                        ;; The ::traced keywords can be inlined by MrAnderson, so
+                        ;; we catch that case too.
+                        ;; FIXME: This matches values too, not just keys.
+                        (when (seq-find (lambda (k) (and (stringp k)
+                                                         (string-match (rx "clojure.tools.trace/traced" eos) k)))
+                                        meta)
+                          (push sym traced))
+                        (when (and do-deprecated (nrepl-dict-get meta "deprecated"))
+                          (push sym deprecated))
+                        (let ((is-macro (nrepl-dict-get meta "macro"))
+                              (is-function (or (nrepl-dict-get meta "fn")
+                                               (nrepl-dict-get meta "arglists"))))
+                          (cond ((and do-macro is-macro)
+                                 (push sym macros))
+                                ((and do-function is-function)
+                                 (push sym functions))
+                                ((and do-var (not is-function) (not is-macro))
+                                 (push sym vars)))))))))
       ;; For core members, we override `cider-font-lock-dynamically', since all core members should get the same treatment:
       (when (memq 'core cider-font-lock-dynamically)
         (let ((cider-font-lock-dynamically '(function var macro core deprecated)))

--- a/cider-ns.el
+++ b/cider-ns.el
@@ -166,13 +166,13 @@ presenting the error message as an overlay."
   "Refresh LOG-BUFFER with RESPONSE."
   (nrepl-dbind-response response (out err reloading progress status error error-ns after before)
     (cl-flet* ((log (message &optional face)
-                    (cider-emit-into-popup-buffer log-buffer message face t))
+                 (cider-emit-into-popup-buffer log-buffer message face t))
 
                (log-echo (message &optional face)
-                         (log message face)
-                         (unless cider-ns-refresh-show-log-buffer
-                           (let ((message-truncate-lines t))
-                             (message "cider-ns-refresh: %s" message)))))
+                 (log message face)
+                 (unless cider-ns-refresh-show-log-buffer
+                   (let ((message-truncate-lines t))
+                     (message "cider-ns-refresh: %s" message)))))
       (cond
        (out
         (log out))

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -354,11 +354,11 @@ description transform) where transform is called with the param-value if
 present."
   (cl-labels
       ((emit-comment
-        (contents)
-        (insert-before-markers
-         (propertize
-          (if (string-blank-p contents) ";;\n" (concat ";; " contents "\n"))
-          'font-lock-face 'font-lock-comment-face))))
+         (contents)
+         (insert-before-markers
+          (propertize
+           (if (string-blank-p contents) ";;\n" (concat ";; " contents "\n"))
+           'font-lock-face 'font-lock-comment-face))))
     (let ((jack-in-command (plist-get cider-launch-params :jack-in-cmd))
           (cljs-repl-type (plist-get cider-launch-params :cljs-repl-type))
           (cljs-init-form (plist-get cider-launch-params :repl-init-form)))

--- a/cider-selector.el
+++ b/cider-selector.el
@@ -121,56 +121,56 @@ is chosen.  The returned buffer is selected with
                     #'< :key #'car))))
 
 (def-cider-selector-method ?? "Selector help buffer."
-  (ignore-errors (kill-buffer cider-selector-help-buffer))
-  (with-current-buffer (get-buffer-create cider-selector-help-buffer)
-    (insert "CIDER Selector Methods:\n\n")
-    (cl-loop for (key line nil) in cider-selector-methods
-             do (insert (format "%c:\t%s\n" key line)))
-    (goto-char (point-min))
-    (help-mode)
-    (display-buffer (current-buffer) t))
-  (cider-selector)
-  (current-buffer))
+                           (ignore-errors (kill-buffer cider-selector-help-buffer))
+                           (with-current-buffer (get-buffer-create cider-selector-help-buffer)
+                             (insert "CIDER Selector Methods:\n\n")
+                             (cl-loop for (key line nil) in cider-selector-methods
+                                      do (insert (format "%c:\t%s\n" key line)))
+                             (goto-char (point-min))
+                             (help-mode)
+                             (display-buffer (current-buffer) t))
+                           (cider-selector)
+                           (current-buffer))
 
 (cl-pushnew (list ?4 "Select in other window" (lambda () (cider-selector t)))
             cider-selector-methods :key #'car)
 
 (def-cider-selector-method ?c
-  "Most recently visited clojure-mode buffer."
-  (cider-selector--recently-visited-buffer '(clojure-mode clojure-ts-mode)))
+                           "Most recently visited clojure-mode buffer."
+                           (cider-selector--recently-visited-buffer '(clojure-mode clojure-ts-mode)))
 
 (def-cider-selector-method ?e
-  "Most recently visited emacs-lisp-mode buffer."
-  (cider-selector--recently-visited-buffer 'emacs-lisp-mode))
+                           "Most recently visited emacs-lisp-mode buffer."
+                           (cider-selector--recently-visited-buffer 'emacs-lisp-mode))
 
 (def-cider-selector-method ?q "Abort."
-  (top-level))
+                           (top-level))
 
 (def-cider-selector-method ?r
-  "Current REPL buffer or as a fallback, the most recently
+                           "Current REPL buffer or as a fallback, the most recently
 visited cider-repl-mode buffer."
-  (or (cider-current-repl)
-      (cider-selector--recently-visited-buffer 'cider-repl-mode)))
+                           (or (cider-current-repl)
+                               (cider-selector--recently-visited-buffer 'cider-repl-mode)))
 
 (def-cider-selector-method ?m
-  "Current connection's *nrepl-messages* buffer."
-  (nrepl-messages-buffer (cider-current-repl)))
+                           "Current connection's *nrepl-messages* buffer."
+                           (nrepl-messages-buffer (cider-current-repl)))
 
 (def-cider-selector-method ?x
-  "*cider-error* buffer."
-  cider-error-buffer)
+                           "*cider-error* buffer."
+                           cider-error-buffer)
 
 (def-cider-selector-method ?p
-  "*cider-profile* buffer."
-  cider-profile-buffer)
+                           "*cider-profile* buffer."
+                           cider-profile-buffer)
 
 (def-cider-selector-method ?d
-  "*cider-doc* buffer."
-  cider-doc-buffer)
+                           "*cider-doc* buffer."
+                           cider-doc-buffer)
 
 (def-cider-selector-method ?s
-  "*cider-scratch* buffer."
-  (cider-scratch-find-or-create-buffer))
+                           "*cider-scratch* buffer."
+                           (cider-scratch-find-or-create-buffer))
 
 (provide 'cider-selector)
 

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -346,9 +346,9 @@ filters for the resulting machinery."
     (save-excursion
       (goto-char (point-min))
       (cl-flet ((next-detail (end)
-                             (when-let* ((pos (next-single-property-change (point) 'detail)))
-                               (when (< pos end)
-                                 (goto-char pos)))))
+                  (when-let* ((pos (next-single-property-change (point) 'detail)))
+                    (when (< pos end)
+                      (goto-char pos)))))
         (let ((inhibit-read-only t))
           ;; For each cause...
           (while (cider-stacktrace-next-cause)

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -1402,9 +1402,9 @@ If ID is nil, return nil."
   "Pretty print nREPL list like OBJECT.
 FOREGROUND and BUTTON are as in `nrepl-log-pp-object'."
   (cl-flet ((color (str)
-                   (propertize str 'face
-                               (append '(:weight ultra-bold)
-                                       (when foreground `(:foreground ,foreground))))))
+              (propertize str 'face
+                          (append '(:weight ultra-bold)
+                                  (when foreground `(:foreground ,foreground))))))
     (let ((head (format "(%s" (car object))))
       (insert (color head))
       (if (null (cdr object))


### PR DESCRIPTION
I found `eldev lint` emit warnings. this PR solves indent issues.

## before
```
$ eldev lint
[1/3] Installing package ‘dash’ (2.19.1) from ‘gnu’...
[2/3] Installing package ‘package-lint’ (0.23) from ‘melpa-stable’...
[3/3] Installing package ‘elisp-lint’ (0.4.0) from ‘melpa-stable’...
Indenting region... 
Indenting region...done
File ‘cider-apropos.el’: no warnings
Indenting region... 
Indenting region...done
cider-browse-ns.el:271:0 (indent) !           (pred items)
cider-browse-ns.el:272:0 (indent) !           (nrepl-dict-keys (nrepl-dict-filter (lambda (_ var-meta)
cider-browse-ns.el:273:0 (indent) !                                                 (funcall pred var-meta))
cider-browse-ns.el:274:0 (indent) !                                               items))))
Found 4 warnings in file ‘cider-browse-ns.el’
Indenting region... 
Indenting region...done
File ‘cider-browse-spec.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-cheatsheet.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-classpath.el’: no warnings
uncompressing ido.el.gz...
uncompressing ido.el.gz...done
Indenting region... 
Indenting region...done
File ‘cider-client.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-clojuredocs.el’: no warnings
uncompressing url-parse.el.gz...
uncompressing url-parse.el.gz...done
uncompressing arc-mode.el.gz...
uncompressing arc-mode.el.gz...done
Indenting region... 
Indenting region...done
File ‘cider-common.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-completion-context.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-completion.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-connection.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-debug.el’: no warnings
uncompressing org-table.el.gz...
uncompressing org-table.el.gz...done
Indenting region... 
Indenting region...done
cider-doc.el:450:0 (indent)      !                       (insert (if face
cider-doc.el:451:0 (indent)      !                                   (propertize text 'font-lock-face face)
cider-doc.el:452:0 (indent)      !                                 text)
cider-doc.el:453:0 (indent)      !                               (or sep "\n"))))
Found 4 warnings in file ‘cider-doc.el’
Indenting region... 
Indenting region...done
File ‘cider-docstring.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-eldoc.el’: no warnings
Indenting region... 
Indenting region...done
cider-eval.el:409:0 (indent)     !                ()
cider-eval.el:410:0 (indent)     !                (let ((p (or (cider-find-property 'cider-note-p)
cider-eval.el:411:0 (indent)     !                             (cider-find-property 'cider-note-p t))))
cider-eval.el:412:0 (indent)     !                  (when p
cider-eval.el:413:0 (indent)     !                    (goto-char p)
cider-eval.el:414:0 (indent)     !                    (message "%s" (get-char-property p 'cider-note))))))
Found 6 warnings in file ‘cider-eval.el’
Indenting region... 
Indenting region...done
File ‘cider-find.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-format.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-inspector.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-jar.el’: no warnings
cider-log.el:108:Warning (check-declare): said ‘logview--guess-submode’ was defined in logview.el: file not found
cider-log.el:109:Warning (check-declare): said ‘logview-initialized-p’ was defined in logview.el: file not found
cider-log.el:110:Warning (check-declare): said ‘logview-mode’ was defined in logview.el: file not found
Indenting region... 
Invalid function: defmacro
cider-log.el:0:0 (check-declare) (declare-function) file not found: "logview--guess-submode" in file "logview.el"
Found 1 warning in file ‘cider-log.el’
Indenting region... 
Indenting region...done
File ‘cider-macroexpansion.el’: no warnings
Indenting region... 
Indenting region...done
cider-mode.el:792:0 (indent)     !                  (plist)
cider-mode.el:793:0 (indent)     !                  ;; Note that (memq 'function cider-font-lock-dynamically) and similar statements are evaluated differently
cider-mode.el:794:0 (indent)     !                  ;; for `core' - they're always truthy for `core' (see related core-handling code some lines below):
cider-mode.el:795:0 (indent)     !                  (let ((do-function (memq 'function cider-font-lock-dynamically))
cider-mode.el:796:0 (indent)     !                        (do-var (memq 'var cider-font-lock-dynamically))
cider-mode.el:797:0 (indent)     !                        (do-macro (memq 'macro cider-font-lock-dynamically))
cider-mode.el:798:0 (indent)     !                        (do-deprecated (memq 'deprecated cider-font-lock-dynamically)))
cider-mode.el:799:0 (indent)     !                    (while plist
cider-mode.el:800:0 (indent)     !                      (let ((sym (pop plist))
cider-mode.el:801:0 (indent)     !                            (meta (pop plist)))
cider-mode.el:802:0 (indent)     !                        (pcase (nrepl-dict-get meta "cider/instrumented")
cider-mode.el:803:0 (indent)     !                          (`nil nil)
cider-mode.el:804:0 (indent)     !                          (`"\"breakpoint-if-interesting\""
cider-mode.el:805:0 (indent)     !                           (push sym instrumented))
cider-mode.el:806:0 (indent)     !                          (`"\"light-form\""
cider-mode.el:807:0 (indent)     !                           (push sym enlightened)))
cider-mode.el:808:0 (indent)     !                        ;; The ::traced keywords can be inlined by MrAnderson, so
cider-mode.el:809:0 (indent)     !                        ;; we catch that case too.
cider-mode.el:810:0 (indent)     !                        ;; FIXME: This matches values too, not just keys.
cider-mode.el:811:0 (indent)     !                        (when (seq-find (lambda (k) (and (stringp k)
cider-mode.el:812:0 (indent)     !                                                         (string-match (rx "clojure.tools.trace/traced" eos) k)))
cider-mode.el:813:0 (indent)     !                                        meta)
cider-mode.el:814:0 (indent)     !                          (push sym traced))
cider-mode.el:815:0 (indent)     !                        (when (and do-deprecated (nrepl-dict-get meta "deprecated"))
cider-mode.el:816:0 (indent)     !                          (push sym deprecated))
cider-mode.el:817:0 (indent)     !                        (let ((is-macro (nrepl-dict-get meta "macro"))
cider-mode.el:818:0 (indent)     !                              (is-function (or (nrepl-dict-get meta "fn")
cider-mode.el:819:0 (indent)     !                                               (nrepl-dict-get meta "arglists"))))
cider-mode.el:820:0 (indent)     !                          (cond ((and do-macro is-macro)
cider-mode.el:821:0 (indent)     !                                 (push sym macros))
cider-mode.el:822:0 (indent)     !                                ((and do-function is-function)
cider-mode.el:823:0 (indent)     !                                 (push sym functions))
cider-mode.el:824:0 (indent)     !                                ((and do-var (not is-function) (not is-macro))
cider-mode.el:825:0 (indent)     !                                 (push sym vars)))))))))
Found 34 warnings in file ‘cider-mode.el’
Indenting region... 
Indenting region...done
cider-ns.el:169:0 (indent)       !                     (cider-emit-into-popup-buffer log-buffer message face t))
cider-ns.el:172:0 (indent)       !                          (log message face)
cider-ns.el:173:0 (indent)       !                          (unless cider-ns-refresh-show-log-buffer
cider-ns.el:174:0 (indent)       !                            (let ((message-truncate-lines t))
cider-ns.el:175:0 (indent)       !                              (message "cider-ns-refresh: %s" message)))))
Found 5 warnings in file ‘cider-ns.el’
Indenting region... 
Indenting region...done
File ‘cider-overlays.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-popup.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-profile.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-repl-history.el’: no warnings
Indenting region... 
Indenting region...done
cider-repl.el:357:0 (indent)     !         (contents)
cider-repl.el:358:0 (indent)     !         (insert-before-markers
cider-repl.el:359:0 (indent)     !          (propertize
cider-repl.el:360:0 (indent)     !           (if (string-blank-p contents) ";;\n" (concat ";; " contents "\n"))
cider-repl.el:361:0 (indent)     !           'font-lock-face 'font-lock-comment-face))))
Found 5 warnings in file ‘cider-repl.el’
Indenting region... 
Indenting region...done
File ‘cider-resolve.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-scratch.el’: no warnings
Indenting region... 
Indenting region...done
cider-selector.el:124:0 (indent) !   (ignore-errors (kill-buffer cider-selector-help-buffer))
cider-selector.el:125:0 (indent) !   (with-current-buffer (get-buffer-create cider-selector-help-buffer)
cider-selector.el:126:0 (indent) !     (insert "CIDER Selector Methods:\n\n")
cider-selector.el:127:0 (indent) !     (cl-loop for (key line nil) in cider-selector-methods
cider-selector.el:128:0 (indent) !              do (insert (format "%c:\t%s\n" key line)))
cider-selector.el:129:0 (indent) !     (goto-char (point-min))
cider-selector.el:130:0 (indent) !     (help-mode)
cider-selector.el:131:0 (indent) !     (display-buffer (current-buffer) t))
cider-selector.el:132:0 (indent) !   (cider-selector)
cider-selector.el:133:0 (indent) !   (current-buffer))
cider-selector.el:139:0 (indent) !   "Most recently visited clojure-mode buffer."
cider-selector.el:140:0 (indent) !   (cider-selector--recently-visited-buffer '(clojure-mode clojure-ts-mode)))
cider-selector.el:143:0 (indent) !   "Most recently visited emacs-lisp-mode buffer."
cider-selector.el:144:0 (indent) !   (cider-selector--recently-visited-buffer 'emacs-lisp-mode))
cider-selector.el:147:0 (indent) !   (top-level))
cider-selector.el:150:0 (indent) !   "Current REPL buffer or as a fallback, the most recently
cider-selector.el:152:0 (indent) !   (or (cider-current-repl)
cider-selector.el:153:0 (indent) !       (cider-selector--recently-visited-buffer 'cider-repl-mode)))
cider-selector.el:156:0 (indent) !   "Current connection's *nrepl-messages* buffer."
cider-selector.el:157:0 (indent) !   (nrepl-messages-buffer (cider-current-repl)))
cider-selector.el:160:0 (indent) !   "*cider-error* buffer."
cider-selector.el:161:0 (indent) !   cider-error-buffer)
cider-selector.el:164:0 (indent) !   "*cider-profile* buffer."
cider-selector.el:165:0 (indent) !   cider-profile-buffer)
cider-selector.el:168:0 (indent) !   "*cider-doc* buffer."
cider-selector.el:169:0 (indent) !   cider-doc-buffer)
cider-selector.el:172:0 (indent) !   "*cider-scratch* buffer."
cider-selector.el:173:0 (indent) !   (cider-scratch-find-or-create-buffer))
Found 28 warnings in file ‘cider-selector.el’
Indenting region... 
Indenting region...done
cider-stacktrace.el:349:0 (indent) !                              (when-let* ((pos (next-single-property-change (point) 'detail)))
cider-stacktrace.el:350:0 (indent) !                                (when (< pos end)
cider-stacktrace.el:351:0 (indent) !                                  (goto-char pos)))))
Found 3 warnings in file ‘cider-stacktrace.el’
Indenting region... 
Indenting region...done
File ‘cider-tracing.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-util.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-xref-backend.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-xref.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider.el’: no warnings
Indenting region... 
Indenting region...done
nrepl-client.el:1405:0 (indent)  !                    (propertize str 'face
nrepl-client.el:1406:0 (indent)  !                                (append '(:weight ultra-bold)
nrepl-client.el:1407:0 (indent)  !                                        (when foreground `(:foreground ,foreground))))))
Found 3 warnings in file ‘nrepl-client.el’
Indenting region... 
Indenting region...done
File ‘nrepl-dict.el’: no warnings
Linting produced warnings
```

## after
```
$ eldev lint
Indenting region... 
Indenting region...done
File ‘cider-apropos.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-browse-ns.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-browse-spec.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-cheatsheet.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-classpath.el’: no warnings
uncompressing ido.el.gz...
uncompressing ido.el.gz...done
Indenting region... 
Indenting region...done
File ‘cider-client.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-clojuredocs.el’: no warnings
uncompressing url-parse.el.gz...
uncompressing url-parse.el.gz...done
uncompressing arc-mode.el.gz...
uncompressing arc-mode.el.gz...done
Indenting region... 
Indenting region...done
File ‘cider-common.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-completion-context.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-completion.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-connection.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-debug.el’: no warnings
uncompressing org-table.el.gz...
uncompressing org-table.el.gz...done
Indenting region... 
Indenting region...done
File ‘cider-doc.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-docstring.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-eldoc.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-eval.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-find.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-format.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-inspector.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-jar.el’: no warnings
cider-log.el:108:Warning (check-declare): said ‘logview--guess-submode’ was defined in logview.el: file not found
cider-log.el:109:Warning (check-declare): said ‘logview-initialized-p’ was defined in logview.el: file not found
cider-log.el:110:Warning (check-declare): said ‘logview-mode’ was defined in logview.el: file not found
Indenting region... 
Invalid function: defmacro
cider-log.el:0:0 (check-declare) (declare-function) file not found: "logview--guess-submode" in file "logview.el"
Found 1 warning in file ‘cider-log.el’
Indenting region... 
Indenting region...done
File ‘cider-macroexpansion.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-mode.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-ns.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-overlays.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-popup.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-profile.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-repl-history.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-repl.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-resolve.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-scratch.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-selector.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-stacktrace.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-tracing.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-util.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-xref-backend.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider-xref.el’: no warnings
Indenting region... 
Indenting region...done
File ‘cider.el’: no warnings
Indenting region... 
Indenting region...done
File ‘nrepl-client.el’: no warnings
Indenting region... 
Indenting region...done
File ‘nrepl-dict.el’: no warnings
Linting produced warnings
```

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
