### PR TITLE
Improve test suite quality and coverage

### DIFF
--- a/test/cider-browse-spec-tests.el
+++ b/test/cider-browse-spec-tests.el
@@ -74,16 +74,28 @@
 
   (it "renders a s/schema map form"
     (cider-browse-spec-tests--setup-spec-form cider-browse-spec-tests--schema-map-response)
-    (expect (cider-browse-spec--browse ":example/customer")))
+    (let ((buf (cider-browse-spec--browse ":example/customer")))
+      (expect (bufferp buf) :to-be-truthy)
+      (expect (with-current-buffer buf (buffer-string)) :to-match "s/schema")
+      (kill-buffer buf)))
 
   (it "renders a s/schema vector form"
     (cider-browse-spec-tests--setup-spec-form cider-browse-spec-tests--schema-vector-response)
-    (expect (cider-browse-spec--browse ":example/customer")))
+    (let ((buf (cider-browse-spec--browse ":example/customer")))
+      (expect (bufferp buf) :to-be-truthy)
+      (expect (with-current-buffer buf (buffer-string)) :to-match "s/schema")
+      (kill-buffer buf)))
 
   (it "renders a s/select form"
     (cider-browse-spec-tests--setup-spec-form cider-browse-spec-tests--movie-times-user-response)
-    (expect (cider-browse-spec--browse ":user/movie-times-user")))
+    (let ((buf (cider-browse-spec--browse ":user/movie-times-user")))
+      (expect (bufferp buf) :to-be-truthy)
+      (expect (with-current-buffer buf (buffer-string)) :to-match "s/select")
+      (kill-buffer buf)))
 
   (it "renders a s/union form"
     (cider-browse-spec-tests--setup-spec-form cider-browse-spec-tests--company-addr-response)
-    (expect (cider-browse-spec--browse ":user/company-addr"))))
+    (let ((buf (cider-browse-spec--browse ":user/company-addr")))
+      (expect (bufferp buf) :to-be-truthy)
+      (expect (with-current-buffer buf (buffer-string)) :to-match "s/union")
+      (kill-buffer buf))))

--- a/test/cider-client-tests.el
+++ b/test/cider-client-tests.el
@@ -39,8 +39,8 @@
 
 (describe "cider-var-info"
   (it "handles gracefully empty input"
-    (expect (cider-var-info nil) :to-equal nil)
-    (expect (cider-var-info "") :to-equal nil))
+    (expect (cider-var-info nil) :to-be nil)
+    (expect (cider-var-info "") :to-be nil))
 
   (it "returns vars info as an nREPL dict"
     (spy-on 'cider-sync-request:info :and-return-value
@@ -77,7 +77,7 @@
 
   (it "returns nil in the absence of the info and lookup middleware"
     (spy-on 'cider-nrepl-op-supported-p :and-return-value nil)
-    (expect (cider-var-info "str") :to-equal nil)))
+    (expect (cider-var-info "str") :to-be nil)))
 
 (describe "cider-member-info"
   (it "returns member info for a given class and member"
@@ -96,10 +96,10 @@
       (expect (nrepl-dict-get info "class") :to-equal "java.lang.String")))
 
   (it "returns nil when class is nil"
-    (expect (cider-member-info nil "length") :to-equal nil))
+    (expect (cider-member-info nil "length") :to-be nil))
 
   (it "returns nil when member is nil"
-    (expect (cider-member-info "java.lang.String" nil) :to-equal nil)))
+    (expect (cider-member-info "java.lang.String" nil) :to-be nil)))
 
 (describe "cider-classpath-entries"
   (it "uses the classpath op when available"
@@ -146,7 +146,7 @@
 
   (it "returns nil as its default value"
     (setq cider-repl-type nil)
-    (expect (cider-repl-type-for-buffer) :to-equal nil)))
+    (expect (cider-repl-type-for-buffer) :to-be nil)))
 
 (describe "cider-nrepl-send-unhandled-request"
   (it "returns the id of the request sent to nREPL server and ignores the response"
@@ -168,7 +168,7 @@
 (describe "cider-ensure-op-supported"
   (it "returns nil when the op is supported"
     (spy-on 'cider-nrepl-op-supported-p :and-return-value t)
-    (expect (cider-ensure-op-supported "foo") :to-equal nil))
+    (expect (cider-ensure-op-supported "foo") :to-be nil))
   (it "raises a user-error if the op is not supported"
     (spy-on 'cider-nrepl-op-supported-p :and-return-value nil)
     (expect (cider-ensure-op-supported "foo")
@@ -177,7 +177,7 @@
 (describe "cider-ns-form-p"
   (it "doesn't match ns in a string"
       (let ((ns-in-string "\"\n(ns bar)\n\""))
-        (expect (cider-ns-form-p ns-in-string) :to-equal nil)))
+        (expect (cider-ns-form-p ns-in-string) :to-be nil)))
   (it "matches ns"
       (let ((ns "(ns bar)\n"))
         (expect (cider-ns-form-p ns) :to-equal 0)))

--- a/test/cider-clojuredocs-tests.el
+++ b/test/cider-clojuredocs-tests.el
@@ -46,5 +46,5 @@
 (describe "cider-clojuredocs-url"
   (it "creates a clojuredocs search URL"
     (expect (cider-clojuredocs-url "even?" "clojure.core") :to-equal "https://clojuredocs.org/clojure.core/even_q")
-    (expect (cider-clojuredocs-url nil "clojure.core") :to-equal nil)
-    (expect (cider-clojuredocs-url "even?" nil) :to-equal nil)))
+    (expect (cider-clojuredocs-url nil "clojure.core") :to-be nil)
+    (expect (cider-clojuredocs-url "even?" nil) :to-be nil)))

--- a/test/cider-common-tests.el
+++ b/test/cider-common-tests.el
@@ -35,7 +35,7 @@
 ;;; cider-common tests
 (describe "cider-abbreviate-ns"
   (it "handles nil input"
-    (expect (cider-abbreviate-ns nil) :to-equal nil))
+    (expect (cider-abbreviate-ns nil) :to-be nil))
 
   (it "handles empty string input"
     (expect (cider-abbreviate-ns "") :to-equal ""))
@@ -48,7 +48,7 @@
 
 (describe "cider-last-ns-segment"
   (it "handles nil input"
-    (expect (cider-last-ns-segment nil) :to-equal nil))
+    (expect (cider-last-ns-segment nil) :to-be nil))
 
   (it "handles empty string input"
     (expect (cider-last-ns-segment "") :to-equal ""))
@@ -64,7 +64,7 @@
     (expect (cider--kw-to-symbol "symbol") :to-equal "symbol")
     (expect (cider--kw-to-symbol ":clj.core/str") :to-equal "clj.core/str")
     (expect (cider--kw-to-symbol "::keyword") :to-equal "keyword")
-    (expect (cider--kw-to-symbol nil) :to-equal nil)))
+    (expect (cider--kw-to-symbol nil) :to-be nil)))
 
 (describe "cider-make-tramp-prefix"
   (it "returns tramp-prefix only"
@@ -122,9 +122,9 @@
               :to-equal /home/host/project/src/namespace.clj))
   (it "returns nil if no prefixes match ('from-nrepl)"
       (expect (cider--translate-path-test `((,/docker/src . ,/home/host/project/src)) /home/host/random/file.clj 'from-nrepl)
-              :to-equal nil)
+              :to-be nil)
       (expect (cider--translate-path-from-nrepl-test `((,/docker/src . ,/home/host/project/src)) /home/host/random/file.clj)
-              :to-equal nil))
+              :to-be nil))
   (it "won't replace a prefix in the middle of the path ('from-nrepl)"
       (expect (cider--translate-path-test `((,/src . ,/host)) /src/project/src/ns.clj 'from-nrepl)
               :to-equal /host/project/src/ns.clj)
@@ -156,9 +156,9 @@
               :to-equal /docker/src/namespace.clj))
   (it "returns nil if no prefixes match ('to-nrepl)"
       (expect (cider--translate-path-test `((,/docker/src . ,/home/host/project/src)) /home/host/random/file.clj 'to-nrepl)
-              :to-equal nil)
+              :to-be nil)
       (expect (cider--translate-path-to-nrepl-test `((,/docker/src . ,/home/host/project/src)) /home/host/random/file.clj)
-              :to-equal nil))
+              :to-be nil))
   (it "won't replace a prefix in the middle of the path ('to-nrepl)"
       (expect (cider--translate-path-test `((,/src . ,/host)) /host/project/host/ns.clj 'to-nrepl)
               :to-equal /src/project/host/ns.clj)

--- a/test/cider-completion-tests.el
+++ b/test/cider-completion-tests.el
@@ -32,38 +32,36 @@
 
 (describe "cider-enable-flex-completion"
   (when (>= emacs-major-version 27)
-    (cl-assert (not (member 'flex (assq 'styles (assq 'cider completion-category-overrides)))))
-    (let ((old-value completion-category-overrides))
-      (unwind-protect
-          (progn
-            (it "adds `flex' and `basic' as a fallback"
-              (let ((expected-category-overrides '((cider (styles flex basic)))))
-                (cider-enable-flex-completion)
-                (expect (member 'flex (assq 'styles (assq 'cider completion-category-overrides)))
-                        :to-be-truthy)
-                (expect (member 'basic (assq 'styles (assq 'cider completion-category-overrides)))
-                        :to-be-truthy)
-                (expect completion-category-overrides :to-equal expected-category-overrides)))
+    (it "adds `flex' and `basic' as a fallback"
+      (let ((completion-category-overrides nil))
+        (cider-enable-flex-completion)
+        (expect (member 'flex (assq 'styles (assq 'cider completion-category-overrides)))
+                :to-be-truthy)
+        (expect (member 'basic (assq 'styles (assq 'cider completion-category-overrides)))
+                :to-be-truthy)
+        (expect completion-category-overrides
+                :to-equal '((cider (styles flex basic))))))
 
-            (it "doesn't add `cycle'"
-              (expect (assq 'cycle (assq 'cider completion-category-overrides))
-                      :to-be nil))
+    (it "doesn't add `cycle'"
+      (let ((completion-category-overrides nil))
+        (cider-enable-flex-completion)
+        (expect (assq 'cycle (assq 'cider completion-category-overrides))
+                :to-be nil)))
 
-            (it "adds just `flex' if there is another style present"
-              (setq completion-category-overrides '((cider (styles partial-completion))))
-              (cider-enable-flex-completion)
-              (expect (member 'flex (assq 'styles (assq 'cider completion-category-overrides)))
-                      :to-be-truthy)
-              (expect (member 'partial-completion (assq 'styles (assq 'cider completion-category-overrides)))
-                      :to-be-truthy)
-              (expect (member 'basic (assq 'styles (assq 'cider completion-category-overrides)))
-                      :to-be nil))
+    (it "adds just `flex' if there is another style present"
+      (let ((completion-category-overrides '((cider (styles partial-completion)))))
+        (cider-enable-flex-completion)
+        (expect (member 'flex (assq 'styles (assq 'cider completion-category-overrides)))
+                :to-be-truthy)
+        (expect (member 'partial-completion (assq 'styles (assq 'cider completion-category-overrides)))
+                :to-be-truthy)
+        (expect (member 'basic (assq 'styles (assq 'cider completion-category-overrides)))
+                :to-be nil)))
 
-            (it "doesn't re-add `flex' if already present, preserving `cycle' as well"
-              (let ((with-flex-and-cycle '((cider (styles basic flex)
-                                                  (cycle t)))))
-                (setq completion-category-overrides with-flex-and-cycle)
-                (cider-enable-flex-completion)
-                (expect completion-category-overrides
-                        :to-equal with-flex-and-cycle))))
-        (setq completion-category-overrides old-value)))))
+    (it "doesn't re-add `flex' if already present, preserving `cycle' as well"
+      (let ((completion-category-overrides '((cider (styles basic flex)
+                                                    (cycle t)))))
+        (cider-enable-flex-completion)
+        (expect completion-category-overrides
+                :to-equal '((cider (styles basic flex)
+                                   (cycle t))))))))

--- a/test/cider-connection-tests.el
+++ b/test/cider-connection-tests.el
@@ -153,11 +153,11 @@
         (it "returns nil"
           ;; for clj
           (with-repl-buffer ses-name 'cljs _b1
-            (expect (cider-current-repl 'clj) :to-equal nil))
+            (expect (cider-current-repl 'clj) :to-be nil))
 
           ;; for cljs
           (with-repl-buffer ses-name 'clj _b2
-            (expect (cider-current-repl 'cljs) :to-equal nil))))
+            (expect (cider-current-repl 'cljs) :to-be nil))))
 
       (describe "when type argument is not given"
 
@@ -184,13 +184,13 @@
             (with-repl-buffer ses-name 'clj _b1
               (with-temp-buffer
                 (setq major-mode 'clojurescript-mode)
-                (expect (cider-current-repl) :to-equal nil)))
+                (expect (cider-current-repl) :to-be nil)))
 
             ;; for cljs
             (with-repl-buffer ses-name 'cljs _b2
               (with-temp-buffer
                 (setq major-mode 'clojure-mode)
-                (expect (cider-current-repl) :to-equal nil))))))))
+                (expect (cider-current-repl) :to-be nil))))))))
 
   (describe "when multiple sessions exist"
     (it "always returns the most recently used connection"
@@ -242,9 +242,9 @@
 
   (describe "when there are no active connections"
     (it "returns nil"
-      (expect (cider-repls) :to-equal nil)
-      (expect (cider-repls 'clj) :to-equal nil)
-      (expect (cider-repls 'cljs) :to-equal nil)))
+      (expect (cider-repls) :to-be nil)
+      (expect (cider-repls 'clj) :to-be nil)
+      (expect (cider-repls 'cljs) :to-be nil)))
 
   (describe "when multiple sessions exist"
     (it "always returns the most recently used connection"
@@ -594,7 +594,7 @@
         (with-repl-buffer ses-name 'clj _b1
           (setq cider-default-session "nonexistent-session")
           ;; Should warn and return nil (stale default session yields no REPLs)
-          (expect (cider-repls) :to-equal nil)))))
+          (expect (cider-repls) :to-be nil)))))
 
   (describe "cider-set-default-session"
     (it "sets the default session from active sessions"
@@ -608,7 +608,7 @@
     (it "clears the default session"
       (setq cider-default-session "some-session")
       (cider-clear-default-session)
-      (expect cider-default-session :to-equal nil)))
+      (expect cider-default-session :to-be nil)))
 
   (describe "cider--connection-info with default session"
     (before-each

--- a/test/cider-eldoc-tests.el
+++ b/test/cider-eldoc-tests.el
@@ -37,7 +37,7 @@
     (expect (cider--find-rest-args-position ["fmt" "&" "arg"])
             :to-equal 1)
     (expect (cider--find-rest-args-position ["fmt" "arg"])
-            :to-equal nil)))
+            :to-be nil)))
 
 (describe "cider--eldoc-format-class-names"
   :var (class-names)
@@ -181,7 +181,7 @@
         (insert "(a (b b) (c c) d)"))
       (search-forward "d")
       (let ((cider-eldoc-max-num-sexps-to-skip 2))
-        (expect (cider-eldoc-beginning-of-sexp) :to-equal nil)
+        (expect (cider-eldoc-beginning-of-sexp) :to-be nil)
         (expect (point) :to-equal 4)))))
 
 (describe "cider--eldoc-remove-dot"
@@ -218,7 +218,7 @@
               '("eldoc-info" ("clojure.core" "inc" (("x"))) "thing" "inc" "pos" 0))
       ;; eldoc can be nil
       (search-forward "1")
-      (expect (cider-eldoc-info-in-current-sexp) :to-equal nil)
+      (expect (cider-eldoc-info-in-current-sexp) :to-be nil)
       ;; when cursor is at the end of sexp, display eldoc of first symbol
       (search-forward "]")
       (expect (cider-eldoc-info-in-current-sexp) :to-equal
@@ -239,7 +239,7 @@
                 '("eldoc-info" ("clojure.core" "map" (("f") ("f" "coll"))) "thing" "map" "pos" 1))
         ;; eldoc can be nil
         (search-forward "1")
-        (expect (cider-eldoc-info-in-current-sexp) :to-equal nil)
+        (expect (cider-eldoc-info-in-current-sexp) :to-be nil)
         ;; when cursor is at the end of sexp, display eldoc of first symbol
         (search-forward "]")
         (expect (cider-eldoc-info-in-current-sexp) :to-equal

--- a/test/cider-error-parsing-tests.el
+++ b/test/cider-error-parsing-tests.el
@@ -46,7 +46,7 @@
            (info (cider-extract-error-info cider-compilation-regexp message)))
       (expect (cider-error-test--file-name info) :to-equal "/some/test/file/core.clj")
       (expect (cider-error-test--line-num info) :to-equal 31)
-      (expect (cider-error-test--col-num info) :to-equal nil)
+      (expect (cider-error-test--col-num info) :to-be nil)
       (expect (cider-error-test--face info) :to-equal 'cider-error-highlight-face))
 
     ;; test-cider-extract-error-info-14-windows
@@ -54,15 +54,15 @@
            (info (cider-extract-error-info cider-compilation-regexp message)))
       (expect (cider-error-test--file-name info) :to-equal "c:\\some\\test\\file\\core.clj")
       (expect (cider-error-test--line-num info) :to-equal 31)
-      (expect (cider-error-test--col-num info) :to-equal nil)
+      (expect (cider-error-test--col-num info) :to-be nil)
       (expect (cider-error-test--face info) :to-equal 'cider-error-highlight-face))
 
     ;; test-cider-extract-error-info-14-no-file
     (let* ((message "Syntax error compiling at (REPL:31). Unable to resolve symbol: dummy in this context.")
            (info (cider-extract-error-info cider-compilation-regexp message)))
-      (expect (cider-error-test--file-name info) :to-equal nil)
+      (expect (cider-error-test--file-name info) :to-be nil)
       (expect (cider-error-test--line-num info) :to-equal 31)
-      (expect (cider-error-test--col-num info) :to-equal nil)
+      (expect (cider-error-test--col-num info) :to-be nil)
       (expect (cider-error-test--face info) :to-equal 'cider-error-highlight-face))
 
 
@@ -71,15 +71,15 @@
            (info (cider-extract-error-info cider-compilation-regexp message)))
       (expect (cider-error-test--file-name info) :to-equal "/some/othertest/file/core.clj")
       (expect (cider-error-test--line-num info) :to-equal 24)
-      (expect (cider-error-test--col-num info) :to-equal nil)
+      (expect (cider-error-test--col-num info) :to-be nil)
       (expect (cider-error-test--face info) :to-equal 'cider-warning-highlight-face))
 
     ;; test-cider-extract-warning-info-14-no-file
     (let* ((message "Reflection warning, NO_SOURCE_PATH:24 - reference to field getCanonicalPath can't be resolved.")
            (info (cider-extract-error-info cider-compilation-regexp message)))
-      (expect (cider-error-test--file-name info) :to-equal nil)
+      (expect (cider-error-test--file-name info) :to-be nil)
       (expect (cider-error-test--line-num info) :to-equal 24)
-      (expect (cider-error-test--col-num info) :to-equal nil)
+      (expect (cider-error-test--col-num info) :to-be nil)
       (expect (cider-error-test--face info) :to-equal 'cider-warning-highlight-face))
 
     ;; test-cider-extract-error-info-15
@@ -93,7 +93,7 @@
     ;; test-cider-extract-error-info-15-no-file
     (let* ((message "Syntax error compiling at (REPL:31:3). Unable to resolve symbol: dummy in this context")
            (info (cider-extract-error-info cider-compilation-regexp message)))
-      (expect (cider-error-test--file-name info) :to-equal nil)
+      (expect (cider-error-test--file-name info) :to-be nil)
       (expect (cider-error-test--line-num info) :to-equal 31)
       (expect (cider-error-test--col-num info) :to-equal 3)
       (expect (cider-error-test--face info) :to-equal 'cider-error-highlight-face))
@@ -109,7 +109,7 @@
     ;; test-cider-extract-warning-info-15-no-file
     (let* ((message "Reflection warning, NO_SOURCE_PATH:24:43 - reference to field getCanonicalPath can't be resolved.")
            (info (cider-extract-error-info cider-compilation-regexp message)))
-      (expect (cider-error-test--file-name info) :to-equal nil)
+      (expect (cider-error-test--file-name info) :to-be nil)
       (expect (cider-error-test--line-num info) :to-equal 24)
       (expect (cider-error-test--col-num info) :to-equal 43)
       (expect (cider-error-test--face info) :to-equal 'cider-warning-highlight-face))))

--- a/test/cider-eval-tests.el
+++ b/test/cider-eval-tests.el
@@ -39,7 +39,7 @@
     (expect (cider-extract-error-info cider-compilation-regexp "Syntax error reading source at (/Users/vemv/haystack/src/haystack/parser.cljc:13:0).")
             :to-equal '("/Users/vemv/haystack/src/haystack/parser.cljc" 13 0 cider-error-highlight-face "Syntax error reading source at (/Users/vemv/haystack/src/haystack/parser.cljc:13:0)."))
     (expect (cider-extract-error-info cider-compilation-regexp "Syntax error FOOING clojure.core/let at (src/haystack/analyzer.clj:18:1).\n[1] - failed: even-number-of-forms? at: [:bindings] spec: :clojure.core.specs.alpha/bindings\n")
-            :to-equal nil)))
+            :to-be nil)))
 
 (describe "cider--shorten-error-message"
   (it "strips compilation error prefixes"

--- a/test/cider-eval-tests.el
+++ b/test/cider-eval-tests.el
@@ -88,3 +88,35 @@
   (it "closes open maps and vectors"
     (expect (cider--insert-closing-delimiters "{:a [1 2")
             :to-equal "{:a [1 2]}")))
+
+(describe "cider-clojure-compilation-error-phases"
+  (it "returns the default value when set to t"
+    (let ((cider-clojure-compilation-error-phases t))
+      (expect (cider-clojure-compilation-error-phases)
+              :to-equal cider-clojure-compilation-error-phases-default-value)))
+
+  (it "returns the custom value when not t"
+    (let ((cider-clojure-compilation-error-phases '(:compile-error)))
+      (expect (cider-clojure-compilation-error-phases)
+              :to-equal '(:compile-error)))))
+
+(describe "cider--guess-eval-context"
+  (it "extracts let bindings from parent forms"
+    (with-temp-buffer
+      (delay-mode-hooks (clojure-mode))
+      (insert "(let [x 1\n      y 2]\n  |)")
+      (goto-char (point-min))
+      (search-forward "|")
+      (delete-char -1)
+      (let ((ctx (cider--guess-eval-context)))
+        (expect ctx :to-match "x 1")
+        (expect ctx :to-match "y 2"))))
+
+  (it "returns empty string when not inside a let"
+    (with-temp-buffer
+      (delay-mode-hooks (clojure-mode))
+      (insert "(defn foo [] |)")
+      (goto-char (point-min))
+      (search-forward "|")
+      (delete-char -1)
+      (expect (cider--guess-eval-context) :to-equal ""))))

--- a/test/cider-find-tests.el
+++ b/test/cider-find-tests.el
@@ -83,15 +83,15 @@ stuff"
             (expect (cider-symbol-at-point 'look-back) :to-equal "::foo")))
 
         (nrepl-dbind-response (cider--find-keyword-loc "::some.ns/bar") (dest dest-point)
-          (expect dest-point :to-equal nil))
+          (expect dest-point :to-be nil))
 
         (nrepl-dbind-response (cider--find-keyword-loc ":some.ns/bar") (dest dest-point)
-          (expect dest-point :to-equal nil))
+          (expect dest-point :to-be nil))
 
         (expect (cider--find-keyword-loc ":foo") :to-throw 'user-error)
 
         (nrepl-dbind-response (cider--find-keyword-loc ":unrelated/foo") (dest dest-point)
-          (expect dest-point :to-equal nil))
+          (expect dest-point :to-be nil))
 
         (nrepl-dbind-response (cider--find-keyword-loc "::unrelated/foo") (dest dest-point)
-          (expect dest-point :to-equal nil))))))
+          (expect dest-point :to-be nil))))))

--- a/test/cider-overlay-tests.el
+++ b/test/cider-overlay-tests.el
@@ -227,6 +227,6 @@ being set that way"
     (cider--with-overlay ("ok")
       (mapc #'cider--delete-overlay (overlays-at (point-min)))
       (setq overlay-position (mapcar #'overlay-start (overlays-at (point-min))))
-      (expect overlay-position :to-equal nil))))
+      (expect overlay-position :to-be nil))))
 
 ;;; cider-overlay-tests.el ends here

--- a/test/cider-resolve-tests.el
+++ b/test/cider-resolve-tests.el
@@ -82,11 +82,11 @@
   (it "returns nil for missing keys"
     (with-mock-ns-cache
       (expect (cider-resolve--get-in "myapp.core" "interns" "nonexistent")
-              :to-equal nil)))
+              :to-be nil)))
 
   (it "returns nil when no REPL is connected"
     (spy-on 'cider-current-repl :and-return-value nil)
-    (expect (cider-resolve--get-in "myapp.core") :to-equal nil)))
+    (expect (cider-resolve--get-in "myapp.core") :to-be nil)))
 
 (describe "cider-resolve-alias"
   (it "resolves a known alias to its namespace"
@@ -142,7 +142,7 @@
   (it "returns nil for completely unknown vars"
     (with-mock-ns-cache
       (expect (cider-resolve-var "myapp.core" "totally-unknown")
-              :to-equal nil))))
+              :to-be nil))))
 
 (describe "cider-resolve-core-ns"
   (it "returns clojure.core for Clojure REPLs"
@@ -152,7 +152,7 @@
 
   (it "returns nil when no REPL is connected"
     (spy-on 'cider-current-repl :and-return-value nil)
-    (expect (cider-resolve-core-ns) :to-equal nil)))
+    (expect (cider-resolve-core-ns) :to-be nil)))
 
 (describe "cider-resolve-ns-symbols"
   (it "returns interned symbols for a namespace"
@@ -171,6 +171,6 @@
 
   (it "returns nil for unknown namespaces"
     (with-mock-ns-cache
-      (expect (cider-resolve-ns-symbols "nonexistent.ns") :to-equal nil))))
+      (expect (cider-resolve-ns-symbols "nonexistent.ns") :to-be nil))))
 
 ;;; cider-resolve-tests.el ends here

--- a/test/cider-stacktrace-tests.el
+++ b/test/cider-stacktrace-tests.el
@@ -171,9 +171,9 @@
     (it "returns nil"
       (setq cider-stacktrace-suppressed-errors '())
       (expect (cider-stacktrace-some-suppressed-errors-p '("a"))
-              :to-equal nil)
+              :to-be nil)
       (expect (cider-stacktrace-some-suppressed-errors-p '())
-              :to-equal nil)))
+              :to-be nil)))
 
   (describe "when some errors are suppressed"
     (it "returns a list of suppressed errors and all errors associated with them"

--- a/test/cider-test-tests.el
+++ b/test/cider-test-tests.el
@@ -117,3 +117,18 @@
         (when (buffer-live-p buf1) (kill-buffer buf1))
         (when (buffer-live-p buf2) (kill-buffer buf2))
         (setq cider-test--spinner-buffers nil)))))
+
+(describe "cider-test--extract-from-actual"
+  (it "extracts the first form from an actual result"
+    (expect (cider-test--extract-from-actual "(not (= 3 4))" 1)
+            :to-equal "3"))
+
+  (it "extracts the second form from an actual result"
+    (expect (cider-test--extract-from-actual "(not (= 3 4))" 2)
+            :to-equal "4"))
+
+  (it "handles nested forms"
+    (expect (cider-test--extract-from-actual "(not (= {:a 1} {:a 2}))" 1)
+            :to-equal "{:a 1}")
+    (expect (cider-test--extract-from-actual "(not (= {:a 1} {:a 2}))" 2)
+            :to-equal "{:a 2}")))

--- a/test/cider-test-tests.el
+++ b/test/cider-test-tests.el
@@ -113,7 +113,7 @@
                     :not :to-be-truthy)
             (expect (spinner--active-p (buffer-local-value 'spinner-current buf2))
                     :not :to-be-truthy)
-            (expect cider-test--spinner-buffers :to-equal nil))
+            (expect cider-test--spinner-buffers :to-be nil))
         (when (buffer-live-p buf1) (kill-buffer buf1))
         (when (buffer-live-p buf2) (kill-buffer buf2))
         (setq cider-test--spinner-buffers nil)))))

--- a/test/cider-tests--no-auto.el
+++ b/test/cider-tests--no-auto.el
@@ -97,4 +97,4 @@ from the latter. Remaining content is compared for string equality."
 
 (describe "cider-test-all-docs"
   (it "returns nil if `cider-doc' output matches with the `clojure.repl/doc'"
-    (expect (cider-test-all-docs) :to-equal nil)))
+    (expect (cider-test-all-docs) :to-be nil)))

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -553,7 +553,7 @@
             (expect (buffer-local-value 'cider-repl-type client-buffer)
                     :to-equal 'cljs)
             (expect (buffer-local-value 'cider-repl-cljs-upgrade-pending client-buffer)
-                    :to-equal nil)
+                    :to-be nil)
             ;; kill server
             (delete-process (get-buffer-process client-buffer))))))
     (it "for a custom REPL type project that needs to switch to cljs"

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -350,7 +350,7 @@ buffer."
     (expect (cider--project-name "/home/user/projects/my-app") :to-equal "my-app"))
 
   (it "returns nil for nil input"
-    (expect (cider--project-name nil) :to-equal nil)))
+    (expect (cider--project-name nil) :to-be nil)))
 
 (describe "cider-propertize"
   (it "applies the correct face for each kind"
@@ -459,21 +459,23 @@ and some other vars (like clojure.core/filter).
       (expect (cider--find-symbol-xref) :to-equal "references")
       (expect (cider--find-symbol-xref) :to-equal "clojure.core/map")
       (expect (cider--find-symbol-xref) :to-equal "clojure.core/filter")
-      (expect (cider--find-symbol-xref) :to-equal nil))))
+      (expect (cider--find-symbol-xref) :to-be nil))))
 
 (describe "major-mode-predicates"
-  (with-temp-buffer
-    (it "matches clojure-mode"
+  (it "matches clojure-mode"
+    (with-temp-buffer
       (clojure-mode)
       (expect (cider-clojure-major-mode-p) :to-be-truthy)
       (expect (cider-clojurescript-major-mode-p) :not :to-be-truthy)
-      (expect (cider-clojurec-major-mode-p) :not :to-be-truthy))
-    (it "matches clojurescript-mode"
+      (expect (cider-clojurec-major-mode-p) :not :to-be-truthy)))
+  (it "matches clojurescript-mode"
+    (with-temp-buffer
       (clojurescript-mode)
       (expect (cider-clojure-major-mode-p) :to-be-truthy)
       (expect (cider-clojurescript-major-mode-p) :to-be-truthy)
-      (expect (cider-clojurec-major-mode-p) :not :to-be-truthy))
-    (it "matches clojurec-mode"
+      (expect (cider-clojurec-major-mode-p) :not :to-be-truthy)))
+  (it "matches clojurec-mode"
+    (with-temp-buffer
       (clojurec-mode)
       (expect (cider-clojure-major-mode-p) :to-be-truthy)
       (expect (cider-clojurescript-major-mode-p) :not :to-be-truthy)

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -480,3 +480,46 @@ and some other vars (like clojure.core/filter).
       (expect (cider-clojure-major-mode-p) :to-be-truthy)
       (expect (cider-clojurescript-major-mode-p) :not :to-be-truthy)
       (expect (cider-clojurec-major-mode-p) :to-be-truthy))))
+
+(describe "cider-plist-get"
+  (it "retrieves values using equal comparison"
+    (let ((plist '("name" "foo" "ns" "bar")))
+      (expect (cider-plist-get plist "name") :to-equal "foo")
+      (expect (cider-plist-get plist "ns") :to-equal "bar")))
+
+  (it "returns nil for missing keys"
+    (let ((plist '("name" "foo")))
+      (expect (cider-plist-get plist "missing") :to-be nil)))
+
+  (it "works with an empty plist"
+    (expect (cider-plist-get nil "key") :to-be nil)))
+
+(describe "cider-plist-put"
+  (it "sets a value using equal comparison"
+    (let ((plist '("name" "foo" "ns" "bar")))
+      (expect (cider-plist-get (cider-plist-put plist "name" "baz") "name")
+              :to-equal "baz")))
+
+  (it "adds a new key-value pair"
+    (let ((plist '("name" "foo")))
+      (expect (cider-plist-get (cider-plist-put plist "ns" "bar") "ns")
+              :to-equal "bar"))))
+
+(describe "cider-intern-keys"
+  (it "converts string keys to symbols"
+    (expect (cider-intern-keys '("foo" 1 "bar" 2))
+            :to-equal '(foo 1 bar 2)))
+
+  (it "leaves symbol keys unchanged"
+    (expect (cider-intern-keys '(foo 1 bar 2))
+            :to-equal '(foo 1 bar 2)))
+
+  (it "returns nil for nil input"
+    (expect (cider-intern-keys nil) :to-be nil)))
+
+(describe "cider-maybe-intern"
+  (it "interns a string"
+    (expect (cider-maybe-intern "foo") :to-equal 'foo))
+
+  (it "returns a symbol as-is"
+    (expect (cider-maybe-intern 'foo) :to-equal 'foo)))

--- a/test/clojure-ts-mode/cider-find-ts-tests.el
+++ b/test/clojure-ts-mode/cider-find-ts-tests.el
@@ -71,18 +71,18 @@ stuff"
             (expect (cider-symbol-at-point 'look-back) :to-equal "::foo")))
 
         (nrepl-dbind-response (cider--find-keyword-loc "::some.ns/bar") (dest dest-point)
-          (expect dest-point :to-equal nil))
+          (expect dest-point :to-be nil))
 
         (nrepl-dbind-response (cider--find-keyword-loc ":some.ns/bar") (dest dest-point)
-          (expect dest-point :to-equal nil))
+          (expect dest-point :to-be nil))
 
         (expect (cider--find-keyword-loc ":foo") :to-throw 'user-error)
 
         (nrepl-dbind-response (cider--find-keyword-loc ":unrelated/foo") (dest dest-point)
-          (expect dest-point :to-equal nil))
+          (expect dest-point :to-be nil))
 
         (nrepl-dbind-response (cider--find-keyword-loc "::unrelated/foo") (dest dest-point)
-          (expect dest-point :to-equal nil))))))
+          (expect dest-point :to-be nil))))))
 
 (provide 'cider-find-ts-tests)
 ;;; cider-find-ts-tests.el ends here

--- a/test/integration/integration-tests.el
+++ b/test/integration/integration-tests.el
@@ -627,7 +627,7 @@ If CLI-COMMAND is nil, then use the default."
       (with-temp-buffer
         (setq-local cider-connect-default-params '(:host "localhost"))
         (ignore-errors (call-interactively 'cider-connect))
-        (expect host-prompt :to-equal nil)
+        (expect host-prompt :to-be nil)
         (expect port-prompt :to-equal t))
       (with-temp-buffer
         (setq host-prompt nil port-prompt nil)
@@ -638,5 +638,5 @@ If CLI-COMMAND is nil, then use the default."
           (error
            (expect e :to-equal
                    '(error "[nREPL] Direct connection to localhost:65536 failed"))))
-        (expect host-prompt :to-equal nil)
-        (expect port-prompt :to-equal nil)))))
+        (expect host-prompt :to-be nil)
+        (expect port-prompt :to-be nil)))))

--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -118,11 +118,11 @@
     (expect (nrepl--port-string-to-number "1234\nfoobar")
             :to-equal 1234)
     (expect (nrepl--port-string-to-number "")
-            :to-equal nil)
+            :to-be nil)
     (expect (nrepl--port-string-to-number "\n")
-            :to-equal nil)
+            :to-be nil)
     (expect (nrepl--port-string-to-number "adas\n")
-            :to-equal nil)))
+            :to-be nil)))
 
 (describe "nrepl-parse-port"
   (it "standard"

--- a/test/nrepl-dict-tests.el
+++ b/test/nrepl-dict-tests.el
@@ -64,12 +64,12 @@
   (it "returns `nil' if dict doesn't contain the element"
     (setq input '(dict 1 "a" 2 "B" "3" "d" 4 nil sym yes))
 
-    (expect (nrepl-dict-contains input 11) :to-equal nil)
-    (expect (nrepl-dict-contains input 12) :to-equal nil)
-    (expect (nrepl-dict-contains input "13") :to-equal nil)
-    (expect (nrepl-dict-contains input 14) :to-equal nil)
-    (expect (nrepl-dict-contains input 'missing) :to-equal nil)
-    (expect (nrepl-dict-contains input nil) :to-equal nil)))
+    (expect (nrepl-dict-contains input 11) :to-be nil)
+    (expect (nrepl-dict-contains input 12) :to-be nil)
+    (expect (nrepl-dict-contains input "13") :to-be nil)
+    (expect (nrepl-dict-contains input 14) :to-be nil)
+    (expect (nrepl-dict-contains input 'missing) :to-be nil)
+    (expect (nrepl-dict-contains input nil) :to-be nil)))
 
 (describe "nrepl-dict-get"
   :var (input)
@@ -82,16 +82,16 @@
       (expect (nrepl-dict-get input 1) :to-equal "a")
       (expect (nrepl-dict-get input 2) :to-equal "B")
       (expect (nrepl-dict-get input "3") :to-equal "d")
-      (expect (nrepl-dict-get input 4) :to-equal nil)
-      (expect (nrepl-dict-get input 'sym) :to-equal'yes)
+      (expect (nrepl-dict-get input 4) :to-be nil)
+      (expect (nrepl-dict-get input 'sym) :to-equal 'yes)
       (expect (nrepl-dict-get input nil) :to-equal 'nil-val))
 
     (it "ignores the default value, if given"
       (expect (nrepl-dict-get input 1 "default") :to-equal "a")
       (expect (nrepl-dict-get input 2 "default") :to-equal "B")
       (expect (nrepl-dict-get input "3" "default") :to-equal "d")
-      (expect (nrepl-dict-get input 4 "default") :to-equal nil)
-      (expect (nrepl-dict-get input 'sym "default") :to-equal'yes)
+      (expect (nrepl-dict-get input 4 "default") :to-be nil)
+      (expect (nrepl-dict-get input 'sym "default") :to-equal 'yes)
       (expect (nrepl-dict-get input nil "default") :to-equal 'nil-val)))
 
   (describe "when key is not present in the dict"
@@ -99,11 +99,11 @@
       (setq input '(dict 1 "a" 2 "B" "3" "d" 4 nil sym yes)))
 
     (it "returns nil, when default value is not given"
-      (expect (nrepl-dict-get input 11) :to-equal nil)
-      (expect (nrepl-dict-get input "13") :to-equal nil)
-      (expect (nrepl-dict-get input 14) :to-equal nil)
-      (expect (nrepl-dict-get input 'missing) :to-equal nil)
-      (expect (nrepl-dict-get input nil) :to-equal nil))
+      (expect (nrepl-dict-get input 11) :to-be nil)
+      (expect (nrepl-dict-get input "13") :to-be nil)
+      (expect (nrepl-dict-get input 14) :to-be nil)
+      (expect (nrepl-dict-get input 'missing) :to-be nil)
+      (expect (nrepl-dict-get input nil) :to-be nil))
 
     (it "returns the default value, if given"
       (expect (nrepl-dict-get input 11 "default") :to-equal "default")


### PR DESCRIPTION
Fix several structural and consistency issues in the test suite and add specs for untested functions.

Quality fixes:
- Fix with-temp-buffer placement in cider-util-tests (tests now get isolated buffers)
- Make cider-completion-tests self-contained (no shared mutable state between tests)
- Strengthen cider-browse-spec-tests assertions (verify buffer content, not just truthy)
- Replace `:to-equal nil` with `:to-be nil` across all test files
- Fix missing space in nrepl-dict-tests (`:to-equal'yes`)

New specs for: `cider-plist-get/put`, `cider-intern-keys`, `cider-maybe-intern`, `cider-clojure-compilation-error-phases`, `cider--guess-eval-context`, `cider-test--extract-from-actual`.

Total specs: 490 -> 507.