### PR TITLE
Cache the running-nREPL path scan with a short TTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#3645](https://github.com/clojure-emacs/cider/issues/3645): Show a spinner in the mode line while tests are running.
 - [#3865](https://github.com/clojure-emacs/cider/pull/3865): Add default session feature to bypass sesman's project-based dispatch (`cider-set-default-session`, `cider-clear-default-session`).
 - Introduce `cider-jack-in-tools` and `cider-register-jack-in-tool` so third-party packages can register new project tools for `cider-jack-in` and `cider-jack-in-universal`.
+- Cache the result of `cider--running-nrepl-paths` (used by `cider-locate-running-nrepl-ports`) for `cider-running-nrepl-paths-cache-ttl` seconds (default 5). Repeated `cider-connect` completions no longer re-spawn a fresh round of `ps`/`lsof` subprocesses each time. `cider-clear-running-nrepl-paths-cache` discards the cache on demand.
 
 ### Bugs fixed
 

--- a/lisp/cider.el
+++ b/lisp/cider.el
@@ -1977,12 +1977,52 @@ Do it by looping over the open REPL buffers."
                       (list dir (prin1-to-string port))))))
                (seq-filter #'identity)))
 
-(defun cider--running-nrepl-paths ()
-  "Retrieve project paths of running nREPL servers.
-Search for lein or java processes including nrepl.command nREPL."
+(defcustom cider-running-nrepl-paths-cache-ttl 5.0
+  "How long, in seconds, to cache the running-nREPL path scan.
+Each scan spawns several `ps' and `lsof' subprocesses; caching across
+back-to-back endpoint completions avoids redundant work.  The cache is
+keyed by `default-directory', so each TRAMP host has its own entry.
+
+Set to 0 (or any non-positive number) to disable caching."
+  :type 'number
+  :safe #'numberp
+  :package-version '(cider . "1.22.0"))
+
+(defvar cider--running-nrepl-paths-cache nil
+  "Cache for `cider--running-nrepl-paths'.
+An alist of (KEY . (TIMESTAMP . PATHS)).  KEY is `default-directory' at
+the time of the scan; TIMESTAMP is `float-time'; PATHS is the result.")
+
+(defun cider-clear-running-nrepl-paths-cache ()
+  "Discard the cached running-nREPL path scan.
+Use this if you suspect the cache is stale (e.g. you just started or
+killed an nREPL server) and don't want to wait out
+`cider-running-nrepl-paths-cache-ttl'."
+  (interactive)
+  (setq cider--running-nrepl-paths-cache nil))
+
+(defun cider--running-nrepl-paths-uncached ()
+  "Retrieve project paths of running nREPL servers, without caching.
+Search for lein or java processes running nREPL."
   (append (cider--invoke-running-nrepl-path #'cider--running-lein-nrepl-paths)
           (cider--invoke-running-nrepl-path #'cider--running-local-nrepl-paths)
           (cider--invoke-running-nrepl-path #'cider--running-non-lein-nrepl-paths)))
+
+(defun cider--running-nrepl-paths ()
+  "Retrieve project paths of running nREPL servers, with TTL caching.
+The cache TTL is controlled by `cider-running-nrepl-paths-cache-ttl';
+see also `cider-clear-running-nrepl-paths-cache'."
+  (let* ((key default-directory)
+         (entry (assoc key cider--running-nrepl-paths-cache))
+         (now (float-time)))
+    (if (and entry
+             (> cider-running-nrepl-paths-cache-ttl 0)
+             (< (- now (cadr entry)) cider-running-nrepl-paths-cache-ttl))
+        (cddr entry)
+      (let ((paths (cider--running-nrepl-paths-uncached)))
+        (setf (alist-get key cider--running-nrepl-paths-cache nil nil #'equal)
+              (cons now paths))
+        paths))))
 
 (defun cider--identify-buildtools-present (&optional project-dir)
   "Identify build systems present by their build files in PROJECT-DIR.

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -727,4 +727,36 @@
     (expect (cider-locate-running-nrepl-ports "from-dir")
             :to-equal '(("from-dir" "4567") ("lein" "1234") ("local" "2345") ("non-lein" "3456")))))
 
+(describe "cider--running-nrepl-paths cache"
+  (before-each
+    (cider-clear-running-nrepl-paths-cache)
+    (spy-on 'cider--running-nrepl-paths-uncached
+            :and-return-value '(("p" "1"))))
+
+  (it "scans only once for back-to-back calls within the TTL"
+    (let ((cider-running-nrepl-paths-cache-ttl 60))
+      (cider--running-nrepl-paths)
+      (cider--running-nrepl-paths)
+      (cider--running-nrepl-paths)
+      (expect 'cider--running-nrepl-paths-uncached :to-have-been-called-times 1)))
+
+  (it "rescans on every call when the TTL is 0"
+    (let ((cider-running-nrepl-paths-cache-ttl 0))
+      (cider--running-nrepl-paths)
+      (cider--running-nrepl-paths)
+      (expect 'cider--running-nrepl-paths-uncached :to-have-been-called-times 2)))
+
+  (it "rescans after the cache has been cleared"
+    (let ((cider-running-nrepl-paths-cache-ttl 60))
+      (cider--running-nrepl-paths)
+      (cider-clear-running-nrepl-paths-cache)
+      (cider--running-nrepl-paths)
+      (expect 'cider--running-nrepl-paths-uncached :to-have-been-called-times 2)))
+
+  (it "keeps separate entries for different default-directory keys"
+    (let ((cider-running-nrepl-paths-cache-ttl 60))
+      (let ((default-directory "/tmp/a/")) (cider--running-nrepl-paths))
+      (let ((default-directory "/tmp/b/")) (cider--running-nrepl-paths))
+      (expect 'cider--running-nrepl-paths-uncached :to-have-been-called-times 2))))
+
 ;;; cider-tests.el ends here


### PR DESCRIPTION
Small follow-up to #3885. Each `cider-locate-running-nrepl-ports` call (driven by `cider-connect` endpoint completion) spawns roughly six subprocesses: one `ps` for lein, one `ps` for non-lein, then `lsof` twice per java/babashka PID found. Repeated completions inside one minibuffer session re-ran the full scan every time.

This PR memoizes `cider--running-nrepl-paths` with a small alist keyed by `default-directory` (so different TRAMP hosts stay isolated) and a configurable TTL. Default `cider-running-nrepl-paths-cache-ttl` is 5 seconds -- enough to collapse a burst of back-to-back completions onto a single scan, short enough that a server you just started shows up promptly.

`cider-clear-running-nrepl-paths-cache` is the on-demand reset for users who want to bypass the TTL after starting/killing a server.

Four Buttercup specs cover the cache hit path, the TTL=0 disable path, the manual clear, and per-`default-directory` isolation.