### PR TITLE
save-mark-and-excursion that nasty call to check-parens

### DIFF
--- a/cider-completion-context.el
+++ b/cider-completion-context.el
@@ -51,7 +51,7 @@
 Note that this context is slightly different than that of
 `cider-completion-get-context-at-point': this one does not include
 the current symbol at point."
-  (when (save-excursion
+  (when (save-mark-and-excursion
           (condition-case _
               (progn
                 (up-list)
@@ -78,7 +78,7 @@ the current symbol at point."
   "Extract the context at point.
 If point is not inside the list, returns nil; otherwise return \"top-level\"
 form, with symbol at point replaced by __prefix__."
-  (when (save-excursion
+  (when (save-mark-and-excursion
           (condition-case _
               (progn
                 (up-list)


### PR DESCRIPTION
nasty (check-parens)
it mess up marks selection in my idiosyncratic config of emacs

i.e when activating a mark, then moving around, and suddenly `cider-completion-get-info-context-at-point' get triggered by a timer, and mess-up my desired mark-region by another mark-region created from a mix of my starting point of activating mark and then end point of `check-parens'


So I put it in (save-mark-and-excursion) instead of only (save-excursion)

The only one that was messing with my usage was in "cider-completion-get-info-context-at-point" 

but who knows, maybe "cider-completion-get-context-at-point" also mess someone's emacs usage

So to be safe, did it to both, also because kinda hard to pinpoint the issue from a user perspective with an emacs loaded full of so many modes & customization, because its triggered by a timer...

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!