### PR TITLE
Fix the malformed Clojure Interaction mode menu

### DIFF
--- a/doc/modules/ROOT/pages/usage/misc_features.adoc
+++ b/doc/modules/ROOT/pages/usage/misc_features.adoc
@@ -14,6 +14,11 @@ kbd:[M-x] `cider-scratch` command. This is a great way to play
 around with some code without having to create source files or pollute
 the REPL buffer and is very similar to Emacs's own `+*scratch*+` buffer.
 
+In the scratchpad, kbd:[C-j] (`cider-eval-print-last-sexp`) evaluates the
+expression before point and prints its value inline, advancing point;
+kbd:[C-u C-j] pretty-prints the result instead. `cider-scratch-reset`
+clears the buffer back to its initial state.
+
 == Find References
 
 NOTE: The functionality is based on https://metaredux.com/posts/2019/12/11/hard-cider-find-usages.html[ideas from this article] and was

--- a/lisp/cider-scratch.el
+++ b/lisp/cider-scratch.el
@@ -52,9 +52,9 @@
     (easy-menu-define cider-clojure-interaction-mode-menu map
       "Menu for Clojure Interaction mode"
       '("Clojure Interaction"
-        (["Eval and print last sexp" #'cider-eval-print-last-sexp]
-         "--"
-         ["Reset" #'cider-scratch-reset])))
+        ["Eval and print last sexp" cider-eval-print-last-sexp]
+        "--"
+        ["Reset" cider-scratch-reset]))
     map))
 
 (defconst cider-scratch-buffer-name "*cider-scratch*")


### PR DESCRIPTION
Part of the per-module audit cleanups.

The `easy-menu-define` for `cider-clojure-interaction-mode` (the scratchpad's major mode) wrapped its two entries plus the separator in an extra set of parens, so easymenu read them as a *submenu* named after the first vector. The result: "Eval and print last sexp" showed up as an empty submenu instead of a working command. The vector elements were also sharp-quoted (`#'foo`), which easymenu wraps in generated `menu-function-N` lambdas. Flattened the entries and switched to bare command symbols, matching the convention in `cider-browse-spec.el`.

Also documented the scratchpad's `C-j` / `C-u C-j` eval keys and `cider-scratch-reset` in the manual, which weren't mentioned.

No automated test - easymenu structure isn't meaningfully unit-testable; the fix mirrors the established in-tree convention.

- [x] Tests pass (`eldev test`)
- [x] Linter clean (`eldev lint`)
- [x] Changelog + manual updated