### PR TITLE
Correct load-path in hacking docs after move of *.el to lisp/

### DIFF
--- a/doc/modules/ROOT/pages/contributing/hacking.adoc
+++ b/doc/modules/ROOT/pages/contributing/hacking.adoc
@@ -49,7 +49,7 @@ eldev build :autoloads
 [source,lisp]
 ----
 ;; load CIDER from its source code
-(add-to-list 'load-path "~/projects/cider")
+(add-to-list 'load-path "~/projects/cider/lisp")
 (load "cider-autoloads" t t)
 ----
 


### PR DESCRIPTION
Update [hacking docs][1] with correct `load-path`, now that the `.el` files have been moved to the `lisp` subdirectory.
Only change to documentation, so no Changelog entry.

[1]: https://docs.cider.mx/cider/contributing/hacking.html
