### PR TITLE
Fix error popup on pprint-eval-last-sexp

### DIFF
--- a/cider-eval.el
+++ b/cider-eval.el
@@ -915,7 +915,7 @@ This is used by pretty-printing commands."
            (cider-popup-buffer-quit-function t)))
        ;; also call the default nrepl-err-handler, so that our custom behavior doesn't void the base behavior:
        (when nrepl-err-handler
-         (funcall nrepl-err-handler buffer)))
+         (funcall nrepl-err-handler (current-buffer))))
      ;; content type handler:
      nil
      ;; truncated handler:


### PR DESCRIPTION
Empirically, this fixes #3827 .  I have no idea why this works, but it seems to work.  Maybe this should not be merged and there is a better fix, but I'm sending this PR to reference from the issue.
