### PR TITLE
[Fix #3725] Use defvaralias for x-gtk-use-system-tooltips on emacs29

### DIFF
--- a/cider-mode.el
+++ b/cider-mode.el
@@ -1062,7 +1062,12 @@ property."
 
 
 ;;; Minor-mode definition
-(defvar x-gtk-use-system-tooltips)
+
+(if (and (> emacs-major-version 28)
+         (not (boundp 'x-gtk-use-system-tooltips)))
+    ;; The x-gtk prefix has been dropped in Emacs 29
+    (defvaralias 'x-gtk-use-system-tooltips 'use-system-tooltips)
+  (defvar x-gtk-use-system-tooltips))
 
 ;;;###autoload
 (define-minor-mode cider-mode


### PR DESCRIPTION
Hi,

This should fix the issue with defining the now deprecated variable`x-gtk-use-system-tooltips` as a variable, as discussed here: #3725.
