### PR TITLE
Tear down SSH tunnel on abnormal client disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `nrepl--ssh-tunnel-connect` no longer routes its `ssh` invocation through a shell. The tunnel command is now spawned via `start-process` with an explicit arg list, eliminating shell-quoting hazards in user/host components.
 - Plug five request-id leaks in raw nREPL response handlers (`cider/test-stacktrace`, `cider/test-var-query`, `cider/analyze-last-stacktrace`, `cider/ns-reload`, `cider/get-state`). They never called `nrepl--mark-id-completed`, so their ids accumulated in the connection's `nrepl-pending-requests` for the lifetime of the session.
 - A response-handler error or an unrecognized response id no longer aborts the nREPL response queue. `nrepl-client-filter` wraps the dispatch call in `with-demoted-errors`, and the no-callback case in `nrepl--dispatch-response` is now a `message` instead of a hard error -- so a single misbehaving callback can no longer drop later responses on the floor.
+- `nrepl-client-sentinel` now tears down the SSH tunnel buffer/process when the client connection closes. Previously only the orderly `cider-quit` path killed the tunnel, so an abnormal disconnect (server crash, network drop) left the `ssh` subprocess as a zombie until Emacs exited.
 
 ### Changes
 

--- a/lisp/nrepl-client.el
+++ b/lisp/nrepl-client.el
@@ -343,6 +343,17 @@ and kill the process buffer."
                                                                        (current-time-string)))
           'face 'error))
         (run-hooks 'nrepl-disconnected-hook)
+        ;; Tear down the SSH tunnel, if any, so its `ssh' subprocess
+        ;; doesn't outlive the connection.  The orderly path through
+        ;; `cider--close-connection' already does this; we duplicate it
+        ;; here so abnormal disconnects (server crash, network drop,
+        ;; client process killed) don't leak the tunnel.
+        (when (buffer-live-p nrepl-tunnel-buffer)
+          (when-let* ((tunnel-proc (get-buffer-process nrepl-tunnel-buffer)))
+            (when (process-live-p tunnel-proc)
+              (delete-process tunnel-proc)))
+          (kill-buffer nrepl-tunnel-buffer))
+        (setq nrepl-tunnel-buffer nil)
         (let ((server-buffer nrepl-server-buffer))
           (when (and (buffer-live-p server-buffer)
                      (not (process-get process :keep-server)))


### PR DESCRIPTION
Found during a wider audit of connection handling.

`nrepl--ssh-tunnel-connect` spawns a separate `ssh` subprocess for port forwarding and stashes it on the client buffer's `nrepl-tunnel-buffer`. The orderly teardown path -- `cider-quit` → `cider--close-connection` -- already kills the tunnel buffer cleanly.

But the `nrepl-client-sentinel` path, which fires on abnormal client-process death (server crash, network drop, the client process getting killed), only ran the disconnect hooks and the `nrepl--maybe-kill-server-buffer` cleanup. Neither of those touches the tunnel, so the `ssh` subprocess kept running until Emacs itself exited. On macOS / Linux you'd see it via `ps`; on Windows it's worse since `taskkill` cleanup also doesn't reach it.

Add the tunnel cleanup right next to the existing `nrepl--maybe-kill-server-buffer` call in the sentinel, symmetric with how the server gets handled. Same layering: the transport sentinel owns transport-infrastructure cleanup.