### PR TITLE
[completion] Fix custom completion style and make it default for fuzzy matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+- [#3746](https://github.com/clojure-emacs/cider/issues/3746): Bring back `cider` completion style for activating backend-driven completion.
+
 ### Bugs fixed
 
 - [#3742](https://github.com/clojure-emacs/cider/issues/3742): Restore syntax highlighting in result minibuffer.

--- a/cider-completion.el
+++ b/cider-completion.el
@@ -256,6 +256,14 @@ in the buffer."
 
 ;; Fuzzy completion for company-mode
 
+(defun cider-completion-try-completion (string collection pred _)
+  "Return longest common substring of all completions of STRING in COLLECTION,
+also pass PRED to `try-completion'.
+
+This function is only needed to be a correct citizen in
+`completion-styles-alist'."
+  (try-completion string collection pred))
+
 (defun cider-company-unfiltered-candidates (string &rest _)
   "Return CIDER completion candidates for STRING as is, unfiltered."
   (cider-complete string))
@@ -268,17 +276,40 @@ in the buffer."
 ;;  which introduced `cider-company-enable-fuzzy-completion')
 (add-to-list 'completion-styles-alist
              '(cider
-               cider-company-unfiltered-candidates
+               cider-completion-try-completion
                cider-company-unfiltered-candidates
                "CIDER backend-driven completion style."))
 
 (defun cider-company-enable-fuzzy-completion ()
-  "Enable backend-driven fuzzy completion in the current buffer.
+  "Enables `cider' completion style for CIDER in all buffers.
 
-DEPRECATED: please use `cider-enable-flex-completion' instead."
-  (setq-local completion-styles '(cider)))
+DEPRECATED: please use `cider-enable-cider-completion-style' instead."
+  (interactive)
+  (cider-enable-cider-completion-style))
 
-(make-obsolete 'cider-company-enable-fuzzy-completion 'cider-enable-flex-completion "1.8.0")
+(defun cider-enable-cider-completion-style ()
+  "Enables `cider' completion style for CIDER in all buffers.
+
+This style supports non-prefix completion candidates returned by the
+completion backend.  Only affects the `cider' completion category."
+  (interactive)
+  (let* ((cider (assq 'cider completion-category-overrides))
+         (found-styles (assq 'styles cider))
+         (new-styles (if found-styles
+                         (cons 'styles (cons 'cider (cdr found-styles)))
+                       '(styles cider basic)))
+         (new-cider (if cider
+                        (cons 'cider
+                              (cons new-styles
+                                    (seq-remove (lambda (x) (equal 'styles (car x)))
+                                                (cdr cider))))
+                      (list 'cider new-styles)))
+         (new-overrides (cons new-cider
+                              (seq-remove (lambda (x) (equal 'cider (car x)))
+                                          completion-category-overrides))))
+    (setq completion-category-overrides new-overrides)))
+
+(make-obsolete 'cider-company-enable-fuzzy-completion 'cider-enable-cider-completion-style "1.17.0")
 
 (defun cider-enable-flex-completion ()
   "Enables `flex' (fuzzy) completion for CIDER in all buffers.

--- a/doc/modules/ROOT/pages/usage/code_completion.adoc
+++ b/doc/modules/ROOT/pages/usage/code_completion.adoc
@@ -41,9 +41,12 @@ CIDER defines a specialized completion category through the `cider-complete-at-p
 added to `completion-at-point-functions`, establishing a dedicated completion category named
 `cider`.
 
-The CIDER completion at point function supports most completion styles, including
-`partial-completion`, `orderless` and `flex` (read more below).
-
+The CIDER completion at point function supports most completion styles,
+including `partial-completion`, `orderless` and `flex`. It also supports a
+custom completion style that is confusingly named `cider` too. Activating it
+provides a richer set of completion candidates (see
+xref:usage/code_completion.adoc#fuzzy-candidate-matching[fuzzy candidate
+matching]).
 
 Sometimes the user may want to use a different completion style just for the CIDER
 complete at point function. That can be achieved by setting
@@ -57,8 +60,6 @@ complete at point function. The following snippet accomplishes that:
 
 This specifies that the `cider` completion category should employ the basic completion style by
 default.
-
-You can also enable the `flex` completion style by activating xref:usage/code_completion.adoc#fuzzy-candidate-matching[fuzzy candidate matching].
 
 == Auto-completion
 
@@ -146,15 +147,15 @@ emacs22)` since Emacs 23. For a better description of how those
 completion styles operates, refer to the official Emacs manual on
 https://www.gnu.org/software/emacs/manual/html_node/emacs/Completion-Styles.html[how completion alternatives are chosen].
 
-CIDER provides a function to enable the `flex` completion style for CIDER-specific
+CIDER provides a function to enable the `cider` completion style for CIDER-specific
 completions. If you wish to enable that, you can add this to your config:
 
 [source,lisp]
 ----
-(cider-enable-flex-completion)
+(cider-enable-cider-completion-style)
 ----
 
-This adds the `flex` completion style, as introduced in Emacs 27.
+This adds the `cider` completion style for CIDER buffers.
 
 Now, `company-mode` (and other completion packages like `corfu`) will
 accept certain fuzziness when matching candidates against the
@@ -162,8 +163,6 @@ prefix. For example, typing `mi` will show you `map-indexed` as one of
 the possible completion candidates and `cji` will complete to
 `clojure.java.io`. Different completion examples are shown
 https://github.com/alexander-yakushev/compliment/wiki/Examples[here].
-
-NOTE: `cider-company-enable-fuzzy-completion` (now deprecated) should be used for Emacs < 27. 
 
 === Completion annotations
 


### PR DESCRIPTION
Back to completion woes.

Some time ago we moved the official way to enable fuzzy Compliment-driven completion from a custom completion style to `flex`. This worked correctly until https://github.com/company-mode/company-mode/issues/1493 – cider completion now no longer suggests candidates for class shortnames like e.g. `Persistent`. Nothing has been broken in Company, vice versa, Company has became more like corfu and `complete-at-point`, so it was already broken in those clients.

I tried to fix it for `flex` but did not succeed. It looks like owning a custom completion style is still the proper way to go, so I'm resurrecting it with this PR and undeprecating the previous way to enable "fuzzy" completion. The current _partial_ compatibility with `flex` remains, so if folks prefer to use that, they still can.

I've also fixed our custom completion style so that it is compatible with Emacs machinery – something that users complained about before.
