### PR TITLE
ci: Use only one setup-emacs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,14 +39,7 @@ jobs:
 
     steps:
     - name: Set up Emacs
-      if: "!startsWith (matrix.os, 'windows')"
-      uses: purcell/setup-emacs@master
-      with:
-        version: ${{matrix.emacs_version}}
-
-    - name: Set up Emacs on Windows
-      if: startsWith (matrix.os, 'windows')
-      uses: jcs090218/setup-emacs-windows@master
+      uses: jcs090218/setup-emacs@master
       with:
         version: ${{matrix.emacs_version}}
 


### PR DESCRIPTION
We only need `jcs090218/setup-emacs` since it supports all three platforms. See https://emacs-eldev.github.io/eldev/#continuous-integration.