### PR TITLE
Add jack-in support for ClojureCLR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### New features
 
 - `cider-eval-commands-map` (`C-c C-v` prefix) now binds five long-existing eval commands that previously had no presence under the prefix: `cider-eval-last-sexp-to-repl` (`j`/`C-j`), `cider-eval-print-last-sexp` (`p`/`C-p`), `cider-read-and-eval` (`:`), `cider-eval-defun-to-comment` (`;`), and `cider-pprint-eval-last-sexp-to-repl` (`f j e`).  Existing chords (`C-c M-e`, `C-c M-:`, `C-c M-;`) are unchanged.
+- [#3839](https://github.com/clojure-emacs/cider/pull/3839): Add jack-in support for ClojureCLR.
 
 ### Bugs fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#4143](https://github.com/clojure-emacs/cider/pull/4143): Highlight the `#break`/`#dbg`/`#light` debugging reader tags in `clojure-ts-mode` buffers too.
 - [#4117](https://github.com/clojure-emacs/cider/pull/4117): Add `cider-use-completing-read-for-symbol` (off by default): when enabled, symbol prompts (e.g. `cider-doc`, `cider-find-var`) read through `completing-read` over a lazy, runtime-backed collection, so they work with `completing-read` UIs (Vertico, Ivy, Helm) and annotate candidates with their type and namespace.
 - [#4129](https://github.com/clojure-emacs/cider/pull/4129): Render completion annotations as an aligned type/namespace column (via an `affixation-function`) in UIs that support it, such as the built-in `*Completions*`, Corfu and Vertico.
+- [#3839](https://github.com/clojure-emacs/cider/pull/3839): Add jack-in support for ClojureCLR.
 
 ### Changes
 

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -182,6 +182,7 @@ The following Clojure build tools are supported so far
 - kbd:[M-3 C-c C-x j u] jack-in using babashka.
 - kbd:[M-4 C-c C-x j u] jack-in using nbb.
 - kbd:[M-5 C-c C-x j u] jack-in using basilisp.
+- kbd:[M-6 C-c C-x j u] jack-in using ClojureCLR.
 
 Here is an example of how to bind kbd:[F12] for quickly bringing up a
 babashka REPL:

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -199,6 +199,7 @@ The following Clojure build tools are supported so far
 - kbd:[M-3 C-c C-x j u] jack-in using babashka.
 - kbd:[M-4 C-c C-x j u] jack-in using nbb.
 - kbd:[M-5 C-c C-x j u] jack-in using basilisp.
+- kbd:[M-6 C-c C-x j u] jack-in using ClojureCLR.
 
 Here is an example of how to bind kbd:[F12] for quickly bringing up a
 babashka REPL:

--- a/doc/modules/ROOT/pages/caveats.adoc
+++ b/doc/modules/ROOT/pages/caveats.adoc
@@ -60,13 +60,11 @@ from your Emacs config.
 
 == ClojureCLR Support
 
-CIDER currently has very basic support for ClojureCLR (via Arcadia's nREPL server). The reasons for this are the following:
+CIDER currently has very basic support for ClojureCLR (via either a port of Babashka's nREPL server or Arcadia's nREPL server). The reasons for this are the following:
 
-* nREPL itself runs only on the JVM (because it leverages Java APIs
-internally). There's an
-https://github.com/clojure/clr.tools.nrepl[nREPL port for ClojureCLR], but
-it's not actively maintained and it doesn't behave like the Clojure nREPL.
-* `cider-nrepl` uses a lot of Java code internally itself.
+* The https://github.com/clojure/clr.tools.nrepl/tree/master/partial-nrepl-nrepl-port[nrepl/nrepl port to ClojureCLR] is not yet working
+* `cider-nrepl` uses a lot of Java code internally itself and would need to be adapted/ported like any
+  other clojure library adapted/ported to ClojureCLR.
 
 Those issues are not insurmountable, but are beyond the scope of our current roadmap.
 If someone would like to tackle them, we'd be happy to provide assistance.

--- a/doc/modules/ROOT/pages/caveats.adoc
+++ b/doc/modules/ROOT/pages/caveats.adoc
@@ -64,19 +64,6 @@ loaded. As a workaround remove
 
 from your Emacs config.
 
-== ClojureCLR Support
-
-CIDER currently has very basic support for ClojureCLR (via Arcadia's nREPL server). The reasons for this are the following:
-
-* nREPL itself runs only on the JVM (because it leverages Java APIs
-internally). There's an
-https://github.com/clojure/clr.tools.nrepl[nREPL port for ClojureCLR], but
-it's not actively maintained and it doesn't behave like the Clojure nREPL.
-* `cider-nrepl` uses a lot of Java code internally itself.
-
-Those issues are not insurmountable, but are beyond the scope of our current roadmap.
-If someone would like to tackle them, we'd be happy to provide assistance.
-
 == Injecting dependencies and Leiningen pedantic: abort mode
 
 Because injection currently creates an override of the nREPL dependency that

--- a/doc/modules/ROOT/pages/platforms/clojureclr.adoc
+++ b/doc/modules/ROOT/pages/platforms/clojureclr.adoc
@@ -2,27 +2,27 @@
 
 == Current Status
 
-ClojureCLR on CIDER is not great due to the lack of a fully-functional nREPL
-server for ClojureCLR. There are currently two options:
+You will get basic CIDER functionality with ClojureCLR. Three nREPL server options:
 
-- https://github.com/clojure/clr.tools.nrepl[clr.tools.nrepl]: A direct (but incomplete) port of the reference Clojure nREPL server.
+- https://github.com/clojure/clr.tools.nrepl[clr.tools.nrepl]: At present port of babashka's nREPL server (https://github.com/babashka/babashka.nrepl[babashka.nrepl]).
+- https://github.com/clojure/clr.tools.nrepl/tree/master/partial-nrepl-nrepl-port[port of nrepl/nrepl]: A non-working, work-in-progress port of nrepl/nrepl, which may
+  ultimately better integrate with CIDER once CIDER's middleware (cider-nrepl) is also adapted/ported.
 - https://github.com/arcadia-unity/Arcadia/blob/master/Editor/NRepl.cs[Arcadia's nREPL]: A basic, but working nREPL implementation in C#.
 
-If you need to use CIDER with ClojureCLR today Arcadia's nREPL is your only usable option. That being said - `clr.tools.nrepl` is a much
-more sophisticated project and ideally we should get it over to the finish line.
+An alternative to CIDER & a nREPL server is inf-clojure with ClojureCLR's stock socket REPL server.
 
 == Usage
 
 NOTE: Contributions welcome!
 
-As `cider-jack-in` doesn't support ClojureCLR projects out-of-the-box currently, you'll need to start an nREPL server externally and
-connect to it with `cider-connect`.
+`cider-jack-in-universal` will jack into a clr.tools.nrepl server as long as a `deps-clr.edn` file
+exists in the project directory, otherwise you may call `cider-jack-in-universal` with prefix
+argument 6, by either `M-6` or `C-u 6` followed by `M-x cider-jack-in-universal`.
 
 == Plans
 
 In an ideal world we'll achieve the following objectives:
 
-- out-of-the-box ClojureCLR support with `cider-jack-in`
 - feature parity between Clojure's nREPL implementation and `clr.tools.nrepl` (the project can use some help)
 - adapting `cider-nrepl` for ClojureCLR (some of its codebase is JVM-specific)
 

--- a/doc/modules/ROOT/pages/platforms/clojureclr.adoc
+++ b/doc/modules/ROOT/pages/platforms/clojureclr.adoc
@@ -8,10 +8,9 @@ You will get basic CIDER functionality with ClojureCLR. Two nREPL server options
 - https://github.com/clojure/clr.tools.nrepl/tree/master/partial-nrepl-nrepl-port[port of nrepl/nrepl]: A non-working, work-in-progress port of nrepl/nrepl, which may
   ultimately better integrate with CIDER once CIDER's middleware (cider-nrepl) is also adapted/ported.
 
-CIDER currently has basic support for ClojureCLR via a port of Babashka's nREPL
-  server. The reasons for the basic support is that: `cider-nrepl`, the CIDER
-  middleware, uses a lot of Java code internally itself and would need to be
-  adapted/ported like any other clojure library adapted/ported to ClojureCLR.
+CIDER's support is basic because `cider-nrepl`, the middleware behind most of
+CIDER's features, uses a lot of Java internally and would need to be ported to
+ClojureCLR like any other Clojure library.
 
 Alternatives to using CIDER with ClojureCLR include https://github.com/clojure-emacs/inf-clojure[inf-clojure] and https://github.com/nrepl/neat[neat].
 

--- a/doc/modules/ROOT/pages/platforms/clojureclr.adoc
+++ b/doc/modules/ROOT/pages/platforms/clojureclr.adoc
@@ -4,7 +4,7 @@
 
 You will get basic CIDER functionality with ClojureCLR. Two nREPL server options:
 
-- https://github.com/clojure/clr.tools.nrepl[clr.tools.nrepl]: At present port of babashka's nREPL server (https://github.com/babashka/babashka.nrepl[babashka.nrepl]).
+- https://github.com/clojure/clr.tools.nrepl[clr.tools.nrepl]: currently a port of https://github.com/babashka/babashka.nrepl[babashka.nrepl] to ClojureCLR.
 - https://github.com/clojure/clr.tools.nrepl/tree/master/partial-nrepl-nrepl-port[port of nrepl/nrepl]: A non-working, work-in-progress port of nrepl/nrepl, which may
   ultimately better integrate with CIDER once CIDER's middleware (cider-nrepl) is also adapted/ported.
 

--- a/doc/modules/ROOT/pages/platforms/clojureclr.adoc
+++ b/doc/modules/ROOT/pages/platforms/clojureclr.adoc
@@ -2,27 +2,31 @@
 
 == Current Status
 
-ClojureCLR on CIDER is not great due to the lack of a fully-functional nREPL
-server for ClojureCLR. There are currently two options:
+You will get basic CIDER functionality with ClojureCLR. Two nREPL server options:
 
-- https://github.com/clojure/clr.tools.nrepl[clr.tools.nrepl]: A direct (but incomplete) port of the reference Clojure nREPL server.
-- https://github.com/arcadia-unity/Arcadia/blob/master/Editor/NRepl.cs[Arcadia's nREPL]: A basic, but working nREPL implementation in C#.
+- https://github.com/clojure/clr.tools.nrepl[clr.tools.nrepl]: At present port of babashka's nREPL server (https://github.com/babashka/babashka.nrepl[babashka.nrepl]).
+- https://github.com/clojure/clr.tools.nrepl/tree/master/partial-nrepl-nrepl-port[port of nrepl/nrepl]: A non-working, work-in-progress port of nrepl/nrepl, which may
+  ultimately better integrate with CIDER once CIDER's middleware (cider-nrepl) is also adapted/ported.
 
-If you need to use CIDER with ClojureCLR today Arcadia's nREPL is your only usable option. That being said - `clr.tools.nrepl` is a much
-more sophisticated project and ideally we should get it over to the finish line.
+CIDER currently has basic support for ClojureCLR via a port of Babashka's nREPL
+  server. The reasons for the basic support is that: `cider-nrepl`, the CIDER
+  middleware, uses a lot of Java code internally itself and would need to be
+  adapted/ported like any other clojure library adapted/ported to ClojureCLR.
+
+Alternatives to using CIDER with ClojureCLR include https://github.com/clojure-emacs/inf-clojure[inf-clojure] and https://github.com/nrepl/neat[neat].
 
 == Usage
 
 NOTE: Contributions welcome!
 
-As `cider-jack-in` doesn't support ClojureCLR projects out-of-the-box currently, you'll need to start an nREPL server externally and
-connect to it with `cider-connect`.
+`cider-jack-in-universal` will jack into a clr.tools.nrepl server as long as a `deps-clr.edn` file
+exists in the project directory, otherwise you may call `cider-jack-in-universal` with prefix
+argument 6, by either `M-6` or `C-u 6` followed by `M-x cider-jack-in-universal`.
 
 == Plans
 
 In an ideal world we'll achieve the following objectives:
 
-- out-of-the-box ClojureCLR support with `cider-jack-in`
 - feature parity between Clojure's nREPL implementation and `clr.tools.nrepl` (the project can use some help)
 - adapting `cider-nrepl` for ClojureCLR (some of its codebase is JVM-specific)
 

--- a/lisp/cider-jack-in.el
+++ b/lisp/cider-jack-in.el
@@ -207,6 +207,30 @@ By default we favor the project-specific shadow-cljs over the system-wide."
   :safe #'stringp
   :package-version '(cider . "1.14.0"))
 
+(defcustom cider-clojure-clr-cli-command
+  "cljr"
+  "The command used to execute ClojureCLR."
+  :type 'string
+  :group 'cider
+  :safe #'stringp
+  :package-version '(cider . "1.21.0"))
+
+(defcustom cider-clojure-clr-cli-parameters
+  "-X clojure.tools.nrepl/start-server!"
+  "Params passed to ClojureCLR to start an nREPL server via `cider-jack-in'."
+  :type 'string
+  :group 'cider
+  :safe #'stringp
+  :package-version '(cider . "1.21.0"))
+
+;; Clojure git deps require :git/sha even when :git/tag is set, just do full SHA
+(defcustom cider-clojure-clr-cli-nrepl-sha "a6bf822a5f72ec613f703eaf95420758591f2437"
+  "The version of clr.tools.nrepl injected on jack-in with ClojureCLR."
+  :type 'string
+  :group 'cider
+  :safe #'stringp
+  :package-version '(cider . "1.21.0"))
+
 
 ;;; Jack-in defaults and toggles
 
@@ -623,6 +647,30 @@ Does so by concatenating PARAMS and DEPENDENCIES."
      " "
      params)))
 
+(defun cider-clojure-clr-cli-jack-in-dependencies (params dependencies &optional command)
+  "Create ClojureCLR clr.core.cli jack-in dependencies.
+Does so by concatenating DEPENDENCIES, and PARAMS into a
+suitable `cljr` invocation and quoting, also accounting for COMMAND if
+provided."
+  (let* ((all-deps (thread-last dependencies
+                                (cider--dedupe-deps)
+                                (seq-map (lambda (dep)
+                                           (if (listp (cadr dep))
+                                               (format "%s {%s}"
+                                                       (car dep)
+                                                       (seq-reduce
+                                                        (lambda (acc v)
+                                                          (concat acc (format " :%s \"%s\" " (car v) (cdr v))))
+                                                        (cadr dep)
+                                                        ""))
+                                             (format "%s {:git/sha \"%s\"}" (car dep) (cadr dep)))))))
+         (deps (format "{:deps {%s}}"
+                       (string-join all-deps " ")))
+         (deps-quoted (cider--shell-quote-argument deps command)))
+    (format "-Sdeps %s %s"
+            deps-quoted
+            (if params (format " %s" params) ""))))
+
 (defun cider-add-clojure-dependencies-maybe (dependencies)
   "Return DEPENDENCIES with an added Clojure dependency if requested.
 See also `cider-jack-in-auto-inject-clojure'."
@@ -681,6 +729,12 @@ COMMAND is the resolved jack-in command, used to handle PowerShell quoting."
    params
    (cider-add-clojure-dependencies-maybe cider-jack-in-dependencies)
    (cider-jack-in-normalized-nrepl-middlewares)))
+
+(defun cider--clojure-clr-cli-inject-deps (params _project-type _command)
+  "Inject CIDER deps into PARAMS for a ClojureCLR CLI project."
+  (cider-clojure-clr-cli-jack-in-dependencies
+   params
+   `(("io.github.clojure/clr.tools.nrepl" ,cider-clojure-clr-cli-nrepl-sha))))
 
 (defun cider-inject-jack-in-dependencies (params project-type &optional command)
   "Return PARAMS with injected REPL dependencies for PROJECT-TYPE.
@@ -848,6 +902,13 @@ Throws an error if PROJECT-TYPE is unknown."
                              :params-var 'cider-basilisp-parameters
                              :project-files '("basilisp.edn")
                              :universal-prefix-arg 5)
+
+(cider-register-jack-in-tool 'clojure-clr-cli
+                             :command-var 'cider-clojure-clr-cli-command
+                             :params-var 'cider-clojure-clr-cli-parameters
+                             :project-files '("deps-clr.edn")
+                             :inject-fn #'cider--clojure-clr-cli-inject-deps
+                             :universal-prefix-arg 6)
 
 
 ;;; ClojureScript jack-in helpers

--- a/lisp/cider-jack-in.el
+++ b/lisp/cider-jack-in.el
@@ -775,11 +775,13 @@ COMMAND is the resolved jack-in command, used to handle PowerShell quoting."
    (cider-add-clojure-dependencies-maybe cider-jack-in-dependencies)
    (cider-jack-in-normalized-nrepl-middlewares)))
 
-(defun cider--clojure-clr-cli-inject-deps (params _project-type _command)
-  "Inject CIDER deps into PARAMS for a ClojureCLR CLI project."
+(defun cider--clojure-clr-cli-inject-deps (params _project-type command)
+  "Inject CIDER deps into PARAMS for a ClojureCLR CLI project.
+COMMAND is the resolved jack-in command, used to handle PowerShell quoting."
   (cider-clojure-clr-cli-jack-in-dependencies
    params
-   `(("io.github.clojure/clr.tools.nrepl" ,cider-clojure-clr-cli-nrepl-sha))))
+   `(("io.github.clojure/clr.tools.nrepl" ,cider-clojure-clr-cli-nrepl-sha))
+   command))
 
 (defun cider-inject-jack-in-dependencies (params project-type &optional command)
   "Return PARAMS with injected REPL dependencies for PROJECT-TYPE.

--- a/lisp/cider-jack-in.el
+++ b/lisp/cider-jack-in.el
@@ -225,6 +225,30 @@ By default we favor the project-specific shadow-cljs over the system-wide."
   :safe #'stringp
   :package-version '(cider . "1.14.0"))
 
+(defcustom cider-clojure-clr-cli-command
+  "cljr"
+  "The command used to execute ClojureCLR."
+  :type 'string
+  :group 'cider
+  :safe #'stringp
+  :package-version '(cider . "2.0.1"))
+
+(defcustom cider-clojure-clr-cli-parameters
+  "-X clojure.tools.nrepl/start-server!"
+  "Params passed to ClojureCLR to start an nREPL server via `cider-jack-in'."
+  :type 'string
+  :group 'cider
+  :safe #'stringp
+  :package-version '(cider . "2.0.1"))
+
+;; Clojure git deps require :git/sha even when :git/tag is set, just do full SHA
+(defcustom cider-clojure-clr-cli-nrepl-sha "a6bf822a5f72ec613f703eaf95420758591f2437"
+  "The version of clr.tools.nrepl injected on jack-in with ClojureCLR."
+  :type 'string
+  :group 'cider
+  :safe #'stringp
+  :package-version '(cider . "2.0.1"))
+
 
 ;;; Jack-in defaults and toggles
 
@@ -668,6 +692,30 @@ Does so by concatenating PARAMS and DEPENDENCIES."
      " "
      params)))
 
+(defun cider-clojure-clr-cli-jack-in-dependencies (params dependencies &optional command)
+  "Create ClojureCLR clr.core.cli jack-in dependencies.
+Does so by concatenating DEPENDENCIES, and PARAMS into a
+suitable `cljr` invocation and quoting, also accounting for COMMAND if
+provided."
+  (let* ((all-deps (thread-last dependencies
+                                (cider--dedupe-deps)
+                                (seq-map (lambda (dep)
+                                           (if (listp (cadr dep))
+                                               (format "%s {%s}"
+                                                       (car dep)
+                                                       (seq-reduce
+                                                        (lambda (acc v)
+                                                          (concat acc (format " :%s \"%s\" " (car v) (cdr v))))
+                                                        (cadr dep)
+                                                        ""))
+                                             (format "%s {:git/sha \"%s\"}" (car dep) (cadr dep)))))))
+         (deps (format "{:deps {%s}}"
+                       (string-join all-deps " ")))
+         (deps-quoted (cider--shell-quote-argument deps command)))
+    (format "-Sdeps %s %s"
+            deps-quoted
+            (if params (format " %s" params) ""))))
+
 (defun cider-add-clojure-dependencies-maybe (dependencies)
   "Return DEPENDENCIES with an added Clojure dependency if requested.
 See also `cider-jack-in-auto-inject-clojure'."
@@ -726,6 +774,12 @@ COMMAND is the resolved jack-in command, used to handle PowerShell quoting."
    params
    (cider-add-clojure-dependencies-maybe cider-jack-in-dependencies)
    (cider-jack-in-normalized-nrepl-middlewares)))
+
+(defun cider--clojure-clr-cli-inject-deps (params _project-type _command)
+  "Inject CIDER deps into PARAMS for a ClojureCLR CLI project."
+  (cider-clojure-clr-cli-jack-in-dependencies
+   params
+   `(("io.github.clojure/clr.tools.nrepl" ,cider-clojure-clr-cli-nrepl-sha))))
 
 (defun cider-inject-jack-in-dependencies (params project-type &optional command)
   "Return PARAMS with injected REPL dependencies for PROJECT-TYPE.
@@ -893,6 +947,13 @@ Throws an error if PROJECT-TYPE is unknown."
                              :params-var 'cider-basilisp-parameters
                              :project-files '("basilisp.edn")
                              :dispatch-prefix-arg 5)
+
+(cider-register-jack-in-tool 'clojure-clr-cli
+                             :command-var 'cider-clojure-clr-cli-command
+                             :params-var 'cider-clojure-clr-cli-parameters
+                             :project-files '("deps-clr.edn")
+                             :inject-fn #'cider--clojure-clr-cli-inject-deps
+                             :dispatch-prefix-arg 6)
 
 
 ;;; ClojureScript jack-in helpers


### PR DESCRIPTION
Adds jack-in support for ClojureCLR.

Only changes are in the CIDER (elisp) side.
No changes to the cider-nrepl (Clojure) side are made.

Allows jacking into a ClojureCLR nREPL server **clojure/clr.tools.nrepl** [\[1\]](https://github.com/clojure/clr.tools.nrepl) with CIDER.

**clojure/clr.tools.nrepl** is at present a port of **babashka/babashka.nrepl** [\[2\]](https://github.com/babashka/babashka.nrepl) to ClojureCLR. Which might later change to a port of **nrepl/nrepl** [\[3\]](https://github.com/nrepl/nrepl) once that port to ClojureCLR is working.

So, at present jacking into ClojureCLR nREPL server this PR is set to is just like jacking into a Babashka nREPL server. Default middleware are in those repos not in cider-nrepl. W.r.t. those I see that middleware can be specified/added-to via the `:xform` parameter, but at present the jack in for Babashka doesn't support that so I didn't add it for the jack into ClojureCLR. I guess someone might want to do that with CIDER?

Once the **nrepl/nrepl** port to ClojureCLR is working (in the subdir of **clojure/clr.tools.nrepl**) then better integration with CIDER can be considered, including adapting **cider-nrepl** to ClojureCLR. That's my understanding. I guess that's the direction things are going.

Related: #3361

~~#### Problems with this PR:~~

~~For unknown reasons eventually the sync fails and things don't seem to work.~~

~~At that point reconnecting via CIDER commands doesn't seem to work. Hadn't diagnosed what to do about this, I've come from dotnet-land wanting to use Clojure: I've never used CIDER before so I don't know what to expect. Probably user-error I guess.~~

**EDIT:** Maybe spacing in the docs might be wrong. I eyeballed the formatting. I guess linting might complain if I got that wrong.

#### My use-case/motivation:
For ClojureCLR I think the trend is to use inf-clojure with the socket REPL server, not Cider with an nREPL server. For Calva the vscode plugin for Clojure, [looks like](https://blog.agical.se/en/posts/how-to-create-a-really-simple-clojureclr-dependency-tool/) they've looked into using **clojure/clr.tools.nrepl** (nREPL) for ClojureCLR but I don't use vscode.

I'm using Doom emacs and the clojure module uses CIDER not inf-clojure and I didn't want to deal with remapping hotkeys & other configuration. So I wanted to explore using **clojure/clr.tools.nrepl** as-is with CIDER.

I thought to submit this PR as a basis for others to continue in the effort using & improving CIDER with ClojureCLR.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
