### PR TITLE
Use namespaced nREPL ops to match cider-nrepl 0.59+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Changes
 
+- [#710](https://github.com/clojure-emacs/cider-nrepl/issues/710): Use namespaced nREPL ops (e.g. `cider/info` instead of `info`) to match cider-nrepl 0.59+.
 - Bump the injected `nrepl` to [1.7.0](https://github.com/nrepl/nrepl/blob/master/CHANGELOG.md#170-2026-04-14).
 - Bump the injected `cider-nrepl` to [0.59.0](https://github.com/clojure-emacs/cider-nrepl/blob/master/CHANGELOG.md#0590-2026-04-14).
 - [#3788](https://github.com/clojure-emacs/cider/issues/3788): Remove the `cider-info-form` eval fallback for `cider-var-info`. The `info` and `lookup` nREPL ops are now required.

--- a/lisp/cider-apropos.el
+++ b/lisp/cider-apropos.el
@@ -143,7 +143,7 @@ optionally search doc strings (based on DOCS-P), include private vars
                  (y-or-n-p "Include private symbols? ")
                  (y-or-n-p "Case-sensitive? ")))))
   (cider-ensure-connected)
-  (cider-ensure-op-supported "apropos")
+  (cider-ensure-op-supported "cider/apropos")
   (if-let* ((summary (cider-apropos-summary
                       query ns docs-p privates-p case-sensitive-p))
             (results (cider-sync-request:apropos query ns docs-p privates-p case-sensitive-p)))
@@ -155,7 +155,7 @@ optionally search doc strings (based on DOCS-P), include private vars
   "Shortcut for (cider-apropos <query> nil t)."
   (interactive)
   (cider-ensure-connected)
-  (cider-ensure-op-supported "apropos")
+  (cider-ensure-op-supported "cider/apropos")
   (cider-apropos (read-string "Search for Clojure documentation (a regular expression): ") nil t))
 
 (defun cider-apropos-act-on-symbol (symbol)
@@ -189,7 +189,7 @@ optionally search doc strings (based on DOCS-P), include private vars
                  (y-or-n-p "Include private symbols? ")
                  (y-or-n-p "Case-sensitive? ")))))
   (cider-ensure-connected)
-  (cider-ensure-op-supported "apropos")
+  (cider-ensure-op-supported "cider/apropos")
   (if-let* ((summary (cider-apropos-summary
                       query ns docs-p privates-p case-sensitive-p))
             (results (mapcar (lambda (r) (nrepl-dict-get r "name"))
@@ -202,7 +202,7 @@ optionally search doc strings (based on DOCS-P), include private vars
   "Shortcut for (cider-apropos-select <query> nil t)."
   (interactive)
   (cider-ensure-connected)
-  (cider-ensure-op-supported "apropos")
+  (cider-ensure-op-supported "cider/apropos")
   (cider-apropos-select (read-string "Search for Clojure documentation (a regular expression): ") nil t))
 
 (provide 'cider-apropos)

--- a/lisp/cider-browse-spec.el
+++ b/lisp/cider-browse-spec.el
@@ -368,7 +368,7 @@ a more user friendly representation of SPEC-FORM."
 (defun cider-browse-spec--browse (spec)
   "Browse SPEC."
   (cider-ensure-connected)
-  (cider-ensure-op-supported "spec-form")
+  (cider-ensure-op-supported "cider/spec-form")
   ;; Expand auto-resolved keywords
   (when-let* ((val (and (string-match-p "^::.+" spec)
                         (nrepl-dict-get (cider-sync-tooling-eval spec (cider-current-ns)) "value"))))
@@ -398,7 +398,7 @@ property."
   "Generate and print an example of the current spec."
   (interactive)
   (cider-ensure-connected)
-  (cider-ensure-op-supported "spec-example")
+  (cider-ensure-op-supported "cider/spec-example")
   (if-let* ((spec cider-browse-spec--current-spec))
       (if-let* ((example (cider-sync-request:spec-example spec)))
           (with-current-buffer (cider-popup-buffer cider-browse-spec-example-buffer 'select #'cider-browse-spec-example-mode 'ancillary)
@@ -430,7 +430,7 @@ Generates a new example for the current spec."
   "Open the list of specs that matches REGEX in a popup buffer.
 Displays all specs when REGEX is nil."
   (cider-ensure-connected)
-  (cider-ensure-op-supported "spec-list")
+  (cider-ensure-op-supported "cider/spec-list")
   (let ((filter-regex (or regex "")))
     (with-current-buffer (cider-popup-buffer cider-browse-spec-buffer 'select nil 'ancillary)
       (let ((specs (cider-sync-request:spec-list filter-regex)))

--- a/lisp/cider-client.el
+++ b/lisp/cider-client.el
@@ -530,7 +530,7 @@ When multiple matching vars are returned you'll be prompted to select one,
 unless ALL is truthy."
   (when (and var (not (string= var "")))
     (let ((var-info (cond
-                     ((cider-nrepl-op-supported-p "info") (cider-sync-request:info var nil nil (cider-completion-get-context t)))
+                     ((cider-nrepl-op-supported-p "cider/info") (cider-sync-request:info var nil nil (cider-completion-get-context t)))
                      ((cider-nrepl-op-supported-p "lookup") (cider-sync-request:lookup var)))))
       (if all var-info (cider--var-choice var-info)))))
 
@@ -579,7 +579,7 @@ Emacs Lisp."
 Optional arguments include SEARCH-NS, DOCS-P, PRIVATES-P, CASE-SENSITIVE-P."
   (let* ((query (replace-regexp-in-string "[ \t]+" ".+" query))
          (response (cider-nrepl-send-sync-request
-                    `("op" "apropos"
+                    `("op" "cider/apropos"
                       "ns" ,(cider-current-ns)
                       "query" ,query
                       ,@(when search-ns `("search-ns" ,search-ns))
@@ -593,9 +593,9 @@ Optional arguments include SEARCH-NS, DOCS-P, PRIVATES-P, CASE-SENSITIVE-P."
 
 (defun cider-sync-request:classpath (&optional connection)
   "Return a list of classpath entries for CONNECTION."
-  (cider-ensure-op-supported "classpath" connection)
+  (cider-ensure-op-supported "cider/classpath" connection)
   (thread-first
-    '("op" "classpath")
+    '("op" "cider/classpath")
     (cider-nrepl-send-sync-request connection)
     (nrepl-dict-get "classpath")))
 
@@ -623,7 +623,7 @@ resolve those to absolute paths."
 (defun cider-classpath-entries (&optional connection)
   "Return a list of classpath entries for CONNECTION."
   (seq-map #'expand-file-name ; normalize filenames for e.g. Windows
-           (if (cider-nrepl-op-supported-p "classpath" connection)
+           (if (cider-nrepl-op-supported-p "cider/classpath" connection)
                (cider-sync-request:classpath connection)
              (cider-fallback-eval:classpath))))
 
@@ -639,7 +639,7 @@ resolve those to absolute paths."
 (defun cider-sync-request:complete (prefix context)
   "Return a list of completions for PREFIX using nREPL's \"complete\" op.
 CONTEXT represents a completion context for compliment."
-  (when-let* ((dict (thread-first `("op" "complete"
+  (when-let* ((dict (thread-first `("op" "cider/complete"
                                     "ns" ,(cider-current-ns)
                                     "prefix" ,prefix
                                     "context" ,context
@@ -651,7 +651,7 @@ CONTEXT represents a completion context for compliment."
 
 (defun cider-sync-request:complete-flush-caches ()
   "Send \"complete-flush-caches\" op to flush Compliment's caches."
-  (cider-nrepl-send-sync-request (list "op" "complete-flush-caches"
+  (cider-nrepl-send-sync-request (list "op" "cider/complete-flush-caches"
                                        "session" (cider-nrepl-eval-session))
                                  nil
                                  'abort-on-input))
@@ -659,7 +659,7 @@ CONTEXT represents a completion context for compliment."
 (defun cider-sync-request:info (symbol &optional class member context)
   "Send \"info\" op with parameters SYMBOL or CLASS and MEMBER, honor CONTEXT."
   (let* ((req
-          `("op" "info"
+          `("op" "cider/info"
             "ns" ,(cider-current-ns)
             ,@(when symbol `("sym" ,symbol))
             ,@(when class `("class" ,class))
@@ -694,7 +694,7 @@ CONTEXT represents a completion context for compliment."
 
 (defun cider-sync-request:eldoc (symbol &optional class member context)
   "Send \"eldoc\" op with parameters SYMBOL or CLASS and MEMBER, honor CONTEXT."
-  (when-let* ((eldoc (thread-first `("op" "eldoc"
+  (when-let* ((eldoc (thread-first `("op" "cider/eldoc"
                                      "ns" ,(cider-current-ns)
                                      ,@(when symbol `("sym" ,symbol))
                                      ,@(when class `("class" ,class))
@@ -708,7 +708,7 @@ CONTEXT represents a completion context for compliment."
 
 (defun cider-sync-request:eldoc-datomic-query (symbol)
   "Send \"eldoc-datomic-query\" op with parameter SYMBOL."
-  (when-let* ((eldoc (thread-first `("op" "eldoc-datomic-query"
+  (when-let* ((eldoc (thread-first `("op" "cider/eldoc-datomic-query"
                                      "ns" ,(cider-current-ns)
                                      ,@(when symbol `("sym" ,symbol)))
                                    (cider-nrepl-send-sync-request nil 'abort-on-input))))
@@ -721,7 +721,7 @@ CONTEXT represents a completion context for compliment."
 Optional argument FILTER-REGEX filters specs.  By default, all specs are
 returned."
   (setq filter-regex (or filter-regex ""))
-  (thread-first `("op" "spec-list"
+  (thread-first `("op" "cider/spec-list"
                   "filter-regex" ,filter-regex
                   "ns" ,(cider-current-ns))
                 (cider-nrepl-send-sync-request)
@@ -729,7 +729,7 @@ returned."
 
 (defun cider-sync-request:spec-form (spec)
   "Get SPEC's form from registry."
-  (thread-first `("op" "spec-form"
+  (thread-first `("op" "cider/spec-form"
                   "spec-name" ,spec
                   "ns" ,(cider-current-ns))
                 (cider-nrepl-send-sync-request)
@@ -737,21 +737,21 @@ returned."
 
 (defun cider-sync-request:spec-example (spec)
   "Get an example for SPEC."
-  (thread-first `("op" "spec-example"
+  (thread-first `("op" "cider/spec-example"
                   "spec-name" ,spec)
                 (cider-nrepl-send-sync-request)
                 (nrepl-dict-get "spec-example")))
 
 (defun cider-sync-request:ns-list ()
   "Get a list of the available namespaces."
-  (thread-first `("op" "ns-list"
+  (thread-first `("op" "cider/ns-list"
                   "exclude-regexps" ,cider-filtered-namespaces-regexps)
                 (cider-nrepl-send-sync-request)
                 (nrepl-dict-get "ns-list")))
 
 (defun cider-sync-request:ns-vars (ns)
   "Get a list of the vars in NS."
-  (thread-first `("op" "ns-vars"
+  (thread-first `("op" "cider/ns-vars"
                   "ns" ,ns)
                 (cider-nrepl-send-sync-request)
                 (nrepl-dict-get "ns-vars")))
@@ -773,7 +773,7 @@ Note that even when favoring a url, the url itself might be nil,
 in which case we'll fall back to the resource name."
   (unless ns
     (error "No ns provided"))
-  (let ((response (cider-nrepl-send-sync-request `("op" "ns-path"
+  (let ((response (cider-nrepl-send-sync-request `("op" "cider/ns-path"
                                                    "ns" ,ns))))
     (nrepl-dbind-response response (path url)
       (if (and favor-url url)
@@ -782,14 +782,14 @@ in which case we'll fall back to the resource name."
 
 (defun cider-sync-request:ns-vars-with-meta (ns)
   "Get a map of the vars in NS to its metadata information."
-  (thread-first `("op" "ns-vars-with-meta"
+  (thread-first `("op" "cider/ns-vars-with-meta"
                   "ns" ,ns)
                 (cider-nrepl-send-sync-request)
                 (nrepl-dict-get "ns-vars-with-meta")))
 
 (defun cider-sync-request:private-ns-vars-with-meta (ns)
   "Get a map of the vars in NS to its metadata information."
-  (thread-first `("op" "ns-vars-with-meta"
+  (thread-first `("op" "cider/ns-vars-with-meta"
                   "ns" ,ns
                   "var-query" ,(nrepl-dict "private?" "t"
                                            "include-meta-key" '("private")))
@@ -798,13 +798,13 @@ in which case we'll fall back to the resource name."
 
 (defun cider-sync-request:ns-load-all ()
   "Load all project namespaces."
-  (thread-first '("op" "ns-load-all")
+  (thread-first '("op" "cider/ns-load-all")
                 (cider-nrepl-send-sync-request)
                 (nrepl-dict-get "loaded-ns")))
 
 (defun cider-sync-request:resource (name)
   "Perform nREPL \"resource\" op with resource name NAME."
-  (thread-first `("op" "resource"
+  (thread-first `("op" "cider/resource"
                   "name" ,name)
                 (cider-nrepl-send-sync-request)
                 (nrepl-dict-get "resource-path")))
@@ -812,15 +812,15 @@ in which case we'll fall back to the resource name."
 (defun cider-sync-request:resources-list ()
   "Return a list of all resources on the classpath.
 The result entries are relative to the classpath."
-  (when-let* ((resources (thread-first '("op" "resources-list")
+  (when-let* ((resources (thread-first '("op" "cider/resources-list")
                                        (cider-nrepl-send-sync-request)
                                        (nrepl-dict-get "resources-list"))))
     (seq-map (lambda (resource) (nrepl-dict-get resource "relpath")) resources)))
 
 (defun cider-sync-request:fn-refs (ns sym)
   "Return a list of functions that reference the function identified by NS and SYM."
-  (cider-ensure-op-supported "fn-refs")
-  (thread-first `("op" "fn-refs"
+  (cider-ensure-op-supported "cider/fn-refs")
+  (thread-first `("op" "cider/fn-refs"
                   "ns" ,ns
                   "sym" ,sym)
                 (cider-nrepl-send-sync-request)
@@ -828,8 +828,8 @@ The result entries are relative to the classpath."
 
 (defun cider-sync-request:fn-deps (ns sym)
   "Return a list of function deps for the function identified by NS and SYM."
-  (cider-ensure-op-supported "fn-deps")
-  (thread-first `("op" "fn-deps"
+  (cider-ensure-op-supported "cider/fn-deps")
+  (thread-first `("op" "cider/fn-deps"
                   "ns" ,ns
                   "sym" ,sym)
                 (cider-nrepl-send-sync-request)
@@ -838,7 +838,7 @@ The result entries are relative to the classpath."
 (defun cider-sync-request:format-code (code &optional format-options)
   "Perform nREPL \"format-code\" op with CODE.
 FORMAT-OPTIONS is an optional configuration map for cljfmt."
-  (let* ((request `("op" "format-code"
+  (let* ((request `("op" "cider/format-code"
                     "options" ,(cider--nrepl-format-code-request-options format-options)
                     "code" ,code))
          (response (cider-nrepl-send-sync-request request))
@@ -851,7 +851,7 @@ FORMAT-OPTIONS is an optional configuration map for cljfmt."
 
 (defun cider-sync-request:format-edn (edn right-margin)
   "Perform \"format-edn\" op with EDN and RIGHT-MARGIN."
-  (let* ((request `("op" "format-edn"
+  (let* ((request `("op" "cider/format-edn"
                     "edn" ,edn
                     ,@(cider--nrepl-print-request-plist right-margin)))
          (response (cider-nrepl-send-sync-request request))

--- a/lisp/cider-clojuredocs.el
+++ b/lisp/cider-clojuredocs.el
@@ -40,7 +40,7 @@
 
 (defun cider-sync-request:clojuredocs-lookup (ns sym)
   "Perform nREPL \"clojuredocs-lookup\" op with NS and SYM."
-  (thread-first `("op" "clojuredocs-lookup"
+  (thread-first `("op" "cider/clojuredocs-lookup"
                   "ns" ,ns
                   "sym" ,sym)
                 (cider-nrepl-send-sync-request)
@@ -48,7 +48,7 @@
 
 (defun cider-sync-request:clojuredocs-refresh ()
   "Refresh the ClojureDocs cache."
-  (thread-first '("op" "clojuredocs-refresh-cache")
+  (thread-first '("op" "cider/clojuredocs-refresh-cache")
                 (cider-nrepl-send-sync-request)
                 (nrepl-dict-get "status")))
 

--- a/lisp/cider-completion.el
+++ b/lisp/cider-completion.el
@@ -133,7 +133,7 @@ completion functionality."
    ;; if we don't have a connection, end early
    ((not (cider-connected-p)) nil)
    ;; next we try if cider-nrepl's completion is available
-   ((cider-nrepl-op-supported-p "complete")
+   ((cider-nrepl-op-supported-p "cider/complete")
     (let* ((context (cider-completion-get-context))
            (candidates (cider-sync-request:complete prefix context)))
       (mapcar #'cider-completion--parse-candidate-map candidates)))

--- a/lisp/cider-connection.el
+++ b/lisp/cider-connection.el
@@ -300,7 +300,7 @@ message in the REPL area."
 ;; TODO: Use some null handler here
 (defun cider--subscribe-repl-to-server-out ()
   "Subscribe to the nREPL server's *out*."
-  (cider-nrepl-send-request '("op" "out-subscribe")
+  (cider-nrepl-send-request '("op" "cider/out-subscribe")
                             (cider-interactive-eval-handler (current-buffer))))
 
 (defvar cider-mode)
@@ -383,7 +383,7 @@ buffer."
          ;; If we don't do this the server's output will end up
          ;; in the *nrepl-server* buffer.
          (when (and cider-redirect-server-output-to-repl
-                    (cider-nrepl-op-supported-p "out-subscribe"))
+                    (cider-nrepl-op-supported-p "cider/out-subscribe"))
            (cider--subscribe-repl-to-server-out))
 
          ;; Middleware on cider-nrepl's side is deferred until first usage, but

--- a/lisp/cider-debug.el
+++ b/lisp/cider-debug.el
@@ -102,7 +102,7 @@ configure `cider-debug-prompt' instead."
 (defun cider-browse-instrumented-defs ()
   "List all instrumented definitions."
   (interactive)
-  (if-let* ((all (thread-first (cider-nrepl-send-sync-request '("op" "debug-instrumented-defs"))
+  (if-let* ((all (thread-first (cider-nrepl-send-sync-request '("op" "cider/debug-instrumented-defs"))
                                (nrepl-dict-get "list"))))
       (with-current-buffer (cider-popup-buffer cider-browse-ns-buffer t)
         (let ((inhibit-read-only t))
@@ -137,7 +137,7 @@ configure `cider-debug-prompt' instead."
 (defun cider--debug-init-connection ()
   "Initialize a connection with the cider.debug middleware."
   (cider-nrepl-send-request
-   `("op" "init-debugger"
+   `("op" "cider/init-debugger"
      ,@(cider--nrepl-print-request-plist fill-column))
    #'cider--debug-response-handler))
 
@@ -437,7 +437,7 @@ message."
   (when (and (string-prefix-p ":" command) force)
     (setq command (format "{:response %s :force? true}" command)))
   (cider-nrepl-send-unhandled-request
-   `("op" "debug-input"
+   `("op" "cider/debug-input"
      "input" ,(or command ":quit")
      "key" ,(or key (nrepl-dict-get cider--debug-mode-response "key"))))
   (ignore-errors (cider--debug-mode -1)))

--- a/lisp/cider-doc.el
+++ b/lisp/cider-doc.el
@@ -218,7 +218,7 @@ the value of `cider-prompt-for-symbol'.  With prefix arg ARG, does the
 opposite of what that option dictates."
   (interactive "P")
   (cider-ensure-connected)
-  (cider-ensure-op-supported "info")
+  (cider-ensure-op-supported "cider/info")
   (funcall (cider-prompt-for-symbol-function arg)
            "Javadoc for"
            #'cider-javadoc-handler))

--- a/lisp/cider-eldoc.el
+++ b/lisp/cider-eldoc.el
@@ -395,7 +395,7 @@ Otherwise return the eldoc of the first symbol of the sexp."
   "Return the info for THING (as string).
 This includes the arglist and ns and symbol name (if available)."
   (let ((thing (cider-eldoc--convert-ns-keywords thing)))
-    (when (and (cider-nrepl-op-supported-p "eldoc")
+    (when (and (cider-nrepl-op-supported-p "cider/eldoc")
                thing
                ;; ignore blank things
                (not (string-blank-p thing))

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -399,7 +399,7 @@ Accumulates a list of causes and then calls CALLBACK on causes and phase."
   ;; Causes are returned as a series of messages, which we aggregate in `causes'
   (let (causes ex-phase)
     (cider-nrepl-send-request
-     `("op" "analyze-last-stacktrace")
+     `("op" "cider/analyze-last-stacktrace")
      (lambda (response)
        (nrepl-dbind-response response (status phase)
          (if (member "done" status)
@@ -418,7 +418,7 @@ Show error overlay in BUFFER if needed."
   "This function determines how the error buffer is shown.
 It delegates the actual error content to the eval or op handler.
 Show error overlay in BUFFER if needed."
-  (cond ((cider-nrepl-op-supported-p "analyze-last-stacktrace")
+  (cond ((cider-nrepl-op-supported-p "cider/analyze-last-stacktrace")
          (cider-default-err-op-handler buffer))
         ((cider-library-present-p "clojure.stacktrace")
          (cider-default-err-eval-handler))
@@ -1433,12 +1433,12 @@ passing arguments."
 (defun cider-undef ()
   "Undefine a symbol from the current ns."
   (interactive)
-  (cider-ensure-op-supported "undef")
+  (cider-ensure-op-supported "cider/undef")
   (cider-read-symbol-name
    "Undefine symbol: "
    (lambda (sym)
      (cider-nrepl-send-request
-      `("op" "undef"
+      `("op" "cider/undef"
         "ns" ,(cider-current-ns)
         "sym" ,sym)
       (cider-interactive-eval-handler (current-buffer))))))
@@ -1446,9 +1446,9 @@ passing arguments."
 (defun cider-undef-all (&optional ns)
   "Undefine all symbols and aliases from the namespace NS."
   (interactive)
-  (cider-ensure-op-supported "undef-all")
+  (cider-ensure-op-supported "cider/undef-all")
   (cider-nrepl-send-sync-request
-   `("op" "undef-all"
+   `("op" "cider/undef-all"
      "ns" ,(or ns (cider-current-ns)))))
 
 ;; Eval keymaps
@@ -1606,7 +1606,7 @@ all ns aliases and var mappings from the namespaces being reloaded"
   "Load all namespaces in the current project."
   (interactive)
   (cider-ensure-connected)
-  (cider-ensure-op-supported "ns-load-all")
+  (cider-ensure-op-supported "cider/ns-load-all")
   (when (y-or-n-p "Are you sure you want to load all namespaces in the project? ")
     (message "Loading all project namespaces...")
     (let ((loaded-ns-count (length (cider-sync-request:ns-load-all))))

--- a/lisp/cider-find.el
+++ b/lisp/cider-find.el
@@ -84,7 +84,7 @@ Show results in a different window if OTHER-WINDOW is true."
   (if-let* ((info (cider-var-info symbol-file)))
       (cider--jump-to-loc-from-info info other-window)
     (progn
-      (cider-ensure-op-supported "resource")
+      (cider-ensure-op-supported "cider/resource")
       (if-let* ((resource (cider-sync-request:resource symbol-file))
                 (buffer (cider-find-file resource)))
           (cider-jump-to buffer 0 other-window)
@@ -135,7 +135,7 @@ value is thing at point."
                          nil nil
                          (thing-at-point 'filename))
       (or (thing-at-point 'filename) ""))))
-  (cider-ensure-op-supported "resource")
+  (cider-ensure-op-supported "cider/resource")
   (when (string-empty-p path)
     (error "Cannot find resource for empty path"))
   (if-let* ((resource (cider-sync-request:resource path))
@@ -185,7 +185,7 @@ A prefix ARG of `-` or a double prefix argument causes
 the results to be displayed in a different window."
   (interactive "P")
   (cider-ensure-connected)
-  (cider-ensure-op-supported "ns-path")
+  (cider-ensure-op-supported "cider/ns-path")
   (if ns
       (cider--find-ns ns)
     (let* ((namespaces (cider-sync-request:ns-list))

--- a/lisp/cider-inspector.el
+++ b/lisp/cider-inspector.el
@@ -273,14 +273,14 @@ In particular, it does not read `cider-sexp-at-point'."
 (defun cider-inspector-pop ()
   "Pop the last value off the inspector stack and render it."
   (interactive)
-  (let ((result (cider-nrepl-send-sync-request `("op" "inspect-pop"))))
+  (let ((result (cider-nrepl-send-sync-request `("op" "cider/inspect-pop"))))
     (when (nrepl-dict-get result "value")
       (cider-inspector--render-value result :pop))))
 
 (defun cider-inspector-push (idx)
   "Inspect the value at IDX in the inspector stack and render it."
   (interactive)
-  (let ((result (cider-nrepl-send-sync-request `("op" "inspect-push"
+  (let ((result (cider-nrepl-send-sync-request `("op" "cider/inspect-push"
                                                  "idx" ,idx))))
     (when (nrepl-dict-get result "value")
       (push (point) cider-inspector-location-stack)
@@ -292,7 +292,7 @@ If EX-DATA is true, inspect ex-data of the exception instead."
   (interactive)
   (cl-assert (numberp index))
   (let ((result (cider-nrepl-send-sync-request
-                 `("op" "inspect-last-exception"
+                 `("op" "cider/inspect-last-exception"
                    "index" ,index
                    ,@(when ex-data
                        `("ex-data" "true"))))))
@@ -303,21 +303,21 @@ If EX-DATA is true, inspect ex-data of the exception instead."
 (defun cider-inspector-previous-sibling ()
   "Inspect the previous sibling value within a sequential parent."
   (interactive)
-  (let ((result (cider-nrepl-send-sync-request `("op" "inspect-previous-sibling"))))
+  (let ((result (cider-nrepl-send-sync-request `("op" "cider/inspect-previous-sibling"))))
     (when (nrepl-dict-get result "value")
       (cider-inspector--render-value result))))
 
 (defun cider-inspector-next-sibling ()
   "Inspect the next sibling value within a sequential parent."
   (interactive)
-  (let ((result (cider-nrepl-send-sync-request `("op" "inspect-next-sibling"))))
+  (let ((result (cider-nrepl-send-sync-request `("op" "cider/inspect-next-sibling"))))
     (when (nrepl-dict-get result "value")
       (cider-inspector--render-value result))))
 
 (defun cider-inspector--refresh-with-opts (&rest opts)
   "Invokes `inspect-refresh' op with supplied extra OPTS.
 Re-renders the currently inspected value."
-  (let ((result (cider-nrepl-send-sync-request `("op" "inspect-refresh" ,@opts))))
+  (let ((result (cider-nrepl-send-sync-request `("op" "cider/inspect-refresh" ,@opts))))
     (when (nrepl-dict-get result "value")
       (cider-inspector--render-value result))))
 
@@ -331,7 +331,7 @@ Re-renders the currently inspected value."
 
 Does nothing if already on the last page."
   (interactive)
-  (let ((result (cider-nrepl-send-sync-request '("op" "inspect-next-page"))))
+  (let ((result (cider-nrepl-send-sync-request '("op" "cider/inspect-next-page"))))
     (when (nrepl-dict-get result "value")
       (cider-inspector--render-value result))))
 
@@ -340,7 +340,7 @@ Does nothing if already on the last page."
 
 Does nothing if already on the first page."
   (interactive)
-  (let ((result (cider-nrepl-send-sync-request '("op" "inspect-prev-page"))))
+  (let ((result (cider-nrepl-send-sync-request '("op" "cider/inspect-prev-page"))))
     (when (nrepl-dict-get result "value")
       (cider-inspector--render-value result))))
 
@@ -374,7 +374,7 @@ MAX-NESTED-DEPTH is the new value."
   ;; Disable hint about analytics feature so that it is never displayed again.
   (when cider-inspector-display-analytics-hint
     (customize-set-variable 'cider-inspector-display-analytics-hint nil))
-  (let ((result (cider-nrepl-send-sync-request `("op" "inspect-display-analytics"))))
+  (let ((result (cider-nrepl-send-sync-request `("op" "cider/inspect-display-analytics"))))
     (when (nrepl-dict-get result "value")
       (cider-inspector--render-value result :next-inspectable))))
 
@@ -402,7 +402,7 @@ MAX-NESTED-DEPTH is the new value."
 (defun cider-inspector-toggle-view-mode ()
   "Toggle the view mode of the inspector between normal and object view mode."
   (interactive)
-  (let ((result (cider-nrepl-send-sync-request `("op" "inspect-toggle-view-mode"))))
+  (let ((result (cider-nrepl-send-sync-request `("op" "cider/inspect-toggle-view-mode"))))
     (when (nrepl-dict-get result "value")
       (cider-inspector--render-value result :next-inspectable))))
 
@@ -434,7 +434,7 @@ current-namespace."
   (interactive (let ((ns (cider-current-ns)))
                  (list (cider-inspector--read-var-name-from-user ns)
                        ns)))
-  (when-let* ((result (cider-nrepl-send-sync-request `("op" "inspect-def-current-value"
+  (when-let* ((result (cider-nrepl-send-sync-request `("op" "cider/inspect-def-current-value"
                                                        "ns" ,ns
                                                        "var-name" ,var-name))))
     (cider-inspector--render-value result)
@@ -444,17 +444,17 @@ current-namespace."
   "Print the current value of the inspector."
   (interactive)
   (cider-ensure-connected)
-  (cider-ensure-op-supported "inspect-print-current-value")
+  (cider-ensure-op-supported "cider/inspect-print-current-value")
   (let ((buffer (cider-popup-buffer cider-result-buffer nil 'clojure-mode 'ancillary)))
     (cider-nrepl-send-request
-     `("op" "inspect-print-current-value"
+     `("op" "cider/inspect-print-current-value"
        ,@(cider--nrepl-print-request-plist fill-column))
      (cider-popup-eval-handler buffer))))
 
 (defun cider-inspector-tap-current-val ()
   "Sends the current Inspector current value to `tap>'."
   (interactive)
-  (let ((response (cider-nrepl-send-sync-request '("op" "inspect-tap-current-value"))))
+  (let ((response (cider-nrepl-send-sync-request '("op" "cider/inspect-tap-current-value"))))
     (nrepl-dbind-response response (value err)
       (if value
           (message "Successfully tapped the current Inspector value")
@@ -467,7 +467,7 @@ current-namespace."
     (pcase property
       (`cider-value-idx
        (cl-assert value)
-       (nrepl-dbind-response (cider-nrepl-send-sync-request `("op" "inspect-tap-indexed"
+       (nrepl-dbind-response (cider-nrepl-send-sync-request `("op" "cider/inspect-tap-indexed"
                                                               "idx" ,value))
            (value err)
          (if value

--- a/lisp/cider-macroexpansion.el
+++ b/lisp/cider-macroexpansion.el
@@ -62,8 +62,8 @@ Possible values are:
   "Macroexpand, using EXPANDER, the given EXPR.
 The default for DISPLAY-NAMESPACES is taken from
 `cider-macroexpansion-display-namespaces'."
-  (cider-ensure-op-supported "macroexpand")
-  (let ((result (thread-first `("op" "macroexpand"
+  (cider-ensure-op-supported "cider/macroexpand")
+  (let ((result (thread-first `("op" "cider/macroexpand"
                                 "expander" ,expander
                                 "code" ,expr
                                 "ns" ,(cider-current-ns)

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -176,7 +176,7 @@ With a prefix argument, prompt for function to run instead of -main."
   (cider-ensure-connected)
   (let ((name (or function "-main")))
     (when-let* ((response (cider-nrepl-send-sync-request
-                           `("op" "ns-list-vars-by-name"
+                           `("op" "cider/ns-list-vars-by-name"
                              "name" ,name))))
       (if-let* ((vars (split-string (substring (nrepl-dict-get response "var-list") 1 -1))))
           (cider-interactive-eval

--- a/lisp/cider-ns.el
+++ b/lisp/cider-ns.el
@@ -238,9 +238,9 @@ Its behavior is controlled by `cider-ns-save-files-on-refresh' and
   "Return the reload operation to use.
 Based on OP-NAME and the value of cider-ns-code-reload-tool defcustom."
   (if (eq cider-ns-code-reload-tool 'tools.namespace)
-      (cond ((string= op-name "reload")       "refresh")
-            ((string= op-name "reload-all")   "refresh-all")
-            ((string= op-name "reload-clear") "refresh-clear"))
+      (cond ((string= op-name "reload")       "cider/refresh")
+            ((string= op-name "reload-all")   "cider/refresh-all")
+            ((string= op-name "reload-clear") "cider/refresh-clear"))
 
     (cond ((string= op-name "reload")       "cider.clj-reload/reload")
           ((string= op-name "reload-all")   "cider.clj-reload/reload-all")
@@ -300,7 +300,7 @@ refresh functions (defined in `cider-ns-refresh-before-fn' and
   (let ((clear? (member mode '(clear 16)))
         (all? (member mode '(refresh-all 4)))
         (inhibit-refresh-fns (member mode '(inhibit-fns -1))))
-    (cider-map-repls '(:clj "refresh" "cider.clj-reload/reload")
+    (cider-map-repls '(:clj "cider/refresh" "cider.clj-reload/reload")
       (lambda (conn)
         (cider-ns-refresh--save-modified-buffers conn)
         ;; Inside the lambda, so the buffer is not created if we error out.

--- a/lisp/cider-repl.el
+++ b/lisp/cider-repl.el
@@ -957,7 +957,7 @@ Handles an external-body TYPE by issuing a slurp request to fetch the content."
   (if-let* ((args        (cadr type))
             (access-type (nrepl-dict-get args "access-type")))
       (nrepl-send-request
-       (list "op" "slurp" "url" (nrepl-dict-get args access-type))
+       (list "op" "cider/slurp" "url" (nrepl-dict-get args access-type))
        (cider-repl-handler buffer)
        (cider-current-repl)))
   nil)
@@ -1809,7 +1809,7 @@ The checking is done as follows:
                                             (cider-classpath-entries))))
                                   (process-put proc :cached-classpath cp)
                                   cp)))
-                 (ns-list (when (nrepl-op-supported-p "ns-list" repl)
+                 (ns-list (when (nrepl-op-supported-p "cider/ns-list" repl)
                             (or (process-get proc :all-namespaces)
                                 (let ((ns-list (with-current-buffer repl
                                                  (cider-sync-request:ns-list))))

--- a/lisp/cider-test.el
+++ b/lisp/cider-test.el
@@ -274,7 +274,7 @@ prompt and whether to use a new window.  Similar to `cider-find-var'."
   "Display stacktrace for the erring NS VAR test with the assertion INDEX."
   (let (causes)
     (cider-nrepl-send-request
-     `("op" "test-stacktrace"
+     `("op" "cider/test-stacktrace"
        "ns" ,ns
        "var" ,var
        "index" ,index
@@ -749,10 +749,10 @@ running them."
         (cider-test-spinner-start (current-buffer))
         (setq cider-test--current-repl conn)
         (let* ((retest? (eq :non-passing ns))
-               (request `("op" ,(cond ((stringp ns)         "test")
-                                      ((eq :project ns)     "test-all")
-                                      ((eq :loaded ns)      "test-all")
-                                      (retest?              "retest")))))
+               (request `("op" ,(cond ((stringp ns)         "cider/test")
+                                      ((eq :project ns)     "cider/test-all")
+                                      ((eq :loaded ns)      "cider/test-all")
+                                      (retest?              "cider/retest")))))
           ;; we add optional parts of the request only when relevant
           (when (and (listp include-selectors) include-selectors)
             (setq request (append request `("include" ,include-selectors))))

--- a/lisp/cider-tracing.el
+++ b/lisp/cider-tracing.el
@@ -34,7 +34,7 @@
 
 (defun cider-sync-request:toggle-trace-var (sym)
   "Toggle var tracing for SYM."
-  (thread-first `("op" "toggle-trace-var"
+  (thread-first `("op" "cider/toggle-trace-var"
                   "ns" ,(cider-current-ns)
                   "sym" ,sym)
                 (cider-nrepl-send-sync-request)))
@@ -56,14 +56,14 @@ Prompts for the symbol to use, or uses the symbol at point, depending on
 the value of `cider-prompt-for-symbol'.  With prefix arg ARG, does the
 opposite of what that option dictates."
   (interactive "P")
-  (cider-ensure-op-supported "toggle-trace-var")
+  (cider-ensure-op-supported "cider/toggle-trace-var")
   (funcall (cider-prompt-for-symbol-function arg)
            "Toggle trace for var"
            #'cider--toggle-trace-var))
 
 (defun cider-sync-request:toggle-trace-ns (ns)
   "Toggle namespace tracing for NS."
-  (thread-first `("op" "toggle-trace-ns"
+  (thread-first `("op" "cider/toggle-trace-ns"
                   "ns" ,ns)
                 (cider-nrepl-send-sync-request)))
 
@@ -72,7 +72,7 @@ opposite of what that option dictates."
   "Toggle ns tracing.
 Defaults to the current ns.  With prefix arg QUERY, prompts for a ns."
   (interactive "P")
-  (cider-map-repls '(:clj-strict  "toggle-trace-ns")
+  (cider-map-repls '(:clj-strict  "cider/toggle-trace-ns")
     (lambda (conn)
       (with-current-buffer conn
         (let ((ns (if query

--- a/lisp/cider-xref-backend.el
+++ b/lisp/cider-xref-backend.el
@@ -44,7 +44,7 @@
   ;; backends, if cider-nrepl is not loaded.
   (when (or
          ;; the main requirement:
-         (cider-nrepl-op-supported-p "ns-path" nil 'skip-ensure)
+         (cider-nrepl-op-supported-p "cider/ns-path" nil 'skip-ensure)
          ;; the fallback, used for bare nrepl or babashka integrations:
          (cider-nrepl-op-supported-p "lookup" nil 'skip-ensure))
     'cider))
@@ -108,7 +108,7 @@ These are used for presentation purposes."
 (cl-defmethod xref-backend-references ((_backend (eql cider)) var)
   "Find references of VAR."
   (cider-ensure-connected)
-  (cider-ensure-op-supported "fn-refs")
+  (cider-ensure-op-supported "cider/fn-refs")
   (when-let* ((ns (cider-current-ns))
               (results (cider-sync-request:fn-refs ns var))
               (previously-existing-buffers (buffer-list)))
@@ -150,7 +150,7 @@ These are used for presentation purposes."
 (cl-defmethod xref-backend-apropos ((_backend (eql cider)) pattern)
   "Find all symbols that match regexp PATTERN."
   (cider-ensure-connected)
-  (cider-ensure-op-supported "apropos")
+  (cider-ensure-op-supported "cider/apropos")
   (when-let* ((ns (cider-current-ns))
               (results (cider-sync-request:apropos pattern ns t t completion-ignore-case)))
     (mapcar (lambda (info)

--- a/lisp/cider-xref.el
+++ b/lisp/cider-xref.el
@@ -120,7 +120,7 @@ the symbol found by the xref search as argument."
   "Show all functions that reference the var matching NS and SYMBOL."
   (interactive)
   (cider-ensure-connected)
-  (cider-ensure-op-supported "fn-refs")
+  (cider-ensure-op-supported "cider/fn-refs")
   (if-let* ((ns (or ns (cider-current-ns)))
             (symbol (or symbol (cider-symbol-at-point)))
             (results (cider-sync-request:fn-refs ns symbol)))
@@ -132,7 +132,7 @@ the symbol found by the xref search as argument."
   "Show all functions referenced by the var matching NS and SYMBOL."
   (interactive)
   (cider-ensure-connected)
-  (cider-ensure-op-supported "fn-deps")
+  (cider-ensure-op-supported "cider/fn-deps")
   (if-let* ((ns (or ns (cider-current-ns)))
             (symbol (or symbol (cider-symbol-at-point)))
             (results (cider-sync-request:fn-deps ns symbol)))
@@ -157,7 +157,7 @@ the symbol found by the xref search as argument."
   "Displays the references for NS and SYMBOL using completing read."
   (interactive)
   (cider-ensure-connected)
-  (cider-ensure-op-supported "fn-refs")
+  (cider-ensure-op-supported "cider/fn-refs")
   (if-let* ((ns (or ns (cider-current-ns)))
             (symbol (or symbol (cider-symbol-at-point)))
             (results (mapcar (lambda (d) (nrepl-dict-get d "name")) (cider-sync-request:fn-refs ns symbol)))
@@ -170,7 +170,7 @@ the symbol found by the xref search as argument."
   "Displays the function dependencies for  NS and SYMBOL using completing read."
   (interactive)
   (cider-ensure-connected)
-  (cider-ensure-op-supported "fn-deps")
+  (cider-ensure-op-supported "cider/fn-deps")
   (if-let* ((ns (or ns (cider-current-ns)))
             (symbol (or symbol (cider-symbol-at-point)))
             (results (mapcar (lambda (d) (nrepl-dict-get d "name")) (cider-sync-request:fn-deps ns symbol)))


### PR DESCRIPTION
cider-nrepl now namespaces all its ops (e.g. \`info\` -> \`cider/info\`). The old names are kept as deprecated aliases, but we should use the canonical names going forward.

Purely mechanical string replacement across 20 files - no logic changes. nREPL built-in ops (\`completions\`, \`lookup\`, \`eval\`, etc.) are left unchanged.

Relates to clojure-emacs/cider-nrepl#710.