### PR TITLE
Fall back to legacy op names for older cider-nrepl

### DIFF
--- a/lisp/cider-client.el
+++ b/lisp/cider-client.el
@@ -171,19 +171,46 @@ nREPL connection."
           (clojure-expected-ns path)))
     (clojure-expected-ns path)))
 
+(defun cider--fallback-op (op connection)
+  "Return the effective op name for OP on CONNECTION.
+Try OP as-is first, then fall back to the unprefixed name for
+backward compatibility with older cider-nrepl versions that don't
+use namespaced ops."
+  (let ((legacy (string-remove-prefix "cider/" op)))
+    (cond
+     ((nrepl-op-supported-p op connection) op)
+     ((and (not (equal op legacy))
+           (nrepl-op-supported-p legacy connection))
+      legacy)
+     (t op))))
+
 (defun cider-nrepl-op-supported-p (op &optional connection skip-ensure)
   "Check whether the CONNECTION supports the nREPL middleware OP.
+Also checks for the unprefixed legacy name when OP starts with
+\"cider/\", for backward compatibility with older cider-nrepl.
 Skip check if repl is active if SKIP-ENSURE is non nil."
-  (nrepl-op-supported-p op (or connection
-                               (cider-current-repl 'infer (if skip-ensure
-                                                              nil
-                                                            'ensure)))))
+  (let ((conn (or connection
+                  (cider-current-repl 'infer (if skip-ensure nil 'ensure)))))
+    (or (nrepl-op-supported-p op conn)
+        (let ((legacy (string-remove-prefix "cider/" op)))
+          (and (not (equal op legacy))
+               (nrepl-op-supported-p legacy conn))))))
 
 (defun cider-ensure-op-supported (op &optional connection)
   "Check for support of middleware op OP for CONNECTION.
 Signal an error if it is not supported."
   (unless (cider-nrepl-op-supported-p op connection)
     (user-error "`%s' requires the nREPL op \"%s\" (provided by cider-nrepl)" this-command op)))
+
+(defun cider--resolve-op-in-request (request connection)
+  "Resolve the op in REQUEST to a name supported by CONNECTION.
+Falls back to the unprefixed legacy op name when the server
+doesn't support namespaced ops."
+  (let* ((op (cider-plist-get request "op"))
+         (effective (cider--fallback-op op connection)))
+    (if (equal op effective)
+        request
+      (cider-plist-put (copy-sequence request) "op" effective))))
 
 (defun cider-nrepl-send-request (request callback &optional connection tooling)
   "Send REQUEST and register response handler CALLBACK.
@@ -192,9 +219,9 @@ REQUEST is a pair list of the form (\"op\" \"operation\" \"par1-name\"
 If CONNECTION is provided dispatch to that connection instead of
 the current connection.  Return the id of the sent message.
 If TOOLING is truthy then the tooling session is used."
-  (nrepl-send-request request callback (or connection
-                                           (cider-current-repl 'infer 'ensure))
-                      tooling))
+  (let ((conn (or connection (cider-current-repl 'infer 'ensure))))
+    (nrepl-send-request (cider--resolve-op-in-request request conn)
+                        callback conn tooling)))
 
 (defun cider-nrepl-send-sync-request (request &optional connection
                                               abort-on-input callback)
@@ -205,17 +232,19 @@ If ABORT-ON-INPUT is non-nil, the function will return nil
 at the first sign of user input, so as not to hang the
 interface.
 if CALLBACK is non-nil, it will additionally be called on all received messages."
-  (nrepl-send-sync-request request
-                           (or connection (cider-current-repl 'infer 'ensure))
-                           abort-on-input
-                           nil
-                           callback))
+  (let ((conn (or connection (cider-current-repl 'infer 'ensure))))
+    (nrepl-send-sync-request (cider--resolve-op-in-request request conn)
+                             conn
+                             abort-on-input
+                             nil
+                             callback)))
 
 (defun cider-nrepl-send-unhandled-request (request &optional connection)
   "Send REQUEST to the nREPL CONNECTION and ignore any responses.
 Immediately mark the REQUEST as done.  Return the id of the sent message."
   (let* ((conn (or connection (cider-current-repl 'infer 'ensure)))
-         (id (nrepl-send-request request #'ignore conn)))
+         (id (nrepl-send-request (cider--resolve-op-in-request request conn)
+                                 #'ignore conn)))
     (with-current-buffer conn
       (nrepl--mark-id-completed id))
     id))

--- a/lisp/cider-connection.el
+++ b/lisp/cider-connection.el
@@ -1074,7 +1074,7 @@ filters out all the REPLs that do not support the designated ops."
                           (cider-cljs-pending-p b)
                         (and (cider--match-repl-type type b)
                              (seq-every-p (lambda (op)
-                                            (nrepl-op-supported-p op b))
+                                            (cider-nrepl-op-supported-p op b))
                                           required-ops))))
                     repls)
         (when ensure

--- a/lisp/cider-repl.el
+++ b/lisp/cider-repl.el
@@ -956,10 +956,9 @@ Part of the default `cider-repl-content-type-handler-alist'."
 Handles an external-body TYPE by issuing a slurp request to fetch the content."
   (if-let* ((args        (cadr type))
             (access-type (nrepl-dict-get args "access-type")))
-      (nrepl-send-request
+      (cider-nrepl-send-request
        (list "op" "cider/slurp" "url" (nrepl-dict-get args access-type))
-       (cider-repl-handler buffer)
-       (cider-current-repl)))
+       (cider-repl-handler buffer)))
   nil)
 
 (defvar cider-repl-content-type-handler-alist
@@ -981,12 +980,12 @@ nREPL ops, it may be convenient to prevent inserting a prompt.")
 (defun cider--maybe-get-state-cljs ()
   "Invokes `cider/get-state' when it's possible to do so."
   (when-let ((conn (cider-current-repl 'cljs)))
-    (when (nrepl-op-supported-p "cider/get-state" conn)
-      (nrepl-send-request '("op" "cider/get-state")
-                          (lambda (_response)
-                            ;; No action is necessary: this request results in `cider-repl--state-handler` being called.
-                            )
-                          conn))))
+    (when (cider-nrepl-op-supported-p "cider/get-state" conn)
+      (cider-nrepl-send-request '("op" "cider/get-state")
+                                (lambda (_response)
+                                  ;; No action is necessary: this request results in `cider-repl--state-handler` being called.
+                                  )
+                                conn))))
 
 (defun cider--maybe-get-state-for-shadow-cljs (buffer &optional err)
   "Refresh the changed namespaces metadata given BUFFER and ERR (stderr string).
@@ -1809,7 +1808,7 @@ The checking is done as follows:
                                             (cider-classpath-entries))))
                                   (process-put proc :cached-classpath cp)
                                   cp)))
-                 (ns-list (when (nrepl-op-supported-p "cider/ns-list" repl)
+                 (ns-list (when (cider-nrepl-op-supported-p "cider/ns-list" repl)
                             (or (process-get proc :all-namespaces)
                                 (let ((ns-list (with-current-buffer repl
                                                  (cider-sync-request:ns-list))))

--- a/test/cider-client-tests.el
+++ b/test/cider-client-tests.el
@@ -174,6 +174,38 @@
     (expect (cider-ensure-op-supported "foo")
             :to-throw 'user-error)))
 
+(describe "cider--fallback-op"
+  (it "returns the namespaced op when it is supported"
+    (spy-on 'nrepl-op-supported-p :and-call-fake
+            (lambda (op _conn) (equal op "cider/info")))
+    (expect (cider--fallback-op "cider/info" :fake-conn) :to-equal "cider/info"))
+
+  (it "falls back to the unprefixed name when namespaced op is not supported"
+    (spy-on 'nrepl-op-supported-p :and-call-fake
+            (lambda (op _conn) (equal op "info")))
+    (expect (cider--fallback-op "cider/info" :fake-conn) :to-equal "info"))
+
+  (it "returns the op as-is when neither version is supported"
+    (spy-on 'nrepl-op-supported-p :and-return-value nil)
+    (expect (cider--fallback-op "cider/info" :fake-conn) :to-equal "cider/info"))
+
+  (it "does not strip prefix from non-cider ops"
+    (spy-on 'nrepl-op-supported-p :and-return-value nil)
+    (expect (cider--fallback-op "completions" :fake-conn) :to-equal "completions")))
+
+(describe "cider--resolve-op-in-request"
+  (it "rewrites the op in the request when falling back"
+    (spy-on 'cider--fallback-op :and-return-value "info")
+    (let ((result (cider--resolve-op-in-request '("op" "cider/info" "ns" "user") :fake-conn)))
+      (expect (cider-plist-get result "op") :to-equal "info")
+      (expect (cider-plist-get result "ns") :to-equal "user")))
+
+  (it "returns the request unchanged when no fallback is needed"
+    (spy-on 'cider--fallback-op :and-return-value "cider/info")
+    (let* ((request '("op" "cider/info" "ns" "user"))
+           (result (cider--resolve-op-in-request request :fake-conn)))
+      (expect result :to-equal request))))
+
 (describe "cider-ns-form-p"
   (it "doesn't match ns in a string"
       (let ((ns-in-string "\"\n(ns bar)\n\""))

--- a/test/clojure-ts-mode/cider-connection-ts-tests.el
+++ b/test/clojure-ts-mode/cider-connection-ts-tests.el
@@ -32,16 +32,20 @@
 (require 'cider-connection)
 
 (describe "Enable cider-minor mode on clojure-ts-mode buffers"
-  (setq clojure-ts-mode-hook nil)
-  (with-temp-buffer
-    (clojure-ts-mode)
-    (it "should enable cider-mode in the clojure-ts-mode buffer"
-      (cider-enable-on-existing-clojure-buffers)
-      (expect local-minor-modes :to-contain 'cider-mode)
-      (expect clojure-ts-mode-hook :to-contain #'cider-mode))
-    (it "should disable cider-mode in the clojure-ts-mode-buffer"
-      (cider-disable-on-existing-clojure-buffers)
-      (expect local-minor-modes :not :to-contain 'cider-mode))))
+  (it "should enable cider-mode in the clojure-ts-mode buffer"
+    (let ((clojure-ts-mode-hook nil))
+      (with-temp-buffer
+        (clojure-ts-mode)
+        (cider-enable-on-existing-clojure-buffers)
+        (expect local-minor-modes :to-contain 'cider-mode)
+        (expect clojure-ts-mode-hook :to-contain #'cider-mode))))
+  (it "should disable cider-mode in the clojure-ts-mode buffer"
+    (let ((clojure-ts-mode-hook nil))
+      (with-temp-buffer
+        (clojure-ts-mode)
+        (cider-enable-on-existing-clojure-buffers)
+        (cider-disable-on-existing-clojure-buffers)
+        (expect local-minor-modes :not :to-contain 'cider-mode)))))
 
 (describe "cider-repl-type-for-buffers"
   (it "correctly detects corresponding repl type based on clojure-ts-* major mode"


### PR DESCRIPTION
When connected to an older cider-nrepl that doesn't support namespaced ops (e.g. `cider/info`), automatically fall back to the unprefixed name (e.g. `info`).

The fallback is transparent - all call sites keep using the canonical `cider/`-prefixed names. Resolution happens in two places:

- `cider-nrepl-op-supported-p` checks both the namespaced and legacy name
- The three send functions (`cider-nrepl-send-request`, `cider-nrepl-send-sync-request`, `cider-nrepl-send-unhandled-request`) resolve the op before sending

Also switches a few remaining direct `nrepl-send-request` / `nrepl-op-supported-p` calls on cider ops to use the cider wrappers so they get the fallback too.