### PR TITLE
Add support for pretty printing values in the inspector.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- [#3813](https://github.com/clojure-emacs/cider/pull/3813) Add support for pretty printing values in the inspector.
 - [#3802](https://github.com/clojure-emacs/cider/issues/3802): Inspector analytics.
 - [#3802](https://github.com/clojure-emacs/cider/issues/3802): Inspector table view-mode.
 - [orchard#320](https://github.com/clojure-emacs/orchard/pull/320): Info: recognize printed Java classes/methods and munged Clojure functions in stacktrace outputs.

--- a/cider-inspector.el
+++ b/cider-inspector.el
@@ -78,6 +78,11 @@ The max depth can be also changed interactively within the inspector."
   :type 'boolean
   :package-version '(cider . "0.15.0"))
 
+(defcustom cider-inspector-pretty-print nil
+  "When true, pretty print values in the inspector."
+  :type 'boolean
+  :package-version '(cider . "1.18.0"))
+
 (defcustom cider-inspector-skip-uninteresting t
   "Controls whether to skip over uninteresting values in the inspector.
 Only applies to navigation with `cider-inspector-prev-inspectable-object'
@@ -140,6 +145,7 @@ Can be turned to nil once the user sees and acknowledges the feature."
     (define-key map "n" #'cider-inspector-next-inspectable-object)
     (define-key map [(shift tab)] #'cider-inspector-previous-inspectable-object)
     (define-key map "p" #'cider-inspector-previous-inspectable-object)
+    (define-key map "P" #'cider-inspector-toggle-pretty-print)
     (define-key map ":" #'cider-inspect-expr-from-inspector)
     (define-key map "f" #'forward-char)
     (define-key map "b" #'backward-char)
@@ -349,6 +355,15 @@ MAX-NESTED-DEPTH is the new value."
     (when (nrepl-dict-get result "value")
       (cider-inspector--render-value result :next-inspectable))))
 
+(defun cider-inspector-toggle-pretty-print ()
+  "Toggle the pretty printing of values in the inspector."
+  (interactive)
+  (let ((result (cider-nrepl-send-sync-request
+                 `("op" "inspect-toggle-pretty-print")
+                 (cider-current-repl))))
+    (when (nrepl-dict-get result "value")
+      (cider-inspector--render-value result))))
+
 (defun cider-inspector-toggle-view-mode ()
   "Toggle the view mode of the inspector between normal and object view mode."
   (interactive)
@@ -508,7 +523,9 @@ MAX-COLL-SIZE if non nil."
               ,@(when cider-inspector-max-nested-depth
                   `("max-nested-depth" ,cider-inspector-max-nested-depth))
               ,@(when cider-inspector-display-analytics-hint
-                  `("display-analytics-hint" "true"))))
+                  `("display-analytics-hint" "true"))
+              ,@(when cider-inspector-pretty-print
+                  `("pretty-print" "true"))))
     (cider-nrepl-send-sync-request (cider-current-repl))))
 
 (declare-function cider-set-buffer-ns "cider-mode")

--- a/doc/modules/ROOT/pages/debugging/inspector.adoc
+++ b/doc/modules/ROOT/pages/debugging/inspector.adoc
@@ -81,6 +81,10 @@ You'll have access to additional keybindings in the inspector buffer
 | Switch the rendering of the current value between `:normal`, `:table`, and
   `:object` view modes. In `:table` mode, render the value as a table  (only supported for sequences of maps or tuples). In `:object` mode, any value is rendered as a plain Java object (by displaying its fields) instead of custom rendering rules that the Inspector applies in `:normal` mode.
 
+| kbd:[P]
+| `cider-inspector-toggle-pretty-print`
+| Toggle the pretty printing of values in the inspector. You can set the `cider-inspector-pretty-print` customization option to `t`, if you always want values to be be pretty printed.
+
 | kbd:[d]
 | `cider-inspector-def-current-val`
 | Defines a var in the REPL namespace with current inspector value. If you tend to always choose the same name(s), you may want to set the `cider-inspector-preferred-var-names` customization option.
@@ -129,6 +133,10 @@ listed in the table above.
 
 If you enable `cider-inspector-fill-frame`, the inspector window fills its
 frame.
+
+You can toggle the pretty printing of values in the inspector with
+kbd:[P] and customize their initial presentation by adjusting the
+`cider-inspector-pretty-print` customization option.
 
 When you define a var using kbd:[d], a var name can be suggested (default none).
 You can customize this value via the `cider-inspector-preferred-var-names`


### PR DESCRIPTION
This is the CIDER part of pretty printing values in the Inspector. The changes to Orchard and cider-nrepl are here:
- https://github.com/clojure-emacs/orchard/pull/335
- https://github.com/clojure-emacs/cider-nrepl/pull/932

You can now toggle the pretty printing of values in the inspector with the `P` key and customize their initial presentation by adjusting the `cider-inspector-pretty-print` customization option.

The data structure shown on the following pictures was this:

```
{{:a 0
  :bb "000"
  :ccc []
  :d [{:a 0 :bb "000" :ccc []}
      {:a -1 :bb "111" :ccc [1]}
      {:a -2 :bb "222" :ccc [2 1]}
      {:a -3 :bb "333" :ccc [3 2 1]}
      {:a -4 :bb "444" :ccc [4 3 2 1]}]}
 {:a -1
  :bb "111"
  :ccc [1]
  :d [{:a 0 :bb "000" :ccc []}
      {:a -1 :bb "111" :ccc [1]}
      {:a -2 :bb "222" :ccc [2 1]}
      {:a -3 :bb "333" :ccc [3 2 1]}
      {:a -4 :bb "444" :ccc [4 3 2 1]}]}}
```

Without pretty printing enabled (as before):

![map-normal-mode](https://github.com/user-attachments/assets/7c97ab7d-bbf6-4649-b343-8f1828687253)

With pretty printing enabled (in normal mode):

![pprint-normal-mode](https://github.com/user-attachments/assets/3857658d-f5fc-44fb-b402-0cf1c93f986a)

With pretty printing enabled (in object mode):

![pprint-object-mode](https://github.com/user-attachments/assets/c519ba2c-82b3-43ec-8022-26ba32db6ec0)

-----------------

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
