### PR TITLE
[Fix #3754] Fix regex in `cider-ns-from-p`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## master (unreleased)
 
 ### Changes
-
+- [#3754](https://github.com/clojure-emacs/cider/issues/3754): Fix regex in `cider-ns-from-p`.
 - [#3753](https://github.com/clojure-emacs/cider/pull/3753): Add `cider-log-show-frameworks` command to show available log frameworks in a buffer.
 - [#3746](https://github.com/clojure-emacs/cider/issues/3746): Bring back `cider` completion style for activating backend-driven completion.
 

--- a/cider-client.el
+++ b/cider-client.el
@@ -108,7 +108,7 @@ EVAL-BUFFER is the buffer where the spinner was started."
 ;;; Evaluation helpers
 (defun cider-ns-form-p (form)
   "Check if FORM is an ns form."
-  (string-match-p "^[[:space:]]*\(ns\\([[:space:]]*$\\|[[:space:]]+\\)" form))
+  (string-match-p "\\`[[:space:]]*\(ns\\([[:space:]]*$\\|[[:space:]]+\\)" form))
 
 (defun cider-ns-from-form (ns-form)
   "Get ns substring from NS-FORM."

--- a/test/cider-client-tests.el
+++ b/test/cider-client-tests.el
@@ -132,6 +132,17 @@
     (expect (cider-ensure-op-supported "foo")
             :to-throw 'user-error)))
 
+(describe "cider-ns-form-p"
+  (it "doesn't match ns in a string"
+      (let ((ns-in-string "\"\n(ns bar)\n\""))
+        (expect (cider-ns-form-p ns-in-string) :to-equal nil)))
+  (it "matches ns"
+      (let ((ns "(ns bar)\n"))
+        (expect (cider-ns-form-p ns) :to-equal 0)))
+  (it "matches ns with leading spaces"
+      (let ((ns "  (ns bar)\n"))
+        (expect (cider-ns-form-p ns) :to-equal 0))))
+
 (describe "cider-expected-ns"
   (before-each
     (spy-on 'cider-connected-p :and-return-value t)


### PR DESCRIPTION
Fix regex in `cider-ns-form-p` so it doesn't match "ns-like" forms inside a string. See #3754 
-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

