### PR TITLE
Add nrepl-make-eval-handler with a keyword-arg API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#3865](https://github.com/clojure-emacs/cider/pull/3865): Add default session feature to bypass sesman's project-based dispatch (`cider-set-default-session`, `cider-clear-default-session`).
 - Introduce `cider-jack-in-tools` and `cider-register-jack-in-tool` so third-party packages can register new project tools for `cider-jack-in` and `cider-jack-in-universal`.
 - Cache the result of `cider--running-nrepl-paths` (used by `cider-locate-running-nrepl-ports`) for `cider-running-nrepl-paths-cache-ttl` seconds (default 5). Repeated `cider-connect` completions no longer re-spawn a fresh round of `ps`/`lsof` subprocesses each time. `cider-clear-running-nrepl-paths-cache` discards the cache on demand.
+- New `nrepl-make-eval-handler` with a keyword-arg API (`:on-value`, `:on-stdout`, `:on-stderr`, `:on-done`, `:on-eval-error`, `:on-content-type`, `:on-truncated`). Sub-handlers no longer take a buffer argument -- they close over whatever they need. `nrepl-make-response-handler`, the legacy 7-positional-arg form, is preserved as an obsolete shim that adapts the old (buffer x) lambdas to the new (x) lambdas, so existing extensions keep working.
 
 ### Bugs fixed
 

--- a/lisp/cider-client.el
+++ b/lisp/cider-client.el
@@ -493,7 +493,7 @@ itself is present."
 
 (defun cider-interrupt-handler (buffer)
   "Create an interrupt response handler for BUFFER."
-  (nrepl-make-response-handler buffer nil nil nil nil))
+  (nrepl-make-eval-handler :buffer buffer))
 
 (defun cider-interrupt ()
   "Interrupt any pending evaluations."
@@ -901,14 +901,11 @@ FORMAT-OPTIONS is an optional configuration map for cljfmt."
     (nrepl-dict-get response "formatted-edn")))
 
 ;;; Dealing with input
-;; TODO: Replace this with some nil handler.
 (defun cider-stdin-handler (&optional _buffer)
-  "Make a stdin response handler for _BUFFER."
-  (nrepl-make-response-handler (current-buffer)
-                               (lambda (_buffer _value))
-                               (lambda (_buffer _out))
-                               (lambda (_buffer _err))
-                               nil))
+  "Make a stdin response handler for _BUFFER.
+Intentionally swallows value/out/err so the response is consumed without
+side effects; only the global handlers fire (need-input, eval-error, ...)."
+  (nrepl-make-eval-handler :buffer (current-buffer)))
 
 (defun cider-need-input (buffer)
   "Handle an need-input request from BUFFER."

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -627,32 +627,26 @@ The handler simply inserts the result value in BUFFER."
   (let ((eval-buffer (current-buffer))
         (res "")
         (failed nil))
-    (nrepl-make-response-handler (or buffer eval-buffer)
-                                 ;; value handler:
-                                 (lambda (_buffer value)
-                                   (with-current-buffer buffer
-                                     (insert value))
-                                   (when cider-eval-register
-                                     (setq res (concat res value))))
-                                 ;; stdout handler:
-                                 (lambda (_buffer out)
-                                   (cider-repl-emit-interactive-stdout out))
-                                 ;; stderr handler:
-                                 (lambda (_buffer err)
-                                   (cider-repl-emit-interactive-stderr err)
-                                   ;; Don't jump
-                                   (cider-handle-compilation-errors err eval-buffer t))
-                                 ;; done handler:
-                                 (lambda (_buffer)
-                                   (when cider-eval-register
-                                     (set-register cider-eval-register res))
-                                   (when (and (not failed)
-                                              on-success-callback)
-                                     (funcall on-success-callback)))
-                                 ;; eval-error handler
-                                 (lambda (_buffer)
-                                   (setq failed t)
-                                   (funcall nrepl-err-handler-function source-buffer)))))
+    (nrepl-make-eval-handler
+     :buffer (or buffer eval-buffer)
+     :on-value (lambda (value)
+                 (with-current-buffer buffer
+                   (insert value))
+                 (when cider-eval-register
+                   (setq res (concat res value))))
+     :on-stdout (lambda (out) (cider-repl-emit-interactive-stdout out))
+     :on-stderr (lambda (err)
+                  (cider-repl-emit-interactive-stderr err)
+                  ;; Don't jump
+                  (cider-handle-compilation-errors err eval-buffer t))
+     :on-done (lambda ()
+                (when cider-eval-register
+                  (set-register cider-eval-register res))
+                (when (and (not failed) on-success-callback)
+                  (funcall on-success-callback)))
+     :on-eval-error (lambda ()
+                      (setq failed t)
+                      (funcall nrepl-err-handler-function source-buffer)))))
 
 (defun cider--emit-interactive-eval-output (output repl-emit-function)
   "Emit output resulting from interactive code evaluation.
@@ -733,106 +727,94 @@ when `cider-auto-inspect-after-eval' is non-nil."
          (end (when end (copy-marker end)))
          (fringed nil)
          (res ""))
-    (nrepl-make-response-handler
-     (or buffer eval-buffer)
-     ;; value handler:
-     (lambda (_buffer value)
-       (setq res (concat res value))
-       (cider--display-interactive-eval-result res 'value end))
-     ;; stdout handler:
-     (lambda (_buffer out)
-       (cider-emit-interactive-eval-output out))
-     ;; stderr handler:
-     (lambda (_buffer err)
-       (cider-emit-interactive-eval-err-output err)
-       (cider-handle-compilation-errors
-        err eval-buffer
-        ;; Disable jumping behavior when compiling a single form because
-        ;; lines tend to be spurious (e.g. 0:0) and the jump brings us to
-        ;; the beginning of the same form anyway.
-        t))
-     ;; done handler:
-     (lambda (buffer)
-       (if beg
-           (unless fringed
-             (cider--make-fringe-overlays-for-region beg end)
-             (setq fringed t))
-         (cider--make-fringe-overlay end))
-       (when (and cider-auto-inspect-after-eval
-                  (boundp 'cider-inspector-buffer)
-                  (windowp (get-buffer-window cider-inspector-buffer 'visible)))
-         (cider-inspect-last-result)
-         (select-window (get-buffer-window buffer)))
-       (when cider-eval-register
-         (set-register cider-eval-register res))))))
+    (nrepl-make-eval-handler
+     :buffer (or buffer eval-buffer)
+     :on-value (lambda (value)
+                 (setq res (concat res value))
+                 (cider--display-interactive-eval-result res 'value end))
+     :on-stdout (lambda (out) (cider-emit-interactive-eval-output out))
+     :on-stderr (lambda (err)
+                  (cider-emit-interactive-eval-err-output err)
+                  (cider-handle-compilation-errors
+                   err eval-buffer
+                   ;; Disable jumping behavior when compiling a single form
+                   ;; because lines tend to be spurious (e.g. 0:0) and the
+                   ;; jump brings us to the beginning of the same form anyway.
+                   t))
+     :on-done (lambda ()
+                (if beg
+                    (unless fringed
+                      (cider--make-fringe-overlays-for-region beg end)
+                      (setq fringed t))
+                  (cider--make-fringe-overlay end))
+                (let ((target (or buffer eval-buffer)))
+                  (when (and cider-auto-inspect-after-eval
+                             (boundp 'cider-inspector-buffer)
+                             (windowp (get-buffer-window cider-inspector-buffer 'visible)))
+                    (cider-inspect-last-result)
+                    (select-window (get-buffer-window target))))
+                (when cider-eval-register
+                  (set-register cider-eval-register res))))))
 
 
 (defun cider-load-file-handler (&optional buffer done-handler)
   "Make a load file handler for BUFFER.
 Optional argument DONE-HANDLER lambda will be run once load is complete."
-  (let ((eval-buffer (current-buffer))
-        (res ""))
-    (nrepl-make-response-handler (or buffer eval-buffer)
-                                 ;; value
-                                 (lambda (buffer value)
-                                   (cider--display-interactive-eval-result value 'value)
-                                   (when cider-eval-register
-                                     (setq res (concat res value)))
-                                   (when (buffer-live-p buffer)
-                                     (with-current-buffer buffer
-                                       (cider--make-fringe-overlays-for-region (point-min) (point-max))
-                                       (run-hooks 'cider-file-loaded-hook))))
-                                 ;; stdout
-                                 (lambda (_buffer value)
-                                   (cider-emit-interactive-eval-output value))
-                                 ;; stderr
-                                 (lambda (_buffer err)
-                                   (cider-emit-interactive-eval-err-output err)
-                                   (cider-handle-compilation-errors err eval-buffer))
-                                 ;; done
-                                 (lambda (buffer)
-                                   (when cider-eval-register
-                                     (set-register cider-eval-register res))
-                                   (when done-handler
-                                     (funcall done-handler buffer))))))
+  (let* ((eval-buffer (current-buffer))
+         (target (or buffer eval-buffer))
+         (res ""))
+    (nrepl-make-eval-handler
+     :buffer target
+     :on-value (lambda (value)
+                 (cider--display-interactive-eval-result value 'value)
+                 (when cider-eval-register
+                   (setq res (concat res value)))
+                 (when (buffer-live-p target)
+                   (with-current-buffer target
+                     (cider--make-fringe-overlays-for-region (point-min) (point-max))
+                     (run-hooks 'cider-file-loaded-hook))))
+     :on-stdout (lambda (out) (cider-emit-interactive-eval-output out))
+     :on-stderr (lambda (err)
+                  (cider-emit-interactive-eval-err-output err)
+                  (cider-handle-compilation-errors err eval-buffer))
+     :on-done (lambda ()
+                (when cider-eval-register
+                  (set-register cider-eval-register res))
+                (when done-handler
+                  (funcall done-handler target))))))
 
 (defun cider-eval-print-handler (&optional buffer)
   "Make a handler for evaluating and printing result in BUFFER."
   ;; NOTE: cider-eval-register behavior is not implemented here for performance reasons.
   ;; See https://github.com/clojure-emacs/cider/pull/3162
-  (nrepl-make-response-handler (or buffer (current-buffer))
-                               (lambda (buffer value)
-                                 (with-current-buffer buffer
-                                   (insert
-                                    (if (derived-mode-p 'cider-clojure-interaction-mode)
-                                        (format "\n%s\n" value)
-                                      value))))
-                               (lambda (_buffer out)
-                                 (cider-emit-interactive-eval-output out))
-                               (lambda (_buffer err)
-                                 (cider-emit-interactive-eval-err-output err))
-                               ()))
+  (let ((target (or buffer (current-buffer))))
+    (nrepl-make-eval-handler
+     :buffer target
+     :on-value (lambda (value)
+                 (with-current-buffer target
+                   (insert (if (derived-mode-p 'cider-clojure-interaction-mode)
+                               (format "\n%s\n" value)
+                             value))))
+     :on-stdout (lambda (out) (cider-emit-interactive-eval-output out))
+     :on-stderr (lambda (err) (cider-emit-interactive-eval-err-output err)))))
 
 (defun cider-eval-print-with-comment-handler (buffer location comment-prefix)
   "Make a handler for evaluating and printing commented results in BUFFER.
 LOCATION is the location marker at which to insert.  COMMENT-PREFIX is the
 comment prefix to use."
   (let ((res ""))
-    (nrepl-make-response-handler buffer
-                                 (lambda (_buffer value)
-                                   (setq res (concat res value)))
-                                 (lambda (_buffer out)
-                                   (cider-emit-interactive-eval-output out))
-                                 (lambda (_buffer err)
-                                   (cider-emit-interactive-eval-err-output err))
-                                 (lambda (buffer)
-                                   (with-current-buffer buffer
-                                     (save-excursion
-                                       (goto-char (marker-position location))
-                                       (insert (concat comment-prefix
-                                                       res "\n"))))
-                                   (when cider-eval-register
-                                     (set-register cider-eval-register res))))))
+    (nrepl-make-eval-handler
+     :buffer buffer
+     :on-value (lambda (value) (setq res (concat res value)))
+     :on-stdout (lambda (out) (cider-emit-interactive-eval-output out))
+     :on-stderr (lambda (err) (cider-emit-interactive-eval-err-output err))
+     :on-done (lambda ()
+                (with-current-buffer buffer
+                  (save-excursion
+                    (goto-char (marker-position location))
+                    (insert (concat comment-prefix res "\n"))))
+                (when cider-eval-register
+                  (set-register cider-eval-register res))))))
 
 (defun cider-maybe-insert-multiline-comment (result comment-prefix continued-prefix comment-postfix)
   "Insert eval RESULT at current location if RESULT is not empty.
@@ -860,26 +842,24 @@ COMMENT-PREFIX is the comment prefix for the first line of output.
 CONTINUED-PREFIX is the comment prefix to use for the remaining lines.
 COMMENT-POSTFIX is the text to output after the last line."
   (let ((res ""))
-    (nrepl-make-response-handler
-     buffer
-     (lambda (_buffer value)
-       (setq res (concat res value)))
-     nil
-     (lambda (_buffer err)
-       (setq res (concat res err)))
-     (lambda (buffer)
-       (with-current-buffer buffer
-         (save-excursion
-           (goto-char (marker-position location))
-           ;; edge case: defun at eob
-           (unless (bolp) (insert "\n"))
-           (cider-maybe-insert-multiline-comment res comment-prefix continued-prefix comment-postfix)))
-       (when cider-eval-register
-         (set-register cider-eval-register res)))
-     nil
-     nil
-     (lambda (_buffer warning)
-       (setq res (concat res warning))))))
+    (nrepl-make-eval-handler
+     :buffer buffer
+     :on-value (lambda (value) (setq res (concat res value)))
+     :on-stderr (lambda (err) (setq res (concat res err)))
+     :on-done (lambda ()
+                (with-current-buffer buffer
+                  (save-excursion
+                    (goto-char (marker-position location))
+                    ;; edge case: defun at eob
+                    (unless (bolp) (insert "\n"))
+                    (cider-maybe-insert-multiline-comment
+                     res comment-prefix continued-prefix comment-postfix)))
+                (when cider-eval-register
+                  (set-register cider-eval-register res)))
+     :on-truncated (lambda ()
+                     ;; Preserve the (incidentally nil) warning the legacy
+                     ;; truncated-handler form passed through.
+                     (setq res (concat res nil))))))
 
 (defun cider-popup-eval-handler (&optional buffer _bounds source-buffer)
   "Make a handler for printing evaluation results in popup BUFFER,
@@ -890,36 +870,27 @@ This is used by pretty-printing commands."
   ;; NOTE: cider-eval-register behavior is not implemented here for performance reasons.
   ;; See https://github.com/clojure-emacs/cider/pull/3162
   (let ((chosen-buffer (or buffer (current-buffer))))
-    (nrepl-make-response-handler
-     chosen-buffer
-     ;; value handler:
-     (lambda (buffer value)
-       (cider-emit-into-popup-buffer buffer (ansi-color-apply value) nil t))
-     ;; stdout handler:
-     (lambda (_buffer out)
-       (cider-emit-interactive-eval-output out))
-     ;; stderr handler:
-     (lambda (_buffer err)
-       (cider-emit-interactive-eval-err-output err))
-     ;; done handler:
-     nil
-     ;; eval-error handler:
-     (lambda (_buffer)
-       (when (and (buffer-live-p chosen-buffer)
-                  (member (buffer-name chosen-buffer)
-                          cider-ancillary-buffers))
-         (with-selected-window (get-buffer-window chosen-buffer)
-           (cider-popup-buffer-quit-function t)))
-       ;; also call the default nrepl-err-handler-function, so that our custom behavior doesn't void the base behavior:
-       (when nrepl-err-handler-function
-         (funcall nrepl-err-handler-function source-buffer)))
-     ;; content type handler:
-     nil
-     ;; truncated handler:
-     (lambda (buffer)
-       (let ((warning (format "\n... output truncated to %sB ..."
-                              (file-size-human-readable cider-print-quota))))
-         (cider-emit-into-popup-buffer buffer warning 'font-lock-warning-face t))))))
+    (nrepl-make-eval-handler
+     :buffer chosen-buffer
+     :on-value (lambda (value)
+                 (cider-emit-into-popup-buffer chosen-buffer (ansi-color-apply value) nil t))
+     :on-stdout (lambda (out) (cider-emit-interactive-eval-output out))
+     :on-stderr (lambda (err) (cider-emit-interactive-eval-err-output err))
+     :on-eval-error (lambda ()
+                      (when (and (buffer-live-p chosen-buffer)
+                                 (member (buffer-name chosen-buffer)
+                                         cider-ancillary-buffers))
+                        (with-selected-window (get-buffer-window chosen-buffer)
+                          (cider-popup-buffer-quit-function t)))
+                      ;; also call the default nrepl-err-handler-function so
+                      ;; our custom behavior doesn't void the base behavior:
+                      (when nrepl-err-handler-function
+                        (funcall nrepl-err-handler-function source-buffer)))
+     :on-truncated (lambda ()
+                     (let ((warning (format "\n... output truncated to %sB ..."
+                                            (file-size-human-readable cider-print-quota))))
+                       (cider-emit-into-popup-buffer chosen-buffer warning
+                                                     'font-lock-warning-face t))))))
 
 
 ;;; Interactive valuation commands

--- a/lisp/cider-profile.el
+++ b/lisp/cider-profile.el
@@ -53,11 +53,12 @@
   "CIDER profiling submenu.")
 
 (defun cider-profile--make-response-handler (handler &optional buffer)
-  "Make a response handler using value handler HANDLER for connection BUFFER.
-
-Optional argument BUFFER defaults to current buffer."
-  (nrepl-make-response-handler
-   (or buffer (current-buffer)) handler nil nil nil))
+  "Make a response handler that calls HANDLER with the response value.
+HANDLER takes one argument (the value).  BUFFER, defaulting to the
+current buffer, is used by the global nREPL handlers (e.g. error)."
+  (nrepl-make-eval-handler
+   :buffer (or buffer (current-buffer))
+   :on-value handler))
 
 ;;;###autoload
 (defun cider-profile-ns-toggle (&optional query)
@@ -75,7 +76,7 @@ current ns."
      `("op" "cider/profile-toggle-ns"
        "ns" ,ns)
      (cider-profile--make-response-handler
-      (lambda (_buffer value)
+      (lambda (value)
         (pcase value
           ("profiled" (message "Profiling enabled for %s" ns))
           ("unprofiled" (message "Profiling disabled for %s" ns)))))))
@@ -97,7 +98,7 @@ With prefix arg or no symbol at point, prompts for a var."
           "ns" ,ns
           "sym" ,sym)
         (cider-profile--make-response-handler
-         (lambda (_buffer value)
+         (lambda (value)
            (pcase value
              ("profiled" (message "Profiling enabled for %s/%s" ns sym))
              ("unprofiled" (message "Profiling disabled for %s/%s" ns sym)))))))))
@@ -124,7 +125,7 @@ With prefix arg or no symbol at point, prompts for a var."
   (cider-nrepl-send-request
    '("op" "cider/profile-clear")
    (cider-profile--make-response-handler
-    (lambda (_buffer value)
+    (lambda (value)
       (when (equal value "cleared")
         (message "Cleared profile data"))))))
 

--- a/lisp/cider-repl.el
+++ b/lisp/cider-repl.el
@@ -271,16 +271,14 @@ This cache is stored in the connection buffer.")
 (defun cider-repl-init-eval-handler (&optional callback)
   "Make an nREPL evaluation handler for use during REPL init.
 Run CALLBACK once the evaluation is complete."
-  (nrepl-make-response-handler (current-buffer)
-                               (lambda (_buffer _value))
-                               (lambda (buffer out)
-                                 (cider-repl-emit-stdout buffer out))
-                               (lambda (buffer err)
-                                 (cider-repl-emit-stderr buffer err))
-                               (lambda (buffer)
-                                 (cider-repl-emit-prompt buffer)
-                                 (when callback
-                                   (funcall callback)))))
+  (let ((buffer (current-buffer)))
+    (nrepl-make-eval-handler
+     :buffer buffer
+     :on-stdout (lambda (out) (cider-repl-emit-stdout buffer out))
+     :on-stderr (lambda (err) (cider-repl-emit-stderr buffer err))
+     :on-done (lambda ()
+                (cider-repl-emit-prompt buffer)
+                (when callback (funcall callback))))))
 
 (defun cider-repl-eval-init-code (&optional callback)
   "Evaluate `cider-repl-init-code' in the current REPL.
@@ -1044,35 +1042,36 @@ and responding to them.")
 (defun cider-repl-handler (buffer)
   "Make an nREPL evaluation handler for the REPL BUFFER."
   (let ((show-prompt t))
-    (nrepl-make-response-handler
-     buffer
-     (lambda (buffer value)
-       (cider-repl-emit-result buffer value t))
-     (lambda (buffer out)
-       (dolist (f cider--repl-stdout-functions)
-         (funcall f buffer out))
-       (cider-repl-emit-stdout buffer out))
-     (lambda (buffer err)
-       (dolist (f cider--repl-stderr-functions)
-         (funcall f buffer err))
-       (cider-repl-emit-stderr buffer err))
-     (lambda (buffer)
-       (when show-prompt
-         (cider-repl-emit-prompt buffer))
-       (when cider-repl-buffer-size-limit
-         (cider-repl-maybe-trim-buffer buffer))
-       (dolist (f cider--repl-done-functions)
-         (funcall f buffer)))
-     nrepl-err-handler-function
-     (lambda (buffer value content-type)
-       (if-let* ((content-attrs (cadr content-type))
-                 (content-type* (car content-type))
-                 (handler (cdr (assoc content-type*
-                                      cider-repl-content-type-handler-alist))))
-           (setq show-prompt (funcall handler content-type buffer value nil t))
-         (cider-repl-emit-result buffer value t t)))
-     (lambda (buffer warning)
-       (cider-repl-emit-stderr buffer warning)))))
+    (nrepl-make-eval-handler
+     :buffer buffer
+     :on-value (lambda (value)
+                 (cider-repl-emit-result buffer value t))
+     :on-stdout (lambda (out)
+                  (dolist (f cider--repl-stdout-functions)
+                    (funcall f buffer out))
+                  (cider-repl-emit-stdout buffer out))
+     :on-stderr (lambda (err)
+                  (dolist (f cider--repl-stderr-functions)
+                    (funcall f buffer err))
+                  (cider-repl-emit-stderr buffer err))
+     :on-done (lambda ()
+                (when show-prompt
+                  (cider-repl-emit-prompt buffer))
+                (when cider-repl-buffer-size-limit
+                  (cider-repl-maybe-trim-buffer buffer))
+                (dolist (f cider--repl-done-functions)
+                  (funcall f buffer)))
+     :on-content-type (lambda (value content-type)
+                        (if-let* ((content-attrs (cadr content-type))
+                                  (content-type* (car content-type))
+                                  (handler (cdr (assoc content-type*
+                                                       cider-repl-content-type-handler-alist))))
+                            (setq show-prompt (funcall handler content-type buffer value nil t))
+                          (cider-repl-emit-result buffer value t t)))
+     :on-truncated (lambda ()
+                     ;; Preserve the (incidentally nil) warning the legacy
+                     ;; truncated-handler form passed through.
+                     (cider-repl-emit-stderr buffer nil)))))
 
 (defun cider--repl-request-plist ()
   "Plist to be merged into REPL eval requests."
@@ -1283,14 +1282,11 @@ With a prefix argument CLEAR-REPL it will clear the entire REPL buffer instead."
 
 (defun cider-repl-switch-ns-handler (buffer)
   "Make an nREPL evaluation handler for the REPL BUFFER's ns switching."
-  (nrepl-make-response-handler buffer
-                               (lambda (_buffer _value))
-                               (lambda (buffer out)
-                                 (cider-repl-emit-stdout buffer out))
-                               (lambda (buffer err)
-                                 (cider-repl-emit-stderr buffer err))
-                               (lambda (buffer)
-                                 (cider-repl-emit-prompt buffer))))
+  (nrepl-make-eval-handler
+   :buffer buffer
+   :on-stdout (lambda (out) (cider-repl-emit-stdout buffer out))
+   :on-stderr (lambda (err) (cider-repl-emit-stderr buffer err))
+   :on-done (lambda () (cider-repl-emit-prompt buffer))))
 
 (defun cider-repl-set-ns (ns)
   "Switch the namespace of the REPL buffer to NS.

--- a/lisp/nrepl-client.el
+++ b/lisp/nrepl-client.el
@@ -612,7 +612,8 @@ which we can eventually reuse."
 
 ;;; Client: Response Handling
 ;; After being decoded, responses (aka, messages from the server) are dispatched
-;; to handlers. Handlers are constructed with `nrepl-make-response-handler'.
+;; to handlers. Handlers for `eval'-style requests are typically built with
+;; `nrepl-make-eval-handler'.
 
 (define-obsolete-variable-alias 'nrepl-err-handler 'nrepl-err-handler-function "1.17.0")
 (defvar nrepl-err-handler-function nil
@@ -655,60 +656,61 @@ Displays the notification via `message'."
                 (format "%s: %s" (upcase type) msg))))
     (message msg)))
 
-(defun nrepl-make-response-handler (buffer value-handler stdout-handler
-                                           stderr-handler done-handler
-                                           &optional eval-error-handler
-                                           content-type-handler
-                                           truncated-handler)
-  "Make a response handler for connection BUFFER.
-A handler is a function that takes one argument - response received from
-the server process.  The response is an alist that contains at least `id'
-and `session' keys.  Other standard response keys are `value', `out', `err',
-and `status'.
+(cl-defun nrepl-make-eval-handler (&key buffer
+                                        on-value on-stdout on-stderr on-done
+                                        on-eval-error on-content-type on-truncated)
+  "Build a callback for an nREPL `eval'-style response stream.
 
-The presence of a particular key determines the type of the response.  For
-example, if `value' key is present, the response is of type `value', if
-`out' key is present the response is `stdout' etc.
+Returns a function of one argument (the decoded response dict).  The
+handler dispatches on the standard eval response slots and invokes
+whichever of the keyword sub-handlers has been provided:
 
-Depending on the type, the handler dispatches the appropriate value to one
-of the supplied handlers: VALUE-HANDLER, STDOUT-HANDLER, STDERR-HANDLER,
-DONE-HANDLER, EVAL-ERROR-HANDLER, CONTENT-TYPE-HANDLER, and
-TRUNCATED-HANDLER.
+  :on-value         called with VALUE when the response carries one.
+  :on-stdout        called with the OUT string for stdout chunks.
+  :on-stderr        called with the ERR string for stderr chunks.
+  :on-done          called with no arguments on the final \"done\" status.
+  :on-eval-error    called with no arguments on \"eval-error\" status.
+                    If omitted, falls back to `nrepl-err-handler-function'
+                    (which is then invoked with BUFFER).
+  :on-content-type  called with (BODY CONTENT-TYPE) when the response
+                    carries a `content-type' slot.  BODY has been
+                    base64-decoded when the response indicates so.
+  :on-truncated     called with no arguments when the response is flagged
+                    as truncated by `nrepl.middleware.print'.
 
-Handlers are functions of the buffer and the value they handle, except for
-the optional CONTENT-TYPE-HANDLER which should be a function of the buffer,
-content, the content-type to be handled as a list `(type attrs)'.
-
-If the optional EVAL-ERROR-HANDLER is nil, the default `nrepl-err-handler-function'
-is used.  If any of the other supplied handlers are nil nothing happens for
-the corresponding type of response."
+Sub-handlers do not receive BUFFER -- close over whatever buffer or other
+context you need.  BUFFER is only passed to the global handlers
+configured via `nrepl-namespace-handler-function',
+`nrepl-err-handler-function', and `nrepl-need-input-handler-function'."
   (lambda (response)
     (nrepl-dbind-response response (content-type content-transfer-encoding body
                                                  value ns out err status id)
       (when (and ns nrepl-namespace-handler-function)
         (funcall nrepl-namespace-handler-function buffer ns))
-      (cond ((and content-type content-type-handler)
-             (funcall content-type-handler buffer
+      (cond ((and content-type on-content-type)
+             (funcall on-content-type
                       (if (string= content-transfer-encoding "base64")
                           (base64-decode-string body)
                         body)
                       content-type))
             (value
-             (when value-handler
-               (funcall value-handler buffer value)))
+             (when on-value
+               (funcall on-value value)))
             (out
-             (when stdout-handler
-               (funcall stdout-handler buffer out)))
+             (when on-stdout
+               (funcall on-stdout out)))
             (err
-             (when stderr-handler
-               (funcall stderr-handler buffer err)))
+             (when on-stderr
+               (funcall on-stderr err)))
             (status
-             (when (and truncated-handler (member "nrepl.middleware.print/truncated" status))
-               (funcall truncated-handler buffer))
+             (when (and on-truncated (member "nrepl.middleware.print/truncated" status))
+               (funcall on-truncated))
              (when (member "interrupted" status)
                (message "Evaluation interrupted."))
              (when (member "eval-error" status)
-               (funcall (or eval-error-handler nrepl-err-handler-function) buffer))
+               (cond (on-eval-error (funcall on-eval-error))
+                     (nrepl-err-handler-function
+                      (funcall nrepl-err-handler-function buffer))))
              (when (member "namespace-not-found" status)
                (message "Namespace `%s' not found." ns))
              (when (and (member "need-input" status)
@@ -716,8 +718,44 @@ the corresponding type of response."
                (funcall nrepl-need-input-handler-function buffer))
              (when (member "done" status)
                (nrepl--mark-id-completed id)
-               (when done-handler
-                 (funcall done-handler buffer))))))))
+               (when on-done
+                 (funcall on-done))))))))
+
+(defun nrepl-make-response-handler (buffer value-handler stdout-handler
+                                           stderr-handler done-handler
+                                           &optional eval-error-handler
+                                           content-type-handler
+                                           truncated-handler)
+  "Make a response handler for connection BUFFER.
+
+This is the legacy positional-arg form retained for backward
+compatibility with extensions.  It adapts the (BUFFER VALUE)-style
+sub-handlers expected here to the simpler (VALUE)-style sub-handlers of
+`nrepl-make-eval-handler', which is the form new code should use.
+
+VALUE-HANDLER, STDOUT-HANDLER, STDERR-HANDLER, DONE-HANDLER and
+EVAL-ERROR-HANDLER each receive BUFFER as their first argument; the
+optional CONTENT-TYPE-HANDLER receives BUFFER plus content and content
+type; TRUNCATED-HANDLER receives BUFFER alone.  Any handler given as nil
+results in the corresponding response branch being a no-op."
+  (declare (obsolete nrepl-make-eval-handler "1.22"))
+  (nrepl-make-eval-handler
+   :buffer buffer
+   :on-value (when value-handler
+               (lambda (value) (funcall value-handler buffer value)))
+   :on-stdout (when stdout-handler
+                (lambda (out) (funcall stdout-handler buffer out)))
+   :on-stderr (when stderr-handler
+                (lambda (err) (funcall stderr-handler buffer err)))
+   :on-done (when done-handler
+              (lambda () (funcall done-handler buffer)))
+   :on-eval-error (when eval-error-handler
+                    (lambda () (funcall eval-error-handler buffer)))
+   :on-content-type (when content-type-handler
+                      (lambda (decoded type)
+                        (funcall content-type-handler buffer decoded type)))
+   :on-truncated (when truncated-handler
+                   (lambda () (funcall truncated-handler buffer)))))
 
 ;;; Client: Request Core API
 

--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -200,6 +200,69 @@
                             "-l" "my-user"
                             "my-host"))))
 
+(describe "nrepl-make-eval-handler"
+  :var (nrepl-namespace-handler-function
+        nrepl-err-handler-function
+        nrepl-need-input-handler-function
+        nrepl-pending-requests
+        nrepl-completed-requests)
+  (before-each
+    (setq nrepl-namespace-handler-function nil
+          nrepl-err-handler-function nil
+          nrepl-need-input-handler-function nil
+          ;; `nrepl--mark-id-completed' touches these buffer-locals on
+          ;; every "done" status; give it real tables to operate on.
+          nrepl-pending-requests (make-hash-table :test 'equal)
+          nrepl-completed-requests (make-hash-table :test 'equal)))
+
+  (it "dispatches value/out/err to the right keyword sub-handlers"
+    (let (calls)
+      (let ((handler (nrepl-make-eval-handler
+                      :on-value  (lambda (v) (push (cons 'val v) calls))
+                      :on-stdout (lambda (o) (push (cons 'out o) calls))
+                      :on-stderr (lambda (e) (push (cons 'err e) calls)))))
+        (funcall handler '(dict "id" "1" "value" "42"))
+        (funcall handler '(dict "id" "1" "out"   "hi"))
+        (funcall handler '(dict "id" "1" "err"   "boom")))
+      (expect (reverse calls)
+              :to-equal '((val . "42") (out . "hi") (err . "boom")))))
+
+  (it "calls :on-done with no args on the done status"
+    (let* (called
+           (handler (nrepl-make-eval-handler
+                     :on-done (lambda () (setq called t)))))
+      (funcall handler '(dict "id" "1" "status" ("done")))
+      (expect called :to-be t)))
+
+  (it "falls back to nrepl-err-handler-function when :on-eval-error is omitted"
+    (let* (received-buffer
+           (nrepl-err-handler-function (lambda (b) (setq received-buffer b)))
+           (handler (nrepl-make-eval-handler :buffer 'sentinel)))
+      (funcall handler '(dict "id" "1" "status" ("eval-error")))
+      (expect received-buffer :to-be 'sentinel)))
+
+  (it "prefers :on-eval-error over the global handler when both are set"
+    (let* (custom-called global-called
+           (nrepl-err-handler-function (lambda (_) (setq global-called t)))
+           (handler (nrepl-make-eval-handler
+                     :on-eval-error (lambda () (setq custom-called t)))))
+      (funcall handler '(dict "id" "1" "status" ("eval-error")))
+      (expect custom-called :to-be t)
+      (expect global-called :to-be nil)))
+
+  (it "decodes base64 content for :on-content-type"
+    (let (received-body received-type)
+      (let ((handler (nrepl-make-eval-handler
+                      :on-content-type (lambda (body type)
+                                         (setq received-body body
+                                               received-type type)))))
+        (funcall handler '(dict "id" "1"
+                                "content-type" ("text/plain" ())
+                                "content-transfer-encoding" "base64"
+                                "body" "aGVsbG8="))) ; "hello"
+      (expect received-body :to-equal "hello")
+      (expect received-type :to-equal '("text/plain" ())))))
+
 (describe "nrepl-client-lifecycle"
   (it "start and stop nrepl client process"
 


### PR DESCRIPTION
Closes the long-standing #1099 (and #1098 by extension).

`nrepl-make-response-handler` has had a 7-positional-arg signature for years, with five sub-handlers that all received a `(BUFFER VALUE)` pair whether they used the buffer or not. A survey of the 14 in-tree call sites showed the majority ignore it as `_buffer`. Beyond the cosmetic noise, the positional API is hard to read at a call site -- `(nrepl-make-response-handler buffer nil nil nil nil)` reveals nothing about intent.

This PR adds `nrepl-make-eval-handler` with a keyword-arg form:

```elisp
(nrepl-make-eval-handler
 :buffer buf
 :on-value  (lambda (value) ...)
 :on-stdout (lambda (out) ...)
 :on-stderr (lambda (err) ...)
 :on-done   (lambda () ...)
 :on-eval-error    (lambda () ...)
 :on-content-type  (lambda (body type) ...)
 :on-truncated     (lambda () ...))
```

Sub-handlers take only the slot they care about and close over whatever buffer/marker/state they need. `:buffer` is still forwarded to the global handlers configured via `nrepl-namespace-handler-function`, `nrepl-err-handler-function`, and `nrepl-need-input-handler-function`.

### Backward compatibility

`nrepl-make-response-handler` stays as a thin shim that adapts the old `(BUFFER X)` lambdas to the new `(X)` lambdas, marked obsolete via `(declare (obsolete ...))` so byte-compile nudges extension authors to migrate. Existing extensions keep working unchanged.

### Migrated in-tree

All 14 callers in `cider-client.el`, `cider-repl.el`, `cider-eval.el`, and `cider-profile.el` now use the new form:

| Caller | Before | After |
|---|---|---|
| `cider-interrupt-handler` | `(buffer nil nil nil nil)` | `:buffer buffer` |
| `cider-stdin-handler` | three `_buffer _x` no-ops + nil | `:buffer (current-buffer)` |
| `cider-profile--make-response-handler` | wraps a `(buffer value)` cb | wraps a `(value)` cb |
| `cider-repl-init-eval-handler` | 5 args, 4 lambdas | 4 keyword slots |
| `cider-repl-handler` | 8 positional slots | 7 keyword slots |
| ... | ... | ... |

Net diff: -264 / +331 across the seven files (most of the +331 is the new function definition + tests).

### Tests

Five new Buttercup specs in `test/nrepl-client-tests.el` cover:

- `value`/`out`/`err` dispatch routing
- `:on-done` is invoked with no args on the `done` status
- `:on-eval-error` falls back to `nrepl-err-handler-function` when omitted, and is preferred when both are set
- base64 content decoding for `:on-content-type`

Full suite: 534/536 pass, 0 failures.

### What's not in this PR (deferred)

- **Convenience builders** for the recurring patterns (`emit-interactive-stdout`, `emit-stderr`, etc.) -- many call sites in the migration table above could collapse further, but that's a separate cleanup.
- **Hoisting CIDER-specific concerns out of `nrepl-client.el`** (the `"namespace-not-found"` message, the `"Evaluation interrupted."` message, `nrepl-err-handler-function` being CIDER-specific). That changes how a few public-ish dynamic vars work and deserves its own discussion.

Each of those can ship independently on top of this.