### PR TITLE
[Inspector] Reimplement point retention between inspector screen changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 - [#3777](https://github.com/clojure-emacs/cider/issues/3777): Inspector no longer displays parsed Javadoc for Java classes and members.
+- [#3784](https://github.com/clojure-emacs/cider/issues/3784): Inspector: make point less erratic when navigating between inspector screens.
 
 ## 1.17.1 (2025-02-25)
 

--- a/cider-debug.el
+++ b/cider-debug.el
@@ -683,7 +683,7 @@ needed.  It is expected to contain at least \"key\", \"input-type\", and
              (setq cider--debug-mode-response response)
              (cider--debug-mode 1)))
           (when inspect
-            (cider-inspector--render-value inspect)))
+            (cider-inspector--render-value inspect :next-inspectable)))
       ;; If something goes wrong, we send a "quit" or the session hangs.
       (error (cider-debug-mode-send-reply ":quit" key)
              (message "Error encountered while handling the debug message: %S" e)))))

--- a/cider-debug.el
+++ b/cider-debug.el
@@ -683,7 +683,6 @@ needed.  It is expected to contain at least \"key\", \"input-type\", and
              (setq cider--debug-mode-response response)
              (cider--debug-mode 1)))
           (when inspect
-            (setq cider-inspector--current-repl (cider-current-repl))
             (cider-inspector--render-value inspect)))
       ;; If something goes wrong, we send a "quit" or the session hangs.
       (error (cider-debug-mode-send-reply ":quit" key)


### PR DESCRIPTION
Two changes here:

1. I extracted the mechanism of binding a specific REPL connection to an inspector buffer into a separate variable in `cider-connection.el` and taught `(cider-current-repl)` to recognize it. In the future, other ancillary buffers (e.g. `*cider-error*`) will use this variable too instead of re-implementing this locally.
2. The current approach to remembering point location between screen changes in the inspector is not realiable. For example, it uses a single stack when navigating to prev/next page where ideally it should be a stack of stacks. As a result, the point jumps quite chaotically when using the inspector. I simplified the approach – now, there is only one stack for inspector push/pop operations. For other operations (prev/next page, siblings, non-updating operations), the point is kept in the same place where it is now. In operations that completely re-render the inspector, the point is "reset" to the first inspectable object. 

-----------------

- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)