### PR TITLE
Show spinner in mode line while tests are running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- [#3645](https://github.com/clojure-emacs/cider/issues/3645): Show a spinner in the mode line while tests are running.
 - [#3865](https://github.com/clojure-emacs/cider/pull/3865): Add default session feature to bypass sesman's project-based dispatch (`cider-set-default-session`, `cider-clear-default-session`).
 
 ### Bugs fixed
@@ -12,6 +13,9 @@
 ### Changes
 
 - Bump the injected nREPL version to 1.6.
+### Changes
+
+- Rename `cider-eval-spinner-type`, `cider-show-eval-spinner`, and `cider-eval-spinner-delay` to `cider-spinner-type`, `cider-show-spinner`, and `cider-spinner-delay`.  The old names are kept as obsolete aliases.
 
 ## 1.21.0 (2026-02-07)
 

--- a/lisp/cider-client.el
+++ b/lisp/cider-client.el
@@ -40,9 +40,13 @@
 (require 'nrepl-client)
 
 
-;;; Eval spinner
-(defcustom cider-eval-spinner-type 'progress-bar
-  "Appearance of the evaluation spinner.
+;;; Spinner
+(define-obsolete-variable-alias 'cider-eval-spinner-type 'cider-spinner-type "1.18.0")
+(define-obsolete-variable-alias 'cider-show-eval-spinner 'cider-show-spinner "1.18.0")
+(define-obsolete-variable-alias 'cider-eval-spinner-delay 'cider-spinner-delay "1.18.0")
+
+(defcustom cider-spinner-type 'progress-bar
+  "Appearance of the spinner.
 
 Value is a symbol.  The possible values are the symbols in the
 `spinner-types' variable."
@@ -50,14 +54,14 @@ Value is a symbol.  The possible values are the symbols in the
   :group 'cider
   :package-version '(cider . "0.10.0"))
 
-(defcustom cider-show-eval-spinner t
-  "When true, show the evaluation spinner in the mode line."
+(defcustom cider-show-spinner t
+  "When true, show a spinner in the mode line for long-running operations."
   :type 'boolean
   :group 'cider
   :package-version '(cider . "0.10.0"))
 
-(defcustom cider-eval-spinner-delay 1
-  "Amount of time, in seconds, after which the evaluation spinner will be shown."
+(defcustom cider-spinner-delay 1
+  "Amount of time, in seconds, after which the spinner will be shown."
   :type 'integer
   :group 'cider
   :package-version '(cider . "0.10.0"))
@@ -83,12 +87,12 @@ resulting value are used to compute completions."
   :package-version '(cider . "1.2.0"))
 
 (defun cider-spinner-start (buffer)
-  "Start the evaluation spinner in BUFFER.
-Do nothing if `cider-show-eval-spinner' is nil."
-  (when cider-show-eval-spinner
+  "Start a spinner in BUFFER.
+Do nothing if `cider-show-spinner' is nil."
+  (when cider-show-spinner
     (with-current-buffer buffer
-      (spinner-start cider-eval-spinner-type nil
-                     cider-eval-spinner-delay))))
+      (spinner-start cider-spinner-type nil
+                     cider-spinner-delay))))
 
 (defun cider-eval-spinner (eval-buffer response)
   "Handle RESPONSE stopping the spinner.
@@ -227,7 +231,7 @@ buffer, defaults to (cider-current-repl)."
     (run-hooks 'cider-before-eval-hook)
     (nrepl-request:eval input
                         (lambda (response)
-                          (when cider-show-eval-spinner
+                          (when cider-show-spinner
                             (cider-eval-spinner connection response))
                           (when (and (buffer-live-p eval-buffer)
                                      (member "done" (nrepl-dict-get response "status")))

--- a/lisp/cider-test.el
+++ b/lisp/cider-test.el
@@ -61,6 +61,9 @@
   :type 'boolean
   :package-version '(cider . "0.9.0"))
 
+(defvar cider-test--spinner-buffers nil
+  "List of buffers where test spinners are active.")
+
 (defvar cider-test--current-repl nil
   "Contains the reference to the REPL where the tests were last invoked from.
 This is needed for *cider-test-report* navigation
@@ -540,6 +543,26 @@ timing data for the overall run, per-namespace, and per-var respectively."
       (current-buffer))))
 
 
+;;; Test spinner
+
+(defun cider-test-spinner-start (buffer)
+  "Start a test spinner in BUFFER.
+Uses `cider-show-spinner' to decide whether to show it.
+Tracks BUFFER for later cleanup by `cider-test-spinner-stop'."
+  (when (and cider-show-spinner
+             (buffer-live-p buffer)
+             (not (memq buffer cider-test--spinner-buffers)))
+    (cider-spinner-start buffer)
+    (push buffer cider-test--spinner-buffers)))
+
+(defun cider-test-spinner-stop ()
+  "Stop all active test spinners."
+  (dolist (buffer cider-test--spinner-buffers)
+    (when (buffer-live-p buffer)
+      (with-current-buffer buffer
+        (when spinner-current (spinner-stop)))))
+  (setq cider-test--spinner-buffers nil))
+
 ;;; Message echo
 
 (defun cider-test-echo-running (ns &optional test)
@@ -723,6 +746,7 @@ running them."
               ;; we generate a different message when running individual tests
               (cider-test-echo-running ns (car tests))
             (cider-test-echo-running ns)))
+        (cider-test-spinner-start (current-buffer))
         (setq cider-test--current-repl conn)
         (let* ((retest? (eq :non-passing ns))
                (request `("op" ,(cond ((stringp ns)         "test")
@@ -747,6 +771,10 @@ running them."
            request
            (lambda (response)
              (nrepl-dbind-response response (summary results status out err elapsed-time ns-elapsed-time var-elapsed-time)
+               (when (or (member "done" status)
+                         (member "error" status)
+                         (member "namespace-not-found" status))
+                 (cider-test-spinner-stop))
                (cond ((member "namespace-not-found" status)
                       (unless silent
                         (message "No test namespace: %s" (cider-propertize ns 'ns))))

--- a/test/cider-test-tests.el
+++ b/test/cider-test-tests.el
@@ -27,6 +27,7 @@
 
 (require 'buttercup)
 (require 'cider-test)
+(require 'spinner)
 
 ;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
 
@@ -41,3 +42,51 @@
     (expect (cider-test--string-contains-newline "Hello\\nWorld")
             :to-equal
             t)))
+
+(describe "cider-test-spinner-start"
+  (it "starts a spinner in the given buffer when enabled"
+    (let ((cider-show-spinner t)
+          (buf (generate-new-buffer " *test-spinner*")))
+      (unwind-protect
+          (progn
+            (cider-test-spinner-start buf)
+            (expect (buffer-local-value 'spinner-current buf) :to-be-truthy)
+            (expect cider-test--spinner-buffers :to-contain buf))
+        (when (buffer-live-p buf)
+          (with-current-buffer buf
+            (when spinner-current (spinner-stop)))
+          (kill-buffer buf))
+        (setq cider-test--spinner-buffers nil))))
+
+  (it "does nothing when cider-show-spinner is nil"
+    (let ((cider-show-spinner nil)
+          (buf (generate-new-buffer " *test-spinner*")))
+      (unwind-protect
+          (progn
+            (cider-test-spinner-start buf)
+            (expect (buffer-local-value 'spinner-current buf) :not :to-be-truthy)
+            (expect cider-test--spinner-buffers :not :to-contain buf))
+        (kill-buffer buf)))))
+
+(describe "cider-test-spinner-stop"
+  (it "stops spinners in all tracked buffers"
+    (let ((cider-show-spinner t)
+          (buf1 (generate-new-buffer " *test-spinner-1*"))
+          (buf2 (generate-new-buffer " *test-spinner-2*")))
+      (unwind-protect
+          (progn
+            (cider-test-spinner-start buf1)
+            (cider-test-spinner-start buf2)
+            (expect (spinner--active-p (buffer-local-value 'spinner-current buf1))
+                    :to-be-truthy)
+            (expect (spinner--active-p (buffer-local-value 'spinner-current buf2))
+                    :to-be-truthy)
+            (cider-test-spinner-stop)
+            (expect (spinner--active-p (buffer-local-value 'spinner-current buf1))
+                    :not :to-be-truthy)
+            (expect (spinner--active-p (buffer-local-value 'spinner-current buf2))
+                    :not :to-be-truthy)
+            (expect cider-test--spinner-buffers :to-equal nil))
+        (when (buffer-live-p buf1) (kill-buffer buf1))
+        (when (buffer-live-p buf2) (kill-buffer buf2))
+        (setq cider-test--spinner-buffers nil)))))


### PR DESCRIPTION
Fixes #3645.

Shows a mode line spinner while tests are running, reusing the existing spinner infrastructure from `cider-client.el`. Also renames the eval-specific spinner defcustoms (`cider-eval-spinner-type`, `cider-show-eval-spinner`, `cider-eval-spinner-delay`) to generic names (`cider-spinner-type`, `cider-show-spinner`, `cider-spinner-delay`) since they now control spinners for both eval and test operations. Old names are kept as obsolete aliases.