### PR TITLE
Fix multiple evaluation in nrepl-dbind-response

### DIFF
--- a/lisp/nrepl-dict.el
+++ b/lisp/nrepl-dict.el
@@ -230,10 +230,12 @@ If NO-JOIN is given, return the first non nil dict."
   "Destructure an nREPL RESPONSE dict.
 Bind the value of the provided KEYS and execute BODY."
   (declare (debug (form (&rest symbolp) body)))
-  `(let ,(mapcar (lambda (key)
-                   `(,key (nrepl-dict-get ,response ,(format "%s" key))))
-                 keys)
-     ,@body))
+  (let ((response-var (gensym "response")))
+    `(let* ((,response-var ,response)
+            ,@(mapcar (lambda (key)
+                        `(,key (nrepl-dict-get ,response-var ,(format "%s" key))))
+                      keys))
+       ,@body)))
 (put 'nrepl-dbind-response 'lisp-indent-function 2)
 
 (provide 'nrepl-dict)

--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -75,7 +75,20 @@
                 (id session status)
               (list id session status))
             :to-equal
-            '("2" "39f630b9-9545-4ea0-860e-9846681d0741" ("done")))))
+            '("2" "39f630b9-9545-4ea0-860e-9846681d0741" ("done"))))
+
+  (it "binds missing keys to nil"
+    (nrepl-dbind-response '(dict "foo" "1") (foo bar)
+      (expect foo :to-equal "1")
+      (expect bar :to-equal nil)))
+
+  (it "evaluates the response expression only once"
+    (let ((call-count 0))
+      (nrepl-dbind-response (progn (cl-incf call-count) ; side-effectful
+                                   '(dict "a" "1" "b" "2" "c" "3"))
+          (a b c)
+        (ignore a b c))
+      (expect call-count :to-equal 1))))
 
 (describe "nrepl-make-buffer-name"
   :var (nrepl-format-buffer-name-function default-directory-backup


### PR DESCRIPTION
`nrepl-dbind-response` spliced the response expression directly into each binding, causing it to be evaluated once per key. When the expression has side effects (e.g. `cider-nrepl-send-sync-request`), this fires the operation multiple times.

Discovered via `cider-inspector-tap-at-point` tapping the value twice. (Note: this was the only callsite which passes a side-effectful expression directly, as a result of refactor 9dc5107e8b48dbd5839df03ce533c4afa3682fb5; all other 50+ call sites pass plain variables or pure computations)

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
