### PR TITLE
Decouple cider-eval.el from cider-repl.el at the require level

### DIFF
--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -54,9 +54,21 @@
 (require 'cider-common)
 (require 'cider-overlays)
 (require 'cider-popup)
-(require 'cider-repl)
 (require 'cider-stacktrace)
 (require 'cider-util)
+
+;; cider-eval.el and cider-repl.el are intentionally decoupled at the require
+;; level.  cider-repl.el is always loaded before any interactive evaluation
+;; happens (a REPL buffer must exist), so these functions are available at
+;; runtime.  The coupling is through two narrow interfaces:
+;;
+;; 1. Output emission - eval handlers route stdout/stderr to the REPL buffer.
+;; 2. Namespace caching - ns forms are cached in the REPL buffer for change
+;;    detection and syntax highlighting.
+(declare-function cider-repl-emit-interactive-stdout "cider-repl")
+(declare-function cider-repl-emit-interactive-stderr "cider-repl")
+(declare-function cider-repl--ns-form-changed-p "cider-repl")
+(declare-function cider-repl--cache-ns-form "cider-repl")
 
 (defconst cider-read-eval-buffer "*cider-read-eval*")
 (defconst cider-result-buffer "*cider-result*")


### PR DESCRIPTION
cider-eval.el had a hard require on cider-repl.el, but only uses four functions from it: the output emission pair (emit-interactive-stdout/stderr) and the namespace caching pair (ns-form-changed-p/cache-ns-form). Since a REPL buffer always exists before any interactive evaluation happens, these are guaranteed to be available at runtime.

This replaces the require with declare-function forms and a descriptive comment explaining the two narrow interfaces between the modules. The decoupling is now symmetric - cider-repl.el already used declare-function for the two eval functions it references.