### PR TITLE
Tidy cider-endpoint (dead code, redundant call, docstrings, docs)

### DIFF
--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -484,7 +484,10 @@ A few things still need attention when jacking in over TRAMP:
   `default-directory`.  When you invoke `cider-connect` from a TRAMP
   buffer, CIDER queries the remote host -- assuming `ps` and `lsof` are
   installed there.  If they aren't, the completion list will simply be
-  empty.
+  empty.  The scan result is cached per `default-directory` for
+  `cider-running-nrepl-paths-cache-ttl` seconds (5 by default), so
+  back-to-back completions don't re-spawn the subprocesses; call
+  `cider-clear-running-nrepl-paths-cache` to discard it on demand.
 - *Server-printed bind addresses.*  Some servers (e.g. babashka) print
   the bound address as `localhost`, `127.0.0.1`, or `0.0.0.0`.  CIDER
   treats those as wildcard/loopback and falls back to the TRAMP host so

--- a/lisp/cider-endpoint.el
+++ b/lisp/cider-endpoint.el
@@ -180,14 +180,12 @@ of remote SSH hosts."
                           (eq ?d filetype))))))
 
 (defun cider--path->path-port-pairs (path)
-  "Given PATH, returns all the possible <path, port> pairs."
+  "Return all the possible <path, port> pairs for PATH."
   (thread-last path
                cider--file-path
                nrepl-extract-ports
                (mapcar (lambda (port)
-                         (list path port)))
-               ;; remove nils that may have been returned due to permission errors:
-               (seq-filter #'identity)))
+                         (list path port)))))
 
 
 ;;; Running nREPL discovery
@@ -209,7 +207,7 @@ called from a TRAMP buffer."
     (buffer-string)))
 
 (defun cider--invoke-running-nrepl-path (f)
-  "Invokes F safely.
+  "Invoke F safely.
 
 Necessary since we run some OS-specific commands that may fail."
   (condition-case nil
@@ -305,8 +303,9 @@ Do it by looping over the open REPL buffers."
                (seq-map
                 (lambda (b)
                   (with-current-buffer b
-                    (when-let ((dir (plist-get (cider--gather-connect-params) :project-dir))
-                               (port (plist-get (cider--gather-connect-params) :port)))
+                    (when-let* ((params (cider--gather-connect-params))
+                                (dir (plist-get params :project-dir))
+                                (port (plist-get params :port)))
                       (list dir (prin1-to-string port))))))
                (seq-filter #'identity)))
 


### PR DESCRIPTION
Part of the per-module audit cleanups. All behavior-preserving.

- `cider--path->path-port-pairs` ended with `(seq-filter #'identity)`, but the preceding `mapcar` always produces non-nil `(path port)` cells and `nrepl-extract-ports` already drops nils, so the filter was dead. Removed it (and the stale comment).
- `cider--running-local-nrepl-paths` called `cider--gather-connect-params` twice in the same `when-let`; bind it once via `when-let*`.
- Fixed two non-imperative docstrings (`returns`/`Invokes`).
- Documented the running-nREPL path-scan cache (`cider-running-nrepl-paths-cache-ttl` and `cider-clear-running-nrepl-paths-cache`) in the endpoint-discovery note.

- [x] Tests pass (`eldev test`)
- [x] Linter clean (`eldev lint`)