### PR TITLE
Always use plists to represent nrepl requests

### DIFF
--- a/cider-debug.el
+++ b/cider-debug.el
@@ -143,11 +143,8 @@ configure `cider-debug-prompt' instead."
 (defun cider--debug-init-connection ()
   "Initialize a connection with the cider.debug middleware."
   (cider-nrepl-send-request
-   (thread-last
-     (map-merge 'list
-                '(("op" "init-debugger"))
-                (cider--nrepl-print-request-map fill-column))
-     (seq-mapcat #'identity))
+   `("op" "init-debugger"
+     ,@(cider--nrepl-print-request-plist fill-column))
    #'cider--debug-response-handler))
 
 

--- a/cider-log.el
+++ b/cider-log.el
@@ -282,13 +282,11 @@ It will not be used if the package hasn't been installed."
   "Format the log EVENT from the APPENDER of the log FRAMEWORK."
   (cider-ensure-op-supported "cider/log-format-event")
   (thread-first
-    (seq-mapcat #'identity
-                (map-merge 'list
-                           (cider--nrepl-print-request-map fill-column)
-                           `(("op" "cider/log-format-event")
-                             ("framework" ,(cider-log-framework-id framework))
-                             ("appender" ,(cider-log-appender-id appender))
-                             ("event" ,(cider-log-event-id event)))))
+    `("op" "cider/log-format-event"
+      "framework" ,(cider-log-framework-id framework)
+      "appender" ,(cider-log-appender-id appender)
+      "event" ,(cider-log-event-id event)
+      ,@(cider--nrepl-print-request-plist fill-column))
     (cider-nrepl-send-sync-request)
     (nrepl-dict-get "cider/log-format-event")))
 

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -290,9 +290,8 @@ Run CALLBACK once the evaluation is complete."
   "Evaluate `cider-repl-init-code' in the current REPL.
 Run CALLBACK once the evaluation is complete."
   (interactive)
-  (let* ((request (map-merge 'hash-table
-                             (cider--repl-request-map fill-column)
-                             '(("inhibit-cider-middleware" "true")))))
+  (let* ((request `(,@(cider--repl-request-plist)
+                    "inhibit-cider-middleware" "true")))
     (cider-nrepl-request:eval
      ;; Ensure we evaluate _something_ so the initial namespace is correctly set
      (thread-first (or cider-repl-init-code '("nil"))
@@ -301,10 +300,7 @@ Run CALLBACK once the evaluation is complete."
      nil
      (line-number-at-pos (point))
      (cider-column-number-at-pos (point))
-     (thread-last
-       request
-       (map-pairs)
-       (seq-mapcat #'identity)))))
+     request)))
 
 (defun cider-repl-init (buffer &optional callback)
   "Initialize the REPL in BUFFER.
@@ -1083,15 +1079,13 @@ and responding to them.")
      (lambda (buffer warning)
        (cider-repl-emit-stderr buffer warning)))))
 
-(defun cider--repl-request-map (right-margin)
-  "Map to be merged into REPL eval requests.
-RIGHT-MARGIN is as in `cider--nrepl-print-request-map'."
-  (map-merge 'hash-table
-             (cider--nrepl-print-request-map right-margin)
-             (unless cider-repl-use-pretty-printing
-               '(("nrepl.middleware.print/print" "cider.nrepl.pprint/pr")))
-             (when cider-repl-use-content-types
-               (cider--nrepl-content-type-map))))
+(defun cider--repl-request-plist ()
+  "Plist to be merged into REPL eval requests."
+  `(,@(cider--nrepl-print-request-plist fill-column)
+    ,@(unless cider-repl-use-pretty-printing
+        `("nrepl.middleware.print/print" "cider.nrepl.pprint/pr"))
+    ,@(when cider-repl-use-content-types
+        `("content-type" "true"))))
 
 (defun cider-repl--send-input (&optional newline)
   "Go to the end of the input and send the current input.
@@ -1132,10 +1126,7 @@ If NEWLINE is true then add a newline at the end of the input."
          (cider-current-ns)
          (line-number-at-pos input-start)
          (cider-column-number-at-pos input-start)
-         (thread-last
-           (cider--repl-request-map fill-column)
-           (map-pairs)
-           (seq-mapcat #'identity)))))))
+         (cider--repl-request-plist))))))
 
 (defun cider-repl-return (&optional end-of-input)
   "Evaluate the current input string, or insert a newline.

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -931,14 +931,6 @@ through the `cider-stacktrace-suppressed-errors' variable."
   "Return the Cider NREPL op to analyze STACKTRACE."
   (list "op" "analyze-stacktrace" "stacktrace" stacktrace))
 
-(defun cider-stacktrace--stacktrace-request (stacktrace)
-  "Return the Cider NREPL request to analyze STACKTRACE."
-  (thread-last
-    (map-merge 'list
-               (list (cider-stacktrace--analyze-stacktrace-op stacktrace))
-               (cider--nrepl-print-request-map fill-column))
-    (seq-mapcat #'identity)))
-
 (defun cider-stacktrace--analyze-render (causes)
   "Render the CAUSES of the stacktrace analysis result."
   (let ((buffer (get-buffer-create cider-error-buffer)))
@@ -953,7 +945,9 @@ through the `cider-stacktrace-suppressed-errors' variable."
     (set-text-properties 0 (length stacktrace) nil stacktrace))
   (let (causes)
     (cider-nrepl-send-request
-     (cider-stacktrace--stacktrace-request stacktrace)
+     `("op" "analyze-stacktrace"
+       "stacktrace" ,stacktrace
+       ,@(cider--nrepl-print-request-plist fill-column))
      (lambda (response)
        (setq causes (nrepl-dbind-response response (class status)
                       (cond (class (cons response causes))

--- a/cider-test.el
+++ b/cider-test.el
@@ -272,14 +272,11 @@ prompt and whether to use a new window.  Similar to `cider-find-var'."
   "Display stacktrace for the erring NS VAR test with the assertion INDEX."
   (let (causes)
     (cider-nrepl-send-request
-     (thread-last
-       (map-merge 'list
-                  `(("op" "test-stacktrace")
-                    ("ns" ,ns)
-                    ("var" ,var)
-                    ("index" ,index))
-                  (cider--nrepl-print-request-map fill-column))
-       (seq-mapcat #'identity))
+     `("op" "test-stacktrace"
+       "ns" ,ns
+       "var" ,var
+       "index" ,index
+       ,@(cider--nrepl-print-request-plist fill-column))
      (lambda (response)
        (nrepl-dbind-response response (class status)
          (cond (class  (setq causes (cons response causes)))

--- a/nrepl-dict.el
+++ b/nrepl-dict.el
@@ -174,6 +174,16 @@ FUNCTION should be a function taking two arguments, key and value."
             (cons obj (car stack)))
           (cdr stack))))
 
+(defun nrepl--alist-to-plist (maybe-alist)
+  "Transform MAYBE-ALIST into a plist if it is an alist.
+Compatibility function for functions that used to accepts nrepl request
+options as alists.  A warning will be printed if alist is received."
+  (let ((first-arg (car-safe maybe-alist)))
+    (if (or (null first-arg) (not (listp first-arg)))
+        maybe-alist ;; It is a plist - don't have to convert
+      (warn "Received alist where it should have been plist: %s" maybe-alist)
+      (seq-mapcat #'identity maybe-alist))))
+
 (defun nrepl--merge (dict1 dict2 &optional no-join)
   "Join nREPL dicts DICT1 and DICT2 in a meaningful way.
 String values for non \"id\" and \"session\" keys are concatenated. Lists


### PR DESCRIPTION
This PR tries to unify forming requests to nREPL to always use plists. Plists are what is expected by lower level functions already. This PR fixes existing callsites in "private" API. In one public function, `cider-interactive-eval`, a backward compatibility transformer is added to handle alist->plist conversion.