### PR TITLE
Fix cider-find-keyword for clojure-ts-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 - [#3789](https://github.com/clojure-emacs/cider/issues/3796): Completion: disable client-side sorting (defer to backend-provided candidate order).
 - [#3797](https://github.com/clojure-emacs/cider/issues/3797): Completion: enable `cider-completion-style` by default (this enables richer completion suggestions where candidates don't have to strictly match the prefix).
 
+### Bugs fixed
+
+- `cider-find-keyword` doesn't work with `clojure-ts-mode`.
+
 ## 1.17.1 (2025-02-25)
 
 ### Changes

--- a/cider-find.el
+++ b/cider-find.el
@@ -206,7 +206,7 @@ are disregarded."
             (current-point (point)))
         (while continue
           (setq found (and (search-forward-regexp kw nil 'noerror)
-                           (member 'clojure-keyword-face (text-properties-at (1- (point))))))
+                           (cider-keyword-at-point-p (1- (point)))))
           (setq continue (and (not found)
                               ;; if we haven't moved, there's nothing left to search:
                               (not (equal current-point (point)))))

--- a/cider-util.el
+++ b/cider-util.el
@@ -69,6 +69,10 @@ Setting this to nil removes the fontification restriction."
   "Return non-nil if current buffer is managed by a ClojureC major mode."
   (derived-mode-p 'clojurec-mode 'clojure-ts-clojurec-mode))
 
+(defun cider-clojure-ts-mode-p ()
+  "Return non-nil if current buffer is managed by a Clojure[TS] major mode."
+  (derived-mode-p 'clojure-ts-mode))
+
 (defun cider-util--clojure-buffers ()
   "Return a list of all existing `clojure-mode' buffers."
   (seq-filter
@@ -106,6 +110,18 @@ which nREPL uses for temporary evaluation file names."
 If BUFFER is provided act on that buffer instead."
   (with-current-buffer (or buffer (current-buffer))
     (or (cider-clojurec-major-mode-p))))
+
+(defun cider-keyword-at-point-p (&optional point)
+  "Return non-nil if POINT is in a Clojure keyword.
+
+Take into consideration current major mode."
+  (let ((pos (or point (point))))
+    (if (and (cider-clojure-ts-mode-p)
+             (fboundp 'clojure-ts--keyword-node-p)
+             (fboundp 'treesit-node-parent)
+             (fboundp 'treesit-node-at))
+        (clojure-ts--keyword-node-p (treesit-node-parent (treesit-node-at pos)))
+      (member 'clojure-keyword-face (text-properties-at pos)))))
 
 
 ;;; Thing at point

--- a/test/clojure-ts-mode/cider-find-ts-tests.el
+++ b/test/clojure-ts-mode/cider-find-ts-tests.el
@@ -1,0 +1,88 @@
+;;; cider-find-ts-tests.el ---                       -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025  Roman Rudakov
+
+;; Author: Roman Rudakov <rrudakov@fastmail.com>
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This is part of CIDER
+
+;;; Code:
+
+(require 'buttercup)
+(require 'cider-find)
+
+(describe "cider--find-keyword-loc (TreeSitter)"
+  (it "finds the given keyword, discarding false positives"
+    (with-clojure-ts-buffer "(ns some.ns)
+;; ::foo
+\"::foo\"
+#_::foo
+::foobar
+\"
+::foo
+\"
+::foo
+more
+stuff"
+      (let* ((sample-buffer (current-buffer)))
+        (spy-on 'cider-ensure-connected :and-return-value t)
+        (spy-on 'cider-sync-request:ns-path :and-call-fake (lambda (kw-ns _)
+                                                             kw-ns))
+        (spy-on 'cider-resolve-alias :and-call-fake (lambda (_ns ns-qualifier)
+                                                      ns-qualifier))
+        (spy-on 'cider-find-file :and-call-fake (lambda (kw-ns)
+                                                  (when (equal kw-ns "some.ns")
+                                                    sample-buffer)))
+
+        (nrepl-dbind-response (cider--find-keyword-loc "::some.ns/foo") (dest dest-point)
+          (expect dest-point :to-equal 63)
+          (with-current-buffer dest
+            (goto-char dest-point)
+            ;; important - ensure that we're looking at ::foo and not ::foobar:
+            (expect (cider-symbol-at-point 'look-back) :to-equal "::foo")))
+
+        (nrepl-dbind-response (cider--find-keyword-loc "::foo") (dest dest-point)
+          (expect dest-point :to-equal 63)
+          (with-current-buffer dest
+            (goto-char dest-point)
+            ;; important - ensure that we're looking at ::foo and not ::foobar:
+            (expect (cider-symbol-at-point 'look-back) :to-equal "::foo")))
+
+        (nrepl-dbind-response (cider--find-keyword-loc ":some.ns/foo") (dest dest-point)
+          (expect dest-point :to-equal 63)
+          (with-current-buffer dest
+            (goto-char dest-point)
+            ;; important - ensure that we're looking at ::foo and not ::foobar:
+            (expect (cider-symbol-at-point 'look-back) :to-equal "::foo")))
+
+        (nrepl-dbind-response (cider--find-keyword-loc "::some.ns/bar") (dest dest-point)
+          (expect dest-point :to-equal nil))
+
+        (nrepl-dbind-response (cider--find-keyword-loc ":some.ns/bar") (dest dest-point)
+          (expect dest-point :to-equal nil))
+
+        (expect (cider--find-keyword-loc ":foo") :to-throw 'user-error)
+
+        (nrepl-dbind-response (cider--find-keyword-loc ":unrelated/foo") (dest dest-point)
+          (expect dest-point :to-equal nil))
+
+        (nrepl-dbind-response (cider--find-keyword-loc "::unrelated/foo") (dest dest-point)
+          (expect dest-point :to-equal nil))))))
+
+(provide 'cider-find-ts-tests)
+;;; cider-find-ts-tests.el ends here


### PR DESCRIPTION
Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes. There are warnings, but not because of my changes.
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

Currently `cider-find-keyword` doesn't work with `clojure-ts-mode`, because it relies on `clojure-keyword-face` text property (which is different for keywords for `clojure-ts-mode`). I've introduced a small helper which uses text property for `clojure-mode` and tree sitter based predicate for `clojure-ts-mode`.