### PR TITLE
Remove sesman dependency from nrepl-client.el

### DIFF
--- a/lisp/cider-connection.el
+++ b/lisp/cider-connection.el
@@ -38,6 +38,9 @@
 (require 'cider-popup)
 (require 'cider-util)
 
+;; Override nrepl-client's default REPL buffer name.
+(setq nrepl-repl-buffer-name-template "*cider-repl %s(%r:%S)*")
+
 (defcustom cider-session-name-template "%J:%h:%p"
   "Format string to use for session names.
 See `cider-format-connection-params' for available format characters."
@@ -915,6 +918,11 @@ PARAMS is a plist as received by `cider-repl-create'."
       (when (not (cider-clojure-major-mode-p))
         (cider-set-buffer-ns ns)))))
 
+(defun cider--remove-session-on-disconnect (client-buffer kill-server-p)
+  "Remove CLIENT-BUFFER from its sesman session.
+When KILL-SERVER-P is non-nil, also remove the associated server."
+  (sesman-remove-object 'CIDER nil client-buffer kill-server-p 'no-error))
+
 (defun cider--handle-notification (response)
   "Handle notification status in nREPL RESPONSE.
 Emits the notification message to the REPL buffer."
@@ -954,10 +962,11 @@ function with the repl buffer set as current."
       (sesman-add-object 'CIDER ses-name buffer 'allow-new)
       (unless (derived-mode-p 'cider-repl-mode)
         (cider-repl-mode))
-      (setq nrepl-err-handler #'cider-default-err-handler
+      (setq nrepl-err-handler-function #'cider-default-err-handler
             nrepl-need-input-handler-function #'cider-need-input
             nrepl-namespace-handler-function #'cider--update-buffer-ns
             nrepl-close-connection-handler-function #'cider--close-connection
+            nrepl-client-disconnected-handler-function #'cider--remove-session-on-disconnect
             nrepl-format-buffer-name-function #'cider-format-connection-params
             nrepl-client-name "CIDER"
             nrepl-client-version cider-version

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -641,7 +641,7 @@ The handler simply inserts the result value in BUFFER."
                                  ;; eval-error handler
                                  (lambda (_buffer)
                                    (setq failed t)
-                                   (funcall nrepl-err-handler source-buffer)))))
+                                   (funcall nrepl-err-handler-function source-buffer)))))
 
 (defun cider--emit-interactive-eval-output (output repl-emit-function)
   "Emit output resulting from interactive code evaluation.
@@ -899,9 +899,9 @@ This is used by pretty-printing commands."
                           cider-ancillary-buffers))
          (with-selected-window (get-buffer-window chosen-buffer)
            (cider-popup-buffer-quit-function t)))
-       ;; also call the default nrepl-err-handler, so that our custom behavior doesn't void the base behavior:
-       (when nrepl-err-handler
-         (funcall nrepl-err-handler source-buffer)))
+       ;; also call the default nrepl-err-handler-function, so that our custom behavior doesn't void the base behavior:
+       (when nrepl-err-handler-function
+         (funcall nrepl-err-handler-function source-buffer)))
      ;; content type handler:
      nil
      ;; truncated handler:

--- a/lisp/cider-repl.el
+++ b/lisp/cider-repl.el
@@ -1060,7 +1060,7 @@ and responding to them.")
          (cider-repl-maybe-trim-buffer buffer))
        (dolist (f cider--repl-done-functions)
          (funcall f buffer)))
-     nrepl-err-handler
+     nrepl-err-handler-function
      (lambda (buffer value content-type)
        (if-let* ((content-attrs (cadr content-type))
                  (content-type* (car content-type))

--- a/lisp/nrepl-client.el
+++ b/lisp/nrepl-client.el
@@ -38,10 +38,9 @@
 ;;
 ;; The nREPL communication process can be broadly represented as follows:
 ;;
-;;    1) The server process is started as an Emacs subprocess (usually by
-;;       `cider-jack-in', which in turn fires up an nREPL server).  Note that
-;;       if a connection was established using `cider-connect' there won't be
-;;       a server process.
+;;    1) The server process is started as an Emacs subprocess (e.g. via
+;;       `nrepl-start-server-process').  Note that if a connection was
+;;       established directly there won't be a server process.
 ;;
 ;;    2) The server's process filter (`nrepl-server-filter') detects the
 ;;       connection port from the first plain text response from the server and
@@ -74,7 +73,6 @@
 (require 'cl-lib)
 (require 'nrepl-dict)
 (require 'nrepl-bencode)
-(require 'sesman)
 (require 'tramp)
 
 ;;; Custom
@@ -159,7 +157,9 @@ To be used for tooling calls (i.e. completion, eldoc, etc)")
 
 (defconst nrepl-message-buffer-name-template "*nrepl-messages %s(%r:%S)*")
 (defconst nrepl-error-buffer-name "*nrepl-error*")
-(defconst nrepl-repl-buffer-name-template "*cider-repl %s(%r:%S)*")
+(defvar nrepl-repl-buffer-name-template "*nrepl-repl %s(%r:%S)*"
+  "Template for naming REPL buffers.
+See `nrepl-format-buffer-name-function' for the format specifiers.")
 (defconst nrepl-server-buffer-name-template "*nrepl-server %s*")
 (defconst nrepl-tunnel-buffer-name-template "*nrepl-tunnel %s*")
 
@@ -314,9 +314,10 @@ and kill the process buffer."
              (substring message 0 -1)))
   (when (equal (process-status process) 'closed)
     (when-let* ((client-buffer (process-buffer process)))
-      (sesman-remove-object 'CIDER nil client-buffer
-                            (not (process-get process :keep-server))
-                            'no-error)
+      (when nrepl-client-disconnected-handler-function
+        (funcall nrepl-client-disconnected-handler-function
+                 client-buffer
+                 (not (process-get process :keep-server))))
       (nrepl--clear-client-sessions client-buffer)
       (with-current-buffer client-buffer
         (goto-char (point-max))
@@ -607,8 +608,10 @@ which we can eventually reuse."
 ;; After being decoded, responses (aka, messages from the server) are dispatched
 ;; to handlers. Handlers are constructed with `nrepl-make-response-handler'.
 
-(defvar nrepl-err-handler nil
-  "Evaluation error handler.")
+(define-obsolete-variable-alias 'nrepl-err-handler 'nrepl-err-handler-function "1.17.0")
+(defvar nrepl-err-handler-function nil
+  "Function to call on evaluation errors.
+Called with one argument: the REPL buffer.")
 
 (defvar nrepl-need-input-handler-function nil
   "Function to call when the server requests stdin input.
@@ -619,6 +622,11 @@ When nil, need-input requests are ignored.")
   "Function to call when the server reports a namespace change.
 Called with two arguments: BUFFER and NS (string).
 When nil, namespace changes are ignored.")
+
+(defvar nrepl-client-disconnected-handler-function nil
+  "Function to call when a client connection is closed.
+Called with two arguments: CLIENT-BUFFER and KILL-SERVER-P.
+Used by the client to clean up session state on disconnect.")
 
 (defun nrepl--mark-id-completed (id)
   "Move ID from `nrepl-pending-requests' to `nrepl-completed-requests'.
@@ -665,7 +673,7 @@ Handlers are functions of the buffer and the value they handle, except for
 the optional CONTENT-TYPE-HANDLER which should be a function of the buffer,
 content, the content-type to be handled as a list `(type attrs)'.
 
-If the optional EVAL-ERROR-HANDLER is nil, the default `nrepl-err-handler'
+If the optional EVAL-ERROR-HANDLER is nil, the default `nrepl-err-handler-function'
 is used.  If any of the other supplied handlers are nil nothing happens for
 the corresponding type of response."
   (lambda (response)
@@ -694,7 +702,7 @@ the corresponding type of response."
              (when (member "interrupted" status)
                (message "Evaluation interrupted."))
              (when (member "eval-error" status)
-               (funcall (or eval-error-handler nrepl-err-handler) buffer))
+               (funcall (or eval-error-handler nrepl-err-handler-function) buffer))
              (when (member "namespace-not-found" status)
                (message "Namespace `%s' not found." ns))
              (when (and (member "need-input" status)
@@ -794,7 +802,7 @@ command and e.g. notify the user about them."
     (when (member "done" status)
       (nrepl-dbind-response response (ex err eval-error id)
         (when (and ex err eval-error)
-          (funcall nrepl-err-handler))
+          (funcall nrepl-err-handler-function))
         (when id
           (with-current-buffer connection
             (nrepl--mark-id-completed id)))


### PR DESCRIPTION
Replace the hardcoded `sesman-remove-object` call in `nrepl-client-sentinel` with a `nrepl-client-disconnected-handler-function` hook. CIDER sets this to handle session cleanup on disconnect.

Also makes `nrepl-repl-buffer-name-template` a `defvar` with a generic default (`*nrepl-repl*`), overridden by CIDER to `*cider-repl*` on load. Updates commentary to remove CIDER-specific function references.

After this, nrepl-client.el depends only on: `seq`, `subr-x`, `cl-lib`, `nrepl-dict`, `nrepl-bencode`, and `tramp`. No CIDER or sesman dependencies remain.