### PR TITLE
Move four cljs-only items from cider.el to cider-cljs.el

### DIFF
--- a/lisp/cider-cljs.el
+++ b/lisp/cider-cljs.el
@@ -42,7 +42,11 @@
 (require 'clojure-mode)
 
 (require 'cider-client)
+(require 'cider-jack-in)
 (require 'nrepl-dict)
+
+;; Defined in cider.el; used by `cider--update-cljs-type'.
+(declare-function cider--update-do-prompt "cider")
 
 (defcustom cider-check-cljs-repl-requirements t
   "When non-nil will run the requirement checks for the different cljs repls.
@@ -375,6 +379,13 @@ nil."
     (cider-verify-clojurescript-is-present)
     (cider-verify-cljs-repl-requirements cljs-type)))
 
+(defcustom cider-offer-to-open-cljs-app-in-browser t
+  "When nil, do not offer to open ClojureScript apps in a browser on connect."
+  :type 'boolean
+  :group 'cider
+  :safe #'booleanp
+  :version '(cider . "0.15.0"))
+
 (defun cider--offer-to-open-app-in-browser (server-buf)
   "Look for a server address in SERVER-BUF and offer to open it."
   (when (buffer-live-p server-buf)
@@ -385,6 +396,50 @@ nil."
                               (match-string 0))))
           (when (y-or-n-p (format "Visit ‘%s’ in a browser? " url))
             (browse-url url)))))))
+
+(defcustom cider-connect-default-cljs-params nil
+  "Default plist of params for connecting to a ClojureScript REPL.
+Recognized keys are :host, :port and :project-dir.
+
+If non-nil, overrides `cider-connect-default-params' for the commands
+`cider-connect-cljs' and (the latter half of) `cider-connect-clj&cljs'.
+
+Note: it is recommended to set the variable `cider-default-cljs-repl'
+instead of specifying the :cljs-repl-type key."
+  :type '(plist :key-type
+                (choice (const :host)
+                        (const :port)
+                        (const :project-dir)))
+  :group 'cider)
+
+(defun cider--update-cljs-type (params)
+  "Update :cljs-repl-type in PARAMS."
+  (with-current-buffer (or (plist-get params :--context-buffer)
+                           (current-buffer))
+    (let ((params (cider--update-do-prompt params))
+          (inferred-type (or (plist-get params :cljs-repl-type)
+                             cider-default-cljs-repl)))
+      (plist-put params :cljs-repl-type
+                 (if (plist-get params :do-prompt)
+                     (cider-select-cljs-repl inferred-type)
+                   (or inferred-type
+                       (cider-select-cljs-repl)))))))
+
+(defmacro cider--with-cljs-jack-in-deps (&rest body)
+  "Run BODY with the cljs jack-in deps appended to the regular ones.
+`cider--update-jack-in-cmd' picks up these dynamic vars indirectly when
+constructing the jack-in command, so they must be in effect for the
+duration of the param-update pipeline."
+  (declare (indent 0) (debug t))
+  `(let ((cider-jack-in-dependencies
+          (append cider-jack-in-dependencies cider-jack-in-cljs-dependencies))
+         (cider-jack-in-lein-plugins
+          (append cider-jack-in-lein-plugins cider-jack-in-cljs-lein-plugins))
+         (cider-jack-in-nrepl-middlewares
+          (append cider-jack-in-nrepl-middlewares cider-jack-in-cljs-nrepl-middlewares)))
+     ,@body))
+
+(put 'cider--with-cljs-jack-in-deps 'lisp-indent-function 0)
 
 (provide 'cider-cljs)
 

--- a/lisp/cider.el
+++ b/lisp/cider.el
@@ -328,12 +328,6 @@ some hardened environments forbid self-attach."
   :safe #'booleanp
   :version '(cider . "1.15.0"))
 
-(defcustom cider-offer-to-open-cljs-app-in-browser t
-  "When nil, do not offer to open ClojureScript apps in a browser on connect."
-  :type 'boolean
-  :safe #'booleanp
-  :version '(cider . "0.15.0"))
-
 (defvar cider-ps-running-lein-nrepls-command "ps u | grep leiningen"
   "Process snapshot command used in `cider-locate-running-nrepl-ports'.")
 
@@ -543,22 +537,6 @@ Also checks whether a matching session already exists."
                 (cider--check-existing-session)
                 (cider--update-jack-in-cmd)))
 
-(defmacro cider--with-cljs-jack-in-deps (&rest body)
-  "Run BODY with the cljs jack-in deps appended to the regular ones.
-`cider--update-jack-in-cmd' picks up these dynamic vars indirectly when
-constructing the jack-in command, so they must be in effect for the
-duration of the param-update pipeline."
-  (declare (indent 0) (debug t))
-  `(let ((cider-jack-in-dependencies
-          (append cider-jack-in-dependencies cider-jack-in-cljs-dependencies))
-         (cider-jack-in-lein-plugins
-          (append cider-jack-in-lein-plugins cider-jack-in-cljs-lein-plugins))
-         (cider-jack-in-nrepl-middlewares
-          (append cider-jack-in-nrepl-middlewares cider-jack-in-cljs-nrepl-middlewares)))
-     ,@body))
-
-(put 'cider--with-cljs-jack-in-deps 'lisp-indent-function 0)
-
 ;;;###autoload
 (defun cider-jack-in-clj (params)
   "Start an nREPL server for the current project and connect to it.
@@ -680,21 +658,6 @@ the corresponding user prompts.
 This defcustom is intended for use with .dir-locals.el on a per-project basis.
 See `cider-connect-default-cljs-params' in order to specify a separate set
 of params for cljs REPL connections.
-
-Note: it is recommended to set the variable `cider-default-cljs-repl'
-instead of specifying the :cljs-repl-type key."
-  :type '(plist :key-type
-                (choice (const :host)
-                        (const :port)
-                        (const :project-dir)))
-  :group 'cider)
-
-(defcustom cider-connect-default-cljs-params nil
-  "Default plist of params for connecting to a ClojureScript REPL.
-Recognized keys are :host, :port and :project-dir.
-
-If non-nil, overrides `cider-connect-default-params' for the commands
-`cider-connect-cljs' and (the latter half of) `cider-connect-clj&cljs'.
 
 Note: it is recommended to set the variable `cider-default-cljs-repl'
 instead of specifying the :cljs-repl-type key."
@@ -838,19 +801,6 @@ Params is a plist with the following keys (non-exhaustive)
             (thread-first params
                           (plist-put :project-dir proj-dir)
                           (plist-put :--context-buffer (current-buffer)))))))))
-
-(defun cider--update-cljs-type (params)
-  "Update :cljs-repl-type in PARAMS."
-  (with-current-buffer (or (plist-get params :--context-buffer)
-                           (current-buffer))
-    (let ((params (cider--update-do-prompt params))
-          (inferred-type (or (plist-get params :cljs-repl-type)
-                             cider-default-cljs-repl)))
-      (plist-put params :cljs-repl-type
-                 (if (plist-get params :do-prompt)
-                     (cider-select-cljs-repl inferred-type)
-                   (or inferred-type
-                       (cider-select-cljs-repl)))))))
 
 (defcustom cider-edit-jack-in-command nil
   "When truthy allow the user to edit the command."


### PR DESCRIPTION
Follow-up to #3903. Pulls four small cljs-only forms out of cider.el so cider-cljs.el is the single home for cljs concerns:

- `cider-offer-to-open-cljs-app-in-browser` - toggle for the browser-opener that already lives in cider-cljs.el.
- `cider-connect-default-cljs-params` - the cljs counterpart of `cider-connect-default-params`.
- `cider--update-cljs-type` - tiny param updater that only touches `cider-select-cljs-repl` / `cider-default-cljs-repl`, both already in cider-cljs.el.
- `cider--with-cljs-jack-in-deps` - macro that let-binds the cljs jack-in vars (which now live in cider-jack-in.el) for the duration of jack-in-cljs flows.

cider-cljs.el now requires `cider-jack-in` for the macro's references, and forward-declares `cider--update-do-prompt` (which stays in cider.el). 50 lines out of cider.el, 55 into cider-cljs.el.

- [x] Compiles clean with `eldev compile --warnings-as-errors`
- [x] All 547 tests pass (`eldev test`)
- [x] No CHANGELOG entry — pure refactor, no user-visible change