### PR TITLE
Build cider.debug's response handler with nrepl-make-eval-handler

### DIFF
--- a/lisp/cider-debug.el
+++ b/lisp/cider-debug.el
@@ -35,7 +35,7 @@
 (require 'cider-inspector)
 (require 'cider-util)
 (require 'cider-common)
-(require 'nrepl-client) ; `nrepl--mark-id-completed'
+(require 'nrepl-client) ; `nrepl-make-eval-handler', `nrepl-dbind-response'
 (require 'nrepl-dict)
 
 
@@ -117,29 +117,33 @@ configure `cider-debug-prompt' instead."
                                      ns)))))
     (message "No currently instrumented definitions")))
 
-(defun cider--debug-response-handler (response)
-  "Handles RESPONSE from the cider.debug middleware."
-  (nrepl-dbind-response response (status id causes caught-msg)
-    (when (member "enlighten" status)
-      (cider--handle-enlighten response))
-    (when (or (member "eval-error" status)
-              (member "stack" status))
-      ;; TODO: Make the error buffer a bit friendlier when we're just printing
-      ;; the stack.
-      (if cider-show-error-buffer
-          (cider--render-stacktrace-causes causes)
-        (cider--debug-display-result-overlay nil caught-msg)))
-    (when (member "need-debug-input" status)
-      (cider--handle-debug response))
-    (when (member "done" status)
-      (nrepl--mark-id-completed id))))
+(defun cider--debug-response-handler ()
+  "Build a handler for responses from the cider.debug middleware.
+Dispatches on the debug-specific status flags (`enlighten',
+`eval-error', `stack', `need-debug-input').  Bookkeeping for the
+\"done\" status (request-id cleanup) is handled by
+`nrepl-make-eval-handler' itself."
+  (nrepl-make-eval-handler
+   :on-status (lambda (status response)
+                (nrepl-dbind-response response (causes caught-msg)
+                  (when (member "enlighten" status)
+                    (cider--handle-enlighten response))
+                  (when (or (member "eval-error" status)
+                            (member "stack" status))
+                    ;; TODO: Make the error buffer a bit friendlier when we're
+                    ;; just printing the stack.
+                    (if cider-show-error-buffer
+                        (cider--render-stacktrace-causes causes)
+                      (cider--debug-display-result-overlay nil caught-msg)))
+                  (when (member "need-debug-input" status)
+                    (cider--handle-debug response))))))
 
 (defun cider--debug-init-connection ()
   "Initialize a connection with the cider.debug middleware."
   (cider-nrepl-send-request
    `("op" "cider/init-debugger"
      ,@(cider--nrepl-print-request-plist fill-column))
-   #'cider--debug-response-handler))
+   (cider--debug-response-handler)))
 
 
 ;;; Debugging overlays


### PR DESCRIPTION
Small follow-up to the #1099 arc.

`cider--debug-response-handler` was a hand-rolled callback that dispatched on the debug-specific status flags (`enlighten`, `eval-error`, `stack`, `need-debug-input`, `done`) and explicitly called `nrepl--mark-id-completed` for the `done` branch.

Now that `nrepl-make-eval-handler` has an `:on-status` slot (#3892), this handler fits the eval-handler shape exactly: pass an `:on-status` that walks the same status flags and let the helper handle the mark-id-completed bookkeeping for free.

Changes the function from "I am a handler" to "I build a handler" (call site goes from `#'cider--debug-response-handler` to `(cider--debug-response-handler)`), matching the convention of `cider-make-eval-handler`, `cider-repl-handler`, etc. No behavior change.

Found during a wider audit of `nrepl-send-request` callbacks — this was the only hand-rolled handler whose dispatch fit the new abstraction. Five other raw response handlers consume non-eval slots (`results`, `summary`, `phase`, etc.) and don't migrate as cleanly; those will get a separate small PR for an unrelated mark-id-completed leak the audit also surfaced.