### PR TITLE
Add command to print the current value of the inspector.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- [#3810](https://github.com/clojure-emacs/cider/pull/3810): Add the `cider-inspector-print-current-value` command to print the current value of the inspector.
 - [#3813](https://github.com/clojure-emacs/cider/pull/3813) Add support for pretty printing values in the inspector.
 - [#3802](https://github.com/clojure-emacs/cider/issues/3802): Inspector analytics.
 - [#3802](https://github.com/clojure-emacs/cider/issues/3802): Inspector table view-mode.

--- a/doc/modules/ROOT/pages/debugging/inspector.adoc
+++ b/doc/modules/ROOT/pages/debugging/inspector.adoc
@@ -89,6 +89,10 @@ You'll have access to additional keybindings in the inspector buffer
 | `cider-inspector-def-current-val`
 | Defines a var in the REPL namespace with current inspector value. If you tend to always choose the same name(s), you may want to set the `cider-inspector-preferred-var-names` customization option.
 
+| kbd:[C-c C-p]
+| `cider-inspector-print-current-value`
+| Print the current value of the inspector to the `cider-result-buffer`.
+
 | kbd:[9]
 | `cider-inspector-previous-sibling`
 | Navigates to the previous sibling, within a sequential collection.


### PR DESCRIPTION
This PR adds the interactive `cider-inspector-print-current-value` command that prints the current value of the inspector to the `cider-inspector-value-buffer` with the usual pretty printing machinery.

The NREPL part is here: https://github.com/clojure-emacs/cider-nrepl/pull/933

When pressing "P" in the inspector the currently inspected value is printed in a new popup buffer (on the left side in the picture).

![cider-inspect-print-current-value](https://github.com/user-attachments/assets/052d1a82-86d5-4423-8701-144d22dcb4fd)

I see it as the inspectors brother of `cider-pprint-eval-last-sexp` which I use all the time.

This is the functionality I initially suggested, before working on the pretty mode. I think it is still useful. What I would like to have is a quick way to pretty print the current value of the inspector in the same familiar way my eye is used to, as the Clojure pretty printer (or what we are using in CIDER). 

The new pretty mode does print more pretty, but differently, it uses "inspector mode" printing.

That's why I think this could be a useful addition. 

Wdyt?

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
