### PR TITLE
Silence common byte-compile warnings on MELPA install

### DIFF
--- a/lisp/cider-docstring.el
+++ b/lisp/cider-docstring.el
@@ -79,7 +79,7 @@ otherwise, it's included as-is."
                              ""))))
 
 (defcustom cider-docstring-max-lines 20
-  "The maximum number of docstring lines that will be rendered in a UI widget (or the echo area).
+  "Maximum number of docstring lines rendered in a UI widget or the echo area.
 
 Note that `cider-docstring' will trim thing smartly, for Java doc comments:
 * First, the whole doc comment will be attempted to be rendered.
@@ -87,13 +87,14 @@ Note that `cider-docstring' will trim thing smartly, for Java doc comments:
   we will use only the first sentence and the block tags
   (that is, the params/throws/returns info).
 * If that exceeds `cider-docstring-max-lines', we will use only the block tags.
-* If that exceeds `cider-docstring-max-lines', we will use only the first sentence."
+* If that exceeds `cider-docstring-max-lines', we will use only the first
+  sentence."
   :type 'integer
   :group 'cider
   :package-version '(cider . "1.8.0"))
 
 (defun cider--attempt-invalid? (attempt)
-  "Check if ATTEMPT is either nil or exceeds `cider-docstring-max-lines' in line count."
+  "Check if ATTEMPT is nil or has more lines than `cider-docstring-max-lines'."
   (or (not attempt)
       (and attempt
            (> (length (split-string attempt "\n"))
@@ -106,7 +107,8 @@ Note that `cider-docstring' will trim thing smartly, for Java doc comments:
 
 (defun cider--render-docstring (eldoc-info)
   "Renders the docstring from ELDOC-INFO based on its length and content.
-Prioritize rendering as much as possible while staying within `cider-docstring-max-lines'."
+Prioritize rendering as much as possible while staying within
+`cider-docstring-max-lines'."
   (let* ((first-sentence-fragments (cider-plist-get eldoc-info "doc-first-sentence-fragments"))
          (body-fragments (cider-plist-get eldoc-info "doc-fragments"))
          (block-tags-fragments (cider-plist-get eldoc-info "doc-block-tags-fragments"))

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -484,7 +484,8 @@ Show error overlay in BUFFER if needed."
   "A few example values that will match:
 \"Reflection warning, /tmp/foo/src/foo/core.clj:14:1 - \"
 \"Syntax error compiling at (src/workspace_service.clj:227:3).\"
-\"Unexpected error (ClassCastException) macroexpanding defmulti at (src/haystack/parser.cljc:21:1).\"")
+\"Unexpected error (ClassCastException) macroexpanding defmulti at
+ (src/haystack/parser.cljc:21:1).\"")
 
 
 (defconst cider-module-info-regexp

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -50,6 +50,9 @@
 
 (require 'clojure-mode)
 
+(require 'nrepl-client)
+(require 'nrepl-dict)
+
 (require 'cider-client)
 (require 'cider-common)
 (require 'cider-overlays)

--- a/lisp/cider-find.el
+++ b/lisp/cider-find.el
@@ -255,8 +255,8 @@ integer on successful finds, nil otherwise."
   "Find the namespace of the keyword at point and its primary occurrence there.
 
 For instance - if the keyword at point is \":cider.demo/keyword\", this command
-would find the namespace \"cider.demo\" and afterwards find the primary (most relevant or first)
-mention of \"::keyword\" there.
+would find the namespace \"cider.demo\" and afterwards find the primary
+\(most relevant or first) mention of \"::keyword\" there.
 
 Prompt according to prefix ARG and `cider-prompt-for-symbol'.
 A single or double prefix argument inverts the meaning of

--- a/lisp/cider-inspector.el
+++ b/lisp/cider-inspector.el
@@ -261,7 +261,7 @@ current buffer's namespace."
       (cider-inspector--render-value result :next-inspectable))))
 
 (defun cider-inspect-expr-from-inspector ()
-  "Performs `cider-inspect-expr' in a way that is suitable from the Inspector itself.
+  "Run `cider-inspect-expr' in a way that's suitable from the Inspector itself.
 In particular, it does not read `cider-sexp-at-point'."
   (interactive)
   (let* ((ns (cider-current-ns))

--- a/lisp/cider-macroexpansion.el
+++ b/lisp/cider-macroexpansion.el
@@ -42,7 +42,7 @@ Possible values are:
 
   `qualified' ;=> Vars are fully-qualified in the expansion
   `none'      ;=> Vars are displayed without namespace qualification
-  `tidy'      ;=> Vars that are :refer-ed or defined in the current namespace are
+  `tidy'      ;=> Vars that are :refer-ed or in the current namespace are
                  displayed with their simple name, non-referred vars from other
                  namespaces are referred using the alias for that namespace (if
                  defined), other vars are displayed fully qualified."

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -648,9 +648,10 @@ that should be font-locked:
    `var': Any non-local var gets the `font-lock-variable-name-face'.
    `deprecated' (default): Any deprecated var gets the `cider-deprecated-face'
    face.
-   `core' (default): Any symbol from clojure.core/cljs.core.  The selected face will depend on type.
-   Note that while rendering `core', all types of vars (`macro', `function', `var', `deprecated')
-   will be honored, regardless of the user's customization value.
+   `core' (default): Any symbol from clojure.core/cljs.core.  The selected
+   face will depend on type.  Note that while rendering `core', all types of
+   vars (`macro', `function', `var', `deprecated') will be honored,
+   regardless of the user's customization value.
 
 The value can also be t, which means to font-lock as much as possible."
   :type '(choice (set :tag "Fine-tune font-locking"

--- a/lisp/cider-repl.el
+++ b/lisp/cider-repl.el
@@ -1773,7 +1773,7 @@ constructs."
 
 The checking is done as follows:
 
-* If the current buffer's name equals to the value of `cider-test-report-buffer',
+* If the current buffer's name equals the value of `cider-test-report-buffer',
   only accept the given session's repl if it equals `cider-test--current-repl'
 * Consider if the buffer belongs to `cider-ancillary-buffers'
 * Consider the buffer's filename, strip any Docker/TRAMP details from it

--- a/lisp/cider.el
+++ b/lisp/cider.el
@@ -1422,8 +1422,8 @@ These are used as arguments to the commands `cider-connect-clj',
 the corresponding user prompts.
 
 This defcustom is intended for use with .dir-locals.el on a per-project basis.
-See `cider-connect-default-cljs-params' in order to specify a separate set of params
-for cljs REPL connections.
+See `cider-connect-default-cljs-params' in order to specify a separate set
+of params for cljs REPL connections.
 
 Note: it is recommended to set the variable `cider-default-cljs-repl'
 instead of specifying the :cljs-repl-type key."

--- a/lisp/cider.el
+++ b/lisp/cider.el
@@ -1209,10 +1209,10 @@ nil."
     (cider-verify-clojurescript-is-present)
     (cider-verify-cljs-repl-requirements cljs-type)))
 
-(defun cider--offer-to-open-app-in-browser (server-buffer)
-  "Look for a server address in SERVER-BUFFER and offer to open it."
-  (when (buffer-live-p server-buffer)
-    (with-current-buffer server-buffer
+(defun cider--offer-to-open-app-in-browser (server-buf)
+  "Look for a server address in SERVER-BUF and offer to open it."
+  (when (buffer-live-p server-buf)
+    (with-current-buffer server-buf
       (save-excursion
         (goto-char (point-min))
         (when-let* ((url (and (search-forward-regexp "http://localhost:[0-9]+" nil 'noerror)
@@ -1272,11 +1272,11 @@ project context even if the user has switched buffers in the meantime."
      (plist-get params :project-dir)
      (plist-get params :jack-in-cmd)
      (when on-port-callback
-       (lambda (server-buffer)
+       (lambda (server-buf)
          (if (buffer-live-p orig-buffer)
              (with-current-buffer orig-buffer
-               (funcall on-port-callback server-buffer))
-           (funcall on-port-callback server-buffer)))))))
+               (funcall on-port-callback server-buf))
+           (funcall on-port-callback server-buf)))))))
 
 (defun cider--update-params (params)
   "Fill-in the passed in PARAMS plist needed to start an nREPL server.
@@ -1313,8 +1313,8 @@ double prefix prompt for all these parameters."
   (let ((params (cider--update-params params)))
     (cider--start-nrepl-server
      params
-     (lambda (server-buffer)
-       (cider-connect-sibling-clj params server-buffer)))))
+     (lambda (server-buf)
+       (cider-connect-sibling-clj params server-buf)))))
 
 (defun cider-start-nrepl-server (params)
   "Start an nREPL server for the current project, but don't connect to it.
@@ -1338,8 +1338,8 @@ these parameters."
     (let ((params (cider--update-params params)))
       (cider--start-nrepl-server
        params
-       (lambda (server-buffer)
-         (cider-connect-sibling-cljs params server-buffer))))))
+       (lambda (server-buf)
+         (cider-connect-sibling-cljs params server-buf))))))
 
 ;;;###autoload
 (defun cider-jack-in-clj&cljs (&optional params soft-cljs-start)
@@ -1361,8 +1361,8 @@ only when the ClojureScript dependencies are met."
                                 (plist-put :do-prompt nil))))
       (cider--start-nrepl-server
        params
-       (lambda (server-buffer)
-         (let ((clj-repl (cider-connect-sibling-clj params server-buffer)))
+       (lambda (server-buf)
+         (let ((clj-repl (cider-connect-sibling-clj params server-buf)))
            (if soft-cljs-start
                (when (cider--check-cljs (plist-get params :cljs-repl-type) 'no-error)
                  (cider-connect-sibling-cljs params clj-repl))


### PR DESCRIPTION
A few warnings show up when end users install the latest CIDER from MELPA. Most are real source-side issues that we masked locally because `Eldev` sets `byte-compile-docstring-max-column` to 100 and pre-loads files before compiling them.

Three commits, one issue each:

1. Add the missing explicit `nrepl-client` / `nrepl-dict` requires in `cider-eval.el`. It was relying on a transitive chain through `cider-client → cider-session → nrepl-client`, which the byte compiler doesn't always follow, leading to "function not known to be defined" warnings for `nrepl-make-eval-handler` etc.
2. Rename the `server-buffer` parameter (one defun + four lambdas in `cider.el`) to `server-buf`, since `server-buffer` is a `defvar` in built-in `server.el` and the lexical binding shadows it.
3. Trim a handful of docstrings down to ≤80 columns so end users compiling with the default 80-col limit don't get warnings.

- [x] All tests are passing (`eldev test`) — 547 specs, 0 failed
- [x] Compiles clean with `eldev compile --warnings-as-errors`, and also clean when re-run with the strict `byte-compile-docstring-max-column 80`
- [ ] No CHANGELOG entry — these are compile-warning fixes, not user-visible behavior changes