### PR TITLE
jack-in: TRAMP fixes, runtime defaults, tests, docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 - [#3209](https://github.com/clojure-emacs/cider/issues/3209): Fix `cider-format` dropping non-map cljfmt options (e.g. `remove-consecutive-blank-lines?`).
 - `cider-jack-in-clj` now restores the originating buffer when running its connect callback, matching the behavior of `cider-jack-in-cljs` and `cider-jack-in-clj&cljs`.
+- `cider-locate-running-nrepl-ports` now runs its `ps`/`lsof` probes via `process-file`, so endpoint completion for `cider-connect` works correctly from a TRAMP buffer (it inspects the remote host instead of the local one). Same for the `lsof` health check on `.nrepl-port` files.
+- `cider-clojure-cli-command` and `cider-jack-in-default` no longer freeze their auto-detection result at package load time. With the new `nil` default, CIDER picks the right command/tool at jack-in time, so installing Clojure (or moving it on PATH) no longer requires restarting Emacs.
+- `cider--update-project-dir` no longer reuses a single `*cider-context-buffer*` across calls. Each invocation gets a unique hidden buffer, so concurrent or interrupted jack-ins don't stomp each other.
+- `nrepl-server-filter` now treats wildcard/loopback printed bind addresses (`localhost`, `127.0.0.1`, `0.0.0.0`, `::1`, `::`) as "use the calling context", so jacking in over TRAMP to a server that prints `localhost` connects to the TRAMP host instead of the local machine.
 
 ### Changes
 

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -152,8 +152,10 @@ In tools.deps, add this to one of the aliases that you enable with the REPL:
 If you try to run `cider-jack-in` outside a project
 directory, CIDER will warn you and ask you to confirm whether you
 really want to do this; more often than not, this is an accident.  If
-you decide to proceed, CIDER will invoke the command configured in
-`cider-jack-in-default` (defaults to `clj`, Clojure's basic startup command).
+you decide to proceed, CIDER will invoke the tool configured in
+`cider-jack-in-default`.  When that variable is `nil` (the default),
+CIDER auto-detects at jack-in time, picking `clojure-cli` if `clojure`
+is on `PATH`, otherwise falling back to `lein`.
 
 TIP: You can set `cider-allow-jack-in-without-project` to `t` if you'd like to
 disable the warning displayed when jacking-in outside a project.
@@ -191,24 +193,39 @@ babashka REPL:
                                 (cider-jack-in-universal 3)))
 ----
 
-The list of available build tools to consider is configured in
-`cider-jack-in-universal-options`. Each element of the list consists
-of the tool name and its setup options. Taking `nbb` as an example
-from the list:
+The set of available tools is the subset of `cider-jack-in-tools` that
+declare a `:universal-prefix-arg`.  Each tool entry is registered via
+`cider-register-jack-in-tool` and looks like this:
 
 [source,lisp]
 ----
-(nbb         (:prefix-arg 4 :cmd (:jack-in-type cljs :project-type nbb :cljs-repl-type nbb :edit-project-dir t)))
+(cider-register-jack-in-tool 'nbb
+                             :command-var 'cider-nbb-command
+                             :params-var 'cider-nbb-parameters
+                             :project-files '("nbb.edn")
+                             :resolver #'cider--resolve-prefix-command
+                             :universal-prefix-arg 4
+                             :jack-in-type 'cljs
+                             :cljs-repl-type 'nbb)
 ----
 
-with
+The keys in the property list:
 
-. `:prefix-arg` assigns the `nbb` tool name a numerical argument prefix of 4.
-. `:cmd` how to invoke the command.
-.. `:jack-in-type` use a `cljs` repl.
-.. `:project-type` use `nbb` (see `jack-in-command`) to bring up the nREPL server.
-.. `:cljs-repl-type` client uses the `nbb` cljs repl type (see `cider-cljs-repl-types`) to initialize server.
-.. `:edit-project-dir` ask the user to confirm root directory to use as base.
+- `:command-var` and `:params-var` -- variable symbols holding the
+  executable name and the params string.
+- `:project-files` -- file names that mark a project of this type.
+- `:resolver` -- optional, defaults to `cider--resolve-command`.  Use
+  `cider--resolve-prefix-command` for `npx X` style invocations or
+  `cider--resolve-project-command` for project-relative scripts.
+- `:inject-fn` -- optional, function `(PARAMS PROJECT-TYPE COMMAND)` that
+  returns PARAMS with REPL deps injected.  Tools without one (e.g.
+  babashka, nbb, basilisp) skip injection.
+- `:universal-prefix-arg`, `:jack-in-type`, `:cljs-repl-type` -- used by
+  `cider-jack-in-universal` to dispatch.  Tools without a
+  `:universal-prefix-arg` are not selectable through that command.
+
+You can register additional tools, or replace existing ones, with the
+same call.
 
 === Customizing the Jack-in Command Behavior
 
@@ -225,6 +242,21 @@ a REPL for one or the other.
 
 NOTE: The examples use only `cider-jack-in`, but this behavior is consistent
 for all `cider-jack-in-\*` commands.
+
+==== Overriding the jack-in command per buffer
+
+Setting the buffer-local `cider-jack-in-cmd` to a complete command line
+makes `cider-jack-in-\*` use it verbatim, bypassing the project-type
+detection, the resolver, and dependency injection.  This is the simplest
+escape hatch when CIDER's auto-derivation does the wrong thing -- common
+inside containers, on TRAMP, or when you need to launch the server with
+a custom wrapper script.
+
+[source,lisp]
+----
+;; .dir-locals.el
+((nil . ((cider-jack-in-cmd . "ssh my-box -t bb nrepl-server localhost:0"))))
+----
 
 You can further customize the command line CIDER uses for `cider-jack-in` by
 modifying some options. Those differ a bit between the various tools,
@@ -406,6 +438,32 @@ You can run `cider-jack-in-\*` while working with remote files over TRAMP. CIDER
 will reuse existing SSH connection's parameters (like port and username) for establishing a SSH tunnel.
 The same will happen if you try to `cider-connect-\*` to a host that matches the one you're currently
 connected to.
+
+==== Known TRAMP caveats
+
+A few things still need attention when jacking in over TRAMP:
+
+- *Executable resolution is best-effort on remote hosts.*  CIDER cannot
+  reliably check whether a given command exists on the other side, so a
+  missing executable typically only surfaces when the server fails to
+  start.  When in doubt, set `cider-jack-in-cmd` (see
+  <<Overriding the jack-in command per buffer>>) to the exact command
+  line you want to run.
+- *Endpoint discovery for `cider-connect`* (`cider-locate-running-nrepl-ports`)
+  inspects processes via `ps`/`lsof` on the host given by the buffer's
+  `default-directory`.  When you invoke `cider-connect` from a TRAMP
+  buffer, CIDER queries the remote host -- assuming `ps` and `lsof` are
+  installed there.  If they aren't, the completion list will simply be
+  empty.
+- *Server-printed bind addresses.*  Some servers (e.g. babashka) print
+  the bound address as `localhost`, `127.0.0.1`, or `0.0.0.0`.  CIDER
+  treats those as wildcard/loopback and falls back to the TRAMP host so
+  the resulting connection lands on the right machine; an explicit
+  non-loopback host in the server's output is honored as-is.
+- *Quoting on Windows is local-OS-aware.*  PowerShell-specific encoding
+  is selected from your local `cider-clojure-cli-command`, not the
+  remote host's shell, so cross-OS jack-ins (e.g. Linux Emacs ->
+  Windows host) may need an explicit `cider-jack-in-cmd`.
 
 NOTE: For Docker containers, running `cider-jack-in-\*` over TRAMP may technically work but it may give mixed results.
 Please check out the following section for the recommended approaches.

--- a/lisp/cider.el
+++ b/lisp/cider.el
@@ -317,8 +317,11 @@ The repl dependendcies are most likely to be nREPL middlewares."
 
 (defcustom cider-enable-nrepl-jvmti-agent nil
   "When t, add `-Djdk.attach.allowAttachSelf' to the command line arguments.
-This allows nREPL JVMTI agent to be loaded.  It is needed for evaluation
-interruption to properly work on Java 21 and above."
+This is required for nREPL's bundled JVMTI agent to load, which in turn
+is required for eval interruption (e.g. \\[cider-interrupt]) to work
+reliably on Java 21 and later -- earlier JDKs do not need it.  Disabled
+by default because attaching the agent has a small startup cost and
+some hardened environments forbid self-attach."
   :type 'boolean
   :safe #'booleanp
   :version '(cider . "1.15.0"))

--- a/lisp/cider.el
+++ b/lisp/cider.el
@@ -122,17 +122,17 @@
   :type 'string
   :safe #'stringp)
 
-(defcustom cider-clojure-cli-command
-  (if (and (eq system-type 'windows-nt)
-           (null (executable-find "clojure")))
-      "powershell"
-    "clojure")
+(defcustom cider-clojure-cli-command nil
   "The command used to execute clojure with tools.deps.
+When nil (the default), CIDER auto-detects the command at jack-in time:
+\"clojure\" if available on PATH, otherwise \"powershell\" on Windows.
+This avoids freezing the auto-detection result at package load time.
+
 Don't use clj here, as it doesn't work when spawned from Emacs due to it
-using rlwrap.  If on Windows and no \"clojure\" executable is found we
-default to \"powershell\"."
-  :type 'string
-  :safe #'stringp
+using rlwrap."
+  :type '(choice (const :tag "Auto-detect" nil)
+                 (string :tag "Custom command"))
+  :safe (lambda (s) (or (null s) (stringp s)))
   :package-version '(cider . "0.17.0"))
 
 (defcustom cider-clojure-cli-parameters
@@ -239,16 +239,16 @@ By default we favor the project-specific shadow-cljs over the system-wide."
   :safe #'stringp
   :package-version '(cider . "1.14.0"))
 
-(defcustom cider-jack-in-default
-  (if (executable-find "clojure") 'clojure-cli 'lein)
+(defcustom cider-jack-in-default nil
   "The default tool to use when doing `cider-jack-in' outside a project.
-This value will only be consulted when no identifying file types, i.e.
-project.clj for leiningen or deps.edn for clojure-cli, could be found.
+This value is consulted when no identifying file types (e.g. project.clj
+for Leiningen or deps.edn for the Clojure CLI) are found.
 
-As the Clojure CLI is bundled with Clojure itself, it's the default.
-In the absence of the Clojure CLI (e.g. on Windows), we fallback
-to Leiningen."
-  :type '(choice (const lein)
+When nil (the default), CIDER auto-detects at jack-in time, picking
+`clojure-cli' when \"clojure\" is on PATH, else `lein'.  Set this
+explicitly to skip the auto-detection."
+  :type '(choice (const :tag "Auto-detect" nil)
+                 (const lein)
                  (const clojure-cli)
                  (const shadow-cljs)
                  (const gradle)
@@ -388,17 +388,27 @@ Signal a `user-error' if PROJECT-TYPE is not registered."
   (interactive)
   (message "CIDER %s" (cider--version)))
 
+(defun cider--jack-in-tool-command (spec)
+  "Return the command for tool SPEC.
+Prefers a non-nil value of the :command-var, falling back to the result
+of :default-command-fn when the var is nil or unset.  Returns nil if
+neither produces a value."
+  (or (when-let* ((var (plist-get spec :command-var))) (symbol-value var))
+      (when-let* ((fn (plist-get spec :default-command-fn))) (funcall fn))))
+
 (defun cider-jack-in-command (project-type)
   "Determine the command `cider-jack-in' needs to invoke for the PROJECT-TYPE."
-  (symbol-value (plist-get (cider--jack-in-tool project-type) :command-var)))
+  (or (cider--jack-in-tool-command (cider--jack-in-tool project-type))
+      (user-error "No command configured for project type `%S'" project-type)))
 
 (defun cider-jack-in-resolve-command (project-type)
   "Determine the resolved file path to `cider-jack-in-command'.
 Throws an error if PROJECT-TYPE is unknown."
   (let* ((spec (cider--jack-in-tool project-type))
-         (command (symbol-value (plist-get spec :command-var)))
+         (command (cider--jack-in-tool-command spec))
          (resolver (or (plist-get spec :resolver) #'cider--resolve-command)))
-    (funcall resolver command)))
+    (when command
+      (funcall resolver command))))
 
 (defun cider-jack-in-params (project-type)
   "Determine the commands params for `cider-jack-in' for the PROJECT-TYPE."
@@ -761,6 +771,17 @@ See also `cider-jack-in-auto-inject-clojure'."
               dependencies))
     dependencies))
 
+(defun cider--default-clojure-cli-command ()
+  "Return the auto-detected Clojure CLI command.
+Picks \"clojure\" when found on PATH, else falls back to \"powershell\"
+on Windows.  Used as the :default-command-fn for the clojure-cli tool
+when `cider-clojure-cli-command' is nil."
+  (if (and (eq system-type 'windows-nt)
+           (not (file-remote-p default-directory))
+           (null (executable-find "clojure")))
+      "powershell"
+    "clojure"))
+
 (defun cider--lein-inject-deps (params _project-type _command)
   "Inject CIDER deps into PARAMS for a Leiningen project."
   (cider-lein-jack-in-dependencies
@@ -809,6 +830,7 @@ with its nREPL middleware and dependencies."
 
 (cider-register-jack-in-tool 'clojure-cli
                              :command-var 'cider-clojure-cli-command
+                             :default-command-fn #'cider--default-clojure-cli-command
                              :params-var 'cider-clojure-cli-parameters
                              :project-files '("deps.edn")
                              :inject-fn #'cider--clojure-cli-inject-deps
@@ -1995,12 +2017,20 @@ PROJECT-DIR defaults to the current project."
              choices nil t nil nil default)))
           (choices
            (car choices))
-          ;; TODO: Move this fallback outside the project-type check
-          ;; if we're outside a project we fallback to whatever tool
-          ;; is specified in `cider-jack-in-default' (normally clojure-cli)
-          ;; `cider-jack-in-default' used to be a string prior to CIDER
-          ;; 0.18, therefore the need for `cider-maybe-intern'
-          (t (cider-maybe-intern cider-jack-in-default)))))
+          ;; If we're outside a project, fall back to the configured (or
+          ;; auto-detected) default tool.  `cider-jack-in-default' used to
+          ;; be a string prior to CIDER 0.18, hence `cider-maybe-intern'.
+          (t (cider--effective-jack-in-default)))))
+
+(defun cider--effective-jack-in-default ()
+  "Return `cider-jack-in-default', auto-detecting when nil.
+Auto-detect picks `clojure-cli' if \"clojure\" is on PATH at call time,
+otherwise `lein'."
+  (or (cider-maybe-intern cider-jack-in-default)
+      (if (and (not (file-remote-p default-directory))
+               (executable-find "clojure"))
+          'clojure-cli
+        'lein)))
 
 (defun cider--universal-jack-in-tools ()
   "Return the subset of `cider-jack-in-tools' usable by `cider-jack-in-universal'.

--- a/lisp/cider.el
+++ b/lisp/cider.el
@@ -1561,21 +1561,19 @@ Params is a plist with the following keys (non-exhaustive)
         (plist-put params :project-dir
                    (or proj-dir
                        (clojure-project-dir (cider-current-dir))))
-      ;; If proj-dir is not a parent of default-directory, transfer all local
-      ;; variables and hack dir-local variables into a temporary buffer and keep
-      ;; that buffer within `params` for the later use by other --update-
-      ;; functions. The context buffer should not be used outside of the param
-      ;; initialization pipeline. Therefore, we don't bother with making it
-      ;; unique or killing it anywhere.
-      (let ((context-buf-name " *cider-context-buffer*"))
-        (when (get-buffer context-buf-name)
-          (kill-buffer context-buf-name))
-        (with-current-buffer (get-buffer-create context-buf-name)
+      ;; If proj-dir is not a parent of default-directory, transfer all
+      ;; local variables and hack dir-local variables into a temporary
+      ;; buffer kept on `params' for the rest of the param-update pipeline.
+      ;; Generate a unique buffer name so that interleaved or interrupted
+      ;; jack-ins do not stomp each other.  The buffer is hidden and small;
+      ;; it is left for Emacs to reclaim when no longer referenced.
+      (let ((context-buf (generate-new-buffer " *cider-context-buffer*" t)))
+        (with-current-buffer context-buf
           (dolist (pair (buffer-local-variables orig-buffer))
             (pcase pair
               (`(,name . ,value)        ;ignore unbound variables
                (ignore-errors (set (make-local-variable name) value))))
-            (setq-local buffer-file-name nil))
+          (setq-local buffer-file-name nil))
           (let ((default-directory proj-dir))
             (hack-dir-local-variables-non-file-buffer)
             (thread-first params

--- a/lisp/cider.el
+++ b/lisp/cider.el
@@ -1836,6 +1836,22 @@ of remote SSH hosts."
                ;; remove nils that may have been returned due to permission errors:
                (seq-filter #'identity)))
 
+(defun cider--shell-command-to-string (command)
+  "Run shell COMMAND via `process-file-shell-command' and return its output.
+Unlike `shell-command-to-string', this respects `default-directory', so
+it executes on the remote host when called from a TRAMP buffer."
+  (with-temp-buffer
+    (process-file-shell-command command nil t)
+    (buffer-string)))
+
+(defun cider--process-file-to-string (program &rest args)
+  "Run PROGRAM with ARGS via `process-file' and return its output.
+Honors `default-directory', so it executes on the remote host when
+called from a TRAMP buffer."
+  (with-temp-buffer
+    (apply #'process-file program nil t nil args)
+    (buffer-string)))
+
 (defun cider--invoke-running-nrepl-path (f)
   "Invokes F safely.
 
@@ -1865,6 +1881,14 @@ of list of the form (project-dir port)."
                                  (nth 1 x))))
                  (seq-uniq))))
 
+(defun cider--lsof-fn-field (lsof-args)
+  "Run lsof with LSOF-ARGS and return the first \"n\" (name) field.
+Returns nil if lsof produced no name field."
+  (thread-last (apply #'cider--process-file-to-string "lsof" lsof-args)
+               (split-string)
+               (seq-find (lambda (s) (string-prefix-p "n" s)))
+               (funcall (lambda (s) (and s (substring s 1))))))
+
 (defun cider--running-lein-nrepl-paths ()
   "Retrieve project paths of running lein nREPL servers.
 Use `cider-ps-running-lein-nrepls-command' and
@@ -1872,7 +1896,7 @@ Use `cider-ps-running-lein-nrepls-command' and
   (unless (eq system-type 'windows-nt)
     (let (paths)
       (with-temp-buffer
-        (insert (shell-command-to-string cider-ps-running-lein-nrepls-command))
+        (insert (cider--shell-command-to-string cider-ps-running-lein-nrepls-command))
         (dolist (regexp cider-ps-running-lein-nrepl-path-regexp-list)
           (goto-char 1)
           (while (re-search-forward regexp nil t)
@@ -1887,7 +1911,7 @@ Use `cider-ps-running-lein-nrepls-command' and
     (let* ((bb-indicator "--nrepl-server")
            (non-lein-nrepl-pids
             (thread-last (split-string
-                          (shell-command-to-string
+                          (cider--shell-command-to-string
                            ;; some of the `ps u` lines we intend to catch:
                            ;; <username> 15411 0.0  0.0 37915744  16084 s000  S+ 3:02PM 0:00.02 bb --nrepl-server
                            ;; <username> 13835 0.1 11.2 37159036 7528432 s009 S+ 2:47PM 6:41.29 java -cp src -m nrepl.cmdline
@@ -1901,36 +1925,17 @@ Use `cider-ps-running-lein-nrepls-command' and
       (when non-lein-nrepl-pids
         (thread-last non-lein-nrepl-pids
                      (mapcar (lambda (pid)
-                               (let* (
-                                      ;; -a: This flag is used to combine conditions with AND instead of OR
-                                      ;; -d: Lists only the file descriptors that match the given <descriptor>
-                                      ;; -n: Inhibits the conversion of network numbers to host names.
-                                      ;; -Fn: output file entry information as separate lines, with 'n' designating network info.
-                                      ;; -p: specifies the <PID>.
-                                      (directory (thread-last (split-string (shell-command-to-string (concat "lsof -a -d cwd -n -Fn -p " pid))
-                                                                            "\n")
-                                                              (seq-map (lambda (s)
-                                                                         (when (string-prefix-p "n" s)
-                                                                           (replace-regexp-in-string "^n" "" s))))
-                                                              (seq-filter #'identity)
-                                                              car))
-                                      ;; -a: This flag is used to combine conditions with AND instead of OR
-                                      ;; -n: Inhibits the conversion of network numbers to host names.
-                                      ;; -P: (important!) Ensure ports are shown as numbers, even if they have a well-known name.
-                                      ;; -Fn: output file entry information as separate lines, with 'n' designating network info.
-                                      ;; -i: this option selects the listing of all network files.
-                                      ;; -p: specifies the <PID>.
-                                      (port (thread-last (split-string (shell-command-to-string (concat "lsof -n -P -Fn -i -a -p " pid))
-                                                                       "\n")
-                                                         (seq-map (lambda (s)
-                                                                    (when (string-prefix-p "n" s)
-                                                                      (replace-regexp-in-string ".*:" "" s))))
-                                                         (seq-filter #'identity)
-                                                         (seq-filter (lambda (s)
-                                                                       (condition-case nil
-                                                                           (numberp (read s))
-                                                                         (error nil))))
-                                                         car)))
+                               (let* ((directory (cider--lsof-fn-field
+                                                  (list "-a" "-d" "cwd" "-n" "-Fn" "-p" pid)))
+                                      (port-line (cider--lsof-fn-field
+                                                  (list "-n" "-P" "-Fn" "-i" "-a" "-p" pid)))
+                                      (port (when port-line
+                                              (replace-regexp-in-string ".*:" "" port-line)))
+                                      (port (when (and port
+                                                       (condition-case nil
+                                                           (numberp (read port))
+                                                         (error nil)))
+                                              port)))
                                  (list directory port))))
                      (seq-filter #'cadr))))))
 

--- a/lisp/nrepl-client.el
+++ b/lisp/nrepl-client.el
@@ -250,8 +250,13 @@ Discards it if it can be determined that the port is not active."
                 (port-number (nrepl--port-string-to-number port-string)))
       (if (eq system-type 'windows-nt)
           port-string
+        ;; `process-file-shell-command' honors `default-directory' and so
+        ;; runs lsof on the remote host when FILE lives on TRAMP.
         (unless (equal ""
-                       (shell-command-to-string (format "lsof -i:%s" port-number)))
+                       (with-temp-buffer
+                         (process-file-shell-command
+                          (format "lsof -i:%s" port-number) nil t)
+                         (buffer-string)))
           port-string)))))
 
 (defun nrepl--ssh-file-name-matches-host-p (file-name host)

--- a/lisp/nrepl-client.el
+++ b/lisp/nrepl-client.el
@@ -1024,9 +1024,19 @@ up."
                                :port path
                                :socket-file path)))
                       ((string-match nrepl-listening-inet-address-regexp output)
-                       (let ((host (or (match-string 2 output)
-                                       (file-remote-p default-directory 'host)
-                                       "localhost"))
+                       (let* ((printed-host (match-string 2 output))
+                              (tramp-host (file-remote-p default-directory 'host))
+                              ;; When the server prints a wildcard or loopback
+                              ;; address, use the TRAMP host (if any) so we
+                              ;; connect to the remote machine, not the local
+                              ;; one.  Otherwise trust the printed host.
+                              (host (cond
+                                     ((or (null printed-host)
+                                          (member printed-host
+                                                  '("localhost" "127.0.0.1"
+                                                    "0.0.0.0" "::1" "::")))
+                                      (or tramp-host "localhost"))
+                                     (t printed-host)))
                              (port (string-to-number (match-string 1 output))))
                          (message "[nREPL] server started on %s" port)
                          (list :host host :port port))))))

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -115,6 +115,96 @@
         (expect (cider-project-type) :to-equal 'lein)))))
 
 ;;; cider-jack-in tests
+
+(describe "cider-jack-in-tools registry"
+  (it "registers each built-in tool with command-var, params-var, and project-files"
+    (dolist (tool '(clojure-cli lein babashka shadow-cljs gradle nbb basilisp))
+      (let ((spec (alist-get tool cider-jack-in-tools)))
+        (expect spec :not :to-be nil)
+        (expect (plist-get spec :command-var) :to-be-truthy)
+        (expect (plist-get spec :params-var) :to-be-truthy)
+        (expect (plist-get spec :project-files) :to-be-truthy))))
+
+  (it "errors on lookup for an unknown project type"
+    (expect (cider--jack-in-tool 'no-such-tool) :to-throw 'user-error))
+
+  (describe "cider-register-jack-in-tool"
+    (it "adds new entries and replaces existing ones"
+      (let ((cider-jack-in-tools cider-jack-in-tools))
+        (cider-register-jack-in-tool 'my-test-tool
+                                     :command-var 'cider-lein-command
+                                     :params-var 'cider-lein-parameters
+                                     :project-files '("my.edn"))
+        (expect (cider--jack-in-tool 'my-test-tool) :not :to-be nil)
+        (cider-register-jack-in-tool 'my-test-tool
+                                     :command-var 'cider-lein-command
+                                     :params-var 'cider-lein-parameters
+                                     :project-files '("replaced.edn"))
+        (expect (plist-get (cider--jack-in-tool 'my-test-tool) :project-files)
+                :to-equal '("replaced.edn"))))))
+
+(describe "cider-inject-jack-in-dependencies (no-op tools)"
+  (it "returns params unchanged for babashka"
+    (expect (cider-inject-jack-in-dependencies "nrepl-server localhost:0" 'babashka)
+            :to-equal "nrepl-server localhost:0"))
+  (it "returns params unchanged for nbb"
+    (expect (cider-inject-jack-in-dependencies "nrepl-server" 'nbb)
+            :to-equal "nrepl-server"))
+  (it "returns params unchanged for basilisp"
+    (expect (cider-inject-jack-in-dependencies "nrepl-server" 'basilisp)
+            :to-equal "nrepl-server")))
+
+(describe "cider-inject-jack-in-dependencies (shadow-cljs)"
+  :var (cider-jack-in-dependencies cider-jack-in-nrepl-middlewares)
+  (before-each
+    (setq cider-injected-nrepl-version "1.2.3"
+          cider-injected-middleware-version "2.3.4"
+          cider-jack-in-dependencies nil
+          cider-jack-in-nrepl-middlewares '("cider.nrepl/cider-middleware")))
+  (it "prepends -d flags for the required deps"
+    (expect (cider-inject-jack-in-dependencies "server" 'shadow-cljs)
+            :to-equal "-d nrepl/nrepl:1.2.3 -d cider/cider-nrepl:2.3.4 server")))
+
+(describe "cider-jack-in-universal"
+  :var (chosen-fn chosen-args)
+  (before-each
+    (setq chosen-fn nil chosen-args nil)
+    (spy-on 'cider-jack-in-clj
+            :and-call-fake (lambda (params) (setq chosen-fn 'clj chosen-args params)))
+    (spy-on 'cider-jack-in-cljs
+            :and-call-fake (lambda (params) (setq chosen-fn 'cljs chosen-args params)))
+    (spy-on 'clojure-project-dir :and-return-value nil))
+
+  (it "dispatches to cider-jack-in-clj for a clj prefix-arg"
+    (cider-jack-in-universal 2)
+    (expect chosen-fn :to-be 'clj)
+    (expect (plist-get chosen-args :project-type) :to-be 'lein)
+    (expect (plist-get chosen-args :edit-project-dir) :to-be t))
+
+  (it "dispatches to cider-jack-in-cljs for a cljs prefix-arg"
+    (cider-jack-in-universal 4)
+    (expect chosen-fn :to-be 'cljs)
+    (expect (plist-get chosen-args :project-type) :to-be 'nbb)
+    (expect (plist-get chosen-args :cljs-repl-type) :to-be 'nbb))
+
+  (it "errors on an unknown numeric prefix-arg"
+    (expect (cider-jack-in-universal 99) :to-throw))
+
+  (it "prompts via completing-read when arg is nil and no project is found"
+    (spy-on 'completing-read :and-return-value "babashka")
+    (cider-jack-in-universal nil)
+    (expect chosen-fn :to-be 'clj)
+    (expect (plist-get chosen-args :project-type) :to-be 'babashka)))
+
+(describe "cider--identify-buildtools-present"
+  (it "returns each tool whose project-files exist"
+    (spy-on 'file-exists-p
+            :and-call-fake (lambda (f) (member f '("project.clj" "deps.edn"))))
+    (let ((found (cider--identify-buildtools-present "/tmp/")))
+      (expect found :to-contain 'lein)
+      (expect found :to-contain 'clojure-cli)
+      (expect found :not :to-contain 'gradle))))
+
 (describe "cider--gradle-dependency-notation"
   (it "returns a GAV when given a two-element list"
     (expect (cider--gradle-dependency-notation '("cider/piggieback" "1.2.3"))

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -101,10 +101,18 @@
         (expect (cider-project-type) :to-equal 'build-tool2))))
 
   (describe "when there are no choices available"
-    (it "returns the value of `cider-jack-in-default'"
-      (spy-on 'cider--identify-buildtools-present
-              :and-return-value '())
-      (expect (cider-project-type) :to-equal cider-jack-in-default))))
+    (before-each
+      (spy-on 'cider--identify-buildtools-present :and-return-value '()))
+    (it "returns the value of `cider-jack-in-default' when explicitly set"
+      (let ((cider-jack-in-default 'shadow-cljs))
+        (expect (cider-project-type) :to-equal 'shadow-cljs)))
+    (it "auto-detects when `cider-jack-in-default' is nil"
+      (let ((cider-jack-in-default nil))
+        (spy-on 'executable-find :and-return-value t)
+        (expect (cider-project-type) :to-equal 'clojure-cli))
+      (let ((cider-jack-in-default nil))
+        (spy-on 'executable-find :and-return-value nil)
+        (expect (cider-project-type) :to-equal 'lein)))))
 
 ;;; cider-jack-in tests
 (describe "cider--gradle-dependency-notation"

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -37,6 +37,7 @@
     (let ((inhibit-message t)) (customize-group 'cider))))
 
 (describe "cider-figwheel-main-init-form"
+  :var (cider-figwheel-main-default-options)
   ;; whitespace checks sprinkled amongst other tests
   (describe "from options"
     (it "leaves keywords alone"
@@ -55,7 +56,7 @@
   (describe "from minibuffer"
     (before-each
       ;; not necessary as of this writing, but it can't hurt
-      (setq-local cider-figwheel-main-default-options nil))
+      (setq cider-figwheel-main-default-options nil))
     (it "leaves keywords alone"
       (spy-on 'completing-read :and-return-value ":prod")
       (spy-on 'cider--figwheel-main-get-builds :and-return-value '("dev" "prod"))
@@ -237,15 +238,18 @@
                               (shell-quote-argument "--middleware=other-ns/other-middleware")))))
 
 (describe "cider-inject-jack-in-dependencies"
-  :var (cider-jack-in-dependencies cider-jack-in-nrepl-middlewares cider-jack-in-lein-plugins cider-jack-in-dependencies-exclusions)
+  :var (cider-jack-in-dependencies cider-jack-in-nrepl-middlewares
+        cider-jack-in-lein-plugins cider-jack-in-dependencies-exclusions
+        cider-injected-nrepl-version cider-injected-middleware-version
+        cider-enable-nrepl-jvmti-agent)
 
   (describe "when there is a single dependency"
     (before-each
-      (setq-local cider-injected-nrepl-version "1.2.3")
-      (setq-local cider-injected-middleware-version "2.3.4")
-      (setq-local cider-jack-in-nrepl-middlewares '("cider.nrepl/cider-middleware"))
-      (setq-local cider-jack-in-dependencies-exclusions '())
-      (setq-local cider-enable-nrepl-jvmti-agent t))
+      (setq cider-injected-nrepl-version "1.2.3"
+            cider-injected-middleware-version "2.3.4"
+            cider-jack-in-nrepl-middlewares '("cider.nrepl/cider-middleware")
+            cider-jack-in-dependencies-exclusions '()
+            cider-enable-nrepl-jvmti-agent t))
 
     (it "can inject dependencies in a lein project"
       (expect (cider-inject-jack-in-dependencies "repl :headless" 'lein)
@@ -257,7 +261,7 @@
                                 " -- repl :headless")))
 
     (it "can inject dependencies in a lein project with an exclusion"
-      (setq-local cider-jack-in-dependencies-exclusions '(("nrepl/nrepl" ("org.clojure/clojure"))))
+      (setq cider-jack-in-dependencies-exclusions '(("nrepl/nrepl" ("org.clojure/clojure"))))
       (expect (cider-inject-jack-in-dependencies "repl :headless" 'lein)
               :to-equal (concat
                          "update-in :dependencies conj "
@@ -268,7 +272,7 @@
                          " -- repl :headless")))
 
     (it "can inject dependencies in a lein project with multiple exclusions"
-      (setq-local cider-jack-in-dependencies-exclusions '(("nrepl/nrepl" ("org.clojure/clojure" "foo.bar/baz"))))
+      (setq cider-jack-in-dependencies-exclusions '(("nrepl/nrepl" ("org.clojure/clojure" "foo.bar/baz"))))
       (expect (cider-inject-jack-in-dependencies "repl :headless" 'lein)
               :to-equal (concat "update-in :dependencies conj "
                                 (shell-quote-argument "[nrepl/nrepl \"1.2.3\" :exclusions [org.clojure/clojure foo.bar/baz]]")
@@ -286,10 +290,9 @@
 
   (describe "when there are multiple dependencies"
     (before-each
-      ;; FIXME: Those locals affect tests that follow them
-      (setq-local cider-jack-in-lein-plugins '(("refactor-nrepl" "2.0.0")))
-      (setq-local cider-jack-in-nrepl-middlewares '("refactor-nrepl.middleware/wrap-refactor" "cider.nrepl/cider-middleware"))
-      (setq-local cider-jack-in-dependencies-exclusions '()))
+      (setq cider-jack-in-lein-plugins '(("refactor-nrepl" "2.0.0"))
+            cider-jack-in-nrepl-middlewares '("refactor-nrepl.middleware/wrap-refactor" "cider.nrepl/cider-middleware")
+            cider-jack-in-dependencies-exclusions '()))
     (it "can inject dependencies in a lein project"
       (expect (cider-inject-jack-in-dependencies "repl :headless" 'lein)
               :to-equal (concat "update-in :dependencies conj "
@@ -308,8 +311,8 @@
     (before-each
       (fset 'plugins-predicate (lambda (&rest _) t))
       (fset 'middlewares-predicate (lambda (&rest _) t))
-      (setq-local cider-jack-in-lein-plugins '(("refactor-nrepl" "2.0.0" :predicate plugins-predicate)))
-      (setq-local cider-jack-in-nrepl-middlewares '(("refactor-nrepl.middleware/wrap-refactor" :predicate middlewares-predicate) "cider.nrepl/cider-middleware" ("another/middleware"))))
+      (setq cider-jack-in-lein-plugins '(("refactor-nrepl" "2.0.0" :predicate plugins-predicate))
+            cider-jack-in-nrepl-middlewares '(("refactor-nrepl.middleware/wrap-refactor" :predicate middlewares-predicate) "cider.nrepl/cider-middleware" ("another/middleware"))))
     (it "includes plugins whose predicates return true"
       (expect (cider-jack-in-normalized-lein-plugins)
               :to-equal '(("refactor-nrepl" "2.0.0") ("cider/cider-nrepl" "2.3.4"))))
@@ -349,7 +352,7 @@
       (spy-on 'cider-jack-in-normalized-lein-plugins
               :and-return-value '(("refactor-nrepl" "2.0.0")
                                   ("cider/cider-nrepl" "2.3.4")))
-      (setq-local cider-jack-in-dependencies-exclusions '()))
+      (setq cider-jack-in-dependencies-exclusions '()))
     (it "uses them in a lein project"
       (expect (cider-inject-jack-in-dependencies "repl :headless" 'lein)
               :to-equal (concat "update-in :dependencies conj "
@@ -427,12 +430,17 @@
                               "JABQAFMATgBhAHQAaQB2AGUAQwBvAG0AbQBhAG4AZABBAHIAZwB1AG0AZQBuAHQAUABhAHMAcwBpAG4AZwAgAD0AIAAnAEwAZQBnAGEAYwB5ACcAOwAgAGMAbABvAGoAdQByAGUAIAAiAGMAbQBkAC0AcABhAHIAYQBtAHMAIgA="))))
 
 (describe "cider--update-jack-in-cmd"
+  :var (cider-clojure-cli-command cider-inject-dependencies-at-jack-in
+        cider-allow-jack-in-without-project cider-edit-jack-in-command
+        cider-jack-in-dependencies cider-jack-in-nrepl-middlewares
+        cider-injected-nrepl-version cider-injected-middleware-version
+        cider-clojure-cli-aliases cider-enable-nrepl-jvmti-agent)
   (describe "when 'clojure-cli project type and \"powershell\" command"
     (it "returns a jack-in command using encodedCommand option"
-      (setq-local cider-clojure-cli-command "powershell")
-      (setq-local cider-inject-dependencies-at-jack-in nil)
-      (setq-local cider-allow-jack-in-without-project t)
-      (setq-local cider-edit-jack-in-command nil)
+      (setq cider-clojure-cli-command "powershell"
+            cider-inject-dependencies-at-jack-in nil
+            cider-allow-jack-in-without-project t
+            cider-edit-jack-in-command nil)
       (spy-on 'cider-project-type :and-return-value 'clojure-cli)
       (spy-on 'cider-jack-in-resolve-command :and-return-value "resolved-powershell")
       (spy-on 'cider-jack-in-params :and-return-value "\"cmd-params\"")
@@ -442,37 +450,37 @@
                                 "JABQAFMATgBhAHQAaQB2AGUAQwBvAG0AbQBhAG4AZABBAHIAZwB1AG0AZQBuAHQAUABhAHMAcwBpAG4AZwAgAD0AIAAnAEwAZQBnAGEAYwB5ACcAOwAgAGMAbABvAGoAdQByAGUAIAAiAGMAbQBkAC0AcABhAHIAYQBtAHMAIgA="))))
   (describe "when 'clojure-cli project type"
     (it "uses main opts in an alias to prevent other mains from winning"
-      (setq-local cider-jack-in-dependencies nil)
-      (setq-local cider-jack-in-nrepl-middlewares '("cider.nrepl/cider-middleware"))
-      (setq-local cider-injected-nrepl-version "1.2.3")
-      (setq-local cider-injected-middleware-version "2.3.4")
+      (setq cider-jack-in-dependencies nil
+            cider-jack-in-nrepl-middlewares '("cider.nrepl/cider-middleware")
+            cider-injected-nrepl-version "1.2.3"
+            cider-injected-middleware-version "2.3.4")
       (let ((expected (string-join `("clojure -Sdeps "
                                      ,(shell-quote-argument "{:deps {nrepl/nrepl {:mvn/version \"1.2.3\"} cider/cider-nrepl {:mvn/version \"2.3.4\"}} :aliases {:cider/nrepl {:jvm-opts [\"-Djdk.attach.allowAttachSelf\"], :main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
                                      " -M:cider/nrepl")
                                    "")))
-        (setq-local cider-allow-jack-in-without-project t)
-        (setq-local cider-clojure-cli-command "clojure")
-        (setq-local cider-inject-dependencies-at-jack-in t)
-        (setq-local cider-clojure-cli-aliases nil)
-        (setq-local cider-enable-nrepl-jvmti-agent t)
+        (setq cider-allow-jack-in-without-project t
+              cider-clojure-cli-command "clojure"
+              cider-inject-dependencies-at-jack-in t
+              cider-clojure-cli-aliases nil
+              cider-enable-nrepl-jvmti-agent t)
         (spy-on 'cider-project-type :and-return-value 'clojure-cli)
         (spy-on 'cider-jack-in-resolve-command :and-return-value "clojure")
         (expect (plist-get (cider--update-jack-in-cmd nil) :jack-in-cmd)
                 :to-equal expected)))
 
     (it "allows specifying custom aliases with `cider-clojure-cli-aliases`"
-      (setq-local cider-injected-nrepl-version "1.2.3")
-      (setq-local cider-injected-middleware-version "2.3.4")
+      (setq cider-injected-nrepl-version "1.2.3"
+            cider-injected-middleware-version "2.3.4")
       (let ((expected (string-join `("clojure -Sdeps "
                                      ,(shell-quote-argument "{:deps {nrepl/nrepl {:mvn/version \"1.2.3\"} cider/cider-nrepl {:mvn/version \"2.3.4\"}} :aliases {:cider/nrepl {:jvm-opts [\"-Djdk.attach.allowAttachSelf\"], :main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
                                      " -M:dev:test:cider/nrepl")
                                    "")))
-        (setq-local cider-jack-in-dependencies nil)
-        (setq-local cider-clojure-cli-aliases ":dev:test")
-        (setq-local cider-allow-jack-in-without-project t)
-        (setq-local cider-clojure-cli-command "clojure")
-        (setq-local cider-inject-dependencies-at-jack-in t)
-        (setq-local cider-enable-nrepl-jvmti-agent t)
+        (setq cider-jack-in-dependencies nil
+              cider-clojure-cli-aliases ":dev:test"
+              cider-allow-jack-in-without-project t
+              cider-clojure-cli-command "clojure"
+              cider-inject-dependencies-at-jack-in t
+              cider-enable-nrepl-jvmti-agent t)
         (spy-on 'cider-project-type :and-return-value 'clojure-cli)
         (spy-on 'cider-jack-in-resolve-command :and-return-value "clojure")
         (expect (plist-get (cider--update-jack-in-cmd nil) :jack-in-cmd)
@@ -480,8 +488,8 @@
 
     (dolist (command '("clojure" "powershell"))
       (it (format "should remove duplicates, yielding the same result (for %S command invocation)" command)
-        (setq-local cider-injected-nrepl-version "1.2.3")
-        (setq-local cider-injected-middleware-version "2.3.4")
+        (setq cider-injected-nrepl-version "1.2.3"
+              cider-injected-middleware-version "2.3.4")
         ;; repeat the same test for PowerShell too
         (let ((expected (string-join `("-Sdeps "
                                        ,(cider--shell-quote-argument "{:deps {cider/cider-nrepl {:mvn/version \"2.3.4\"} nrepl/nrepl {:mvn/version \"1.2.3\"}} :aliases {:cider/nrepl {:jvm-opts [\"-Djdk.attach.allowAttachSelf\"], :main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}"
@@ -493,8 +501,8 @@
                                                           command)
                   :to-equal expected))))
     (it "handles aliases correctly"
-      (setq-local cider-injected-nrepl-version "1.2.3")
-      (setq-local cider-injected-middleware-version "2.3.4")
+      (setq cider-injected-nrepl-version "1.2.3"
+            cider-injected-middleware-version "2.3.4")
       (let ((expected (string-join `("-Sdeps "
                                      ,(shell-quote-argument "{:deps {cider/cider-nrepl {:mvn/version \"2.3.4\"} nrepl/nrepl {:mvn/version \"1.2.3\"}} :aliases {:cider/nrepl {:jvm-opts [\"-Djdk.attach.allowAttachSelf\"], :main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
                                      " -M:test:cider/nrepl")
@@ -520,19 +528,19 @@
           (expect (cider-clojure-cli-jack-in-dependencies nil deps)
                   :to-equal expected))))
     (it "allows to specify git coordinate as cider-jack-in-dependency"
-      (setq-local cider-injected-nrepl-version "1.2.3")
-      (setq-local cider-injected-middleware-version "2.3.4")
-      (setq-local cider-jack-in-dependencies '(("org.clojure/tools.deps" (("git/sha" . "6ae2b6f71773de7549d7f22759e8b09fec27f0d9")
-                                                                          ("git/url" . "https://github.com/clojure/tools.deps/")))))
+      (setq cider-injected-nrepl-version "1.2.3"
+            cider-injected-middleware-version "2.3.4"
+            cider-jack-in-dependencies '(("org.clojure/tools.deps" (("git/sha" . "6ae2b6f71773de7549d7f22759e8b09fec27f0d9")
+                                                                    ("git/url" . "https://github.com/clojure/tools.deps/")))))
       (let ((expected (string-join `("clojure -Sdeps "
                                      ,(shell-quote-argument "{:deps {nrepl/nrepl {:mvn/version \"1.2.3\"} cider/cider-nrepl {:mvn/version \"2.3.4\"} org.clojure/tools.deps { :git/sha \"6ae2b6f71773de7549d7f22759e8b09fec27f0d9\"  :git/url \"https://github.com/clojure/tools.deps/\" }} :aliases {:cider/nrepl {:jvm-opts [\"-Djdk.attach.allowAttachSelf\"], :main-opts [\"-m\" \"nrepl.cmdline\" \"--middleware\" \"[cider.nrepl/cider-middleware]\"]}}}")
                                      " -M:cider/nrepl")
                                    "")))
-        (setq-local cider-allow-jack-in-without-project t)
-        (setq-local cider-clojure-cli-command "clojure")
-        (setq-local cider-inject-dependencies-at-jack-in t)
-        (setq-local cider-clojure-cli-aliases nil)
-        (setq-local cider-enable-nrepl-jvmti-agent t)
+        (setq cider-allow-jack-in-without-project t
+              cider-clojure-cli-command "clojure"
+              cider-inject-dependencies-at-jack-in t
+              cider-clojure-cli-aliases nil
+              cider-enable-nrepl-jvmti-agent t)
         (spy-on 'cider-project-type :and-return-value 'clojure-cli)
         (spy-on 'cider-jack-in-resolve-command :and-return-value "clojure")
         (expect (plist-get (cider--update-jack-in-cmd nil) :jack-in-cmd)


### PR DESCRIPTION
Final round of cleanup after #3883 (entry-point unification) and #3884 (registry refactor).

### TRAMP / robustness

- `cider-locate-running-nrepl-ports` now drives its `ps`/`lsof` probes through `process-file`, so endpoint completion for `cider-connect` queries the remote host when called from a TRAMP buffer instead of always scraping the local machine. Same change for the `lsof` health check on `.nrepl-port` files in `nrepl-client.el`.
- `cider-clojure-cli-command` and `cider-jack-in-default` no longer freeze their auto-detection at package load. Both default to `nil` now, with the auto-detect logic running at jack-in time. Installing Clojure later, or putting it on `PATH`, doesn't require restarting Emacs. The clojure-cli tool spec gets the fallback via a new `:default-command-fn` registry key.
- `cider--update-project-dir` stops reusing a single shared `*cider-context-buffer*`. Each invocation creates a unique hidden buffer, so concurrent or interrupted jack-ins don't corrupt each other's state.
- `nrepl-server-filter`'s host fallback now treats wildcard/loopback addresses (`localhost`, `127.0.0.1`, `0.0.0.0`, `::1`, `::`) printed by the server as "use the calling context", so a jack-in over TRAMP to e.g. babashka -- which announces `localhost` -- connects to the TRAMP host instead of the local machine. Explicit non-loopback hosts in the server's output are still honored as-is.

### Tests

- New Buttercup specs for the registry: built-in tools have the expected keys, `cider-register-jack-in-tool` add/replace semantics, the no-op injectors (babashka, nbb, basilisp), shadow-cljs `-d` injection, `cider-jack-in-universal` prefix-arg dispatch (clj, cljs, unknown arg, completing-read fallback), and `cider--identify-buildtools-present` iterating the registry.
- Killed the FIXME at `cider-tests.el:191`: the existing jack-in describe blocks were using `setq-local` to override dynamic vars, which leaked into later specs. Replaced with plain `setq` and extended each block's `:var` list so Buttercup's per-spec rebinding actually scopes them.

### Docs

- Rewrote the Universal jack-in section to describe `cider-jack-in-tools` and `cider-register-jack-in-tool` (the variable from #3884 replaced `cider-jack-in-universal-options`).
- New "Overriding the jack-in command per buffer" subsection covering `cider-jack-in-cmd` -- the right escape hatch for containers/TRAMP/wrapper scripts.
- New "Known TRAMP caveats" subsection: executable resolution, endpoint discovery, loopback bind addresses, cross-OS quoting.
- Fixed a stale claim about `cider-jack-in-default` defaulting to `clj`.
- `cider-enable-nrepl-jvmti-agent` docstring now spells out the Java 21 eval-interrupt context.

### Verified

- `eldev compile` clean.
- `eldev test`: 519/522 specs pass, 0 failures, 3 skipped (platform/version-gated; same as master).