### PR TITLE
Use project.el directly for project root detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ### Changes
 
+- Project root detection no longer goes through `clojure-mode'/`clojure-ts-mode'.  New `cider-project-dir' built on top of `project.el' is used instead, with `cider-build-tool-files' as the extra root markers.  This works identically whether the user is in `clojure-mode', `clojure-ts-mode', or even a buffer not visiting a Clojure file (e.g. an `M-x cider-connect' from Dired), and respects any `project-find-functions' the user has configured.
 - [#710](https://github.com/clojure-emacs/cider-nrepl/issues/710): Use namespaced nREPL ops (e.g. `cider/info` instead of `info`) to match cider-nrepl 0.59+.
 - Bump the injected `nrepl` to [1.7.0](https://github.com/nrepl/nrepl/blob/master/CHANGELOG.md#170-2026-04-14).
 - Bump the injected `cider-nrepl` to [0.59.0](https://github.com/clojure-emacs/cider-nrepl/blob/master/CHANGELOG.md#0590-2026-04-14).

--- a/lisp/cider-client.el
+++ b/lisp/cider-client.el
@@ -656,7 +656,7 @@ resolve those to absolute paths."
                        (cider-sync-tooling-eval)
                        (nrepl-dict-get "value")
                        read))
-          (project (clojure-project-dir)))
+          (project (cider-project-dir)))
       (mapcar (lambda (path) (cider--get-abs-path path project)) classpath))))
 
 (defun cider-classpath-entries (&optional connection)

--- a/lisp/cider-cljs.el
+++ b/lisp/cider-cljs.el
@@ -144,7 +144,7 @@ The default options of `browser-repl' and `node-repl' are also included."
 
 (defun cider--shadow-get-builds ()
   "Extract build names from the shadow-cljs.edn config file in the project root."
-  (let ((shadow-edn (concat (clojure-project-dir) "shadow-cljs.edn")))
+  (let ((shadow-edn (concat (cider-project-dir) "shadow-cljs.edn")))
     (when (file-readable-p shadow-edn)
       (with-temp-buffer
         (insert-file-contents shadow-edn)
@@ -206,7 +206,7 @@ Figwheel for details."
 (defun cider--figwheel-main-get-builds ()
   "Extract build names from the <build-id>.cljs.edn config files.
 Fetches them in the project root."
-  (when-let ((project-dir (clojure-project-dir)))
+  (when-let ((project-dir (cider-project-dir)))
     (let ((builds (directory-files project-dir nil ".*\\.cljs\\.edn")))
       (mapcar (lambda (f) (string-match "^\\(.*\\)\\.cljs\\.edn" f)
                 (match-string 1 f))

--- a/lisp/cider-doc.el
+++ b/lisp/cider-doc.el
@@ -394,7 +394,7 @@ Same for `jar:file:...!/' segments."
                   file-with-protocol)))
     (if (string-match "\\`file:\\(.*\\)" result)
         (let ((file (match-string 1 result))
-              (proj-dir (clojure-project-dir)))
+              (proj-dir (cider-project-dir)))
           (if (and proj-dir
                    (file-in-directory-p file proj-dir))
               (file-relative-name file proj-dir)

--- a/lisp/cider-endpoint.el
+++ b/lisp/cider-endpoint.el
@@ -227,7 +227,7 @@ Necessary since we run some OS-specific commands that may fail."
 When DIR is non-nil also look for nREPL port files in DIR.  Return a list
 of list of the form (project-dir port)."
   (let* ((pairs (cider--running-nrepl-paths))
-         (pairs (if-let (c (and dir (clojure-project-dir dir)))
+         (pairs (if-let (c (and dir (cider-project-dir dir)))
                     (append (cider--path->path-port-pairs c) pairs)
                   pairs)))
     (thread-last pairs

--- a/lisp/cider-jack-in.el
+++ b/lisp/cider-jack-in.el
@@ -709,10 +709,10 @@ that host instead of the local one."
 
 (defun cider--resolve-project-command (command)
   "Find COMMAND in project dir or exec path (see variable `exec-path').
-If COMMAND starts with ./ or ../ resolve relative to `clojure-project-dir',
+If COMMAND starts with ./ or ../ resolve relative to `cider-project-dir',
 otherwise resolve via `cider--resolve-command'."
   (if (string-match-p "\\`\\.\\{1,2\\}/" command)
-      (locate-file command (list (clojure-project-dir)) '("" ".bat") 'executable)
+      (locate-file command (list (cider-project-dir)) '("" ".bat") 'executable)
     (cider--resolve-command command)))
 
 (defun cider--resolve-prefix-command (command)
@@ -962,7 +962,7 @@ only when the ClojureScript dependencies are met."
   "Identify build systems present by their build files in PROJECT-DIR.
 PROJECT-DIR defaults to the current project.  The set of recognized build
 files is derived from the :project-files entries in `cider-jack-in-tools'."
-  (let ((default-directory (or project-dir (clojure-project-dir (cider-current-dir)))))
+  (let ((default-directory (or project-dir (cider-project-dir (cider-current-dir)))))
     (delq nil
           (mapcar (lambda (entry)
                     (when (seq-some #'file-exists-p
@@ -1044,7 +1044,7 @@ For example, to jack in to leiningen which is assigned to prefix arg 2 type
 
 M-2 \\[cider-jack-in-universal]."
   (interactive "P")
-  (let ((cpt (clojure-project-dir (cider-current-dir))))
+  (let ((cpt (cider-project-dir (cider-current-dir))))
     (if (or (integerp arg) (null cpt))
         (let* ((tools (cider--universal-jack-in-tools))
                (project-type

--- a/lisp/cider-repl.el
+++ b/lisp/cider-repl.el
@@ -1390,7 +1390,7 @@ regexes from `cider-locref-regexp-alist' to infer locations at point."
                       (let ((file-from-regexp (if (file-name-absolute-p file)
                                                   file
                                                 ;; when not absolute, expand within the current project
-                                                (when-let* ((proj (clojure-project-dir)))
+                                                (when-let* ((proj (cider-project-dir)))
                                                   (expand-file-name file proj)))))
                         (or (when (file-readable-p file-from-regexp)
                               file-from-regexp)
@@ -1598,7 +1598,7 @@ It does not yet set the input history."
   "Find the first suitable directory to store the project's history."
   (seq-find
    (lambda (dir) (and dir (not (tramp-tramp-file-p dir))))
-   (list nrepl-project-dir (clojure-project-dir) default-directory)))
+   (list nrepl-project-dir (cider-project-dir) default-directory)))
 
 (defun cider-repl-history-load (&optional filename)
   "Load history from FILENAME into current session.

--- a/lisp/cider-session.el
+++ b/lisp/cider-session.el
@@ -323,7 +323,7 @@ removed."
   (let* ((dir (directory-file-name
                (abbreviate-file-name
                 (or (plist-get params :project-dir)
-                    (clojure-project-dir (cider-current-dir))
+                    (cider-project-dir (cider-current-dir))
                     default-directory))))
          (short-proj (file-name-nondirectory (directory-file-name dir)))
          (parent-dir (ignore-errors
@@ -403,7 +403,7 @@ Reverts to normal project-based session association."
 
 (cl-defmethod sesman-project ((_system (eql CIDER)))
   "Find project directory."
-  (clojure-project-dir (cider-current-dir)))
+  (cider-project-dir (cider-current-dir)))
 
 (cl-defmethod sesman-more-relevant-p ((_system (eql CIDER)) session1 session2)
   "Figure out if SESSION1 or SESSION2 is more relevant."

--- a/lisp/cider-util.el
+++ b/lisp/cider-util.el
@@ -43,6 +43,11 @@
 (require 'clojure-mode)
 (require 'nrepl-dict)
 
+;; Declared so the byte-compiler doesn't flag the `let' binding in
+;; `cider-project-dir' as an unused lexical variable on Emacs 28,
+;; where project.el doesn't define this variable.
+(defvar project-vc-extra-root-markers)
+
 (defalias 'cider-pop-back #'pop-tag-mark)
 
 (defcustom cider-font-lock-max-length 10000

--- a/lisp/cider-util.el
+++ b/lisp/cider-util.el
@@ -89,6 +89,53 @@ Setting this to nil removes the fontification restriction."
       (file-name-directory buffer-file-name)
     default-directory))
 
+(defcustom cider-build-tool-files
+  '("project.clj"      ; Leiningen
+    "build.boot"       ; Boot
+    "build.gradle"     ; Gradle
+    "build.gradle.kts" ; Gradle Kotlin
+    "deps.edn"         ; Clojure CLI (tools.deps)
+    "shadow-cljs.edn"  ; shadow-cljs
+    "bb.edn"           ; babashka
+    "nbb.edn"          ; nbb
+    "basilisp.edn"     ; Basilisp (Python)
+    )
+  "Files indicating the root of a Clojure project.
+Used by `cider-project-dir' as extra root markers passed to
+`project.el'."
+  :type '(repeat string)
+  :group 'cider
+  :safe (lambda (value)
+          (and (listp value)
+               (cl-every #'stringp value))))
+
+(defun cider-project-dir (&optional dir)
+  "Return the absolute path of the current Clojure project root, or nil.
+DIR defaults to `default-directory'.
+
+Built on top of `project.el', so the result respects any project-discovery
+customization the user has configured (`project-find-functions',
+`project-vc-extra-root-markers', etc.).  `cider-build-tool-files' extends
+the set of markers project.el's VC backend will accept, so a `deps.edn'
+or `project.clj' root wins over a deeper enclosing VC root.
+
+Falls back to a `locate-dominating-file' search against
+`cider-build-tool-files' when project.el doesn't detect anything; this
+also covers Emacs 28, which doesn't have `project-vc-extra-root-markers'."
+  (let ((default-directory (or dir default-directory)))
+    (or (let ((project-vc-extra-root-markers
+               (append (and (boundp 'project-vc-extra-root-markers)
+                            project-vc-extra-root-markers)
+                       cider-build-tool-files)))
+          (when-let* ((proj (project-current)))
+            (expand-file-name (project-root proj))))
+        (when-let* ((hits (delq nil
+                                (mapcar (lambda (f)
+                                          (locate-dominating-file
+                                           default-directory f))
+                                        cider-build-tool-files))))
+          (expand-file-name (car (sort hits #'file-in-directory-p)))))))
+
 (defun cider-in-string-p ()
   "Return non-nil if point is in a string."
   (let ((beg (save-excursion (beginning-of-defun-raw) (point))))

--- a/lisp/cider.el
+++ b/lisp/cider.el
@@ -353,14 +353,14 @@ Params is a plist with the following keys (non-exhaustive)
          (proj-dir (if (or (plist-get params :do-prompt)
                            (plist-get params :edit-project-dir))
                        (read-directory-name "Project: "
-                                            (clojure-project-dir (cider-current-dir)))
+                                            (cider-project-dir (cider-current-dir)))
                      (plist-get params :project-dir)))
          (orig-buffer (current-buffer)))
     (if (or (null proj-dir)
             (file-in-directory-p default-directory proj-dir))
         (plist-put params :project-dir
                    (or proj-dir
-                       (clojure-project-dir (cider-current-dir))))
+                       (cider-project-dir (cider-current-dir))))
       ;; If proj-dir is not a parent of default-directory, transfer all
       ;; local variables and hack dir-local variables into a temporary
       ;; buffer kept on `params' for the rest of the param-update pipeline.

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -179,7 +179,7 @@
             :and-call-fake (lambda (params) (setq chosen-fn 'clj chosen-args params)))
     (spy-on 'cider-jack-in-cljs
             :and-call-fake (lambda (params) (setq chosen-fn 'cljs chosen-args params)))
-    (spy-on 'clojure-project-dir :and-return-value nil))
+    (spy-on 'cider-project-dir :and-return-value nil))
 
   (it "dispatches to cider-jack-in-clj for a clj prefix-arg"
     (cider-jack-in-universal 2)
@@ -572,7 +572,7 @@
           (file-path (concat temporary-file-directory edn-file)))
      (with-temp-file file-path
        (insert ,contents))
-     (spy-on 'clojure-project-dir :and-return-value temporary-file-directory)
+     (spy-on 'cider-project-dir :and-return-value temporary-file-directory)
      ,@body
      (delete-file file-path)))
 
@@ -637,12 +637,12 @@
       (expect (cider--resolve-command "no-such-command") :to-be nil))))
 
 (describe "cider--resolve-project-command"
-  (it "if command starts with ./ it resolves relative to clojure-project-dir"
+  (it "if command starts with ./ it resolves relative to cider-project-dir"
     (spy-on 'locate-file :and-return-value "/project/command")
     (spy-on 'executable-find :and-return-value "/bin/command")
     (expect (cider--resolve-project-command "./command")
             :to-equal "/project/command"))
-  (it "if command starts with ../ it resolves relative to clojure-project-dir"
+  (it "if command starts with ../ it resolves relative to cider-project-dir"
     (spy-on 'locate-file :and-return-value "/project/command")
     (spy-on 'executable-find :and-return-value "/bin/command")
     (expect (cider--resolve-project-command "../command")
@@ -741,7 +741,7 @@
     (spy-on 'cider--running-lein-nrepl-paths :and-return-value '(("lein" "1234")))
     (spy-on 'cider--running-local-nrepl-paths :and-return-value '(("local" "2345")))
     (spy-on 'cider--running-non-lein-nrepl-paths :and-return-value '(("non-lein" "3456")))
-    (spy-on 'clojure-project-dir :and-return-value #'identity)
+    (spy-on 'cider-project-dir :and-return-value #'identity)
     (spy-on 'cider--path->path-port-pairs :and-return-value '(("from-dir" "4567")))
     (spy-on 'directory-file-name :and-call-fake #'identity)
     (spy-on 'file-name-nondirectory :and-call-fake #'identity)


### PR DESCRIPTION
Step 1 of decoupling cider from `clojure-mode`/`clojure-ts-mode` for things that don't actually require either: introduce `cider-project-dir` (built on top of `project.el`) and migrate every `clojure-project-dir` call site to it.

Why this is better than dispatching between `clojure-project-dir` and `clojure-ts-project-dir`:

- The two have different semantics today. `clojure-project-dir` uses `locate-dominating-file` directly, while `clojure-ts-project-dir` goes through `project.el`. The same file can return different roots depending on which major mode is active. One source of truth removes that.
- Works the same in `clojure-mode`, `clojure-ts-mode`, or any other buffer (e.g. `M-x cider-connect` from Dired).
- Respects `project-find-functions`, `project-vc-extra-root-markers`, etc., the same project.el customization users already have configured for everything else in Emacs.
- `cider-build-tool-files` is appended to `project-vc-extra-root-markers` so a `deps.edn`/`project.clj` root wins over a deeper enclosing VC root.
- Falls back to `locate-dominating-file` against `cider-build-tool-files` when `project.el` doesn't detect anything. That also handles Emacs 28, which doesn't have `project-vc-extra-root-markers`.

No caching layer for now. `project.el`'s detection is already cheap in the common case, and adding a cache would need an invalidation story we don't have yet. Easy follow-up if profiling turns up a hot path.

Follow-ups in the same direction (not in this PR): `cider-expected-ns`, and migrating `cider-get-ns-name` off the `up-list`-based path entirely.