### PR TITLE
Use indent-according-to-mode in cider-maybe-insert-multiline-comment

### DIFF
--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -377,7 +377,7 @@ RESULT will be preceded by COMMENT-PREFIX.
 CONTINUED-PREFIX is inserted for each additional line of output.
 COMMENT-POSTFIX is inserted after final text output."
   (unless (string= result "")
-    (clojure-indent-line)
+    (indent-according-to-mode)
     (let ((lines (split-string result "[\n]+" t))
           (beg (point))
           (col (current-indentation)))


### PR DESCRIPTION
`clojure-indent-line` was the only direct indent-function call in cider tied to a specific major mode. Replacing it with `indent-according-to-mode` dispatches via the active mode's `indent-line-function`, so the call works identically in `clojure-mode` (where it lands on `clojure-indent-line`) and in `clojure-ts-mode` (where it's the tree-sitter-driven `clojure-ts-indent-line`), without cider having to know which mode is active.

One-line change. Continues the small decoupling sweep from PRs #3922 and #3924.