### PR TITLE
[Fix: #3786] Sort dictionaries by key in nrepl-bencode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 ### Bugs fixed
 
 - [#3784](https://github.com/clojure-emacs/cider/issues/3784): Inspector: make point less erratic when navigating between inspector screens.
+- [#3786](https://github.com/clojure-emacs/cider/issues/3786): Sort dictionaries by key in nrepl-bencode
 
 ### Bugs fixed
 

--- a/nrepl-dict.el
+++ b/nrepl-dict.el
@@ -37,7 +37,9 @@
 
 (defun nrepl-dict (&rest key-vals)
   "Create nREPL dict from KEY-VALS."
-  (cons 'dict key-vals))
+  (if (cl-evenp (length key-vals))
+      (cons 'dict key-vals)
+    (error "An even number of KEY-VALS is needed to build a dict object")))
 
 (defun nrepl-dict-from-hash (hash)
   "Create nREPL dict from HASH."

--- a/test/nrepl-bencode-tests.el
+++ b/test/nrepl-bencode-tests.el
@@ -327,10 +327,48 @@ If object is incomplete, return a decoded path."
                   "int" 1
                   "int-list" (1 2 3 4 5)
                   "string" "f30dbd69-7095-40c1-8e98-7873ae71a07f"
-                  "dict" (dict "k1" 1 "k2" 2 "k3" "333333")
+                  "unordered-dict" (dict "k3" "333333" "k2" 2 "k1" 1)
                   "status" ("eval-error")))
-      (expect (car (nrepl-bdecode-string (nrepl-bencode obj)))
-              :to-equal obj))))
+      ;; Bencoded dicts may change the order of the keys of original
+      ;; dict, as bencoding a dict MUST encode the keys in sorted
+      ;; order.  We need to compare objects taking this into account.
+      (expect (bencodable-obj-equal?
+               obj
+               (car (nrepl-bdecode-string (nrepl-bencode obj))))
+              :to-be t))))
+
+(describe "nrepl--bencode"
+  (it "encodes strings"
+    (expect (nrepl-bencode "spam") :to-equal "4:spam")
+    (expect (nrepl-bencode "") :to-equal "0:")
+    ;; Assuming we use UTF-8 encoded strings, which
+    ;; Clojure/Clojurescript do.
+    (expect (nrepl-bencode "Божидар") :to-equal "14:Божидар"))
+
+  (it "encodes integers"
+    (expect (nrepl-bencode 3) :to-equal "i3e")
+    (expect (nrepl-bencode -3) :to-equal "i-3e"))
+
+  (it "encodes lists"
+    (expect (nrepl-bencode '("spam" "eggs"))
+            :to-equal "l4:spam4:eggse")
+    (expect (nrepl-bencode '("spam" ("eggs" "salt")))
+            :to-equal "l4:spaml4:eggs4:saltee")
+    (expect (nrepl-bencode '(1 2 3 (4 5 (6)) 7 8))
+            :to-equal "li1ei2ei3eli4ei5eli6eeei7ei8ee"))
+
+  (it "encodes dicts"
+    (expect (nrepl-bencode '(dict "spam" "eggs" "cow" "moo"))
+            :to-equal "d3:cow3:moo4:spam4:eggse")
+    (expect (nrepl-bencode '(dict "spam" "eggs"
+                                  "cow" (dict "foo" "foobar" "bar" "baz")))
+            :to-equal "d3:cowd3:bar3:baz3:foo6:foobare4:spam4:eggse"))
+
+  (it "handles nils"
+    (expect (nrepl-bencode '("" nil (dict "" nil)))
+            :to-equal "l0:led0:leee")
+    (expect (nrepl-bencode '("" nil (dict "cow" nil "" 6)))
+            :to-equal "l0:led0:i6e3:cowleee")))
 
 ;; benchmarks
 


### PR DESCRIPTION
CIDER doesn't adhere to Bencode spec which requires dictionary keys to be sorted alphabetically. This hasn't been a problem so far because the bencode reader on nREPL side doesn't validate the order of keys. Still, it will be rigorous to produce correct values according to the selected format.

[Re: #3786]

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [X] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
