### PR TITLE
Add cider-log-show-frameworks command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## master (unreleased)
 
 ### Changes
-
+- [#3753](https://github.com/clojure-emacs/cider/pull/3753) Add `cider-log-show-frameworks` command to show available log frameworks in a buffer.
 - [#3746](https://github.com/clojure-emacs/cider/issues/3746): Bring back `cider` completion style for activating backend-driven completion.
 
 ### Bugs fixed

--- a/doc/modules/ROOT/pages/debugging/logging.adoc
+++ b/doc/modules/ROOT/pages/debugging/logging.adoc
@@ -49,6 +49,7 @@ Its usage is mostly self-describing, since each command has its keybinding attac
 
 To use CIDER Log Mode, there two main ways to get started:
 
+* `M-x cider-log-show-frameworks`, to see the available logging frameworks. If your logging framework is supported but not shown, see the troubleshooting section.
 * `M-x cider-log-event`, which uses transient-mode and will not immediately show the logs (you should use transient-mode to show the `+*cider-log*+` buffer)
 * `M-x cider-log-show` is a newer function that intends to be an "all-in-one" command, intended for a streamlined experience, which can be useful to get started, or for casual usage.
 ** It doesn't use transient-mode - it aims to do everything in one step
@@ -177,6 +178,10 @@ or Clojure CLI aliases.
 
 |===
 | Command | Keyboard shortcut | Description
+
+| `cider-log-show-frameworks`
+| kbd:[C-c M-l f a]
+| Show all available log frameworks in a buffer.
 
 | `cider-log-set-framework`
 | kbd:[C-c M-l f s]
@@ -351,3 +356,9 @@ using logical AND condition. The following filters are available:
 | kbd:[-t]
 | Only include log events that were emitted by a thread in the list of `threads`.
 |===
+
+== Troubleshooting
+
+- Make sure the logging library is actually supported by CIDER Log Mode and that it is on your classpath.
+- Try requiring the https://github.com/clojure-emacs/logjam/tree/master/src/logjam/framework[Logjam] namespace of the logging library, e.g. `(require 'logjam.framework.<jul|logback|timbre|> :reload)` and make sure it can be loaded without errors.
+- Timbre and Encore often have to be upgraded in concert, they use "break versioning". It's often useful to have Timbre + Encore at the latest stable version.


### PR DESCRIPTION
This command renders the available log frameworks in a buffer. It shows the log framework name, the website and javadocs urls and the levels for now.

This is mostly to address @vemv's suggestion to ask the user to run `(cider-sync-request:log-frameworks)`. I hooked the command up at the usual places and added it with a small troubleshooting section to the docs.

We could get even more sophisticated and show the current appenders and consumers but I need a user interface designer for this. Let's do this at some other point.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
