### PR TITLE
Fix to Emacs hang when viewing ClojureDocs for "/"

### DIFF
--- a/lisp/cider-clojuredocs.el
+++ b/lisp/cider-clojuredocs.el
@@ -170,6 +170,10 @@ opposite of what that option dictates."
     (cider-clojuredocs--insert-notes dict)
     (buffer-string)))
 
+(defun cider-clojuredocs--strip-ns (sym)
+  "Strip the namespace prefix from SYM, leaving just the symbol name."
+  (replace-regexp-in-string "\\`[^/]+/" "" sym))
+
 (defun cider-clojuredocs-lookup (sym)
   "Look up the ClojureDocs documentation for SYM."
   (if-let ((docs (cider-sync-request:clojuredocs-lookup (cider-current-ns) sym)))
@@ -178,7 +182,7 @@ opposite of what that option dictates."
         ;; highlight the symbol in question in the docs buffer
         (highlight-regexp
          (regexp-quote
-          (replace-regexp-in-string "^.+?/" "" sym))
+          (cider-clojuredocs--strip-ns sym))
          'bold))
     (user-error "ClojureDocs documentation for %s is not found" sym)))
 

--- a/lisp/cider-clojuredocs.el
+++ b/lisp/cider-clojuredocs.el
@@ -178,8 +178,7 @@ opposite of what that option dictates."
         ;; highlight the symbol in question in the docs buffer
         (highlight-regexp
          (regexp-quote
-          (or (cadr (split-string sym "/"))
-              sym))
+          (replace-regexp-in-string "^.+?/" "" sym))
          'bold))
     (user-error "ClojureDocs documentation for %s is not found" sym)))
 

--- a/test/cider-clojuredocs-tests.el
+++ b/test/cider-clojuredocs-tests.el
@@ -48,3 +48,11 @@
     (expect (cider-clojuredocs-url "even?" "clojure.core") :to-equal "https://clojuredocs.org/clojure.core/even_q")
     (expect (cider-clojuredocs-url nil "clojure.core") :to-be nil)
     (expect (cider-clojuredocs-url "even?" nil) :to-be nil)))
+
+(describe "cider-clojuredocs-lookup-remove-namespace"
+  (it "removes namespace from symbol to highlight only the name"
+    (expect (replace-regexp-in-string "^.+?/" "" "clojure.core//") :to-equal "/")
+    (expect (replace-regexp-in-string "^.+?/" "" "clojure.core/+") :to-equal "+")
+    (expect (replace-regexp-in-string "^.+?/" "" "clojure.core/subs") :to-equal "subs")
+    (expect (replace-regexp-in-string "^.+?/" "" "clojure.string/trim") :to-equal "trim")
+    ))

--- a/test/cider-clojuredocs-tests.el
+++ b/test/cider-clojuredocs-tests.el
@@ -49,10 +49,14 @@
     (expect (cider-clojuredocs-url nil "clojure.core") :to-be nil)
     (expect (cider-clojuredocs-url "even?" nil) :to-be nil)))
 
-(describe "cider-clojuredocs-lookup-remove-namespace"
-  (it "removes namespace from symbol to highlight only the name"
-    (expect (replace-regexp-in-string "^.+?/" "" "clojure.core//") :to-equal "/")
-    (expect (replace-regexp-in-string "^.+?/" "" "clojure.core/+") :to-equal "+")
-    (expect (replace-regexp-in-string "^.+?/" "" "clojure.core/subs") :to-equal "subs")
-    (expect (replace-regexp-in-string "^.+?/" "" "clojure.string/trim") :to-equal "trim")
-    ))
+(describe "cider-clojuredocs--strip-ns"
+  (it "removes the namespace from qualified symbols"
+    (expect (cider-clojuredocs--strip-ns "clojure.core/subs") :to-equal "subs")
+    (expect (cider-clojuredocs--strip-ns "clojure.string/trim") :to-equal "trim"))
+  (it "preserves a slash symbol name (the bug being fixed)"
+    (expect (cider-clojuredocs--strip-ns "clojure.core//") :to-equal "/"))
+  (it "preserves operator-like names"
+    (expect (cider-clojuredocs--strip-ns "clojure.core/+") :to-equal "+"))
+  (it "leaves unqualified symbols unchanged"
+      (expect (cider-clojuredocs--strip-ns "/") :to-equal "/")
+      (expect (cider-clojuredocs--strip-ns "subs") :to-equal "subs")))


### PR DESCRIPTION
Emacs hangs terribly with 100% CPU usage and enormous memory consumption if it is forced to highlight "" in a buffer.

Requesting ClojureDocs for / triggers the issue.
This PR prevents it, by correctly removing the namespace - keeping only the symbol name.

-----------------

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code in the relevant file passes the linter (`eldev lint`)

-----------------

## Steps to reproduce the problem

With cursor after a lone /
Don't do `C-c` `C-d` `C-c`
because it will send Emacs on a memory-eating spree and never return.
Occasionally it's possible to interrupt with `C-g`, but usually one needs to kill the Emacs process.

### CIDER version information
```
;; CIDER 1.22.0-snapshot, nREPL 1.7.0
;; Clojure 1.12.4, Java 25.0.1
```
`cider` master branch
and any version before that, probably since at least 2022

### Emacs version
30.2
28.2

### Operating system
macOS and Linux
