### PR TITLE
[inspector] Render a help block with keybindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [#3645](https://github.com/clojure-emacs/cider/issues/3645): Show a spinner in the mode line while tests are running.
 - [#3865](https://github.com/clojure-emacs/cider/pull/3865): Add default session feature to bypass sesman's project-based dispatch (`cider-set-default-session`, `cider-clear-default-session`).
+- [#3930](https://github.com/clojure-emacs/cider/pull/3930): Inspector: add help message with keybindings.
 - Introduce `cider-jack-in-tools` and `cider-register-jack-in-tool` so third-party packages can register new project tools for `cider-jack-in` and `cider-jack-in-universal`.
 - Cache the result of `cider--running-nrepl-paths` (used by `cider-locate-running-nrepl-ports`) for `cider-running-nrepl-paths-cache-ttl` seconds (default 5). Repeated `cider-connect` completions no longer re-spawn a fresh round of `ps`/`lsof` subprocesses each time. `cider-clear-running-nrepl-paths-cache` discards the cache on demand.
 - New `nrepl-make-eval-handler` with a keyword-arg API:

--- a/doc/modules/ROOT/pages/debugging/inspector.adoc
+++ b/doc/modules/ROOT/pages/debugging/inspector.adoc
@@ -27,7 +27,9 @@ TIP: The current value of the debugger can be sent as well to Clojure's
 tools which render tapped values in a web browser, for example.
 
 You'll have access to additional keybindings in the inspector buffer
-(which is internally using `cider-inspector-mode`):
+(which is internally using `cider-inspector-mode`). All bindings are listed
+at the bottom of the inspector buffer in the `Keybindings` section. It can be
+toggled by pressing kbd:[?].
 
 |===
 | Keyboard shortcut | Command | Description
@@ -127,33 +129,32 @@ You'll have access to additional keybindings in the inspector buffer
 
 |===
 
+=== View modes
+
+The point of the inspector is to display and navigate familiar data structures
+in a more pleasant and obvious way. For example, in the inspector, a sequential
+collection is rendered with each item on its own line and paginated. However,
+for some object types, inspector supports additional view modes. The modes can
+be cycled by calling `cider-inspector-toggle-view-mode` (kbd:[v] by default).
+
+- `:object` - default view mode for rendering any Java object that doesn't have
+  a custom renderer. Displays all object fields and their values. Known types
+  can also be switched to this mode.
+- `:table` - can be enabled when inspecting a sequence of maps when each map has
+  same or mostly same keys.
+- `:hex` - available for byte arrays and ByteBuffer objects, renders them in a
+  "hexdump" style.
+
 == Configuration
 
-By default, navigation skips over values like nils, numbers and
-keywords, which are not interesting to inspect. You can control this
-behavior using the variable `cider-inspector-skip-uninteresting`.
-
-The inspector buffer is automatically selected by default. You
-can disable the auto selection with the variable
-`cider-inspector-auto-select-buffer`.
+You can see and change all variables related to Inspector by doing `M-x
+customize-group cider-inspector`.
 
 You can set the amount of data shown by default with the variables
 `cider-inspector-page-size`, `cider-inspector-max-coll-size`,
 `cider-inspector-max-nested-depth`, and `cider-inspector-max-atom-length`. The
 values can be adjusted for the current inspector buffer using the keybindings
 listed in the table above.
-
-If you enable `cider-inspector-fill-frame`, the inspector window fills its
-frame.
-
-You can toggle the pretty printing of values in the inspector with
-kbd:[P] and customize their initial presentation by adjusting the
-`cider-inspector-pretty-print` customization option.
-
-When you define a var using kbd:[d], a var name can be suggested (default none).
-You can customize this value via the `cider-inspector-preferred-var-names`
-configuration option. Even after setting it, you are free to choose new names on
-the fly, as you type. Most recent names will take priority in subsequent usages.
 
 When `cider-inspector-tidy-qualified-keywords` is enabled, namespace-qualified
 keyword like `::foo` or `::alias/baz` will be displayed in the same manner by

--- a/lisp/cider-inspector.el
+++ b/lisp/cider-inspector.el
@@ -112,11 +112,16 @@ by clicking or navigating to them by other means."
   :type 'boolean
   :package-version '(cider . "0.27.0"))
 
-(defcustom cider-inspector-display-analytics-hint t
-  "When true, display hint about analytics feature for eligible objects.
-Can be turned to nil once the user sees and acknowledges the feature."
+(defcustom cider-inspector-display-analytics-hint nil
+  "Obsolete; no longer used."
   :type 'boolean
   :package-version '(cider . "1.18.0"))
+(make-obsolete 'cider-inspector-display-analytics-hint nil "1.22")
+
+(defcustom cider-inspector-display-help t
+  "When true, render help at the bottom of the inspector page."
+  :type 'boolean
+  :package-version '(cider . "1.22.0"))
 
 (defvar cider-inspector-uninteresting-regexp
   (concat "nil"                      ; nils are not interesting
@@ -164,6 +169,7 @@ Can be turned to nil once the user sees and acknowledges the feature."
     (define-key map "P" #'cider-inspector-toggle-pretty-print)
     (define-key map "S" #'cider-inspector-toggle-sort-maps)
     (define-key map "D" #'cider-inspector-toggle-only-diff)
+    (define-key map "?" #'cider-inspector-toggle-display-help)
     (define-key map (kbd "C-c C-p") #'cider-inspector-print-current-value)
     (define-key map ":" #'cider-inspect-expr-from-inspector)
     (define-key map "f" #'forward-char)
@@ -388,12 +394,15 @@ MAX-NESTED-DEPTH is the new value."
 (defun cider-inspector-display-analytics ()
   "Toggle the display of analytics for the inspected object."
   (interactive)
-  ;; Disable hint about analytics feature so that it is never displayed again.
-  (when cider-inspector-display-analytics-hint
-    (customize-set-variable 'cider-inspector-display-analytics-hint nil))
   (let ((result (cider-nrepl-send-sync-request `("op" "cider/inspect-display-analytics"))))
     (when (nrepl-dict-get result "value")
       (cider-inspector--render-value result :next-inspectable))))
+
+(defun cider-inspector-toggle-display-help ()
+  "Toggle the display of help message in the inspector window."
+  (interactive)
+  (customize-set-variable 'cider-inspector-display-help (not cider-inspector-display-help))
+  (cider-inspector-refresh))
 
 (defun cider-inspector-toggle-pretty-print ()
   "Toggle the pretty printing of values in the inspector."
@@ -499,25 +508,23 @@ current-namespace."
 Set the page size in paginated view to PAGE-SIZE, maximum length of atomic
 collection members to MAX-ATOM-LENGTH, and maximum size of nested collections to
 MAX-COLL-SIZE if non nil."
-  (thread-first
-    (append (nrepl--eval-request expr ns)
-            `("inspect" "true"
-              ,@(when cider-inspector-page-size
-                  `("page-size" ,cider-inspector-page-size))
-              ,@(when cider-inspector-max-atom-length
-                  `("max-atom-length" ,cider-inspector-max-atom-length))
-              ,@(when cider-inspector-max-coll-size
-                  `("max-coll-size" ,cider-inspector-max-coll-size))
-              ,@(when cider-inspector-max-nested-depth
-                  `("max-nested-depth" ,cider-inspector-max-nested-depth))
-              ,@(when cider-inspector-display-analytics-hint
-                  `("display-analytics-hint" "true"))
-              "tidy-qualified-keywords" ,(if cider-inspector-tidy-qualified-keywords
-                                             "true" "false")
-              "pretty-print" ,(if cider-inspector-pretty-print "true" "false")
-              "sort-maps" ,(if cider-inspector-sort-maps "true" "false")
-              "only-diff" ,(if cider-inspector-only-diff "true" "false")))
-    (cider-nrepl-send-sync-request)))
+  (cider-nrepl-send-sync-request
+   (append (nrepl--eval-request expr ns)
+           `("inspect" "true"
+             ,@(when cider-inspector-page-size
+                 `("page-size" ,cider-inspector-page-size))
+             ,@(when cider-inspector-max-atom-length
+                 `("max-atom-length" ,cider-inspector-max-atom-length))
+             ,@(when cider-inspector-max-coll-size
+                 `("max-coll-size" ,cider-inspector-max-coll-size))
+             ,@(when cider-inspector-max-nested-depth
+                 `("max-nested-depth" ,cider-inspector-max-nested-depth))
+             ;; "display-analytics-hint" "nil"
+             "tidy-qualified-keywords" ,(if cider-inspector-tidy-qualified-keywords
+                                            "true" "false")
+             "pretty-print" ,(if cider-inspector-pretty-print "true" "false")
+             "sort-maps" ,(if cider-inspector-sort-maps "true" "false")
+             "only-diff" ,(if cider-inspector-only-diff "true" "false")))))
 
 (declare-function cider-set-buffer-ns "cider-mode")
 
@@ -574,7 +581,9 @@ from stack), `:next-inspectable' (move point to next inspectable object)."
     (let ((inhibit-read-only t))
       (condition-case nil
           (cider-inspector-render* (car (read-from-string str)))
-        (error (insert "\nInspector error for: " str))))
+        (error (insert "\nInspector error for: " str)))
+      (when cider-inspector-display-help
+        (cider-inspector--render-help)))
     (goto-char (point-min))))
 
 (defvar cider-inspector-looking-at-java-p nil)
@@ -734,6 +743,63 @@ that value.
            (cider-inspector-operate-on-point))
           (t
            (error "No clickable part here")))))
+
+(defconst cider-inspector--inline-help-data
+  '((cider-inspector-toggle-display-help . "Show/hide this message")
+    ((cider-inspector-operate-on-point
+      cider-inspector-operate-on-click)
+     . "Inspect object at point")
+    (cider-inspector-pop . "Pop back to outer object")
+    (cider-inspector-refresh . "Refresh current view")
+    ((cider-inspector-next-page cider-inspector-prev-page) . "Scroll to next/previous page")
+    ((cider-inspector-next-inspectable-object
+      cider-inspector-previous-inspectable-object)
+     . "Navigate to next/previous inspectable object")
+    ((cider-inspector-next-sibling cider-inspector-previous-sibling)
+     . "Inspect next/previous sibling in the collection.")
+    (cider-inspector-display-analytics . "Calculate analytics for the current object")
+    (cider-inspector-def-current-val . "Define current value as a top-level var")
+    (cider-inspector-tap-current-val . "Send current value to tap>")
+    (cider-inspector-print-current-value . "Print current value")
+    (cider-inspector-open-thing-at-point . "Open file or URL at point")
+    (cider-inspect-expr-from-inspector . "Inspect prompted expression")
+    (cider-inspector-toggle-view-mode . "Cycle between view modes")
+    (cider-inspector-toggle-pretty-print . "Toggle pretty-printing")
+    (cider-inspector-toggle-sort-maps . "Sort inspected map by key")
+    (cider-inspector-toggle-only-diff . "Hide equal values when rendering a diff")
+    (cider-inspector-set-page-size . "Set pagination page size")
+    (cider-inspector-set-max-atom-length . "Set maximum item length before truncating")
+    (cider-inspector-set-max-coll-size . "Set maximum collection size before truncating")
+    (cider-inspector-set-max-nested-depth . "Set maximum collection depth before truncating")
+    (cider-popup-buffer-quit-function . "Quit inspector")))
+
+(defun cider-inspector--render-help ()
+  "Render a keybinding help block at the bottom of the buffer."
+  (save-excursion
+    (let ((computed-items nil)
+          (max-len 0))
+      (goto-char (point-max))
+      (insert "\n\n")
+      (insert (propertize "--- Keybindings:\n" 'font-lock-face 'font-lock-comment-face))
+      ;; Pre-compute key strings and calculate maximum length
+      (dolist (cmd-pair cider-inspector--inline-help-data)
+        (let* ((cmd (car cmd-pair))
+               (desc (cdr cmd-pair))
+               (keys (mapcar (lambda (k)
+                               (propertize (key-description (where-is-internal k cider-inspector-mode-map t))
+                                           'font-lock-face 'help-key-binding))
+                             (if (atom cmd) (list cmd) cmd)))
+               (key-str (string-join keys ", ")))
+          (setq max-len (max max-len (length key-str)))
+          (push (cons key-str desc) computed-items)))
+      ;; Render lines with right-aligned padding.
+      (dolist (item (nreverse computed-items))
+        (let* ((key-str (car item))
+               (desc (cdr item))
+               (padding (make-string (- max-len (length key-str)) ?\s)))
+          (insert "  " padding key-str
+                  "  " (propertize desc 'font-lock-face 'font-lock-comment-face)
+                  "\n"))))))
 
 (provide 'cider-inspector)
 


### PR DESCRIPTION
Has been yearning for a long time to do this. The help message looks like this:

<img width="669" height="657" alt="image" src="https://github.com/user-attachments/assets/f7be79c7-13b0-4662-8c1a-fa77990f7c85" />

- Helps both the new users with basic commands and adds to discoverability of new features for experienced users.
- Hideable with `?` (or by customizing `cider-inspector-display-help`).
- Allows us to remove hints rendering from Orchard (which are also incorrect if the user redefines the bindings).

Also updated doc page for the inspector. Removed keybindings table to not having to maintain it in one more place (let it live in Emacs now) and directed the configuration to `customize-group` instead of re-listing them all again.

-----------------

- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)