### PR TITLE
Spawn the SSH tunnel without a shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `cider--update-project-dir` no longer reuses a single `*cider-context-buffer*` across calls. Each invocation gets a unique hidden buffer, so concurrent or interrupted jack-ins don't stomp each other.
 - `nrepl-server-filter` now treats wildcard/loopback printed bind addresses (`localhost`, `127.0.0.1`, `0.0.0.0`, `::1`, `::`) as "use the calling context", so jacking in over TRAMP to a server that prints `localhost` connects to the TRAMP host instead of the local machine.
 - `cider--resolve-command` now actually verifies command presence on remote hosts via `executable-find`'s remote search, instead of unconditionally trusting the user-supplied command. A missing tool on the remote side now surfaces immediately during jack-in instead of as a server-startup failure later.
+- `nrepl--ssh-tunnel-connect` no longer routes its `ssh` invocation through a shell. The tunnel command is now spawned via `start-process` with an explicit arg list, eliminating shell-quoting hazards in user/host components.
 
 ### Changes
 

--- a/lisp/nrepl-client.el
+++ b/lisp/nrepl-client.el
@@ -427,10 +427,10 @@ If NO-ERROR is non-nil, show messages instead of throwing an error."
                       (t default-directory)))
          (ssh (or (executable-find "ssh")
                   (error "[nREPL] Cannot locate 'ssh' executable")))
-         (cmd (nrepl--ssh-tunnel-command ssh remote-dir port))
+         (args (nrepl--ssh-tunnel-args remote-dir port))
          (tunnel-buf (nrepl-tunnel-buffer-name
                       `((:host ,host) (:port ,port))))
-         (tunnel (start-process-shell-command "nrepl-tunnel" tunnel-buf cmd)))
+         (tunnel (apply #'start-process "nrepl-tunnel" tunnel-buf ssh args)))
     (process-put tunnel :waiting-for-port t)
     (set-process-filter tunnel (nrepl--ssh-tunnel-filter port))
     (while (and (process-live-p tunnel)
@@ -445,19 +445,20 @@ If NO-ERROR is non-nil, show messages instead of throwing an error."
           (plist-put :tunnel tunnel)
           (plist-put :remote-host host))))))
 
-(defun nrepl--ssh-tunnel-command (ssh dir port)
-  "Command string to open SSH tunnel to the host associated with DIR's PORT."
+(defun nrepl--ssh-tunnel-args (dir port)
+  "Build the ssh program-args list for forwarding PORT from DIR's host.
+Returns the args as a list so the caller can pass them to `start-process'
+without shell intermediation -- this avoids any quoting hazards in the
+host, user or port components.
+
+The -v option is requested because we synchronize on diagnostic output
+to know when port forwarding is up before attempting to connect."
   (with-parsed-tramp-file-name dir v
-    ;; this abuses the -v option for ssh to get output when the port
-    ;; forwarding is set up, which is used to synchronise on, so that
-    ;; the port forwarding is up when we try to connect.
-    (format-spec
-     "%s -v -N -L %p:localhost:%p %u'%h' %n"
-     `((?s . ,ssh)
-       (?p . ,port)
-       (?h . ,v-host)
-       (?u . ,(if v-user (format "-l '%s' " v-user) ""))
-       (?n . ,(if v-port (format "-p '%s' " v-port) ""))))))
+    (append (list "-v" "-N"
+                  "-L" (format "%s:localhost:%s" port port))
+            (when v-user (list "-l" v-user))
+            (when v-port (list "-p" v-port))
+            (list v-host))))
 
 (autoload 'comint-watch-for-password-prompt "comint"  "(autoload).")
 

--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -184,6 +184,22 @@
     (expect (nrepl--ssh-file-name-matches-host-p nil nil)
             :to-be nil)))
 
+(describe "nrepl--ssh-tunnel-args"
+  (it "returns the bare minimum when only host is set"
+    (expect (nrepl--ssh-tunnel-args "/ssh:host:~/x" 12345)
+            :to-equal (list "-v" "-N" "-L" "12345:localhost:12345" "host")))
+  (it "passes user via -l and ssh port via -p"
+    (expect (nrepl--ssh-tunnel-args "/ssh:user@host#2222:~/x" 9999)
+            :to-equal (list "-v" "-N" "-L" "9999:localhost:9999"
+                            "-l" "user"
+                            "-p" "2222"
+                            "host")))
+  (it "passes hyphenated user/host through unmodified (no shell quoting)"
+    (expect (nrepl--ssh-tunnel-args "/ssh:my-user@my-host:~/x" 4242)
+            :to-equal (list "-v" "-N" "-L" "4242:localhost:4242"
+                            "-l" "my-user"
+                            "my-host"))))
+
 (describe "nrepl-client-lifecycle"
   (it "start and stop nrepl client process"
 


### PR DESCRIPTION
Small follow-up to #3885.

`nrepl--ssh-tunnel-connect` was assembling a single shell command string -- with single-quoted host/user/port -- and running it through `start-process-shell-command`. Single quotes don't escape themselves, so an apostrophe anywhere in those components would have broken the quoting (and could in principle have led to unintended shell behavior).

Replace `nrepl--ssh-tunnel-command` (returning a string) with `nrepl--ssh-tunnel-args` (returning a list of args) and spawn `ssh` directly via `start-process`. No shell, no quoting hazard; special characters in user/host pass through to ssh unmodified.

Adds three Buttercup specs locking in the arg order for the host-only, user+port, and hyphenated-user/host cases.