### PR TITLE
Add command to pprint-eval-and-replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New features
 
+- [#3822](https://github.com/clojure-emacs/cider/issues/3822): Add `cider-pprint-eval-last-sexp-and-replace` interactive command.
+
 ### Changes
 
 - [#3816](https://github.com/clojure-emacs/cider/issues/3816): **(Breaking)** Remove enrich-classpath support from cider-jack-in.

--- a/cider-eval.el
+++ b/cider-eval.el
@@ -1036,6 +1036,22 @@ buffer."
                             nil
                             (cider--nrepl-pr-request-plist))))
 
+(defun cider-pprint-eval-last-sexp-and-replace ()
+  "Evaluate the expression preceding point and replace it with its
+pretty-printed result."
+  (interactive)
+  (let ((last-sexp (cider-last-sexp)))
+   ;; we have to be sure the evaluation won't result in an error
+   (cider-nrepl-sync-request:eval last-sexp)
+   ;; seems like the sexp is valid, so we can safely kill it
+   (let ((opoint (point)))
+     (clojure-backward-logical-sexp)
+     (kill-region (point) opoint))
+   (cider-interactive-eval last-sexp
+                           (cider-eval-print-handler)
+                           nil
+                           (cider--nrepl-print-request-plist fill-column))))
+
 (defun cider-eval-list-at-point (&optional output-to-current-buffer)
   "Evaluate the list (eg.  a function call, surrounded by parens) around point.
 If invoked with OUTPUT-TO-CURRENT-BUFFER, output the result to current buffer."
@@ -1472,12 +1488,14 @@ passing arguments."
     ;; single key bindings defined last for display in menu
     (define-key map (kbd "e") #'cider-pprint-eval-last-sexp)
     (define-key map (kbd "d") #'cider-pprint-eval-defun-at-point)
+    (define-key map (kbd "w") #'cider-pprint-eval-last-sexp-and-replace)
     (define-key map (kbd "c e") #'cider-pprint-eval-last-sexp-to-comment)
     (define-key map (kbd "c d") #'cider-pprint-eval-defun-to-comment)
 
     ;; duplicates with C- for convenience
     (define-key map (kbd "C-e") #'cider-pprint-eval-last-sexp)
     (define-key map (kbd "C-d") #'cider-pprint-eval-defun-at-point)
+    (define-key map (kbd "C-w") #'cider-pprint-eval-last-sexp-and-replace)
     (define-key map (kbd "C-c e") #'cider-pprint-eval-last-sexp-to-comment)
     (define-key map (kbd "C-c C-e") #'cider-pprint-eval-last-sexp-to-comment)
     (define-key map (kbd "C-c d") #'cider-pprint-eval-defun-to-comment)

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -337,6 +337,7 @@ If invoked with a prefix ARG eval the expression after inserting it."
     ["Eval last sexp to REPL" cider-eval-last-sexp-to-repl]
     ["Eval last sexp and pretty-print to REPL" cider-pprint-eval-last-sexp-to-repl]
     ["Eval last sexp and pretty-print to comment" cider-pprint-eval-last-sexp-to-comment]
+    ["Eval last sexp and replace with pretty-print" cider-pprint-eval-last-sexp-and-replace]
     "--"
     ["Eval selected region if active, otherwise top-level sexp" cider-eval-dwim]
     ["Eval selected region" cider-eval-region]

--- a/doc/modules/ROOT/pages/usage/cider_mode.adoc
+++ b/doc/modules/ROOT/pages/usage/cider_mode.adoc
@@ -84,6 +84,10 @@ kbd:[C-c C-e]
 | kbd:[C-c C-v C-f e]
 | Evaluate the form preceding point and pretty-print the result in a popup buffer. If invoked with a prefix argument, insert the result into the current buffer as a comment.
 
+| `cider-pprint-eval-last-sexp-and-replace`
+| kbd:[C-c C-v C-f w]
+| Evaluate the form preceding point and replace it with its pretty-printed result.
+
 | `cider-pprint-eval-defun-at-point`
 | kbd:[C-c C-v C-f d]
 | Evaluate the top level form under point and pretty-print the result in a popup buffer. If invoked with a prefix argument, insert the result into the current buffer as a comment.

--- a/doc/modules/ROOT/pages/usage/code_evaluation.adoc
+++ b/doc/modules/ROOT/pages/usage/code_evaluation.adoc
@@ -449,6 +449,10 @@ kbd:[C-c C-v C-q]
 kbd:[C-c C-v C-f e]
 | Evaluate the form preceding point and pretty-print the result in a popup buffer. If invoked with a prefix argument, insert the result into the current buffer as a comment.
 
+| `cider-pprint-eval-last-sexp-and-replace`
+| kbd:[C-c C-v C-f w]
+| Evaluate the form preceding point and replace it with its pretty-printed result.
+
 | `cider-pprint-eval-defun-at-point`
 | kbd:[C-c C-v C-f d]
 | Evaluate the top level form under point and pretty-print the result in a popup buffer. If invoked with a prefix argument, insert the result into the current buffer as a comment.


### PR DESCRIPTION
Add command to eval sexp, pretty-print the result and replace the sexp with the result.

It may come in handy should the CIDER user need to define a large datastructure to debug their code, and change it slightly later.

The behaviour is the same as `cider-eval-print-last-sexp` with optional argument, but with additional replacing the original sexp.

NOTE: 
 - I haven't found tests related to printing, apologies if I missed them.
 - I feel there is refactoring potential here since I just copy-pasted the function essentially, but my elsip-fu is too weak to carry it out ATM.

Closes #3822

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
