### PR TITLE
Fix cider-repl-history overlay lookup ignoring its position

### DIFF
--- a/doc/modules/ROOT/pages/repl/history.adoc
+++ b/doc/modules/ROOT/pages/repl/history.adoc
@@ -126,7 +126,6 @@ when the text is inserted into the REPL.
 this gives the text to use as the separator. The default is a series of ten
 semicolons, which is, of course, a comment in Clojure. The separator could be
 anything, but it may screw up the fontification if you make it something weird.
-* `cider-repl-history-separator-face` - specifies the face for the separator.
 * `cider-repl-history-maximum-display-length` - when nil (the default), all history
 items are displayed in full. If you prefer to have long items abbreviated,
 you can set this variable to an integer, and each item will be limited to that

--- a/lisp/cider-repl-history.el
+++ b/lisp/cider-repl-history.el
@@ -326,11 +326,12 @@ it's turned on."
      before-insert
      (point))))
 
-(defun cider-repl-history-target-overlay-at (_position &optional no-error)
+(defun cider-repl-history-target-overlay-at (position &optional no-error)
   "Return overlay at POSITION that has property `cider-repl-history-target'.
+POSITION defaults to point.
 If no such overlay, raise an error unless NO-ERROR is true, in which
 case return nil."
-  (let ((ovs  (overlays-at (point))))
+  (let ((ovs (overlays-at (or position (point)))))
     (catch 'cider-repl-history-target-overlay-at
       (dolist (ov ovs)
         (when (overlay-get ov 'cider-repl-history-target)
@@ -348,7 +349,7 @@ Might error unless NO-ERROR set."
         (error "No CIDER history item in this buffer")))))
 
 (defun cider-repl-history-do-insert (_buf pt)
-  "Helper function to insert text from BUF at PT into the REPL buffer.
+  "Helper function to insert the history entry at PT into the REPL buffer.
 Also kills *cider-repl-history*."
   ;; Note: as mentioned at the top, this file is based on browse-kill-ring,
   ;; which has numerous insertion options.  The functionality of

--- a/test/cider-repl-history-tests.el
+++ b/test/cider-repl-history-tests.el
@@ -111,6 +111,25 @@
       (expect (car (nth 0 out)) :to-equal 1)
       (expect (car (nth 1 out)) :to-equal 3))))
 
+(describe "cider-repl-history-target-overlay-at"
+  ;; Regression test: the overlay must be looked up at the POSITION
+  ;; argument, not always at point.  The arg used to be ignored and
+  ;; `(point)' hard-coded, so e.g. mouse insertion (which restores point
+  ;; away from the click target) could grab the wrong history entry.
+  (it "honors the POSITION argument instead of point"
+    (with-temp-buffer
+      (insert "AAAAA\nBBBBB\n")
+      (let ((ov-a (make-overlay 2 3))
+            (ov-b (make-overlay 8 9)))
+        (overlay-put ov-a 'cider-repl-history-target "entry-a")
+        (overlay-put ov-b 'cider-repl-history-target "entry-b")
+        (goto-char 2)                   ; point sits on the A overlay
+        ;; ...but we ask for the overlay at the B position
+        (expect (cider-repl-history-target-overlay-at 8) :to-be ov-b)
+        (expect (cider-repl-history-current-string 8) :to-equal "entry-b")
+        ;; a nil position falls back to point (the A overlay)
+        (expect (cider-repl-history-target-overlay-at nil) :to-be ov-a)))))
+
 (provide 'cider-repl-history-tests)
 
 ;;; cider-repl-history-tests.el ends here


### PR DESCRIPTION
Part of the per-module audit cleanups.

`cider-repl-history-target-overlay-at` took a `_position` argument but ignored it, hard-coding `(overlays-at (point))`. That's a real bug for `cider-repl-history-mouse-insert` (mouse-2): it captures the clicked position inside a `save-excursion`, so point is restored to the pre-click location while the intended position is the click target. As a result mouse insertion could grab the wrong history entry. Now the lookup honors the argument (defaulting to point when nil), with a regression test.

Also: reworded the `cider-repl-history-do-insert` docstring (it referenced the ignored `BUF` arg) and removed a stale `cider-repl-history-separator-face` entry from the manual - no such face exists in the code.

- [x] Tests pass (`eldev test`, incl. new spec)
- [x] Linter clean (`eldev lint`)
- [x] Changelog + manual updated