### PR TITLE
[overlays] Fix overlay slowness when huge result is displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Bugs fixed
 
 - [#3763](https://github.com/clojure-emacs/cider/issues/3763): Fix `cider-docview-render` completion popup error when symbol being completed does not have a docstring.
+- [#3774](https://github.com/clojure-emacs/cider/issues/3774): Fix overlay hangup when evaluating huge values.
 
 ## 1.16.1 (2024-12-03)
 


### PR DESCRIPTION
Since calling `string-width` on a big string is very slow, displaying a big overlay (that we truncate later anyway) induces an unnecessary delay.

Here, I solve this by checking first for a too big of a result (10000 characters) that we certainly definitely going to truncate.

-----------------

- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)