### PR TITLE
Drop trivial wrappers around eval handler emit functions

### DIFF
--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -634,7 +634,7 @@ The handler simply inserts the result value in BUFFER."
                    (insert value))
                  (when cider-eval-register
                    (setq res (concat res value))))
-     :on-stdout (lambda (out) (cider-repl-emit-interactive-stdout out))
+     :on-stdout #'cider-repl-emit-interactive-stdout
      :on-stderr (lambda (err)
                   (cider-repl-emit-interactive-stderr err)
                   ;; Don't jump
@@ -732,7 +732,7 @@ when `cider-auto-inspect-after-eval' is non-nil."
      :on-value (lambda (value)
                  (setq res (concat res value))
                  (cider--display-interactive-eval-result res 'value end))
-     :on-stdout (lambda (out) (cider-emit-interactive-eval-output out))
+     :on-stdout #'cider-emit-interactive-eval-output
      :on-stderr (lambda (err)
                   (cider-emit-interactive-eval-err-output err)
                   (cider-handle-compilation-errors
@@ -773,7 +773,7 @@ Optional argument DONE-HANDLER lambda will be run once load is complete."
                    (with-current-buffer target
                      (cider--make-fringe-overlays-for-region (point-min) (point-max))
                      (run-hooks 'cider-file-loaded-hook))))
-     :on-stdout (lambda (out) (cider-emit-interactive-eval-output out))
+     :on-stdout #'cider-emit-interactive-eval-output
      :on-stderr (lambda (err)
                   (cider-emit-interactive-eval-err-output err)
                   (cider-handle-compilation-errors err eval-buffer))
@@ -795,8 +795,8 @@ Optional argument DONE-HANDLER lambda will be run once load is complete."
                    (insert (if (derived-mode-p 'cider-clojure-interaction-mode)
                                (format "\n%s\n" value)
                              value))))
-     :on-stdout (lambda (out) (cider-emit-interactive-eval-output out))
-     :on-stderr (lambda (err) (cider-emit-interactive-eval-err-output err)))))
+     :on-stdout #'cider-emit-interactive-eval-output
+     :on-stderr #'cider-emit-interactive-eval-err-output)))
 
 (defun cider-eval-print-with-comment-handler (buffer location comment-prefix)
   "Make a handler for evaluating and printing commented results in BUFFER.
@@ -806,8 +806,8 @@ comment prefix to use."
     (nrepl-make-eval-handler
      :buffer buffer
      :on-value (lambda (value) (setq res (concat res value)))
-     :on-stdout (lambda (out) (cider-emit-interactive-eval-output out))
-     :on-stderr (lambda (err) (cider-emit-interactive-eval-err-output err))
+     :on-stdout #'cider-emit-interactive-eval-output
+     :on-stderr #'cider-emit-interactive-eval-err-output
      :on-done (lambda ()
                 (with-current-buffer buffer
                   (save-excursion
@@ -874,8 +874,8 @@ This is used by pretty-printing commands."
      :buffer chosen-buffer
      :on-value (lambda (value)
                  (cider-emit-into-popup-buffer chosen-buffer (ansi-color-apply value) nil t))
-     :on-stdout (lambda (out) (cider-emit-interactive-eval-output out))
-     :on-stderr (lambda (err) (cider-emit-interactive-eval-err-output err))
+     :on-stdout #'cider-emit-interactive-eval-output
+     :on-stderr #'cider-emit-interactive-eval-err-output
      :on-eval-error (lambda ()
                       (when (and (buffer-live-p chosen-buffer)
                                  (member (buffer-name chosen-buffer)

--- a/lisp/cider-repl.el
+++ b/lisp/cider-repl.el
@@ -274,8 +274,8 @@ Run CALLBACK once the evaluation is complete."
   (let ((buffer (current-buffer)))
     (nrepl-make-eval-handler
      :buffer buffer
-     :on-stdout (lambda (out) (cider-repl-emit-stdout buffer out))
-     :on-stderr (lambda (err) (cider-repl-emit-stderr buffer err))
+     :on-stdout (apply-partially #'cider-repl-emit-stdout buffer)
+     :on-stderr (apply-partially #'cider-repl-emit-stderr buffer)
      :on-done (lambda ()
                 (cider-repl-emit-prompt buffer)
                 (when callback (funcall callback))))))
@@ -1284,9 +1284,9 @@ With a prefix argument CLEAR-REPL it will clear the entire REPL buffer instead."
   "Make an nREPL evaluation handler for the REPL BUFFER's ns switching."
   (nrepl-make-eval-handler
    :buffer buffer
-   :on-stdout (lambda (out) (cider-repl-emit-stdout buffer out))
-   :on-stderr (lambda (err) (cider-repl-emit-stderr buffer err))
-   :on-done (lambda () (cider-repl-emit-prompt buffer))))
+   :on-stdout (apply-partially #'cider-repl-emit-stdout buffer)
+   :on-stderr (apply-partially #'cider-repl-emit-stderr buffer)
+   :on-done (apply-partially #'cider-repl-emit-prompt buffer)))
 
 (defun cider-repl-set-ns (ns)
   "Switch the namespace of the REPL buffer to NS.


### PR DESCRIPTION
Small cleanup follow-up to #3890.

Several callers of `nrepl-make-eval-handler` wrapped one-arg emit functions in identity lambdas:

```elisp
:on-stdout (lambda (out) (cider-emit-interactive-eval-output out))
:on-stderr (lambda (err) (cider-emit-interactive-eval-err-output err))
```

The wrappers add no behavior -- the wrapped functions already have the slot's expected signature. Replace them with `#'name` direct refs.

For the buffer-bound REPL emitters (`cider-repl-emit-stdout` / `cider-repl-emit-stderr` / `cider-repl-emit-prompt`) the closure over `BUFFER` is genuine, but `apply-partially` (already used in several places across CIDER) expresses that more compactly than a hand-written lambda.

Pure refactor; no behavior change. Full suite still 534/536 pass.

This is what was originally bundled as Step 2 of the response-handler plan -- the win turned out to be smaller and more localized than introducing builder helpers, so it's just a tiny diff.