### PR TITLE
Remove obsolete variables from before 1.0

### DIFF
--- a/cider-client.el
+++ b/cider-client.el
@@ -321,9 +321,6 @@ Here's an example for `pprint':
   :group 'cider
   :package-version '(cider . "0.21.0"))
 
-(make-obsolete-variable 'cider-pprint-fn 'cider-print-fn "0.21")
-(make-obsolete-variable 'cider-pprint-options 'cider-print-options "0.21")
-
 (defcustom cider-print-quota (* 1024 1024)
   "A hard limit on the number of bytes to return from any printing operation.
 Set to nil for no limit."

--- a/cider-debug.el
+++ b/cider-debug.el
@@ -97,10 +97,6 @@ configure `cider-debug-prompt' instead."
                  (const :tag "Both" both))
   :package-version '(cider . "0.9.1"))
 
-(make-obsolete 'cider-debug-print-length 'cider-debug-print-options "0.20")
-(make-obsolete 'cider-debug-print-level 'cider-debug-print-options "0.20")
-(make-obsolete-variable 'cider-debug-print-options 'cider-print-options "0.21")
-
 
 ;;; Implementation
 (declare-function cider-browse-ns--combined-vars-with-meta "cider-browse-ns")

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -95,16 +95,12 @@ focused.  Otherwise the buffer is displayed and focused."
   "Controls whether the REPL buffer is displayed in the current window."
   :type 'boolean)
 
-(make-obsolete-variable 'cider-repl-scroll-on-output 'scroll-conservatively "0.21")
-
 (defcustom cider-repl-use-pretty-printing t
   "Control whether results in the REPL are pretty-printed or not.
 The REPL will use the printer specified in `cider-print-fn'.
 The `cider-toggle-pretty-printing' command can be used to interactively
 change the setting's value."
   :type 'boolean)
-
-(make-obsolete-variable 'cider-repl-pretty-print-width 'cider-print-options "0.21")
 
 (defcustom cider-repl-use-content-types nil
   "Control whether REPL results are presented using content-type information.
@@ -148,9 +144,6 @@ The default option is `cider-repl-indent-and-complete-symbol'.  If
 you'd like to use the default Emacs behavior use
 `indent-for-tab-command'."
   :type 'symbol)
-
-(make-obsolete-variable 'cider-repl-print-length 'cider-print-options "0.21")
-(make-obsolete-variable 'cider-repl-print-level 'cider-print-options "0.21")
 
 (defvar cider-repl-require-repl-utils-code
   '((clj . "(when-let [requires (resolve 'clojure.main/repl-requires)]

--- a/cider-stacktrace.el
+++ b/cider-stacktrace.el
@@ -62,10 +62,6 @@ Pick nil if you prefer the same window as *cider-error*."
   :type 'boolean
   :package-version '(cider . "1.8.0"))
 
-(make-obsolete 'cider-stacktrace-print-length 'cider-stacktrace-print-options "0.20")
-(make-obsolete 'cider-stacktrace-print-level 'cider-stacktrace-print-options "0.20")
-(make-obsolete-variable 'cider-stacktrace-print-options 'cider-print-options "0.21")
-
 (defvar cider-stacktrace-detail-max 2
   "The maximum detail level for causes.")
 
@@ -75,8 +71,6 @@ Pick nil if you prefer the same window as *cider-error*."
 (defvar-local cider-stacktrace-positive-filters nil)
 
 (defconst cider-error-buffer "*cider-error*")
-
-(make-obsolete 'cider-visit-error-buffer 'cider-selector "0.18")
 
 (defcustom cider-stacktrace-suppressed-errors '()
   "Errors that won't make the stacktrace buffer 'pop-over' your active window.

--- a/nrepl-client.el
+++ b/nrepl-client.el
@@ -86,19 +86,6 @@
   :prefix "nrepl-"
   :group 'applications)
 
-;; (defcustom nrepl-buffer-name-separator " "
-;;   "Used in constructing the REPL buffer name.
-;; The `nrepl-buffer-name-separator' separates cider-repl from the project name."
-;;   :type '(string)
-;;   :group 'nrepl)
-(make-obsolete-variable 'nrepl-buffer-name-separator 'cider-session-name-template "0.18")
-
-;; (defcustom nrepl-buffer-name-show-port nil
-;;   "Show the connection port in the nrepl REPL buffer name, if set to t."
-;;   :type 'boolean
-;;   :group 'nrepl)
-(make-obsolete-variable 'nrepl-buffer-name-show-port 'cider-session-name-template "0.18")
-
 (defcustom nrepl-connected-hook nil
   "List of functions to call when connecting to the nREPL server."
   :type 'hook)
@@ -1510,8 +1497,6 @@ The default buffer name is *nrepl-error*."
     (when-let* ((win (get-buffer-window)))
       (set-window-point win (point-max)))
     (setq buffer-read-only t)))
-
-(make-obsolete 'nrepl-default-client-buffer-builder nil "0.18")
 
 (provide 'nrepl-client)
 


### PR DESCRIPTION
All the removed obsolete variables were marked as such back in 2018-2019. I think it's OK to let them go at last.