### PR TITLE
Restore syntax highlighting in result minibuffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+- [#3742](https://github.com/clojure-emacs/cider/issues/3742): Restore syntax highlighting in result minibuffer.
+
 ## 1.16.0 (2024-09-24)
 
 ### Changes

--- a/cider-overlays.el
+++ b/cider-overlays.el
@@ -317,7 +317,7 @@ focused."
                            :where point
                            :duration cider-eval-result-duration
                            :prepend-face (or overlay-face 'cider-result-overlay-face))))
-         (msg (format "%s%s" cider-eval-result-prefix value))
+         (msg (format "%s%s" cider-eval-result-prefix font-value))
          (max-msg-length (* (floor (* (frame-height) max-mini-window-height))
                             (frame-width)))
          (msg (if (> (string-width msg) max-msg-length)


### PR DESCRIPTION
Fixes https://github.com/clojure-emacs/cider/issues/3742.