### PR TITLE
Require nrepl-tests-utils in cider-tests.el

### DIFF
--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -29,6 +29,11 @@
 
 (require 'buttercup)
 (require 'cider)
+;; Provides `nrepl-start-mock-server-process' / `nrepl-tests-poll-until',
+;; used by the cider-connect-sibling-cljs and sesman specs below.  Without
+;; this require those tests fail when the file is loaded in isolation,
+;; because no other test file pulls the helpers in first.
+(require 'nrepl-tests-utils "test/utils/nrepl-tests-utils")
 
 ;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
 


### PR DESCRIPTION
The `cider-connect-sibling-cljs` and `sesman` specs in `cider-tests.el` use `nrepl-start-mock-server-process` and `nrepl-tests-poll-until` from `test/utils/nrepl-tests-utils.el`, but this file never required them.

In a full `eldev test` run things still pass, because `nrepl-client-tests.el` happens to require the helpers earlier and they stay loaded for the rest of the run. As soon as you load `cider-tests.el` on its own (or together with only `cider-connection-tests.el`), the helpers are undefined and three specs error out with `(void-function nrepl-start-mock-server-process)`:

- `cider-connect-sibling-cljs` > "for a custom cljs REPL type project"
- `cider-connect-sibling-cljs` > "for a custom REPL type project that needs to switch to cljs"
- `sesman` > "can restart session"

This was the source of the "3 phantom failures" we kept seeing during the recent jack-in cleanup PRs.

Adding the require makes `cider-tests.el` self-contained, matching the form already used by `nrepl-client-tests.el:33`. Verified across four orderings (file alone, file + connection-tests in either order, full suite) -- all 0 failures, and `cider-tests.el` alone now runs 90 specs (up from 71) because the previously-erroring mock-server specs actually execute.