### PR TITLE
Set `default-directory` in `cider-test-report-mode` buffers to `(cider-project-dir)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@
   - `nrepl-log--pp-listlike` now walks the plist in a single pass instead of copy-sequencing it through a sort/filter/concat pipeline. Specials (`id`, `op`, `session`, `time-stamp`) still print first but in canonical order, and the remaining keys now print in insertion order rather than alphabetically.
   - `pp` was swapped for `prin1` in the non-dict leaf paths of `nrepl-log-pp-object`.
   - `nrepl-message-buffer-max-size` and `nrepl-message-buffer-reduce-denominator` are now `defcustom` to match their docstring intent.
+- Set `default-directory` in `cider-test-report-mode` buffers to `(cider-project-dir)`
 
 ## 1.21.0 (2026-02-07)
 

--- a/lisp/cider-test.el
+++ b/lisp/cider-test.el
@@ -735,7 +735,8 @@ If PROMPT-FOR-FILTERS is non-nil, prompt the user for a test selector filters.
 The include/exclude selectors will be used to filter the tests before
 running them."
   (cider-test-clear-highlights)
-  (let ((include-selectors
+  (let ((cider-project-dir (cider-project-dir))
+        (include-selectors
          (if prompt-for-filters
              (cider-test--prompt-for-selectors
               "Test selectors to include (space separated): ")
@@ -799,9 +800,8 @@ running them."
                                       cider-test-report-buffer
                                       cider-auto-select-test-report-buffer)))
                               (with-current-buffer b
-                                ;; Change the default-directory so that it doesn't affect `sesman--linked-sessions` logic:
                                 (setq-local default-directory
-                                            (with-current-buffer "*Messages*" default-directory)))
+                                            cider-project-dir))
                               (cider-test-render-report
                                b
                                summary


### PR DESCRIPTION
Sets `default-directory` in `cider-test-report-mode` buffers to the value of `(cider-project-dir)` to let other Emacs commands like `magit-status` or `project-find-file` be aware of the current project.

Sesman seems to still work, meaning that pressing RET with POINT at "expected:" or "actual:" jumps correctly to the corresponding test file.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
