### PR TITLE
Fix: Do not call cider-docstring fns unless we have a doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+- [#3763](https://github.com/clojure-emacs/cider/issues/3763): Fix `cider-docview-render` completion popup error when symbol being completed does not have a docstring.
+
 ## 1.16.1 (2024-12-03)
 
 ### Changes

--- a/cider-doc.el
+++ b/cider-doc.el
@@ -428,10 +428,11 @@ in a COMPACT format is specified, FOR-TOOLTIP if specified."
                                                             "doc-first-sentence-fragments" (nrepl-dict-get info "doc-first-sentence-fragments"))))
          (fetched-doc (nrepl-dict-get info "doc"))
          (doc     (or rendered-fragments
-                      (if compact
-                          (cider-docstring--trim
-                           (cider-docstring--format fetched-doc))
-                        fetched-doc)
+                      (when fetched-doc
+                        (if compact
+                            (cider-docstring--trim
+                             (cider-docstring--format fetched-doc))
+                          fetched-doc))
                       (unless compact
                         "Not documented.")))
          (url     (nrepl-dict-get info "url"))


### PR DESCRIPTION
Sometimes, there is no "doc" attribute in the nrepl-dict. In such cases, `fetched-doc` is nil, which causes `cider-docstring--*` functions to error.

We should only call these functions when we have a docstring to render.

Fixes: #3763

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [-] You've added tests (if possible) to cover your change(s)
- [-] All tests are passing (`eldev test`)
- [-] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [-] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [-] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!