### PR TITLE
Tidy cider.el (project-dir nesting, defcustom version, unused requires)

### DIFF
--- a/lisp/cider.el
+++ b/lisp/cider.el
@@ -102,12 +102,10 @@
 (require 'cider-debug)
 (require 'cider-util)
 
-(require 'cl-lib)
 (require 'tramp-sh)
 (require 'subr-x)
 (require 'seq)
 (require 'sesman)
-(require 'package)
 
 (defconst cider-version "1.22.0-snapshot"
   "The current version of CIDER.")
@@ -372,8 +370,8 @@ Params is a plist with the following keys (non-exhaustive)
           (dolist (pair (buffer-local-variables orig-buffer))
             (pcase pair
               (`(,name . ,value)        ;ignore unbound variables
-               (ignore-errors (set (make-local-variable name) value))))
-          (setq-local buffer-file-name nil))
+               (ignore-errors (set (make-local-variable name) value)))))
+          (setq-local buffer-file-name nil)
           (let ((default-directory proj-dir))
             (hack-dir-local-variables-non-file-buffer)
             (thread-first params
@@ -384,7 +382,7 @@ Params is a plist with the following keys (non-exhaustive)
   "When truthy allow the user to edit the command."
   :type 'boolean
   :safe #'booleanp
-  :version '(cider . "0.22.0"))
+  :package-version '(cider . "0.22.0"))
 
 (defvar cider--jack-in-nrepl-params-history nil
   "History list for user-specified jack-in nrepl command params.")


### PR DESCRIPTION
Part of the per-module audit cleanups.

- `cider--update-project-dir` had `(setq-local buffer-file-name nil)` accidentally nested inside the `dolist` (an indentation-masked paren), so it ran on every iteration - and never at all if the buffer had no local variables. Moved it out so it runs exactly once. Idempotent, so output is unchanged for the common case and strictly more correct for the empty case.
- `cider-edit-jack-in-command` used `:version '(cider . "0.22.0")`, but `:version` expects a plain Emacs version string; the `(PACKAGE . VERSION)` cons is the `:package-version` form (used by every other defcustom here). Fixed.
- Dropped the unused `cl-lib` and `package` requires (no `cl-`/`package-` symbols in the file; verified by compile with `--warnings-as-errors`). Kept `tramp-sh`, which registers ssh/scp methods relied on during remote jack-in.

- [x] Tests pass (`eldev test`)
- [x] Linter clean (`eldev lint`)