### PR TITLE
Stop response-handler errors from poisoning the nREPL response queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `cider--resolve-command` now actually verifies command presence on remote hosts via `executable-find`'s remote search, instead of unconditionally trusting the user-supplied command. A missing tool on the remote side now surfaces immediately during jack-in instead of as a server-startup failure later.
 - `nrepl--ssh-tunnel-connect` no longer routes its `ssh` invocation through a shell. The tunnel command is now spawned via `start-process` with an explicit arg list, eliminating shell-quoting hazards in user/host components.
 - Plug five request-id leaks in raw nREPL response handlers (`cider/test-stacktrace`, `cider/test-var-query`, `cider/analyze-last-stacktrace`, `cider/ns-reload`, `cider/get-state`). They never called `nrepl--mark-id-completed`, so their ids accumulated in the connection's `nrepl-pending-requests` for the lifetime of the session.
+- A response-handler error or an unrecognized response id no longer aborts the nREPL response queue. `nrepl-client-filter` wraps the dispatch call in `with-demoted-errors`, and the no-callback case in `nrepl--dispatch-response` is now a `message` instead of a hard error -- so a single misbehaving callback can no longer drop later responses on the floor.
 
 ### Changes
 

--- a/lisp/nrepl-client.el
+++ b/lisp/nrepl-client.el
@@ -282,7 +282,11 @@ functions are demoted to messages, so that they don't prevent the
 callbacks from running.")
 
 (defun nrepl-client-filter (proc string)
-  "Decode message(s) from PROC contained in STRING and dispatch them."
+  "Decode message(s) from PROC contained in STRING and dispatch them.
+Errors raised by individual response handlers (or by the global
+`nrepl-response-handler-functions' hook) are demoted to messages so that
+a single misbehaving callback cannot poison the response queue and drop
+later responses on the floor."
   (let ((string-q (process-get proc :string-q)))
     (queue-enqueue string-q string)
     ;; Start decoding only if the last letter is 'e'
@@ -294,20 +298,26 @@ callbacks from running.")
             (let ((response (queue-dequeue response-q)))
               (with-demoted-errors "Error in one of the `nrepl-response-handler-functions': %s"
                 (run-hook-with-args 'nrepl-response-handler-functions response))
-              (nrepl--dispatch-response response))))))))
+              (with-demoted-errors "Error in nREPL response dispatch: %s"
+                (nrepl--dispatch-response response)))))))))
 
 (defun nrepl--dispatch-response (response)
   "Dispatch the RESPONSE to associated callback.
 First we check the callbacks of pending requests.  If no callback was found,
 we check the completed requests, since responses could be received even for
-older requests with \"done\" status."
+older requests with \"done\" status.
+
+When neither table has a callback for the response's id, log a message
+instead of raising an error: there is nothing actionable for the
+dispatcher to do, and signaling here used to abort processing of any
+later responses sitting in the queue."
   (nrepl-dbind-response response (id)
     (nrepl-log-message response 'response)
     (let ((callback (or (gethash id nrepl-pending-requests)
                         (gethash id nrepl-completed-requests))))
       (if callback
           (funcall callback response)
-        (error "[nREPL] No response handler with id %s found for %s" id (buffer-name))))))
+        (message "[nREPL] No response handler with id %s found for %s" id (buffer-name))))))
 
 (defun nrepl-client-sentinel (process message)
   "Handle sentinel events from PROCESS.

--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -267,6 +267,26 @@
       (expect received-body :to-equal "hello")
       (expect received-type :to-equal '("text/plain" ())))))
 
+(describe "nrepl--dispatch-response"
+  :var (nrepl-pending-requests nrepl-completed-requests)
+  (before-each
+    (setq nrepl-pending-requests (make-hash-table :test 'equal)
+          nrepl-completed-requests (make-hash-table :test 'equal)))
+
+  (it "logs a message instead of erroring when no callback is registered"
+    (spy-on 'message)
+    (nrepl--dispatch-response '(dict "id" "404" "value" "anything"))
+    (expect 'message :to-have-been-called))
+
+  (it "does not raise even when the registered callback throws"
+    (puthash "1" (lambda (_) (error "boom!")) nrepl-pending-requests)
+    ;; Demoted-errors lives in `nrepl-client-filter', so a direct call
+    ;; to the dispatcher with a throwing callback DOES propagate.  This
+    ;; spec just locks the contract: the dispatcher itself doesn't add
+    ;; its own protection -- protection is at the filter layer.
+    (expect (nrepl--dispatch-response '(dict "id" "1" "value" "v"))
+            :to-throw 'error)))
+
 (describe "nrepl-client-lifecycle"
   (it "start and stop nrepl client process"
 


### PR DESCRIPTION
Found during a wider audit of request handling.

`nrepl-client-filter` decodes a batch of responses from the wire and walks them in a `while` loop, dispatching each in turn. A `with-demoted-errors` guard wrapped the global `nrepl-response-handler-functions` hook but stopped there -- the per-request `nrepl--dispatch-response` call ran unprotected.

If that call signaled (because a callback threw, or because no handler was registered for the response's id), the `while (queue-head response-q)` loop aborted and any later decoded responses sitting in the queue were dropped on the floor. The next response stream might keep working, but anything already decoded was lost.

This PR makes two changes:

1. **Wrap `nrepl--dispatch-response` in `with-demoted-errors` too.** Handler bugs become log entries, not stream corruption.
2. **Soften `nrepl--dispatch-response`'s no-callback case from `error` to `message`.** The dispatcher cannot do anything actionable with an unknown id; logging is sufficient and avoids forcing the filter to demote.

Two new specs in `test/nrepl-client-tests.el` cover the soft no-handler path and lock in the dispatcher's contract (errors propagate unless the filter wraps you).