### PR TITLE
[stacktrace] Visual improvements, expand causes by 1 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#3782](https://github.com/clojure-emacs/cider/issues/3782): **(Breaking)** Drop official support for Emacs 26.
 - [#3777](https://github.com/clojure-emacs/cider/issues/3777): Inspector no longer displays parsed Javadoc for Java classes and members.
 - [#3784](https://github.com/clojure-emacs/cider/issues/3784): Inspector: make point less erratic when navigating between inspector screens.
+- [#3790](https://github.com/clojure-emacs/cider/issues/3790): Stacktrace: show messages and data for all exception causes by default.
 
 ## 1.17.1 (2025-02-25)
 


### PR DESCRIPTION
This is a much smaller fish to fry while we are working on #3789.

Two things here: 

- I've improved some spacing for cases when a cause is partially expanded with data vs with no data.
- I made the "level 1" visibility the default for all clauses. Level 1 is where we show exception message and data. Level 0 is when we only show exception class. I don't think make sense to hide the message for nested causes. We even had complaints in the past where users missed the nesting part completely because of that.

### Before

Example code: `(throw (RuntimeException. "shrug" (ex-info "Foo" {:a 1} (ex-info "bar" {:a 2}))))`

<img width="799" alt="image" src="https://github.com/user-attachments/assets/5232dd0f-1116-473b-918f-afd12e29394e" />
^ Causes 2 and 3 are completely collapsed by default.

<img width="792" alt="image" src="https://github.com/user-attachments/assets/984b008a-d4e3-40f5-87b2-5e6d0a254e92" />
^ When level-1 expanded, the cause with data is missing an empty line between the next cause.

### After

<img width="821" alt="image" src="https://github.com/user-attachments/assets/8d64ed9c-fd6e-4206-a0ff-e1002f1cfae5" />
^ Message and data is visible by default for all causes. Empty line is present everywhere.

-----------------

- [x] You've updated the [changelog](../blob/master/CHANGELOG.md)