### PR TITLE
[info] Add support for sources JAR downloading on `info' events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Changes
 
 - Bump the injected nREPL version to [1.3.1](https://github.com/nrepl/nrepl/blob/master/CHANGELOG.md#131-2025-01-01).
-- Bump the injected `cider-nrepl` to [0.51.1](https://github.com/clojure-emacs/cider-nrepl/blob/master/CHANGELOG.md#0511-2025-01-03).
+- Bump the injected `cider-nrepl` to [0.52.0](https://github.com/clojure-emacs/cider-nrepl/blob/master/CHANGELOG.md#0520-2025-01-10).
 - [#3574](https://github.com/clojure-emacs/cider/issues/3574): New value `per-project` for `cider-repl-history-file` to save the history on a per-project basis.
 
 ### Bugs fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- Automatic downloading of third-party Java sources for better Java documentation and jump-to-definition functionality. See [Obtaining source JARs](https://docs.cider.mx/cider/usage/working_with_documentation.html#obtaining-source-jars).
 - CIDER [History](https://docs.cider.mx/cider/repl/history.html): Add a command to delete history item at point.
 
 ### Changes

--- a/cider-client.el
+++ b/cider-client.el
@@ -189,16 +189,20 @@ the current connection.  Return the id of the sent message.
 If TOOLING is truthy then the tooling session is used."
   (nrepl-send-request request callback (or connection (cider-current-repl 'any 'ensure)) tooling))
 
-(defun cider-nrepl-send-sync-request (request &optional connection abort-on-input)
+(defun cider-nrepl-send-sync-request (request &optional connection
+                                              abort-on-input callback)
   "Send REQUEST to the nREPL server synchronously using CONNECTION.
 Hold till final \"done\" message has arrived and join all response messages
 of the same \"op\" that came along and return the accumulated response.
 If ABORT-ON-INPUT is non-nil, the function will return nil
 at the first sign of user input, so as not to hang the
-interface."
+interface.
+if CALLBACK is non-nil, it will additionally be called on all received messages."
   (nrepl-send-sync-request request
                            (or connection (cider-current-repl 'any 'ensure))
-                           abort-on-input))
+                           abort-on-input
+                           nil
+                           callback))
 
 (defun cider-nrepl-send-unhandled-request (request &optional connection)
   "Send REQUEST to the nREPL CONNECTION and ignore any responses.
@@ -341,6 +345,17 @@ The default value in nREPL is 1024."
   :type 'integer
   :group 'cider
   :package-version '(cider . "0.25.0"))
+
+(defcustom cider-download-java-sources nil
+  "Whether to automatically download source artifacts for 3rd-party Java classes.
+
+When enabled, CIDER will attempt to download source JARs from Maven for
+Java classes if the source file is not found locally.  This downloading only
+happens once per artifact, and only when the user jumps to definition or
+requests `cider-doc' on a Java class or a member of the class."
+  :type 'boolean
+  :group 'cider
+  :package-version '(cider . "1.17.0"))
 
 (defun cider--print-fn ()
   "Return the value to send in the nrepl.middleware.print/print slot."
@@ -681,13 +696,25 @@ CONTEXT represents a completion context for compliment."
 
 (defun cider-sync-request:info (symbol &optional class member context)
   "Send \"info\" op with parameters SYMBOL or CLASS and MEMBER, honor CONTEXT."
-  (let ((var-info (thread-first `("op" "info"
-                                  "ns" ,(cider-current-ns)
-                                  ,@(when symbol `("sym" ,symbol))
-                                  ,@(when class `("class" ,class))
-                                  ,@(when member `("member" ,member))
-                                  ,@(when context `("context" ,context)))
-                                (cider-nrepl-send-sync-request (cider-current-repl)))))
+  (let* ((req
+          `("op" "info"
+            "ns" ,(cider-current-ns)
+            ,@(when symbol `("sym" ,symbol))
+            ,@(when class `("class" ,class))
+            ,@(when member `("member" ,member))
+            ,@(when context `("context" ,context))
+            ,@(when cider-download-java-sources `("download-sources-jar" "1"))))
+         (callback
+          (lambda (resp)
+            (let ((status (nrepl-dict-get resp "status"))
+                  (coords (nrepl-dict-get resp "coords")))
+              (when (member "download-sources-jar" status)
+                (message "Local source not found, downloading Java sources for artifact %s/%s %s..."
+                         (nrepl-dict-get coords "group")
+                         (nrepl-dict-get coords "artifact")
+                         (nrepl-dict-get coords "version"))))))
+         (var-info
+          (cider-nrepl-send-sync-request req (cider-current-repl) nil callback)))
     (if (member "no-info" (nrepl-dict-get var-info "status"))
         nil
       var-info)))

--- a/cider-docstring.el
+++ b/cider-docstring.el
@@ -157,7 +157,8 @@ that it usually has two spaces before each line used for indentation
 \(see https://guide.clojure.style/#docstring-indentation).  While displaying
 the docstring to the user, we usually want to control indentation and
 other aspects of the presentation, so we format it before displaying."
-  (replace-regexp-in-string "\n  " "\n" string))
+  (when string
+    (replace-regexp-in-string "\n  " "\n" string)))
 
 (provide 'cider-docstring)
 ;;; cider-docstring.el ends here

--- a/cider.el
+++ b/cider.el
@@ -573,7 +573,7 @@ the artifact.")
 
 Used when `cider-jack-in-auto-inject-clojure' is set to `latest'.")
 
-(defconst cider-required-middleware-version "0.51.1"
+(defconst cider-required-middleware-version "0.52.0"
   "The CIDER nREPL version that's known to work properly with CIDER.")
 
 (defcustom cider-injected-middleware-version cider-required-middleware-version

--- a/dev/docker-sample-project/project.clj
+++ b/dev/docker-sample-project/project.clj
@@ -2,4 +2,4 @@
   :dependencies [[org.clojure/clojure "1.11.1"]
                  [clj-http "3.12.3"]]
   :source-paths ["src"]
-  :plugins [[cider/cider-nrepl "0.51.1"]])
+  :plugins [[cider/cider-nrepl "0.52.0"]])

--- a/dev/tramp-sample-project/project.clj
+++ b/dev/tramp-sample-project/project.clj
@@ -2,5 +2,5 @@
   :dependencies [[org.clojure/clojure "1.11.1"]
                  [clj-http "3.12.3"]]
   :source-paths ["src"]
-  :plugins [[cider/cider-nrepl "0.51.1"]
+  :plugins [[cider/cider-nrepl "0.52.0"]
             [refactor-nrepl "3.9.0"]])

--- a/doc/modules/ROOT/pages/basics/middleware_setup.adoc
+++ b/doc/modules/ROOT/pages/basics/middleware_setup.adoc
@@ -32,14 +32,14 @@ Use the convenient plugin for defaults, either in your project's
 
 [source,clojure]
 ----
-:plugins [[cider/cider-nrepl "0.51.1"]]
+:plugins [[cider/cider-nrepl "0.52.0"]]
 ----
 
 A minimal `profiles.clj` for CIDER would be:
 
 [source,clojure]
 ----
-{:repl {:plugins [[cider/cider-nrepl "0.51.1"]]}}
+{:repl {:plugins [[cider/cider-nrepl "0.52.0"]]}}
 ----
 
 WARNING: Be careful not to place this in the `:user` profile, as this way CIDER's
@@ -59,7 +59,7 @@ all of their projects using a `~/.boot/profile.boot` file like so:
 (require 'boot.repl)
 
 (swap! boot.repl/*default-dependencies*
-       concat '[[cider/cider-nrepl "0.51.1"]])
+       concat '[[cider/cider-nrepl "0.52.0"]])
 
 (swap! boot.repl/*default-middleware*
        conj 'cider.nrepl/cider-middleware)
@@ -76,11 +76,11 @@ run `cider-connect` or `cider-connect-cljs`.
 
 [source,clojure]
 ----
-  :cider-clj {:extra-deps {cider/cider-nrepl {:mvn/version "0.51.1"}}
+  :cider-clj {:extra-deps {cider/cider-nrepl {:mvn/version "0.52.0"}}
               :main-opts ["-m" "nrepl.cmdline" "--middleware" "[cider.nrepl/cider-middleware]"]}
 
   :cider-cljs {:extra-deps {org.clojure/clojurescript {:mvn/version "1.10.339"}
-                            cider/cider-nrepl {:mvn/version "0.51.1"}
+                            cider/cider-nrepl {:mvn/version "0.52.0"}
                             cider/piggieback {:mvn/version "0.5.3"}}
                :main-opts ["-m" "nrepl.cmdline" "--middleware"
                            "[cider.nrepl/cider-middleware,cider.piggieback/wrap-cljs-repl]"]}
@@ -99,7 +99,7 @@ NOTE: Make sure you're using https://github.com/clojurephant/clojurephant[Clojur
 ----
 dependencies {
   devImplementation 'nrepl:nrepl:0.9.0'
-  devImplementation 'cider:cider-nrepl:0.51.1'
+  devImplementation 'cider:cider-nrepl:0.52.0'
 }
 
 tasks.named('clojureRepl') {

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -73,7 +73,7 @@ simple - CIDER simply passes the extra dependencies and nREPL configuration to
 your build tool in the command it runs to start the nREPL server. Here's how
 this looks for `tools.deps`:
 
-  $ clojure -Sdeps '{:deps {nrepl {:mvn/version "1.3.1"} cider/cider-nrepl {:mvn/version "0.51.1"}}}' -m nrepl.cmdline --middleware '["cider.nrepl/cider-middleware"]'
+  $ clojure -Sdeps '{:deps {nrepl {:mvn/version "1.3.1"} cider/cider-nrepl {:mvn/version "0.52.0"}}}' -m nrepl.cmdline --middleware '["cider.nrepl/cider-middleware"]'
 
 TIP: If you don't want `cider-jack-in` to inject dependencies automatically, set
 `cider-inject-dependencies-at-jack-in` to `nil`. Note that you'll have to setup
@@ -350,7 +350,7 @@ It is also possible for plain `clj`, although the command is somewhat longer:
 
 [source,sh]
 ----
-$ clj -Sdeps '{:deps {cider/cider-nrepl {:mvn/version "0.51.1"}}}' -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"
+$ clj -Sdeps '{:deps {cider/cider-nrepl {:mvn/version "0.52.0"}}}' -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"
 ----
 
 Alternatively, you can start nREPL either manually or using the facilities

--- a/doc/modules/ROOT/pages/cljs/shadow-cljs.adoc
+++ b/doc/modules/ROOT/pages/cljs/shadow-cljs.adoc
@@ -62,7 +62,7 @@ And connect to it with `cider-connect`.
 ...For that to work, `shadow-cljs.edn` contents like the following are assumed:
 
 ```clj
- :dependencies [[cider/cider-nrepl "0.51.1"] ;; mandatory (unless it's inherited from deps.edn or otherwise present in the classpath of shadow-cljs's JVM process)
+ :dependencies [[cider/cider-nrepl "0.52.0"] ;; mandatory (unless it's inherited from deps.edn or otherwise present in the classpath of shadow-cljs's JVM process)
                 [refactor-nrepl/refactor-nrepl "3.9.0"]] ;; refactor-nrepl is optional
 
  :nrepl {:middleware [cider.nrepl/cider-middleware ;; it's advisable to explicitly add this middleware. It's automatically added by shadow-cljs (if available in the classpath), unless `:nrepl {:cider false}`

--- a/doc/modules/ROOT/pages/cljs/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/cljs/up_and_running.adoc
@@ -61,7 +61,7 @@ or in `build.gradle`:
 ----
 dependencies {
   devImplementation 'nrepl:nrepl:1.3.1'
-  devImplementation 'cider:cider-nrepl:0.51.1'
+  devImplementation 'cider:cider-nrepl:0.52.0'
   devImplementation 'cider:cider-piggieback:0.5.3'
 }
 

--- a/doc/modules/ROOT/pages/usage/working_with_documentation.adoc
+++ b/doc/modules/ROOT/pages/usage/working_with_documentation.adoc
@@ -17,11 +17,21 @@ as some people prefer to keep holding `Control` and some don't.
 
 Normally the command operates on the symbol at point.  If invoked with a prefix argument, or no symbol is found at point, it will prompt for a symbol.
 
-NOTE: If using `enrich-classpath`, Java doc comments are available and rendered in the same way that Clojure docstrings are.
-They're often much more handy than opening Javadoc in a browser. Starting from CIDER 1.8.0,
-the HTML-like language that they use is nicely rendered into syntax-colored strings, well-aligned tables, etc
+== Local JavaDoc
 
-== JavaDoc
+Most JDK distributions ship with a `src.zip` file (an archive with all base Java source files). If you have such archive present in your JDK, CIDER will automatically parse the source file when you query the documentation for a Java class (e.g. `java.lang.Thread`) or a method (e.g. `java.lang.Thread/currentThread`) and will display the properly formatted JavaDoc in the documentation buffer. You will also see better Eldoc documentation (minibuffer hints) for Java methods. If the source file are present, you are able to jump to class or method definition by pressing kbd:[M-.] on the class name or method name.
+
+Furthermore, CIDER is able to parse JavaDoc source files and jump to definitions for third-party Java libraries if you have downloaded the special `-sources.jar` file for that library. See the next section on how to download source JARs.
+
+== Obtaining source JARs
+
+Since version 1.17, CIDER is able to download the necessary source JAR file automatically when you either request the documentation for a Java class/method or when you jump to the definition of a Java class/method. In order for the sources to be downloaded, you need to enable custom variable `cider-download-java-sources`. When the download triggers, CIDER displays a minibuffer message about that. Fetching a single source JAR usually takes a few seconds. CIDER will make only one attempt to download the source JAR for a particular dependency per process — if it failed to download (usually, because the dependency doesn't have a source JAR published to Maven), CIDER will not retry that until the next restart.
+
+NOTE: While Eldoc functionality benefits from having Java sources, the eldoc itself will not trigger the downloading of Java source JARs. You will have to lookup the documentation once manually or jump to the definition in order for the JAR is downloaded. After that, Eldoc will pick up the Java sources and display better hints.
+
+Alternatively, you can use https://github.com/clojure-emacs/enrich-classpath[`enrich-classpath`] to download all source JARs used by your current project at once. This will incur longer startup time, but will not trigger individual JARs fetching at the runtime.
+
+== Online JavaDoc
 
 CIDER provides a quick access to the online Javadoc documentation
 via the command `cider-javadoc` (kbd:[C-c C-d j] or kbd:[C-c C-d C-j]), using your default browser.

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -939,21 +939,30 @@ the standard session."
 (declare-function cider-repl-emit-interactive-stderr "cider-repl")
 (declare-function cider--render-stacktrace-causes "cider-eval")
 
-(defun nrepl-send-sync-request (request connection &optional abort-on-input tooling)
+(defun nrepl-send-sync-request (request connection &optional abort-on-input
+                                        tooling callback)
   "Send REQUEST to the nREPL server synchronously using CONNECTION.
 Hold till final \"done\" message has arrived and join all response messages
 of the same \"op\" that came along.
 If ABORT-ON-INPUT is non-nil, the function will return nil at the first
 sign of user input, so as not to hang the interface.
-If TOOLING, use the tooling session rather than the standard session."
+If TOOLING, use the tooling session rather than the standard session.
+
+If CALLBACK is non-nil, it will additionally be called on all received
+messages. This shouldn't be used this for any control logic — use the
+asynchronous `nrepl-send-request' directly for that. CALLBACK here should
+be used to react to some intermediate events in an otherwise synchronous
+command and e.g. notify the user about them."
   (let* ((time0 (current-time))
          (response (cons 'dict nil))
          (nrepl-ongoing-sync-request t)
+         (cb (lambda (resp)
+               ;; If caller has provided `callback', call it on the response.
+               (when callback
+                 (funcall callback resp))
+               (nrepl--merge response resp)))
          status)
-    (nrepl-send-request request
-                        (lambda (resp) (nrepl--merge response resp))
-                        connection
-                        tooling)
+    (nrepl-send-request request cb connection tooling)
     (while (and (not (member "done" status))
                 (not (and abort-on-input
                           (input-pending-p))))
@@ -962,7 +971,7 @@ If TOOLING, use the tooling session rather than the standard session."
       ;; anywhere, and we'll just timeout. So we forward it to the user.
       (if (member "need-input" status)
           (progn (cider-need-input (current-buffer))
-                 ;; If the used took a few seconds to respond, we might
+                 ;; If the user took a few seconds to respond, we might
                  ;; unnecessarily timeout, so let's reset the timer.
                  (setq time0 (current-time)))
         ;; break out in case we don't receive a response for a while

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -144,7 +144,7 @@
   (describe "when there is a single dependency"
     (before-each
       (setq-local cider-injected-nrepl-version "0.9.0")
-      (setq-local cider-injected-middleware-version "0.51.1")
+      (setq-local cider-injected-middleware-version "0.52.0")
       (setq-local cider-jack-in-nrepl-middlewares '("cider.nrepl/cider-middleware"))
       (setq-local cider-jack-in-dependencies-exclusions '())
       (setq-local cider-enrich-classpath t)
@@ -155,7 +155,7 @@
               :to-equal (concat "update-in :dependencies conj "
                                 (shell-quote-argument "[nrepl/nrepl \"0.9.0\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[cider/cider-nrepl \"0.51.1\"]")
+                                (shell-quote-argument "[cider/cider-nrepl \"0.52.0\"]")
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[mx.cider/lein-enrich-classpath \"1.19.3\"]")
                                 " -- update-in :jvm-opts conj '\"-Djdk.attach.allowAttachSelf\"'"
@@ -169,7 +169,7 @@
                          "update-in :dependencies conj "
                          (shell-quote-argument "[nrepl/nrepl \"0.9.0\" :exclusions [org.clojure/clojure]]")
                          " -- update-in :plugins conj "
-                         (shell-quote-argument "[cider/cider-nrepl \"0.51.1\"]")
+                         (shell-quote-argument "[cider/cider-nrepl \"0.52.0\"]")
                          " -- update-in :plugins conj "
                          (shell-quote-argument "[mx.cider/lein-enrich-classpath \"1.19.3\"]")
                          " -- update-in :jvm-opts conj '\"-Djdk.attach.allowAttachSelf\"'"
@@ -182,7 +182,7 @@
               :to-equal (concat "update-in :dependencies conj "
                                 (shell-quote-argument "[nrepl/nrepl \"0.9.0\" :exclusions [org.clojure/clojure foo.bar/baz]]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[cider/cider-nrepl \"0.51.1\"]")
+                                (shell-quote-argument "[cider/cider-nrepl \"0.52.0\"]")
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[mx.cider/lein-enrich-classpath \"1.19.3\"]")
                                 " -- update-in :jvm-opts conj '\"-Djdk.attach.allowAttachSelf\"'"
@@ -196,7 +196,7 @@
                          " -d "
                          (shell-quote-argument "nrepl/nrepl:0.9.0")
                          " -d "
-                         (shell-quote-argument "cider/cider-nrepl:0.51.1")
+                         (shell-quote-argument "cider/cider-nrepl:0.52.0")
                          " cider.tasks/add-middleware"
                          " -m "
                          (shell-quote-argument "cider.nrepl/cider-middleware")
@@ -206,7 +206,7 @@
       (expect (cider-inject-jack-in-dependencies "--no-daemon" ":clojureRepl" 'gradle)
               :to-equal (concat "--no-daemon "
                                 "-Pjdk.attach.allowAttachSelf "
-                                (shell-quote-argument "-Pdev.clojurephant.jack-in.nrepl=nrepl:nrepl:0.9.0,cider:cider-nrepl:0.51.1")
+                                (shell-quote-argument "-Pdev.clojurephant.jack-in.nrepl=nrepl:nrepl:0.9.0,cider:cider-nrepl:0.52.0")
                                 " :clojureRepl "
                                 (shell-quote-argument "--middleware=cider.nrepl/cider-middleware")))))
 
@@ -223,7 +223,7 @@
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[refactor-nrepl \"2.0.0\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[cider/cider-nrepl \"0.51.1\"]")
+                                (shell-quote-argument "[cider/cider-nrepl \"0.52.0\"]")
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[mx.cider/lein-enrich-classpath \"1.19.3\"]")
                                 " -- update-in :jvm-opts conj '\"-Djdk.attach.allowAttachSelf\"'"
@@ -237,7 +237,7 @@
                                 " -d "
                                 (shell-quote-argument "nrepl/nrepl:0.9.0")
                                 " -d "
-                                (shell-quote-argument "cider/cider-nrepl:0.51.1")
+                                (shell-quote-argument "cider/cider-nrepl:0.52.0")
                                 " -d "
                                 (shell-quote-argument "refactor-nrepl:2.0.0")
                                 " cider.tasks/add-middleware"
@@ -259,7 +259,7 @@
               :to-equal (concat "-o -U update-in :dependencies conj "
                                 (shell-quote-argument "[nrepl/nrepl \"0.9.0\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[cider/cider-nrepl \"0.51.1\"]")
+                                (shell-quote-argument "[cider/cider-nrepl \"0.52.0\"]")
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[mx.cider/lein-enrich-classpath \"1.19.3\"]")
                                 " -- update-in :jvm-opts conj '\"-Djdk.attach.allowAttachSelf\"'"
@@ -271,7 +271,7 @@
                                 " -d "
                                 (shell-quote-argument "nrepl/nrepl:0.9.0")
                                 " -d "
-                                (shell-quote-argument "cider/cider-nrepl:0.51.1")
+                                (shell-quote-argument "cider/cider-nrepl:0.52.0")
                                 " cider.tasks/add-middleware"
                                 " -m "
                                 (shell-quote-argument "cider.nrepl/cider-middleware")
@@ -280,7 +280,7 @@
       (expect (cider-inject-jack-in-dependencies "--no-daemon" ":clojureRepl" 'gradle)
               :to-equal (concat "--no-daemon "
                                 "-Pjdk.attach.allowAttachSelf "
-                                (shell-quote-argument "-Pdev.clojurephant.jack-in.nrepl=nrepl:nrepl:0.9.0,cider:cider-nrepl:0.51.1")
+                                (shell-quote-argument "-Pdev.clojurephant.jack-in.nrepl=nrepl:nrepl:0.9.0,cider:cider-nrepl:0.52.0")
                                 " :clojureRepl "
                                 (shell-quote-argument "--middleware=cider.nrepl/cider-middleware")))))
 
@@ -295,14 +295,14 @@
       (setq-local cider-jack-in-nrepl-middlewares '(("refactor-nrepl.middleware/wrap-refactor" :predicate middlewares-predicate) "cider.nrepl/cider-middleware" ("another/middleware"))))
     (it "includes plugins whose predicates return true"
       (expect (cider-jack-in-normalized-lein-plugins)
-              :to-equal '(("refactor-nrepl" "2.0.0") ("cider/cider-nrepl" "0.51.1"))))
+              :to-equal '(("refactor-nrepl" "2.0.0") ("cider/cider-nrepl" "0.52.0"))))
     (it "includes middlewares whose predicates return true"
       (expect (cider-jack-in-normalized-nrepl-middlewares)
               :to-equal '("refactor-nrepl.middleware/wrap-refactor" "cider.nrepl/cider-middleware" "another/middleware")))
     (it "ignores plugins whose predicates return false"
       (spy-on 'plugins-predicate :and-return-value nil)
       (expect (cider-jack-in-normalized-lein-plugins)
-              :to-equal '(("cider/cider-nrepl" "0.51.1")))
+              :to-equal '(("cider/cider-nrepl" "0.52.0")))
       (spy-on 'middlewares-predicate :and-return-value nil)
       (expect (cider-jack-in-normalized-nrepl-middlewares)
               :to-equal '("cider.nrepl/cider-middleware" "another/middleware")))
@@ -331,7 +331,7 @@
               :and-return-value '("refactor-nrepl.middleware/wrap-refactor" "cider.nrepl/cider-middleware"))
       (spy-on 'cider-jack-in-normalized-lein-plugins
               :and-return-value '(("refactor-nrepl" "2.0.0")
-                                  ("cider/cider-nrepl" "0.51.1")
+                                  ("cider/cider-nrepl" "0.52.0")
                                   ("mx.cider/lein-enrich-classpath" "1.19.3")))
       (setq-local cider-jack-in-dependencies-exclusions '())
       (setq-local cider-enrich-classpath t))
@@ -342,7 +342,7 @@
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[refactor-nrepl \"2.0.0\"]")
                                 " -- update-in :plugins conj "
-                                (shell-quote-argument "[cider/cider-nrepl \"0.51.1\"]")
+                                (shell-quote-argument "[cider/cider-nrepl \"0.52.0\"]")
                                 " -- update-in :plugins conj "
                                 (shell-quote-argument "[mx.cider/lein-enrich-classpath \"1.19.3\"]")
                                 " -- update-in :jvm-opts conj '\"-Djdk.attach.allowAttachSelf\"'"
@@ -361,7 +361,7 @@
                                 " -d "
                                 (shell-quote-argument "nrepl/nrepl:0.9.0")
                                 " -d "
-                                (shell-quote-argument "cider/cider-nrepl:0.51.1")
+                                (shell-quote-argument "cider/cider-nrepl:0.52.0")
                                 " -d "
                                 (shell-quote-argument "refactor-nrepl:2.0.0")
                                 " cider.tasks/add-middleware"
@@ -456,7 +456,7 @@
       (setq-local cider-jack-in-dependencies nil)
       (setq-local cider-jack-in-nrepl-middlewares '("cider.nrepl/cider-middleware"))
       (let ((expected (string-join `("clojure -Sdeps "
-                                     ,(shell-quote-argument "{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} cider/cider-nrepl {:mvn/version \"0.51.1\"}} :aliases {:cider/nrepl {:jvm-opts [\"-Djdk.attach.allowAttachSelf\"], :main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
+                                     ,(shell-quote-argument "{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} cider/cider-nrepl {:mvn/version \"0.52.0\"}} :aliases {:cider/nrepl {:jvm-opts [\"-Djdk.attach.allowAttachSelf\"], :main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
                                      " -M:cider/nrepl")
                                    "")))
         (setq-local cider-allow-jack-in-without-project t)
@@ -471,7 +471,7 @@
 
     (it "allows specifying custom aliases with `cider-clojure-cli-aliases`"
       (let ((expected (string-join `("clojure -Sdeps "
-                                     ,(shell-quote-argument "{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} cider/cider-nrepl {:mvn/version \"0.51.1\"}} :aliases {:cider/nrepl {:jvm-opts [\"-Djdk.attach.allowAttachSelf\"], :main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
+                                     ,(shell-quote-argument "{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} cider/cider-nrepl {:mvn/version \"0.52.0\"}} :aliases {:cider/nrepl {:jvm-opts [\"-Djdk.attach.allowAttachSelf\"], :main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
                                      " -M:dev:test:cider/nrepl")
                                    "")))
         (setq-local cider-jack-in-dependencies nil)
@@ -489,7 +489,7 @@
       (it (format "should remove duplicates, yielding the same result (for %S command invocation)" command)
         ;; repeat the same test for PowerShell too
         (let ((expected (string-join `("-Sdeps "
-                                       ,(cider--shell-quote-argument "{:deps {cider/cider-nrepl {:mvn/version \"0.51.1\"} nrepl/nrepl {:mvn/version \"0.9.0\"}} :aliases {:cider/nrepl {:jvm-opts [\"-Djdk.attach.allowAttachSelf\"], :main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}"
+                                       ,(cider--shell-quote-argument "{:deps {cider/cider-nrepl {:mvn/version \"0.52.0\"} nrepl/nrepl {:mvn/version \"0.9.0\"}} :aliases {:cider/nrepl {:jvm-opts [\"-Djdk.attach.allowAttachSelf\"], :main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}"
                                                                      command)
                                        " -M:dev:test:cider/nrepl")
                                      "")))
@@ -499,7 +499,7 @@
                   :to-equal expected))))
     (it "handles aliases correctly"
       (let ((expected (string-join `("-Sdeps "
-                                     ,(shell-quote-argument "{:deps {cider/cider-nrepl {:mvn/version \"0.51.1\"} nrepl/nrepl {:mvn/version \"0.9.0\"}} :aliases {:cider/nrepl {:jvm-opts [\"-Djdk.attach.allowAttachSelf\"], :main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
+                                     ,(shell-quote-argument "{:deps {cider/cider-nrepl {:mvn/version \"0.52.0\"} nrepl/nrepl {:mvn/version \"0.9.0\"}} :aliases {:cider/nrepl {:jvm-opts [\"-Djdk.attach.allowAttachSelf\"], :main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
                                      " -M:test:cider/nrepl")
                                    ""))
             (deps '(("nrepl/nrepl" "0.9.0"))))
@@ -527,7 +527,7 @@
                     :to-equal expected)))))
     (it "allows for global options"
         (let ((expected (string-join `("-J-Xverify:none -Sdeps "
-                                       ,(shell-quote-argument "{:deps {cider/cider-nrepl {:mvn/version \"0.51.1\"} nrepl/nrepl {:mvn/version \"0.9.0\"}} :aliases {:cider/nrepl {:jvm-opts [\"-Djdk.attach.allowAttachSelf\"], :main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
+                                       ,(shell-quote-argument "{:deps {cider/cider-nrepl {:mvn/version \"0.52.0\"} nrepl/nrepl {:mvn/version \"0.9.0\"}} :aliases {:cider/nrepl {:jvm-opts [\"-Djdk.attach.allowAttachSelf\"], :main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
                                      " -M:test:cider/nrepl")
                                    ""))
             (deps '(("nrepl/nrepl" "0.9.0"))))
@@ -538,7 +538,7 @@
       (setq-local cider-jack-in-dependencies '(("org.clojure/tools.deps" (("git/sha" . "6ae2b6f71773de7549d7f22759e8b09fec27f0d9")
                                                                           ("git/url" . "https://github.com/clojure/tools.deps/")))))
       (let ((expected (string-join `("clojure -Sdeps "
-                                     ,(shell-quote-argument "{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} cider/cider-nrepl {:mvn/version \"0.51.1\"} org.clojure/tools.deps { :git/sha \"6ae2b6f71773de7549d7f22759e8b09fec27f0d9\"  :git/url \"https://github.com/clojure/tools.deps/\" }} :aliases {:cider/nrepl {:jvm-opts [\"-Djdk.attach.allowAttachSelf\"], :main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
+                                     ,(shell-quote-argument "{:deps {nrepl/nrepl {:mvn/version \"0.9.0\"} cider/cider-nrepl {:mvn/version \"0.52.0\"} org.clojure/tools.deps { :git/sha \"6ae2b6f71773de7549d7f22759e8b09fec27f0d9\"  :git/url \"https://github.com/clojure/tools.deps/\" }} :aliases {:cider/nrepl {:jvm-opts [\"-Djdk.attach.allowAttachSelf\"], :main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
                                      " -M:cider/nrepl")
                                    "")))
         (setq-local cider-allow-jack-in-without-project t)


### PR DESCRIPTION
Sister PRs: https://github.com/clojure-emacs/orchard/pull/310, https://github.com/clojure-emacs/cider-nrepl/pull/911.

This is very raw, I need help with the implementation and with the code style and, probably, a test would be helpful.

1. New customizable `cider-download-sources-jars` to turn on/off the whole thing. Disabled for now, maybe enabled by default some time in the future? Gotta see the feedback.
2. I had to modify the core `nrepl-send-sync-request` so that it can optionally accept a callback function to invoke on the received messages. This is because `info` op can now return an interim response `download-sources-jar` telling the client that it performs the downloading right now and it can take a while. The callback allows to react to this and show user a message while the op itself is still synchronous and waits for `done`. The message hint looks like this:
   ```
   Local source not found, downloading Java sources for artifact org.clojure/clojure 1.12.0...
   ```
   I welcome suggestions about the wording.
3. ~Build tool for the project is currently a placeholder. Do we track somewhere which build tool jack-in used to start the REPL? Damn, now that I thought of it, jack-in is not the only way to start the REPL. Perhaps, I need to rethink the approach and try to figure out the current REPL's build tool on the Clojure side, in either cider-nrepl or Orchard.~ Moved build tool discovery to Orchard.

Anyway, I'm showing this for some initial eyeballing.

More questions:
- Is this a good place for `defcustom`? I've selected it quite randomly.
- Any hints on how can I make a test for this? Something similar to what I did in https://github.com/clojure-emacs/orchard/pull/310.
- Which docs should I update?

-----------------

- [ ] You've added tests (if possible) to cover your change(s)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)