### PR TITLE
Fix cider-browse-ns docstrings and a redundant lookup

### DIFF
--- a/doc/modules/ROOT/pages/usage/misc_features.adoc
+++ b/doc/modules/ROOT/pages/usage/misc_features.adoc
@@ -168,6 +168,9 @@ There are a bunch of useful keybindings that are defined in browser buffers.
 | kbd:[^]
 | Browse all namespaces.
 
+| kbd:[a]
+| Toggle showing all items (ignore active filters).
+
 | kbd:[n]
 | Go to next line.
 

--- a/lisp/cider-browse-ns.el
+++ b/lisp/cider-browse-ns.el
@@ -140,8 +140,8 @@ Available options include `private', `test', `macro', `function', and
   "Return font-lock-face for a var.
 VAR-META contains the metadata information used to decide a face.
 Presence of \"arglists\" and \"macro\" indicates a macro form.
-Only \"arglists\" indicates a function. Otherwise, its a variable.
-If the NAMESPACE is not loaded in the REPL, assume TEXT is a fn."
+Only \"arglists\" indicates a function.  Otherwise, it's a variable.
+When VAR-META is nil, default to `font-lock-function-name-face'."
   (cond
    ((not var-meta) 'font-lock-function-name-face)
    ((and (nrepl-dict-contains var-meta "arglists")
@@ -229,7 +229,7 @@ displayed."
 (defun cider-browse-ns--propertized-item (key items)
   "Return propertized line of item KEY in nrepl-dict ITEMS."
   (let* ((var-meta (nrepl-dict-get items key))
-         (face (cider-browse-ns--text-face (nrepl-dict-get items key)))
+         (face (cider-browse-ns--text-face var-meta))
          (private-p (string= (nrepl-dict-get var-meta "private") "true"))
          (test-p (nrepl-dict-contains var-meta "test"))
          (ns-p (nrepl-dict-contains var-meta "ns")))
@@ -323,7 +323,7 @@ list of items."
     (cider-browse-ns--filter flag)))
 
 (defun cider-browse-ns--group (flag)
-  "Set the group-by option to FLAG and re-renderthe buffer."
+  "Set the group-by option to FLAG and re-render the buffer."
   (setq cider-browse-ns-group-by
         (if (eql flag cider-browse-ns-group-by) nil flag))
   (cider-browse-ns--render-buffer))
@@ -444,7 +444,7 @@ var-meta map."
 
 ;;;###autoload
 (defun cider-browse-ns (namespace)
-  "List all NAMESPACE's vars in BUFFER."
+  "List all NAMESPACE's vars."
   (interactive (list (completing-read "Browse namespace: " (cider-sync-request:ns-list))))
   (with-current-buffer (cider-popup-buffer cider-browse-ns-buffer 'select nil 'ancillary)
     (cider-browse-ns--list (current-buffer)
@@ -454,7 +454,7 @@ var-meta map."
 
 ;;;###autoload
 (defun cider-browse-ns-all ()
-  "List all loaded namespaces in BUFFER."
+  "List all loaded namespaces."
   (interactive)
   (with-current-buffer (cider-popup-buffer cider-browse-ns-buffer 'select nil 'ancillary)
     (let ((names (cider-sync-request:ns-list)))
@@ -508,12 +508,12 @@ Return a list of the type (`ns' or `var') and the value."
   (cider-browse-ns--filter 'var))
 
 (defun cider-browse-ns-group-by-type ()
-  "Toggle visibility of var items displayed in browse-ns buffer."
+  "Group items in the browse-ns buffer by type."
   (interactive)
   (cider-browse-ns--group 'type))
 
 (defun cider-browse-ns-group-by-visibility ()
-  "Toggle visibility of var items displayed in browse-ns buffer."
+  "Group items in the browse-ns buffer by visibility."
   (interactive)
   (cider-browse-ns--group 'visibility))
 


### PR DESCRIPTION
Part of the per-module audit cleanups. All behavior-preserving.

- `cider-browse-ns-group-by-type` / `cider-browse-ns-group-by-visibility` had a copy-pasted "Toggle visibility of var items..." docstring that describes the wrong behavior (they group, not toggle visibility).
- `cider-browse-ns` and `cider-browse-ns-all` docstrings referenced a `BUFFER` argument neither takes (checkdoc flags the bogus uppercase word). Dropped "in BUFFER".
- `cider-browse-ns--text-face` docstring referenced stale `NAMESPACE`/`REPL`/`TEXT` args from an old refactor; now describes only `VAR-META`. Also fixed a "re-renderthe" typo.
- `cider-browse-ns--propertized-item` called `(nrepl-dict-get items key)` twice; reuse the existing `var-meta` binding.
- Documented the `a` (toggle-all) key in the namespace-browser keybindings table.

- [x] Tests pass (`eldev test`)
- [x] Linter clean (`eldev lint`)