### PR TITLE
[completion] Use ignore instead of try-completion-function in CIDER completion style

### DIFF
--- a/cider-completion.el
+++ b/cider-completion.el
@@ -256,14 +256,6 @@ in the buffer."
 
 ;; Fuzzy completion for company-mode
 
-(defun cider-completion-try-completion (string collection pred _)
-  "Return longest common substring of all completions of STRING in COLLECTION,
-also pass PRED to `try-completion'.
-
-This function is only needed to be a correct citizen in
-`completion-styles-alist'."
-  (try-completion string collection pred))
-
 (defun cider-company-unfiltered-candidates (string &rest _)
   "Return CIDER completion candidates for STRING as is, unfiltered."
   (cider-complete string))
@@ -276,7 +268,8 @@ This function is only needed to be a correct citizen in
 ;;  which introduced `cider-company-enable-fuzzy-completion')
 (add-to-list 'completion-styles-alist
              '(cider
-               cider-completion-try-completion
+               ;; Use `ignore' in place of "try-competion function".
+               ignore
                cider-company-unfiltered-candidates
                "CIDER backend-driven completion style."))
 


### PR DESCRIPTION
Should fix #3749.

Turns out the API of a custom completion style's "try-completion function" doesn't match Emacs' own `try-completion` because why the hell should it, right? The API expected from that function is also not documented anywhere.

However, I've seen that `eglot` simply uses `ignore` instead of implementing that function and everything still works. I've verified locally that the completion is still operational with `ignore` there in both company-mode and `M-x complete-symbol`.

Asking @rrudakov to kindly verify the fix locally (you can replace the body of `cider-completion-try-completion` with just returning nil to verify).