### PR TITLE
Plug request-id leaks in raw nREPL response handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `nrepl-server-filter` now treats wildcard/loopback printed bind addresses (`localhost`, `127.0.0.1`, `0.0.0.0`, `::1`, `::`) as "use the calling context", so jacking in over TRAMP to a server that prints `localhost` connects to the TRAMP host instead of the local machine.
 - `cider--resolve-command` now actually verifies command presence on remote hosts via `executable-find`'s remote search, instead of unconditionally trusting the user-supplied command. A missing tool on the remote side now surfaces immediately during jack-in instead of as a server-startup failure later.
 - `nrepl--ssh-tunnel-connect` no longer routes its `ssh` invocation through a shell. The tunnel command is now spawned via `start-process` with an explicit arg list, eliminating shell-quoting hazards in user/host components.
+- Plug five request-id leaks in raw nREPL response handlers (`cider/test-stacktrace`, `cider/test-var-query`, `cider/analyze-last-stacktrace`, `cider/ns-reload`, `cider/get-state`). They never called `nrepl--mark-id-completed`, so their ids accumulated in the connection's `nrepl-pending-requests` for the lifetime of the session.
 
 ### Changes
 

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -412,12 +412,14 @@ Accumulates a list of causes and then calls CALLBACK on causes and phase."
     (cider-nrepl-send-request
      `("op" "cider/analyze-last-stacktrace")
      (lambda (response)
-       (nrepl-dbind-response response (status phase)
-         (if (member "done" status)
-             (funcall callback causes ex-phase)
-           (when phase
-             (setq ex-phase phase))
-           (setq causes (append causes (list response)))))))))
+       (nrepl-dbind-response response (status phase id)
+         (cond ((member "done" status)
+                (nrepl--mark-id-completed id)
+                (funcall callback causes ex-phase))
+               (t
+                (when phase
+                  (setq ex-phase phase))
+                (setq causes (append causes (list response))))))))))
 
 (defun cider-default-err-op-handler (buffer)
   "Display the last exception, with middleware support.

--- a/lisp/cider-ns.el
+++ b/lisp/cider-ns.el
@@ -323,7 +323,10 @@ refresh functions (defined in `cider-ns-refresh-before-fn' and
              ,@(when (and (not inhibit-refresh-fns) cider-ns-refresh-after-fn)
                  `("after" ,cider-ns-refresh-after-fn)))
            (lambda (response)
-             (cider-ns-refresh--handle-response response log-buffer))
+             (cider-ns-refresh--handle-response response log-buffer)
+             (nrepl-dbind-response response (status id)
+               (when (member "done" status)
+                 (nrepl--mark-id-completed id))))
            conn))))))
 
 (provide 'cider-ns)

--- a/lisp/cider-repl.el
+++ b/lisp/cider-repl.el
@@ -983,11 +983,12 @@ nREPL ops, it may be convenient to prevent inserting a prompt.")
   "Invokes `cider/get-state' when it's possible to do so."
   (when-let ((conn (cider-current-repl 'cljs)))
     (when (cider-nrepl-op-supported-p "cider/get-state" conn)
-      (cider-nrepl-send-request '("op" "cider/get-state")
-                                (lambda (_response)
-                                  ;; No action is necessary: this request results in `cider-repl--state-handler` being called.
-                                  )
-                                conn))))
+      ;; Per-response side effects happen via the global
+      ;; `cider-repl--state-handler' on `nrepl-response-handler-functions',
+      ;; so this request itself ignores its responses.  Using the
+      ;; "unhandled" variant marks the id complete immediately and avoids
+      ;; leaking it into `nrepl-pending-requests'.
+      (cider-nrepl-send-unhandled-request '("op" "cider/get-state") conn))))
 
 (defun cider--maybe-get-state-for-shadow-cljs (buffer &optional err)
   "Refresh the changed namespaces metadata given BUFFER and ERR (stderr string).

--- a/lisp/cider-test.el
+++ b/lisp/cider-test.el
@@ -280,7 +280,7 @@ prompt and whether to use a new window.  Similar to `cider-find-var'."
        "index" ,index
        ,@(cider--nrepl-print-request-plist fill-column))
      (lambda (response)
-       (nrepl-dbind-response response (class status)
+       (nrepl-dbind-response response (class status id)
          (cond (class  (setq causes (cons response causes)))
                (status (when causes
                          (cider-stacktrace-render
@@ -288,7 +288,9 @@ prompt and whether to use a new window.  Similar to `cider-find-var'."
                                               cider-auto-select-error-buffer
                                               #'cider-stacktrace-mode
                                               'ancillary)
-                          (reverse causes)))))))
+                          (reverse causes)))
+                       (when (member "done" status)
+                         (nrepl--mark-id-completed id))))))
      cider-test--current-repl)))
 
 (defun cider-test-stacktrace ()
@@ -770,11 +772,12 @@ running them."
           (cider-nrepl-send-request
            request
            (lambda (response)
-             (nrepl-dbind-response response (summary results status out err elapsed-time ns-elapsed-time var-elapsed-time)
+             (nrepl-dbind-response response (summary results status out err elapsed-time ns-elapsed-time var-elapsed-time id)
                (when (or (member "done" status)
                          (member "error" status)
                          (member "namespace-not-found" status))
-                 (cider-test-spinner-stop))
+                 (cider-test-spinner-stop)
+                 (nrepl--mark-id-completed id))
                (cond ((member "namespace-not-found" status)
                       (unless silent
                         (message "No test namespace: %s" (cider-propertize ns 'ns))))


### PR DESCRIPTION
Found during a wider audit of `nrepl-send-request` callbacks (the same audit that produced #3893).

Five raw `(lambda (response) ...)` callbacks passed to `cider-nrepl-send-request` never called `nrepl--mark-id-completed`, so their request ids accumulated in the connection's `nrepl-pending-requests` hash for the lifetime of the session. The dispatcher falls back to the completed table when a pending entry isn't found, so this was silent: not a functional bug, just a slow leak on every response.

| File | Op |
|---|---|
| `cider-test.el` | `cider/test-stacktrace` |
| `cider-test.el` | `cider/test-var-query` (the test runner) |
| `cider-eval.el` | `cider/analyze-last-stacktrace` |
| `cider-ns.el` | `cider/ns-reload` |
| `cider-repl.el` | `cider/get-state` (fire-and-forget) |

Four of them now call `nrepl--mark-id-completed` in their `done`-status branch. The fire-and-forget `cider/get-state` site switches to `cider-nrepl-send-unhandled-request`, which marks the id complete immediately and lets the global `cider-repl--state-handler` hook do the per-response work.

These don't migrate cleanly to `nrepl-make-eval-handler` because they consume non-eval response slots (`results`, `summary`, `phase`, `class`, `reloading`, ...) -- adding a "raw fallback" slot to the eval-handler abstraction for five sites isn't worth it. One-line `mark-id-completed` calls per site is.

Full suite still 542/544 pass (3893 is in flight on a separate branch).