### PR TITLE
Install and use win native gpg port for CI integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
     # instead.
     - name: Setup Scoop and GPG on Windows
       if: startsWith (matrix.os, 'windows')
-    - uses: MinoruSekine/setup-scoop@v4.0.2
+      uses: MinoruSekine/setup-scoop@v4.0.2
       with:
         apps: gpg
         scoop_update: false


### PR DESCRIPTION
Hi,

Could you please review this patch that fixes a recent issue causing the GitHub CI integration tests to fail on MS-Windows?

The problem is that Emacs cannot validate the signatures of the GNU and NonGNU packages because the MSYS2 `gpg` executable available on the Windows runner does not handle native Windows paths correctly. The fix installs a native Windows port of `gpg` via `Scoop` and ensures it appears first in the PATH.

It’s unclear to me how this ever worked on the Windows runner before. Although GitHub recently upgraded to the `windows-2025` image, I don’t see any relevant differences in the available tools compared to the previous `windows-2022` runner, which also fails with the same error.

Thanks

error (for ref):

```
[00:00.016]  Started up on Wed Oct 22 14:11:29 2025
[00:00.016]  Running on GNU Emacs 30.1 (build 2, x86_64-w64-mingw32) of 2025-02-23
[00:00.016]  Emacs source is unknown
[00:00.016]  Project directory: `d:/a/cider/cider/'
[00:00.016]  No file `c:/Users/runneradmin/AppData/Roaming/.config/eldev/config', not applying user-specific configuration
[00:00.016]  Loading file `Eldev'...
[00:00.122]  Using package archive `gnu' at `https://elpa.gnu.org/packages/' with priority 300
[00:00.122]  Using package archive `melpa-unstable' at `https://melpa.org/packages/' with priority 100
[00:00.154]  Reading target dependencies from file `.eldev/30.1/target-dependencies.build'...
[00:00.158]  Target dependency information is up-to-date, not saving...
[00:00.159]  No file `Eldev-local', not customizing build
[00:00.161]  Executing command `test'...
[00:00.161]  Executing `eldev-executing-command-hook'...
[00:00.161]  Executing `eldev-test-hook'...
[00:00.161]  Using cider tests of type `integration'
[00:00.162]  Contents of package archive `gnu' has been fetched already
[00:00.162]  Contents of package archive `melpa-unstable' has been fetched already
[00:00.334]  Will refetch contents of package archive `gnu' to make sure that `melpa-unstable' really needs to be used
[00:00.336]  Fetching contents of package archive `gnu'...
[00:00.578]  Using file `https://elpa.gnu.org/packages/archive-contents' from the global cache (at `c:/Users/runneradmin/AppData/Roaming/.cache/eldev/global-cache/gnu/archive-contents')...
[00:00.662]  File `https://elpa.gnu.org/packages/archive-contents.sig' is not cached, retrieving...
[00:02.197]  Installing package `gnu-elpa-keyring-update' to hopefully solve `bad-signature' problem...
[00:02.198]  Using file `https://elpa.gnu.org/packages/archive-contents' from the global cache (at `c:/Users/runneradmin/AppData/Roaming/.cache/eldev/global-cache/gnu/archive-contents')...
[00:02.332]  File `https://elpa.gnu.org/packages/queue-0.2.tar' is not cached, retrieving...
[00:02.442]  File `https://elpa.gnu.org/packages/queue-0.2.tar.sig' is not cached, retrieving...
[00:02.776]  Installing package `gnu-elpa-keyring-update' to hopefully solve `bad-signature' problem...
[00:02.951]  Using file `https://melpa.org/packages/archive-contents' from the global cache (at `c:/Users/runneradmin/AppData/Roaming/.cache/eldev/global-cache/melpa-unstable/archive-contents')...
[00:03.080]  Using file `https://elpa.gnu.org/packages/archive-contents' from the global cache (at `c:/Users/runneradmin/AppData/Roaming/.cache/eldev/global-cache/gnu/archive-contents')...
[00:03.259]  File `https://elpa.gnu.org/packages/queue-0.2.tar' is not cached, retrieving...
[00:03.398]  File `https://elpa.gnu.org/packages/queue-0.2.tar.sig' is not cached, retrieving...
[00:02.331]  [1/3] Installing package `queue' (0.2) from `gnu'...
[00:04.222]  Debugger entered--Lisp error: (bad-signature "queue-0.2.tar.sig")
               signal(bad-signature ("queue-0.2.tar.sig"))```

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
