### PR TITLE
Make item-lines buttons in cider-ns-browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changes
 
+- Use buttons for items in cider-ns-browser to allow clicking and evil's RET to navigate.
+
 ### Bugs fixed
 
 - [#3853](https://github.com/clojure-emacs/cider/issues/3853): Fix mangling of printed representations.

--- a/cider-browse-ns.el
+++ b/cider-browse-ns.el
@@ -232,7 +232,7 @@ displayed."
       (t "")))))
 
 (defun cider-browse-ns--display-list (keys items max-length &optional label)
-  "Render the items of KEYS as condained in the nrepl-dict ITEMS.
+  "Render the items of KEYS as contained in the nrepl-dict ITEMS.
 
 Pad the row to be MAX-LENGTH+1.  If LABEL is non-nil, add a header to the
 list of items."
@@ -245,7 +245,9 @@ list of items."
              (first-doc-line (cider-browse-ns--first-doc-line doc))
              (item-line (cider-browse-ns--propertized-item key items)))
         (insert "  ")
-        (insert item-line)
+        (insert-text-button item-line
+                            'action (lambda (_) (cider-browse-ns-operate-at-point))
+                            'face (cider-browse-ns--text-face (nrepl-dict-get items key)))
         (when cider-browse-ns-current-ns
           (insert (make-string (+ (- max-length (string-width item-line)) 1) ?·))
           (insert " " (propertize first-doc-line 'font-lock-face 'font-lock-doc-face)))


### PR DESCRIPTION
Especially for evil's RET, and clicking with the mouse

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes -- it doesn't, but not because of this change.
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)