### PR TITLE
Fix font lock error for clojure-ts-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,9 @@
 
 ### Bugs fixed
 
-- `cider-find-keyword` doesn't work with `clojure-ts-mode`.
+- [#3779](https://github.com/clojure-emacs/cider/pull/3779): `cider-find-keyword` doesn't work with `clojure-ts-mode`.
+- [#3791](https://github.com/clojure-emacs/cider/issues/3791): Missing font lock when `cider-font-lock-dynamically` is enabled
+  for `clojure-ts-mode`.
 
 ## 1.17.1 (2025-02-25)
 

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -982,7 +982,12 @@ before point."
                       (not (eq (char-after) ?\()))
                   (condition-case nil
                       (progn (backward-up-list) t)
-                    (scan-error nil))))
+                    (scan-error nil)
+                    ;; In `clojure-ts-mode', when `backward-up-list' is used,
+                    ;; `user-error' is signaled instead of `scan-error' because
+                    ;; the operation is delegated to the `treesit-up-list'
+                    ;; function.
+                    (user-error nil))))
       (setq beg (min beg (point)))
       ;; If there are locals above the current sexp, reapply them to the
       ;; current sexp.


### PR DESCRIPTION
In `clojure-ts-mode` `up-list` delegates it's job to `treesit-up-list`, which signals `user-error` when the top level is reached.

Close #3791 

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
