### PR TITLE
Fix inspector not using the appropriate REPL connection

### DIFF
--- a/cider-log.el
+++ b/cider-log.el
@@ -1422,7 +1422,7 @@ Honors the `cider-log-framework-name' customization variable.
 This function is offered as an alternative to workflows
 based on `transient-mode'."
   (interactive)
-  (cider-current-repl nil 'ensure)
+  (cider-current-repl 'infer 'ensure)
   (let ((framework (cider-log--framework))
         (appender (cider-log--appender))
         (new-default-directory (buffer-local-value 'default-directory (current-buffer))))

--- a/cider-mode.el
+++ b/cider-mode.el
@@ -108,7 +108,7 @@ prefix arg SET-NAMESPACE sets the namespace in the REPL buffer to that of
 the namespace in the Clojure source buffer"
   (interactive "P")
   (cider--switch-to-repl-buffer
-   (cider-current-repl nil 'ensure)
+   (cider-current-repl 'infer 'ensure)
    set-namespace))
 
 (declare-function cider-load-buffer "cider-eval")
@@ -154,7 +154,7 @@ the related commands `cider-repl-clear-buffer' and
 `cider-repl-clear-output'."
   (interactive "P")
   (let ((origin-buffer (current-buffer)))
-    (switch-to-buffer (cider-current-repl nil 'ensure))
+    (switch-to-buffer (cider-current-repl 'infer 'ensure))
     (if clear-repl
         (cider-repl-clear-buffer)
       (cider-repl-clear-output))

--- a/cider-repl.el
+++ b/cider-repl.el
@@ -257,7 +257,7 @@ This cache is stored in the connection buffer.")
 (defun cider-repl-require-repl-utils ()
   "Require standard REPL util functions into the current REPL."
   (interactive)
-  (let* ((current-repl (cider-current-repl nil 'ensure))
+  (let* ((current-repl (cider-current-repl 'infer 'ensure))
          (require-code (cdr (assoc (cider-repl-type current-repl) cider-repl-require-repl-utils-code))))
     (nrepl-send-sync-request
      (cider-plist-put
@@ -1202,7 +1202,7 @@ Closes all open parentheses or bracketed expressions."
   "Switch between the Clojure and ClojureScript REPLs for the current project."
   (interactive)
   ;; FIXME: implement cycling as session can hold more than two REPLs
-  (let* ((this-repl (cider-current-repl nil 'ensure))
+  (let* ((this-repl (cider-current-repl 'infer 'ensure))
          (other-repl (car (seq-remove (lambda (r) (eq r this-repl)) (cider-repls nil t)))))
     (if other-repl
         (switch-to-buffer other-repl)


### PR DESCRIPTION
I believe 9dc5107e8b48dbd5839df03ce533c4afa3682fb5 introduced an issue where the inspector is potentially not using the correct nrepl connection for evaluation. This is because `cider-nrepl-send-sync-request` defaults to `(cider-current-repl 'any 'ensure)` when given no connection, while calling `cider-current-repl` without arguments infers the correct type from the current buffer. This PR simply adds back the calls to `cider-current-repl` to the inspector.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [X] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`eldev test`)
- [X] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [X] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)