### PR TITLE
Fix REPL-unconnected buffer lag by simplifying friendly-session matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 ### Bugs fixed
 
+- [#3933](https://github.com/clojure-emacs/cider/issues/3933): Fix severe editor lag in Clojure buffers when no REPL is linked.  Friendly-session matching no longer scans the project classpath (or the buffer's namespace) on every redisplay; it now just checks whether the buffer's file is under a session's project directory.  Dependency sources jumped to via `cider-find-var` are pinned to their originating session instead.
 - `cider-browse-spec-mode`, `cider-browse-spec-view-mode`, and `cider-browse-spec-example-mode` each have an `easy-menu` now, exposing the drill/browse-all/generate-example commands that previously had no menu affordance.
 - `cider-repl-history-mode` now has an `easy-menu` ("REPL History") covering insert, navigation, search/filter, refresh/delete/undo, and quit.
 - `cider-log-mode` now has an `easy-menu` ("CIDER Log") covering event inspect/print, navigation, and the framework/appender/consumer/event management commands previously only reachable via the `C-c M-l` prefix.

--- a/doc/modules/ROOT/pages/usage/managing_connections.adoc
+++ b/doc/modules/ROOT/pages/usage/managing_connections.adoc
@@ -174,16 +174,25 @@ them in a REPL buffer, as a REPL is an integral part of a session.
 
 == Friendly Sessions
 
-https://github.com/vspinu/sesman[Sesman] defines "friendly" session to allow for on-the-fly operation on
-sessions from contexts where there are no explicit links. In CIDER friendly
-sessions are defined by the project dependencies. For example when you use
-`cider-find-var` (kbd:[M-.]) to navigate to a var definition in a
-dependency project the current project's session becomes a friendly session for
-the dependency.
+https://github.com/vspinu/sesman[Sesman] defines "friendly" sessions to allow for on-the-fly operation on
+sessions from contexts where there are no explicit links. In CIDER a session is
+friendly to a buffer when the buffer's file lives under the session's project
+directory. So if you open a file anywhere in your project, the project's session
+is automatically used even before you link anything explicitly. Explicitly
+linked sessions still have precedence over friendly ones.
 
-When you evaluate some code from a dependency project and there are no explicit
-links in that project, the most recent friendly session is used to evaluate the
-code. Explicitly linked sessions have precedence over the friendly sessions.
+Files that live *outside* the project directory don't match this rule. The most
+common case is jumping to a dependency's source with `cider-find-var`
+(kbd:[M-.]): there CIDER pins the buffer to the session you navigated from, so
+evaluation and other commands keep targeting that REPL. Source buffers you open
+by other means (e.g. a plain `find-file` into a jar) won't be associated
+automatically; link a session explicitly or set `cider-default-session` if you
+need that.
+
+NOTE: Earlier CIDER versions inferred friendly sessions from the full project
+classpath (and, as a fallback, the buffer's namespace). That ran on every
+redisplay and could cause severe editor lag, so it was replaced with the simpler
+project-directory rule described above.
 
 You can disable friendly session inference by customizing
 `sesman-use-friendly-sessions`.

--- a/lisp/cider-common.el
+++ b/lisp/cider-common.el
@@ -128,6 +128,24 @@ On failure, read a symbol name using PROMPT and call CALLBACK with that."
     (error (funcall callback (cider-read-from-minibuffer prompt)))))
 
 (declare-function cider-mode "cider-mode")
+(declare-function cider-current-repl "cider-session")
+(defvar cider--ancillary-buffer-repl)
+
+(defun cider--pin-repl-if-out-of-project (repl)
+  "Pin REPL onto the current buffer if its file is outside REPL's project.
+When jumping to a definition or resource that lives outside the
+originating session's project directory (typically a dependency's
+source), associate the buffer with REPL via `cider--ancillary-buffer-repl'
+so that CIDER commands invoked there target the session the buffer was
+navigated from.  Buffers inside the project directory are left untouched
+so they keep tracking the current session."
+  (when-let* ((repl (and (buffer-live-p repl) repl))
+              (file (buffer-file-name)))
+    (let ((proj-dir (buffer-local-value 'nrepl-project-dir repl)))
+      (when (or (null proj-dir)
+                (not (string-prefix-p (file-name-as-directory (file-truename proj-dir))
+                                      (file-truename file))))
+        (setq-local cider--ancillary-buffer-repl repl)))))
 
 (defcustom cider-jump-to-pop-to-buffer-actions
   '((display-buffer-reuse-window display-buffer-same-window))
@@ -152,47 +170,51 @@ If a cons, it specifies the position as (LINE . COLUMN).  COLUMN can be nil.
 If a symbol, `cider-jump-to' searches for something that looks like the
 symbol's definition in the file.
 If OTHER-WINDOW is non-nil don't reuse current window."
-  (with-no-warnings
-    (xref-push-marker-stack))
-  (if other-window
-      (pop-to-buffer buffer 'display-buffer-pop-up-window)
-    (pop-to-buffer buffer cider-jump-to-pop-to-buffer-actions))
-  (with-current-buffer buffer
-    (widen)
-    (goto-char (point-min))
-    (cider-mode +1)
-    (let ((status
-           (cond
-            ;; Line-column specification.
-            ((consp pos)
-             (forward-line (1- (or (car pos) 1)))
-             (if (cdr pos)
-                 (move-to-column (cdr pos))
-               (back-to-indentation)))
-            ;; Point specification.
-            ((numberp pos)
-             (goto-char pos))
-            ;; Symbol or string.
-            (pos
-             ;; Try to find (def full-name ...).
-             (if (or (save-excursion
-                       (search-forward-regexp (format "(def.*\\s-\\(%s\\)" (regexp-quote pos))
-                                              nil 'noerror))
-                     (let ((name (replace-regexp-in-string ".*/" "" pos)))
-                       ;; Try to find (def name ...).
-                       (or (save-excursion
-                             (search-forward-regexp (format "(def.*\\s-\\(%s\\)" (regexp-quote name))
-                                                    nil 'noerror))
-                           ;; Last resort, just find the first occurrence of `name'.
-                           (save-excursion
-                             (search-forward name nil 'noerror)))))
-                 (goto-char (match-beginning 0))
-               (message "Can't find %s in %s" pos (buffer-file-name))
-               'not-found))
-            (t 'not-found))))
-      (unless (eq status 'not-found)
-        ;; Make sure the location we jump to is centered within the target window
-        (recenter)))))
+  ;; Capture the originating session before `pop-to-buffer' moves us to the
+  ;; target buffer, so out-of-project targets can be pinned to it below.
+  (let ((origin-repl (ignore-errors (cider-current-repl))))
+    (with-no-warnings
+      (xref-push-marker-stack))
+    (if other-window
+        (pop-to-buffer buffer 'display-buffer-pop-up-window)
+      (pop-to-buffer buffer cider-jump-to-pop-to-buffer-actions))
+    (with-current-buffer buffer
+      (widen)
+      (goto-char (point-min))
+      (cider-mode +1)
+      (cider--pin-repl-if-out-of-project origin-repl)
+      (let ((status
+             (cond
+              ;; Line-column specification.
+              ((consp pos)
+               (forward-line (1- (or (car pos) 1)))
+               (if (cdr pos)
+                   (move-to-column (cdr pos))
+                 (back-to-indentation)))
+              ;; Point specification.
+              ((numberp pos)
+               (goto-char pos))
+              ;; Symbol or string.
+              (pos
+               ;; Try to find (def full-name ...).
+               (if (or (save-excursion
+                         (search-forward-regexp (format "(def.*\\s-\\(%s\\)" (regexp-quote pos))
+                                                nil 'noerror))
+                       (let ((name (replace-regexp-in-string ".*/" "" pos)))
+                         ;; Try to find (def name ...).
+                         (or (save-excursion
+                               (search-forward-regexp (format "(def.*\\s-\\(%s\\)" (regexp-quote name))
+                                                      nil 'noerror))
+                             ;; Last resort, just find the first occurrence of `name'.
+                             (save-excursion
+                               (search-forward name nil 'noerror)))))
+                   (goto-char (match-beginning 0))
+                 (message "Can't find %s in %s" pos (buffer-file-name))
+                 'not-found))
+              (t 'not-found))))
+        (unless (eq status 'not-found)
+          ;; Make sure the location we jump to is centered within the target window
+          (recenter))))))
 
 (defun cider--find-buffer-for-file (file)
   "Return a buffer visiting FILE.

--- a/lisp/cider-connection.el
+++ b/lisp/cider-connection.el
@@ -263,7 +263,7 @@ See `cider-connection-capabilities'."
 (declare-function cider--debug-init-connection "cider-debug")
 (declare-function cider-repl-init "cider-repl")
 (declare-function cider-nrepl-op-supported-p "cider-client")
-(declare-function cider--precompute-friendly-session-cache "cider-repl")
+(declare-function cider--cache-session-project-dir "cider-repl")
 (defun cider--connected-handler ()
   "Handle CIDER initialization after nREPL connection has been established.
 This function is appended to `nrepl-connected-hook' in the client process
@@ -303,9 +303,9 @@ buffer."
        (when cider-repl-init-function
          (funcall cider-repl-init-function))
 
-       ;; Populate caches before `cider-enable-on-existing-clojure-buffers',
+       ;; Cache the project dir before `cider-enable-on-existing-clojure-buffers',
        ;; whose mode-line refresh path calls the friendly-session matcher.
-       (cider--precompute-friendly-session-cache)
+       (cider--cache-session-project-dir)
 
        (when cider-auto-mode
          (cider-enable-on-existing-clojure-buffers))

--- a/lisp/cider-repl.el
+++ b/lisp/cider-repl.el
@@ -1882,38 +1882,25 @@ the history file is rewritten if `cider-repl-history-file' is set."
                      (mapconcat #'identity (cider-repl--available-shortcuts) ", "))))
         (error "No command selected")))))
 
-(defun cider--precompute-friendly-session-cache ()
-  "Populate friendly-session matcher caches on the current connection.
+(defun cider--cache-session-project-dir ()
+  "Cache the current connection's project directory for session matching.
 
 Called from `cider--connected-handler' once per new connection.  The
-caches are stored on the connection's process under:
-
-* `:cached-classpath' -- full classpath entries.
-* `:cached-classpath-roots' -- directory roots derived from the
-  classpath (non-JAR entries, deduplicated).
-* `:all-namespaces' -- a snapshot of the namespace list at connect
-  time, used as a fallback for ns-based matching when
-  `cider-repl-ns-cache' is empty.
-
-Errors during fetch are swallowed; an empty cache simply falls through
-to the project-dir / ns-form fallbacks in the matcher."
-  (when-let* ((proc (get-buffer-process (current-buffer))))
-    (let ((classpath (ignore-errors (cider-classpath-entries))))
-      (process-put proc :cached-classpath classpath)
-      (process-put proc :cached-classpath-roots
-                   (thread-last classpath
-                                (seq-remove (lambda (path) (string-suffix-p ".jar" path)))
-                                (mapcar #'file-name-directory)
-                                (delq nil)
-                                (seq-uniq))))
-    (when (cider-nrepl-op-supported-p "cider/ns-list")
-      (process-put proc :all-namespaces
-                   (ignore-errors (cider-sync-request:ns-list))))))
+project directory is stored on the connection's process under
+`:cached-project-dir', resolved via `file-truename' and with a trailing
+slash, so that `cider--sesman-friendly-session-p' can match buffers with
+a cheap `string-prefix-p' check on the hot redisplay path instead of
+resolving symlinks on every call."
+  (when-let* ((proc (get-buffer-process (current-buffer)))
+              (proj-dir (buffer-local-value 'nrepl-project-dir (current-buffer))))
+    (process-put proc :cached-project-dir
+                 (file-name-as-directory (file-truename proj-dir)))))
 
 (defun cider--sesman-friendly-session-p (session &optional debug)
   "Check if SESSION is a friendly session, DEBUG optionally.
 
-The checking is done as follows:
+A session is friendly to the current buffer when the buffer's file lives
+under the session's project directory.  The checking is done as follows:
 
 * If `cider-default-session' is set and the named session still
   exists, only that session is considered friendly (it serves every
@@ -1923,15 +1910,17 @@ The checking is done as follows:
   only accept the given session's repl if it equals `cider-test--current-repl'.
 * Consider if the buffer belongs to `cider-ancillary-buffers'.
 * Consider the buffer's filename, strip any Docker/TRAMP details from it.
-* Check if that filename belongs to the classpath,
-  or to the classpath roots,
-  or to the connection's project directory.
-* As a fallback, check if the buffer's ns form
-  matches any of the loaded namespaces.
+* Check whether that filename lives under the connection's project
+  directory.
 
-Classpath/namespace caches are populated eagerly at connection time
-by `cider--precompute-friendly-session-cache', so this function
-avoids blocking on classpath/ns-list fetches."
+Buffers outside the project directory (e.g. a dependency's source jumped
+to via `cider-find-var') are associated with their originating session
+explicitly through `cider--ancillary-buffer-repl', so they don't rely on
+this matcher.
+
+The project directory is cached at connection time by
+`cider--cache-session-project-dir', so this function does not block on
+any nREPL requests."
   (setcdr session (seq-filter #'buffer-live-p (cdr session)))
   (when-let ((repl (cadr session)))
     (cond
@@ -1955,52 +1944,27 @@ avoids blocking on classpath/ns-list fetches."
      (t
       (when-let* ((proc (get-buffer-process repl))
                   (file (file-truename (or (buffer-file-name) default-directory))))
-        ;; With avfs paths look like /path/to/.avfs/path/to/some.jar#uzip/path/to/file.clj
-        (when (string-match-p "#uzip" file)
-          (let ((avfs-path (directory-file-name (expand-file-name (or (getenv "AVFSBASE")  "~/.avfs/")))))
-            (setq file (replace-regexp-in-string avfs-path "" file t t))))
         (when-let ((tp (cider-tramp-prefix (current-buffer))))
           (setq file (string-remove-prefix tp file)))
         (when (process-live-p proc)
-          (let ((classpath (process-get proc :cached-classpath))
-                (classpath-roots (process-get proc :cached-classpath-roots))
-                (ns-list (process-get proc :all-namespaces))
-                (proj-dir (buffer-local-value 'nrepl-project-dir repl)))
-            ;; Classpath entries can be JAR files (matched as path prefixes of
-            ;; archive-internal paths); roots are real directories and need a
-            ;; proper directory-boundary check.
-            (or (seq-find (lambda (path) (string-prefix-p path file))
-                          classpath)
-                (seq-find (lambda (path) (file-in-directory-p file path))
-                          classpath-roots)
-                (and proj-dir (file-in-directory-p file proj-dir))
+          (let ((proj-dir (or (process-get proc :cached-project-dir)
+                              (when-let ((pd (buffer-local-value 'nrepl-project-dir repl)))
+                                (file-name-as-directory (file-truename pd))))))
+            ;; The project dir is cached as a truename-resolved directory (with
+            ;; a trailing slash), so a plain `string-prefix-p' is both a correct
+            ;; directory-boundary check and cheap enough for the redisplay hot
+            ;; path.  `file' is already resolved via `file-truename' above.
+            (or (and proj-dir (string-prefix-p proj-dir file))
+                ;; For remote (TRAMP/Docker) sessions the project dir is a remote
+                ;; path; translate the local file and match against it.
                 (when-let* ((cider-path-translations (cider--all-path-translations))
                             (translated (cider--translate-path file 'to-nrepl :return-all)))
-                  (seq-find (lambda (translated-path)
-                              (or (seq-find (lambda (path)
-                                              (string-prefix-p path translated-path))
-                                            classpath)
-                                  (seq-find (lambda (path)
-                                              (file-in-directory-p translated-path path))
-                                            classpath-roots)))
-                            translated))
-                (when-let ((ns (condition-case nil
-                                   (substring-no-properties (cider-current-ns :no-default
-                                                                              ;; important - don't query the repl,
-                                                                              ;; avoiding a recursive invocation of `cider--sesman-friendly-session-p`:
-                                                                              :no-repl-check))
-                                 (error nil))))
-                  ;; if the ns form matches with a ns of all runtime namespaces, we can consider the buffer to match
-                  ;; (this is a bit lax, but also quite useful)
-                  (with-current-buffer repl
-                    (or (when cider-repl-ns-cache ;; may be nil on repl startup
-                          (member ns (nrepl-dict-keys cider-repl-ns-cache)))
-                        (member ns ns-list))))
+                  (and proj-dir
+                       (seq-find (lambda (tp) (string-prefix-p proj-dir (file-truename tp)))
+                                 translated)))
                 (when debug
                   (list file
-                        "was not determined to belong to classpath:" classpath
-                        "or classpath-roots:" classpath-roots
-                        "or project-dir:" proj-dir))))))))))
+                        "was not determined to belong to project-dir:" proj-dir))))))))))
 
 (defun cider-debug-sesman-friendly-session-p ()
   "`message's debugging information relative to friendly sessions.

--- a/lisp/cider-session.el
+++ b/lisp/cider-session.el
@@ -463,7 +463,10 @@ Reverts to normal project-based session association."
   "Special buffer-local variable that contains reference to the REPL connection.
 This should be set in ancillary CIDER buffers that originate from some
 event (e.g. *cider-inspector*, *cider-error*) and which never change the
-REPL (connection) which produced them.")
+REPL (connection) which produced them.  It is also set on source buffers
+visited outside the project directory (e.g. a dependency's source jumped
+to via `cider-find-var'), pinning them to the session they were navigated
+from.")
 
 (defun cider-current-repl (&optional type ensure)
   "Get the most recent REPL of TYPE from the current session.
@@ -479,7 +482,8 @@ no linked session or there is no REPL of TYPE within the current session."
                  (eq cider-repl-type type)))
         ;; shortcut when in REPL buffer
         (current-buffer)
-      (or cider--ancillary-buffer-repl
+      (or (and (buffer-live-p cider--ancillary-buffer-repl)
+               cider--ancillary-buffer-repl)
           (let* ((type (if (or (null type)
                                (eq 'infer type))
                            (cider-repl-type-for-buffer)

--- a/test/cider-common-tests.el
+++ b/test/cider-common-tests.el
@@ -29,6 +29,7 @@
 
 (require 'buttercup)
 (require 'cider-common)
+(require 'cider-session)
 
 ;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
 
@@ -183,3 +184,43 @@
               :to-equal /docker/ns.clj)
       (expect (cider--translate-path-to-nrepl-test `((,/docker . ,/host)) /host/ns.clj)
               :to-equal /docker/ns.clj)))
+
+(describe "cider--pin-repl-if-out-of-project"
+  :var (proj-root repl-buf)
+
+  (before-each
+    (setq proj-root (file-name-as-directory
+                     (file-truename (make-temp-file "cider-pin-test-" t)))
+          repl-buf (get-buffer-create "*cider-pin-test-repl*"))
+    (with-current-buffer repl-buf
+      (setq-local nrepl-project-dir proj-root)))
+
+  (after-each
+    (when (buffer-live-p repl-buf)
+      (kill-buffer repl-buf))
+    (when (and proj-root (file-directory-p proj-root))
+      (delete-directory proj-root t)))
+
+  (it "pins the REPL when the buffer's file is outside its project dir"
+      (with-temp-buffer
+        (setq buffer-file-name (expand-file-name "/some/dep/src/ns.clj"))
+        (cider--pin-repl-if-out-of-project repl-buf)
+        (expect cider--ancillary-buffer-repl :to-be repl-buf)))
+
+  (it "leaves the buffer untouched when its file is inside the project dir"
+      (with-temp-buffer
+        (setq buffer-file-name (concat proj-root "src/ns.clj"))
+        (cider--pin-repl-if-out-of-project repl-buf)
+        (expect cider--ancillary-buffer-repl :to-be nil)))
+
+  (it "does nothing for a dead REPL buffer"
+      (kill-buffer repl-buf)
+      (with-temp-buffer
+        (setq buffer-file-name (expand-file-name "/some/dep/src/ns.clj"))
+        (cider--pin-repl-if-out-of-project repl-buf)
+        (expect cider--ancillary-buffer-repl :to-be nil)))
+
+  (it "does nothing for a non-file buffer"
+      (with-temp-buffer
+        (cider--pin-repl-if-out-of-project repl-buf)
+        (expect cider--ancillary-buffer-repl :to-be nil))))

--- a/test/cider-repl-tests.el
+++ b/test/cider-repl-tests.el
@@ -398,39 +398,52 @@ PROPERTY should be a symbol of either 'text, 'ansi-context or
           (expect (cider--sesman-friendly-session-p (list "a-session" b))
                   :to-be-truthy)))))
 
-  (describe "classpath matching"
-    ;; The matcher reads cached classpath/classpath-roots/ns-list from the
-    ;; REPL process.  We stub the process accessors so these tests don't
-    ;; need to spawn real subprocesses.
-    (it "matches when the buffer's directory is under a classpath entry"
+  (describe "project-dir matching"
+    ;; The matcher reads the cached, truename'd project dir from the REPL
+    ;; process.  We stub the process accessors so these tests don't need to
+    ;; spawn real subprocesses.
+    (it "matches when the buffer's file is under the cached project dir"
       (with-repl-buffer "a-session" 'clj b
-        (let ((classpath (list (concat fake-proj-root "src/"))))
-          (spy-on 'get-buffer-process :and-return-value 'fake-proc)
-          (spy-on 'process-live-p :and-return-value t)
-          (spy-on 'process-get :and-call-fake
-                  (lambda (_proc key)
-                    (pcase key (:cached-classpath classpath) (_ nil))))
-          (with-temp-buffer
-            (setq default-directory (concat fake-proj-root "src/foo/"))
-            (expect (cider--sesman-friendly-session-p (list "a-session" b))
-                    :to-be-truthy)))))
+        (spy-on 'get-buffer-process :and-return-value 'fake-proc)
+        (spy-on 'process-live-p :and-return-value t)
+        (spy-on 'process-get :and-call-fake
+                (lambda (_proc key)
+                  (pcase key (:cached-project-dir fake-proj-root) (_ nil))))
+        (with-temp-buffer
+          (setq default-directory (concat fake-proj-root "src/foo/"))
+          (expect (cider--sesman-friendly-session-p (list "a-session" b))
+                  :to-be-truthy))))
 
-    (it "uses `file-in-directory-p' for classpath roots (no spurious prefix matches)"
-      ;; A classpath root of `<root>/foo' must NOT match a file under
-      ;; `<root>/foobar/' -- the bug that `string-prefix-p' had.
+    (it "respects directory boundaries (no spurious prefix matches)"
+      ;; A project dir of `<root>/foo/' must NOT match a file under
+      ;; `<root>/foobar/' -- the trailing slash makes `string-prefix-p'
+      ;; a correct directory-boundary check.
       (with-repl-buffer "a-session" 'clj b
-        (let ((roots (list (concat fake-proj-root "foo/"))))
-          (spy-on 'get-buffer-process :and-return-value 'fake-proc)
-          (spy-on 'process-live-p :and-return-value t)
-          (spy-on 'process-get :and-call-fake
-                  (lambda (_proc key)
-                    (pcase key (:cached-classpath-roots roots) (_ nil))))
-          (with-temp-buffer
-            (setq default-directory (concat fake-proj-root "foobar/src/"))
-            (expect (cider--sesman-friendly-session-p (list "a-session" b))
-                    :not :to-be-truthy)))))
+        (spy-on 'get-buffer-process :and-return-value 'fake-proc)
+        (spy-on 'process-live-p :and-return-value t)
+        (spy-on 'process-get :and-call-fake
+                (lambda (_proc key)
+                  (pcase key
+                    (:cached-project-dir (concat fake-proj-root "foo/"))
+                    (_ nil))))
+        (with-temp-buffer
+          (setq default-directory (concat fake-proj-root "foobar/src/"))
+          (expect (cider--sesman-friendly-session-p (list "a-session" b))
+                  :not :to-be-truthy))))
 
-    (it "falls back to nrepl-project-dir when classpath misses"
+    (it "returns nil for files outside the project dir"
+      (with-repl-buffer "a-session" 'clj b
+        (spy-on 'get-buffer-process :and-return-value 'fake-proc)
+        (spy-on 'process-live-p :and-return-value t)
+        (spy-on 'process-get :and-call-fake
+                (lambda (_proc key)
+                  (pcase key (:cached-project-dir fake-proj-root) (_ nil))))
+        (with-temp-buffer
+          (setq default-directory (file-truename temporary-file-directory))
+          (expect (cider--sesman-friendly-session-p (list "a-session" b))
+                  :not :to-be-truthy))))
+
+    (it "falls back to buffer-local nrepl-project-dir when the cache is empty"
       (with-repl-buffer "a-session" 'clj b
         (with-current-buffer b
           (setq-local nrepl-project-dir fake-proj-root))


### PR DESCRIPTION
Fixes #3933.

The reported lag comes from the friendly-session matcher running on the redisplay hot path (the mode-line `:eval` calls `cider-current-repl`, which scans every session). Since #3909 that scan ran `file-truename` over every classpath root on each call, which is what tipped it into "unusable".

yuhan0's proposed fix (precompute the truename'd roots, revert to `string-prefix-p`) is correct and I started there, but it only makes the per-redisplay scan cheaper - it still iterates the whole classpath, on every cycle, for every session. I went for a deeper change instead because the classpath scan never needed to be there:

friendly sessions were originally introduced (#2446) purely to make `cider-find-var` into a dependency's source resolve to the project's REPL. That single use case is handled much more precisely by pinning the buffer to the session it was navigated from, which is what the first commit does. Once that's in place, the matcher doesn't need classpath or namespace inference at all - it just checks whether the buffer's file lives under a session's project directory, which is one cheap `string-prefix-p`. That also lets us drop the `classpath` and `ns-list` round-trips we were doing at every connection.

The tradeoff: a file *outside* the project dir that you open by some means other than a CIDER navigation command (e.g. a plain `find-file` into a jar) won't auto-associate anymore. `cider-default-session` and explicit sesman links remain the escape hatch. Given how much cheaper and more predictable this makes the common path, I think that's a good trade.

Three focused commits: pin-on-jump first (so dependency navigation keeps working), then the matcher simplification, then docs/changelog.

cc @yuhan0 - thanks for the detailed analysis and root-cause in the issue, it made this easy to reason about.

- [x] The commits are consistent with the contribution guidelines
- [x] You've added tests to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`)
- [x] You've updated the changelog
- [x] You've updated the user manual