### PR TITLE
Verify cider--resolve-command on remote hosts over TRAMP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `cider-clojure-cli-command` and `cider-jack-in-default` no longer freeze their auto-detection result at package load time. With the new `nil` default, CIDER picks the right command/tool at jack-in time, so installing Clojure (or moving it on PATH) no longer requires restarting Emacs.
 - `cider--update-project-dir` no longer reuses a single `*cider-context-buffer*` across calls. Each invocation gets a unique hidden buffer, so concurrent or interrupted jack-ins don't stomp each other.
 - `nrepl-server-filter` now treats wildcard/loopback printed bind addresses (`localhost`, `127.0.0.1`, `0.0.0.0`, `::1`, `::`) as "use the calling context", so jacking in over TRAMP to a server that prints `localhost` connects to the TRAMP host instead of the local machine.
+- `cider--resolve-command` now actually verifies command presence on remote hosts via `executable-find`'s remote search, instead of unconditionally trusting the user-supplied command. A missing tool on the remote side now surfaces immediately during jack-in instead of as a server-startup failure later.
 
 ### Changes
 

--- a/lisp/cider.el
+++ b/lisp/cider.el
@@ -2096,15 +2096,15 @@ M-2 \\[cider-jack-in-universal]."
       (cider-jack-in-clj arg))))
 
 
-;; TODO: Implement a check for command presence over tramp
 (defun cider--resolve-command (command)
-  "Find COMMAND in exec path (see variable `exec-path').
-Return nil if not found.  In case `default-directory' is non-local we
-assume the command is available."
-  (when-let* ((command (or (and (file-remote-p default-directory) command)
-                           (executable-find command)
-                           (executable-find (concat command ".bat")))))
-    (shell-quote-argument command)))
+  "Find COMMAND in `exec-path', or on the remote host's PATH over TRAMP.
+Return the (shell-quoted) absolute path if found, otherwise nil.  When
+`default-directory' is remote, `executable-find' is asked to search on
+that host instead of the local one."
+  (let ((remote (file-remote-p default-directory)))
+    (when-let* ((found (or (executable-find command remote)
+                           (executable-find (concat command ".bat") remote))))
+      (shell-quote-argument found))))
 
 (defun cider--resolve-project-command (command)
   "Find COMMAND in project dir or exec path (see variable `exec-path').

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -615,6 +615,22 @@
                 :to-equal
                 "(do (require '[shadow.cljs.devtools.api :as shadow]) (shadow/watch :client-build) (shadow/watch :other-build) (shadow/nrepl-select :client-build))")))))
 
+(describe "cider--resolve-command"
+  (it "passes the TRAMP host to `executable-find' when default-directory is remote"
+    (let ((default-directory "/ssh:remote-host:/home/me/")
+          (received-remote nil))
+      (spy-on 'executable-find
+              :and-call-fake
+              (lambda (_command &optional remote)
+                (setq received-remote remote)
+                "/usr/bin/clojure"))
+      (cider--resolve-command "clojure")
+      (expect received-remote :to-equal "/ssh:remote-host:")))
+  (it "returns nil when the command is not found on the remote host"
+    (let ((default-directory "/ssh:remote-host:/home/me/"))
+      (spy-on 'executable-find :and-return-value nil)
+      (expect (cider--resolve-command "no-such-command") :to-be nil))))
+
 (describe "cider--resolve-project-command"
   (it "if command starts with ./ it resolves relative to clojure-project-dir"
     (spy-on 'locate-file :and-return-value "/project/command")


### PR DESCRIPTION
Small follow-up to the TRAMP work in #3885.

`cider--resolve-command` previously short-circuited to "trust the user-supplied command" whenever `default-directory` was remote, with a `TODO` noting that real verification was wanted. Emacs 27+ accepts a `REMOTE` argument to `executable-find` that searches the host's PATH via TRAMP, so wire that through.

A missing executable on the remote side now surfaces immediately during jack-in (the existing "executable isn't on your `exec-path'" error) instead of failing later when the server doesn't start. The `.bat` fallback for Windows now also runs on the remote.

Two new specs cover the remote path: that we pass the TRAMP host to `executable-find`, and that we return nil when the command is absent on the remote.