### PR TITLE
Extract with-clojure-buffer to shared test utils

### DIFF
--- a/test/cider-completion-context-tests.el
+++ b/test/cider-completion-context-tests.el
@@ -27,6 +27,7 @@
 
 (require 'buttercup)
 (require 'cider-completion-context)
+(require 'cider-test-utils "test/utils/cider-test-utils")
 
 ;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
 

--- a/test/cider-eval-tests.el
+++ b/test/cider-eval-tests.el
@@ -27,6 +27,7 @@
 
 (require 'buttercup)
 (require 'cider-eval)
+(require 'cider-test-utils "test/utils/cider-test-utils")
 
 ;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
 
@@ -102,21 +103,11 @@
 
 (describe "cider--guess-eval-context"
   (it "extracts let bindings from parent forms"
-    (with-temp-buffer
-      (delay-mode-hooks (clojure-mode))
-      (insert "(let [x 1\n      y 2]\n  |)")
-      (goto-char (point-min))
-      (search-forward "|")
-      (delete-char -1)
+    (with-clojure-buffer "(let [x 1\n      y 2]\n  |)"
       (let ((ctx (cider--guess-eval-context)))
         (expect ctx :to-match "x 1")
         (expect ctx :to-match "y 2"))))
 
   (it "returns empty string when not inside a let"
-    (with-temp-buffer
-      (delay-mode-hooks (clojure-mode))
-      (insert "(defn foo [] |)")
-      (goto-char (point-min))
-      (search-forward "|")
-      (delete-char -1)
+    (with-clojure-buffer "(defn foo [] |)"
       (expect (cider--guess-eval-context) :to-equal ""))))

--- a/test/cider-find-tests.el
+++ b/test/cider-find-tests.el
@@ -27,6 +27,7 @@
 
 (require 'buttercup)
 (require 'cider-find)
+(require 'cider-test-utils "test/utils/cider-test-utils")
 
 ;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
 

--- a/test/cider-ns-tests.el
+++ b/test/cider-ns-tests.el
@@ -27,6 +27,7 @@
 
 (require 'buttercup)
 (require 'cider-ns)
+(require 'cider-test-utils "test/utils/cider-test-utils")
 
 ;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
 

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -29,27 +29,10 @@
 
 (require 'buttercup)
 (require 'cider-util)
+(require 'cider-test-utils "test/utils/cider-test-utils")
 (require 'package)
 
 ;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
-
-(defun with-clojure-buffer--go-to-point ()
-  (when (search-forward "|" nil 'noerror)
-    (delete-char -1)))
-
-(defmacro with-clojure-buffer (contents &rest body)
-  "Execute BODY in a clojure-mode buffer with CONTENTS
-
-CONTENTS is a string containing an optional character `|' indicating the
-cursor position. If not present, the cursor is placed at the end of the
-buffer."
-  (declare (indent 1))
-  `(with-temp-buffer
-     (delay-mode-hooks (clojure-mode))
-     (insert ,contents)
-     (goto-char (point-min))
-     (with-clojure-buffer--go-to-point)
-     ,@body))
 
 ;;; cider-util tests
 

--- a/test/utils/cider-test-utils.el
+++ b/test/utils/cider-test-utils.el
@@ -1,0 +1,51 @@
+;;; cider-test-utils.el  -*- lexical-binding: t; -*-
+
+;; Copyright © 2012-2026 Bozhidar Batsov and CIDER contributors
+
+;; Author: Bozhidar Batsov <bozhidar@batsov.dev>
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; Shared test utilities for the CIDER test suite.
+
+;;; Code:
+
+(require 'clojure-mode)
+
+(defun with-clojure-buffer--go-to-point ()
+  "Move point to the `|' marker and delete it, if present."
+  (when (search-forward "|" nil 'noerror)
+    (delete-char -1)))
+
+(defmacro with-clojure-buffer (contents &rest body)
+  "Execute BODY in a clojure-mode buffer with CONTENTS.
+
+CONTENTS is a string containing an optional character `|' indicating the
+cursor position.  If not present, the cursor is placed at the end of the
+buffer."
+  (declare (indent 1))
+  `(with-temp-buffer
+     (delay-mode-hooks (clojure-mode))
+     (insert ,contents)
+     (goto-char (point-min))
+     (with-clojure-buffer--go-to-point)
+     ,@body))
+
+(provide 'cider-test-utils)
+
+;;; cider-test-utils.el ends here


### PR DESCRIPTION
Move the `with-clojure-buffer` macro from cider-util-tests.el to a shared `test/utils/cider-test-utils.el` so all test files can properly require it.

Previously 3 files (cider-find-tests, cider-ns-tests, cider-completion-context-tests) used the macro by relying on test loading order. Now all consumers explicitly require it. Also replaced manual boilerplate in cider-eval-tests with the shared macro.