### PR TITLE
[inspector] Fix def-current-value selecting wrong REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - [#3742](https://github.com/clojure-emacs/cider/issues/3742): Restore syntax highlighting of result in the minibuffer.
 - [#3747](https://github.com/clojure-emacs/cider/issues/3747): Fix errors when docstring is `nil`.
+- [#3757](https://github.com/clojure-emacs/cider/issues/3757): Fix inspector's def-current-value selecting wrong REPL when multiple are connected.
 
 ## 1.16.0 (2024-09-24)
 

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -388,7 +388,6 @@ current-namespace."
   (interactive (let ((ns (cider-current-ns)))
                  (list (cider-inspector--read-var-name-from-user ns)
                        ns)))
-  (setq cider-inspector--current-repl (cider-current-repl))
   (when-let* ((result (cider-sync-request:inspect-def-current-val ns var-name 'v2)))
     (cider-inspector--render-value result 'v2)
     (message "Defined current inspector value as #'%s/%s" ns var-name)))


### PR DESCRIPTION
Inspector's `cider-inspector-def-current-val` (hotkey `d`) behaves incorrectly if multiple REPLs are connected. It rebinds our carefully managed `cider-inspector--current-repl` with `(cider-current-repl)` which returns whatever in non-file and non-REPL buffers.

Perhaps, this is another reminder to make a generic "we know this buffer is associated with this REPL" variable and account  for it in `(cider-current-repl)`.
