### PR TITLE
[docstring] Don't crash if string doc is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs fixed
 
 - [#3742](https://github.com/clojure-emacs/cider/issues/3742): Restore syntax highlighting in result minibuffer.
+- [#3747](https://github.com/clojure-emacs/cider/issues/3747): Fix errors when docstring is nil.
 
 ## 1.16.0 (2024-09-24)
 

--- a/cider-docstring.el
+++ b/cider-docstring.el
@@ -143,9 +143,10 @@ Prioritize rendering as much as possible while staying within `cider-docstring-m
 
 (cl-defun cider-docstring--trim (string &optional (max-lines cider-docstring-max-lines))
   "Return MAX-LINES of STRING, adding \"...\" if trimming was necessary."
-  (let* ((lines (split-string string "\n"))
-         (string (string-join (seq-take lines max-lines) "\n")))
-    (concat string (when (> (length lines) max-lines) "..."))))
+  (when string
+    (let* ((lines (split-string string "\n"))
+           (string (string-join (seq-take lines max-lines) "\n")))
+      (concat string (when (> (length lines) max-lines) "...")))))
 
 (defun cider-docstring--format (string)
   "Return a nicely formatted STRING to be displayed to the user.


### PR DESCRIPTION
I've observed errors because of this in both eldoc hints and in completion doc popup.
