### PR TITLE
Backfill client-side test coverage

### DIFF
--- a/test/cider-client-tests.el
+++ b/test/cider-client-tests.el
@@ -79,6 +79,47 @@
     (spy-on 'cider-nrepl-op-supported-p :and-return-value nil)
     (expect (cider-var-info "str") :to-equal nil)))
 
+(describe "cider-member-info"
+  (it "returns member info for a given class and member"
+    (spy-on 'cider-sync-request:info :and-return-value
+            '(dict
+              "class" "java.lang.String"
+              "member" "length"
+              "arglists" "()"
+              "returns" "int"
+              "status" ("done")))
+    (spy-on 'cider-nrepl-op-supported-p :and-return-value t)
+    (spy-on 'cider-nrepl-eval-session :and-return-value nil)
+    (spy-on 'cider-current-ns :and-return-value "user")
+    (let ((info (cider-member-info "java.lang.String" "length")))
+      (expect (nrepl-dict-get info "member") :to-equal "length")
+      (expect (nrepl-dict-get info "class") :to-equal "java.lang.String")))
+
+  (it "returns nil when class is nil"
+    (expect (cider-member-info nil "length") :to-equal nil))
+
+  (it "returns nil when member is nil"
+    (expect (cider-member-info "java.lang.String" nil) :to-equal nil)))
+
+(describe "cider-classpath-entries"
+  (it "uses the classpath op when available"
+    (spy-on 'cider-nrepl-op-supported-p :and-return-value t)
+    (spy-on 'cider-sync-request:classpath :and-return-value
+            '("/project/src" "/project/test" "/home/.m2/repository/clojure.jar"))
+    (let ((entries (cider-classpath-entries)))
+      (expect 'cider-sync-request:classpath :to-have-been-called)
+      (expect entries :to-have-same-items-as
+              '("/project/src" "/project/test" "/home/.m2/repository/clojure.jar"))))
+
+  (it "falls back to eval when the classpath op is not available"
+    (spy-on 'cider-nrepl-op-supported-p :and-return-value nil)
+    (spy-on 'cider-fallback-eval:classpath :and-return-value
+            '("/project/src" "/project/test"))
+    (let ((entries (cider-classpath-entries)))
+      (expect 'cider-fallback-eval:classpath :to-have-been-called)
+      (expect entries :to-have-same-items-as
+              '("/project/src" "/project/test")))))
+
 
 (describe "cider-repl-type-for-buffer"
   :var (cider-repl-type)

--- a/test/cider-eval-tests.el
+++ b/test/cider-eval-tests.el
@@ -40,3 +40,51 @@
             :to-equal '("/Users/vemv/haystack/src/haystack/parser.cljc" 13 0 cider-error-highlight-face "Syntax error reading source at (/Users/vemv/haystack/src/haystack/parser.cljc:13:0)."))
     (expect (cider-extract-error-info cider-compilation-regexp "Syntax error FOOING clojure.core/let at (src/haystack/analyzer.clj:18:1).\n[1] - failed: even-number-of-forms? at: [:bindings] spec: :clojure.core.specs.alpha/bindings\n")
             :to-equal nil)))
+
+(describe "cider--shorten-error-message"
+  (it "strips compilation error prefixes"
+    (expect (cider--shorten-error-message
+             "Syntax error compiling clojure.core/let at (src/foo.clj:18:1).\nbad stuff")
+            :to-equal "bad stuff"))
+
+  (it "strips reflection warning prefixes"
+    (expect (cider--shorten-error-message
+             "Reflection warning, /tmp/foo/src/core.clj:14:1 - call to method foo")
+            :to-equal "call to method foo"))
+
+  (it "strips module info suffixes"
+    (expect (cider--shorten-error-message
+             "No matching method found (Long is in module java.base of loader 'bootstrap'; String is in module java.base of loader 'bootstrap')")
+            :to-equal "No matching method found"))
+
+  (it "returns simple messages unchanged"
+    (expect (cider--shorten-error-message "something went wrong")
+            :to-equal "something went wrong")))
+
+(describe "cider--matching-delimiter"
+  (it "returns closing delimiters for opening ones"
+    (expect (cider--matching-delimiter ?\() :to-equal ?\))
+    (expect (cider--matching-delimiter ?\[) :to-equal ?\])
+    (expect (cider--matching-delimiter ?\{) :to-equal ?\}))
+
+  (it "returns opening delimiters for closing ones"
+    (expect (cider--matching-delimiter ?\)) :to-equal ?\()
+    (expect (cider--matching-delimiter ?\]) :to-equal ?\[)
+    (expect (cider--matching-delimiter ?\}) :to-equal ?\{)))
+
+(describe "cider--insert-closing-delimiters"
+  (it "closes open parentheses"
+    (expect (cider--insert-closing-delimiters "(defn foo [x]")
+            :to-equal "(defn foo [x])"))
+
+  (it "closes nested open forms"
+    (expect (cider--insert-closing-delimiters "(let [x (+ 1 2")
+            :to-equal "(let [x (+ 1 2)])"))
+
+  (it "handles already balanced code"
+    (expect (cider--insert-closing-delimiters "(+ 1 2)")
+            :to-equal "(+ 1 2)"))
+
+  (it "closes open maps and vectors"
+    (expect (cider--insert-closing-delimiters "{:a [1 2")
+            :to-equal "{:a [1 2]}")))

--- a/test/cider-resolve-tests.el
+++ b/test/cider-resolve-tests.el
@@ -158,16 +158,16 @@
   (it "returns interned symbols for a namespace"
     (with-mock-ns-cache
       (let ((symbols (cider-resolve-ns-symbols "clojure.set")))
-        (expect (plist-get symbols "union" #'equal) :to-be-truthy))))
+        (expect (cider-plist-get symbols "union") :to-be-truthy))))
 
   (it "includes alias-qualified symbols"
     (with-mock-ns-cache
       (let ((symbols (cider-resolve-ns-symbols "myapp.core")))
         ;; Should include interns
-        (expect (plist-get symbols "my-fn" #'equal) :to-be-truthy)
+        (expect (cider-plist-get symbols "my-fn") :to-be-truthy)
         ;; Should include alias-qualified symbols
-        (expect (plist-get symbols "str/join" #'equal) :to-be-truthy)
-        (expect (plist-get symbols "set/union" #'equal) :to-be-truthy))))
+        (expect (cider-plist-get symbols "str/join") :to-be-truthy)
+        (expect (cider-plist-get symbols "set/union") :to-be-truthy))))
 
   (it "returns nil for unknown namespaces"
     (with-mock-ns-cache

--- a/test/cider-resolve-tests.el
+++ b/test/cider-resolve-tests.el
@@ -1,0 +1,176 @@
+;;; cider-resolve-tests.el  -*- lexical-binding: t; -*-
+
+;; Copyright © 2015-2026 Bozhidar Batsov
+
+;; Author: Bozhidar Batsov <bozhidar@batsov.dev>
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; This file is part of CIDER
+
+;;; Code:
+
+(require 'buttercup)
+(require 'cider-resolve)
+
+;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
+
+;; A mock namespace cache matching the structure documented in cider-resolve.el.
+(defvar cider-resolve-tests--ns-cache
+  '(dict
+    "myapp.core"
+    (dict "aliases"
+          (dict "str" "clojure.string"
+                "set" "clojure.set")
+          "interns"
+          (dict "my-fn" (dict "arglists" "([] [x])")
+                "my-var" (dict "arglists" nil))
+          "refers"
+          (dict "join" "#'clojure.string/join"))
+    "clojure.string"
+    (dict "aliases" (dict)
+          "interns"
+          (dict "join" (dict "arglists" "([coll] [separator coll])")
+                "blank?" (dict "arglists" "([s])"))
+          "refers" (dict))
+    "clojure.set"
+    (dict "aliases" (dict)
+          "interns"
+          (dict "union" (dict "arglists" "([& sets])"))
+          "refers" (dict))
+    "clojure.core"
+    (dict "aliases" (dict)
+          "interns"
+          (dict "map" (dict "arglists" "([f] [f coll])")
+                "filter" (dict "arglists" "([pred] [pred coll])"))
+          "refers" (dict))))
+
+(defmacro with-mock-ns-cache (&rest body)
+  "Execute BODY with a mock REPL buffer containing a namespace cache."
+  (declare (indent 0))
+  `(let ((repl-buf (generate-new-buffer " *mock-repl*")))
+     (unwind-protect
+         (progn
+           (with-current-buffer repl-buf
+             (setq-local cider-repl-ns-cache cider-resolve-tests--ns-cache)
+             (setq-local cider-repl-type 'clj))
+           (spy-on 'cider-current-repl :and-return-value repl-buf)
+           ,@body)
+       (kill-buffer repl-buf))))
+
+(describe "cider-resolve--get-in"
+  (it "retrieves values from the namespace cache"
+    (with-mock-ns-cache
+      (expect (cider-resolve--get-in "myapp.core" "interns" "my-fn")
+              :to-be-truthy)))
+
+  (it "returns nil for missing keys"
+    (with-mock-ns-cache
+      (expect (cider-resolve--get-in "myapp.core" "interns" "nonexistent")
+              :to-equal nil)))
+
+  (it "returns nil when no REPL is connected"
+    (spy-on 'cider-current-repl :and-return-value nil)
+    (expect (cider-resolve--get-in "myapp.core") :to-equal nil)))
+
+(describe "cider-resolve-alias"
+  (it "resolves a known alias to its namespace"
+    (with-mock-ns-cache
+      (expect (cider-resolve-alias "myapp.core" "str")
+              :to-equal "clojure.string")
+      (expect (cider-resolve-alias "myapp.core" "set")
+              :to-equal "clojure.set")))
+
+  (it "returns the alias itself when not found"
+    (with-mock-ns-cache
+      (expect (cider-resolve-alias "myapp.core" "unknown")
+              :to-equal "unknown"))))
+
+(describe "cider-resolve-var"
+  (it "resolves an unqualified var from namespace interns"
+    (with-mock-ns-cache
+      (let ((meta (cider-resolve-var "myapp.core" "my-fn")))
+        (expect meta :to-be-truthy)
+        (expect (nrepl-dict-get meta "arglists") :to-equal "([] [x])"))))
+
+  (it "resolves a namespace-qualified var"
+    (with-mock-ns-cache
+      (let ((meta (cider-resolve-var "myapp.core" "clojure.string/join")))
+        (expect meta :to-be-truthy)
+        (expect (nrepl-dict-get meta "arglists")
+                :to-equal "([coll] [separator coll])"))))
+
+  (it "resolves an alias-qualified var"
+    (with-mock-ns-cache
+      (let ((meta (cider-resolve-var "myapp.core" "str/join")))
+        (expect meta :to-be-truthy)
+        (expect (nrepl-dict-get meta "arglists")
+                :to-equal "([coll] [separator coll])"))))
+
+  (it "resolves a var-quoted qualified var"
+    (with-mock-ns-cache
+      (let ((meta (cider-resolve-var "myapp.core" "#'clojure.string/blank?")))
+        (expect meta :to-be-truthy)
+        (expect (nrepl-dict-get meta "arglists") :to-equal "([s])"))))
+
+  (it "resolves a referred var"
+    (with-mock-ns-cache
+      (let ((meta (cider-resolve-var "myapp.core" "join")))
+        (expect meta :to-be-truthy))))
+
+  (it "falls back to clojure.core for unresolved vars"
+    (with-mock-ns-cache
+      (let ((meta (cider-resolve-var "myapp.core" "map")))
+        (expect meta :to-be-truthy)
+        (expect (nrepl-dict-get meta "arglists") :to-equal "([f] [f coll])"))))
+
+  (it "returns nil for completely unknown vars"
+    (with-mock-ns-cache
+      (expect (cider-resolve-var "myapp.core" "totally-unknown")
+              :to-equal nil))))
+
+(describe "cider-resolve-core-ns"
+  (it "returns clojure.core for Clojure REPLs"
+    (with-mock-ns-cache
+      (let ((result (cider-resolve-core-ns)))
+        (expect result :to-be-truthy))))
+
+  (it "returns nil when no REPL is connected"
+    (spy-on 'cider-current-repl :and-return-value nil)
+    (expect (cider-resolve-core-ns) :to-equal nil)))
+
+(describe "cider-resolve-ns-symbols"
+  (it "returns interned symbols for a namespace"
+    (with-mock-ns-cache
+      (let ((symbols (cider-resolve-ns-symbols "clojure.set")))
+        (expect (plist-get symbols "union" #'equal) :to-be-truthy))))
+
+  (it "includes alias-qualified symbols"
+    (with-mock-ns-cache
+      (let ((symbols (cider-resolve-ns-symbols "myapp.core")))
+        ;; Should include interns
+        (expect (plist-get symbols "my-fn" #'equal) :to-be-truthy)
+        ;; Should include alias-qualified symbols
+        (expect (plist-get symbols "str/join" #'equal) :to-be-truthy)
+        (expect (plist-get symbols "set/union" #'equal) :to-be-truthy))))
+
+  (it "returns nil for unknown namespaces"
+    (with-mock-ns-cache
+      (expect (cider-resolve-ns-symbols "nonexistent.ns") :to-equal nil))))
+
+;;; cider-resolve-tests.el ends here

--- a/test/cider-test-tests.el
+++ b/test/cider-test-tests.el
@@ -27,9 +27,36 @@
 
 (require 'buttercup)
 (require 'cider-test)
+(require 'cider-client)
 (require 'spinner)
 
 ;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
+
+(describe "cider--test-var-p"
+  (it "uses cider/get-state op when available"
+    (spy-on 'cider-nrepl-op-supported-p :and-return-value t)
+    (spy-on 'cider-resolve--get-in :and-return-value t)
+    (expect (cider--test-var-p "myapp.core-test" "my-test") :to-be-truthy)
+    (expect 'cider-resolve--get-in :to-have-been-called-with
+            "myapp.core-test" "interns" "my-test" "test"))
+
+  (it "returns nil via cider/get-state when var is not a test"
+    (spy-on 'cider-nrepl-op-supported-p :and-return-value t)
+    (spy-on 'cider-resolve--get-in :and-return-value nil)
+    (expect (cider--test-var-p "myapp.core" "my-fn") :not :to-be-truthy))
+
+  (it "falls back to eval when cider/get-state is not available"
+    (spy-on 'cider-nrepl-op-supported-p :and-return-value nil)
+    (spy-on 'cider-sync-tooling-eval :and-return-value
+            '(dict "value" "true"))
+    (expect (cider--test-var-p "myapp.core-test" "my-test") :to-be-truthy)
+    (expect 'cider-sync-tooling-eval :to-have-been-called))
+
+  (it "returns nil via eval fallback when var is not a test"
+    (spy-on 'cider-nrepl-op-supported-p :and-return-value nil)
+    (spy-on 'cider-sync-tooling-eval :and-return-value
+            '(dict "value" "false"))
+    (expect (cider--test-var-p "myapp.core" "my-fn") :not :to-be-truthy)))
 
 (describe "cider-test--string-contains-newline"
   (it "Returns `t' only for escaped newlines"

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -319,7 +319,7 @@ buffer."
 
 (describe "cider-in-string-p"
   (it "returns non-nil when point is inside a string"
-    (with-clojure-buffer "(def x \"hel|lo\")"
+    (with-clojure-buffer "(def x \"hell|o\")"
       (expect (cider-in-string-p) :to-be-truthy)))
 
   (it "returns nil when point is outside a string"
@@ -328,7 +328,7 @@ buffer."
 
 (describe "cider-in-comment-p"
   (it "returns non-nil when point is inside a comment"
-    (with-clojure-buffer ";; hel|lo\n(def x 1)"
+    (with-clojure-buffer ";; hell|o\n(def x 1)"
       (expect (cider-in-comment-p) :to-be-truthy)))
 
   (it "returns nil when point is outside a comment"

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -317,6 +317,58 @@ buffer."
     (expect (cider--indent-spec-to-legacy :defn) :to-equal :defn)
     (expect (cider--indent-spec-to-legacy '(1 (:defn))) :to-equal '(1 (:defn)))))
 
+(describe "cider-in-string-p"
+  (it "returns non-nil when point is inside a string"
+    (with-clojure-buffer "(def x \"hel|lo\")"
+      (expect (cider-in-string-p) :to-be-truthy)))
+
+  (it "returns nil when point is outside a string"
+    (with-clojure-buffer "(def| x \"hello\")"
+      (expect (cider-in-string-p) :not :to-be-truthy))))
+
+(describe "cider-in-comment-p"
+  (it "returns non-nil when point is inside a comment"
+    (with-clojure-buffer ";; hel|lo\n(def x 1)"
+      (expect (cider-in-comment-p) :to-be-truthy)))
+
+  (it "returns nil when point is outside a comment"
+    (with-clojure-buffer ";; hello\n(def| x 1)"
+      (expect (cider-in-comment-p) :not :to-be-truthy))))
+
+(describe "cider--tooling-file-p"
+  (it "returns non-nil for form-init files"
+    (expect (cider--tooling-file-p "form-init12345.clj") :to-be-truthy)
+    (expect (cider--tooling-file-p "/tmp/form-init67890.clj") :to-be-truthy))
+
+  (it "returns nil for normal source files"
+    (expect (cider--tooling-file-p "core.clj") :not :to-be-truthy)
+    (expect (cider--tooling-file-p "/src/myapp/core.clj") :not :to-be-truthy)))
+
+(describe "cider--project-name"
+  (it "extracts the project name from a directory path"
+    (expect (cider--project-name "/home/user/projects/my-app/") :to-equal "my-app")
+    (expect (cider--project-name "/home/user/projects/my-app") :to-equal "my-app"))
+
+  (it "returns nil for nil input"
+    (expect (cider--project-name nil) :to-equal nil)))
+
+(describe "cider-propertize"
+  (it "applies the correct face for each kind"
+    (expect (get-text-property 0 'face (cider-propertize "x" 'fn))
+            :to-equal 'font-lock-function-name-face)
+    (expect (get-text-property 0 'face (cider-propertize "x" 'var))
+            :to-equal 'font-lock-variable-name-face)
+    (expect (get-text-property 0 'face (cider-propertize "x" 'ns))
+            :to-equal 'font-lock-type-face)
+    (expect (get-text-property 0 'face (cider-propertize "x" 'macro))
+            :to-equal 'font-lock-keyword-face)
+    (expect (get-text-property 0 'face (cider-propertize "x" 'special-form))
+            :to-equal 'font-lock-keyword-face))
+
+  (it "uses a literal face name as-is"
+    (expect (get-text-property 0 'face (cider-propertize "x" 'font-lock-warning-face))
+            :to-equal 'font-lock-warning-face)))
+
 (describe "cider-version-sans-patch"
   :var (cider-version)
   (it "returns the version sans the patch"


### PR DESCRIPTION
Adds Buttercup specs for several modules that had little or no unit test coverage:

- `cider-util` (untested pure functions)
- `cider-eval` (pure functions)
- `cider-resolve`
- `cider-member-info`, `cider-classpath-entries`, `cider--test-var-p`

All tests are client-side only (no nREPL connection needed).