### PR TITLE
Fix nrepl-err-handler-function arity in nrepl-send-sync-request

### DIFF
--- a/lisp/nrepl-client.el
+++ b/lisp/nrepl-client.el
@@ -859,8 +859,8 @@ command and e.g. notify the user about them."
     ;; If we couldn't finish, return nil.
     (when (member "done" status)
       (nrepl-dbind-response response (ex err eval-error id)
-        (when (and ex err eval-error)
-          (funcall nrepl-err-handler-function))
+        (when (and ex err eval-error nrepl-err-handler-function)
+          (funcall nrepl-err-handler-function connection))
         (when id
           (with-current-buffer connection
             (nrepl--mark-id-completed id)))


### PR DESCRIPTION
Tiny consistency fix surfaced during a wider audit of request handling.

`nrepl-err-handler-function` is documented as "Called with one argument: the REPL buffer", and every other call site in `nrepl-client.el` honors that. The sync-request done-branch was calling it with zero args:

```elisp
(when (and ex err eval-error)
  (funcall nrepl-err-handler-function))
```

This works by accident -- the default value (`cider-default-err-handler`) has its sole argument as `&optional`, so a 0-arg call still runs. Any user-supplied non-optional handler would error out here.

Pass `connection` (already in scope at the call site) and guard on a non-nil handler to match the rest of the file's defensive style.