### PR TITLE
Fix cider-find-keyword honoring the prefix arg

### DIFF
--- a/lisp/cider-find.el
+++ b/lisp/cider-find.el
@@ -38,7 +38,7 @@
 Display the results in a different window."
   (if-let* ((info (cider-var-info var)))
       (progn
-        (if line (setq info (nrepl-dict-put info "line" line)))
+        (when line (setq info (nrepl-dict-put info "line" line)))
         (cider--jump-to-loc-from-info info t))
     (user-error "Symbol `%s' not resolved" var)))
 
@@ -46,7 +46,7 @@ Display the results in a different window."
   "Find the definition of VAR, optionally at a specific LINE."
   (if-let* ((info (cider-var-info var)))
       (progn
-        (if line (setq info (nrepl-dict-put info "line" line)))
+        (when line (setq info (nrepl-dict-put info "line" line)))
         (cider--jump-to-loc-from-info info))
     (user-error "Symbol `%s' not resolved" var)))
 
@@ -116,7 +116,7 @@ inverts the meaning.  A prefix of `-' or a double prefix argument causes
 the results to be displayed in a different window.  A default value of thing
 at point is given when prompted."
   (interactive (cider--find-dwim-interactive "Jump to: "))
-  (cider--find-dwim symbol-file `cider-find-dwim
+  (cider--find-dwim symbol-file 'cider-find-dwim
                     (cider--open-other-window-p current-prefix-arg)))
 
 ;;;###autoload
@@ -157,7 +157,7 @@ This function preserves the `other-window' meaning of ARG."
       (_ 4)))) ; no-prefix -> empty
 
 (defun cider--prefix-invert-prompt-p (arg)
-  "Test prefix value ARG for its effect on `cider-prompt-for-symbol`."
+  "Test prefix value ARG for its effect on `cider-prompt-for-symbol'."
   (let ((narg (prefix-numeric-value arg)))
     (pcase narg
       (16 t) ; empty empty
@@ -193,9 +193,9 @@ the results to be displayed in a different window."
       (cider--find-ns ns (cider--open-other-window-p arg)))))
 
 (defun cider--find-keyword-in-buffer (buffer kw)
-  "Returns the point where `KW' is found in `BUFFER'.
-Returns nil of no matching keyword is found.
-Occurrences of `KW' as (or within) strings, comments, #_ forms, symbols, etc
+  "Return the point where KW is found in BUFFER.
+Return nil if no matching keyword is found.
+Occurrences of KW as (or within) strings, comments, #_ forms, symbols, etc
 are disregarded."
   (with-current-buffer buffer
     (save-excursion
@@ -215,9 +215,9 @@ are disregarded."
           current-point)))))
 
 (defun cider--find-keyword-loc (kw)
-  "Given `KW', returns an nrepl-dict with url, dest, dest-point.
+  "Return an nrepl-dict with url, dest, dest-point for KW.
 
-Returns the dict in all cases.  `dest-point' indicates success:
+Return the dict in all cases.  `dest-point' indicates success:
 integer on successful finds, nil otherwise."
   (let* ((simple-ns-qualifier (and
                                (string-match "^:\\(.+\\)/.+$" kw)
@@ -275,7 +275,7 @@ thing at point."
          (result (cider--find-keyword-loc kw)))
     (nrepl-dbind-response result (dest dest-point)
       (if dest-point
-          (cider-jump-to dest dest-point arg)
+          (cider-jump-to dest dest-point (cider--open-other-window-p arg))
         (progn
           (unless (memq dest before)
             (kill-buffer dest))

--- a/test/cider-find-tests.el
+++ b/test/cider-find-tests.el
@@ -39,6 +39,27 @@
     (spy-on 'cider-nrepl-op-supported-p :and-return-value nil)
     (expect (cider-find-ns) :to-throw 'user-error)))
 
+(describe "cider-find-keyword"
+  ;; Regression test: a single `C-u' must NOT open another window; only `-'
+  ;; or a double prefix should, matching the sibling find commands and the
+  ;; docstring.  Previously the raw prefix arg was passed straight to
+  ;; `cider-jump-to', so any prefix opened another window.
+  (it "dispatches to another window only for `-' or a double prefix"
+    (spy-on 'cider-ensure-connected :and-return-value t)
+    (spy-on 'read-string :and-return-value "::foo")
+    (spy-on 'cider-symbol-at-point :and-return-value "::foo")
+    (spy-on 'cider--find-keyword-loc :and-return-value
+            (nrepl-dict "dest" (current-buffer) "dest-point" 1))
+    (spy-on 'cider-jump-to)
+    (cider-find-keyword '(4))           ; single C-u -> same window
+    (expect (nth 2 (spy-calls-args-for 'cider-jump-to 0)) :to-be nil)
+    (spy-calls-reset 'cider-jump-to)
+    (cider-find-keyword '(16))          ; double C-u -> other window
+    (expect (nth 2 (spy-calls-args-for 'cider-jump-to 0)) :to-be-truthy)
+    (spy-calls-reset 'cider-jump-to)
+    (cider-find-keyword '-)             ; negative -> other window
+    (expect (nth 2 (spy-calls-args-for 'cider-jump-to 0)) :to-be-truthy)))
+
 (describe "cider--find-keyword-loc"
   (it "finds the given keyword, discarding false positives"
     (with-clojure-buffer "(ns some.ns)


### PR DESCRIPTION
First of a series of small per-module cleanups from an audit of the CIDER modules.

The real fix: `cider-find-keyword` passed its raw prefix arg to `cider-jump-to` as the other-window flag, so a single `C-u` (or any prefix) wrongly opened the result in another window. Its docstring and every sibling `cider-find-*` command say only `-` or a double prefix should. Now it routes through `cider--open-other-window-p` like the others, with a regression test.

Along the way I tidied this module's docstrings the audit flagged: imperative mood plus an of/if typo in the keyword-search helpers, a couple of stray backtick/backquote quotes, and `when` for the one-armed `if`s.

- [x] Tests pass (`eldev test`)
- [x] Linter clean (`eldev lint`)
- [x] Changelog updated