### PR TITLE
Optimize cider-get-ns-name for clojure-ts-mode buffers

### DIFF
--- a/lisp/cider-util.el
+++ b/lisp/cider-util.el
@@ -142,10 +142,14 @@ instead."
         (cider--text-or-limits bounds (point) end)))))
 
 (defun cider-get-ns-name ()
-  "Calls `clojure-find-ns', suppressing any errors.
-Therefore, possibly returns nil,
-so please handle that value from any callsites."
-  (clojure-find-ns :supress-errors))
+  "Return the current namespace in the buffer, suppressing any errors.
+Uses `clojure-ts-find-ns' when the buffer is in `clojure-ts-mode',
+otherwise falls back to `clojure-find-ns'.
+Therefore, possibly returns nil, so please handle that value from any callsites."
+  (if (and (cider-clojure-ts-mode-p)
+           (fboundp 'clojure-ts-find-ns))
+      (clojure-ts-find-ns)
+    (clojure-find-ns :supress-errors)))
 
 (defun cider-ns-form ()
   "Retrieve the ns form."


### PR DESCRIPTION
Using `clojure-ts-find-ns` is a bit more efficient as it leverages tree-sitter.

Plus, there seem to be some egde cases where `clojure-find-ns` within a `clojure-ts-mode` buffer makes Emacs hang, as `clojure-find-ns`'s `(while t (up-list nil t t))` loop never terminates because `up-list` delegates to `treesit-forward-sexp`, which not always seems to signal an error.

Unfortunately I wasn't able to reproduce the error case. But as the change is a performance improvement as well, I hope this is acceptable. 