### PR TITLE
Tidy cider-client (require cl-lib, defcustom version, docstrings)

### DIFF
--- a/lisp/cider-client.el
+++ b/lisp/cider-client.el
@@ -25,6 +25,7 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'map)
 (require 'seq)
 (require 'subr-x)
@@ -163,7 +164,8 @@ than \"clj.foo.bar\"."
   :group 'cider
   :safe (lambda (value)
           (and (listp value)
-               (cl-every #'stringp value))))
+               (cl-every #'stringp value)))
+  :package-version '(cider . "1.22.0"))
 
 (defun cider--ns-from-path (path)
   "Derive a Clojure namespace from PATH using project layout heuristics.
@@ -613,8 +615,9 @@ without having to specify a Java class for the current candidate
      ,@body))
 
 (defun cider-class-choice-completing-read (prompt candidates)
-  "A completing read that can be customized with the `advice' mechanism,
-forwarding PROMPT and CANDIDATES as-is.
+  "Read a class choice, forwarding PROMPT and CANDIDATES as-is.
+This is a `completing-read' wrapper that can be customized with the
+`advice' mechanism.
 
 See also: `cider--with-temporary-ido-keys'."
   (completing-read prompt candidates))
@@ -1027,7 +1030,7 @@ side effects; only the global handlers fire (need-input, eval-error, ...)."
   (cider-make-eval-handler :buffer (current-buffer)))
 
 (defun cider-need-input (buffer)
-  "Handle an need-input request from BUFFER."
+  "Handle a need-input request from BUFFER."
   (with-current-buffer buffer
     (let ((map (make-sparse-keymap)))
       (set-keymap-parent map minibuffer-local-map)


### PR DESCRIPTION
Part of the per-module audit cleanups.

- Added `(require 'cl-lib)`. The file uses `cl-defun` (pervasively), plus `cl-every` and `cl-reduce`, but only required `seq`/`map` directly and pulled `cl-lib` in transitively.
- `cider-directory-prefixes` was the only defcustom in the file without a `:package-version`; added one (1.22.0, matching when the ns-derivation heuristics landed).
- Docstrings: `cider-class-choice-completing-read`'s first line wasn't a complete sentence (the sole checkdoc warning in the file), and `cider-need-input` had "Handle an need-input request".

I skipped the audit's optional doc-gap note for `cider-directory-prefixes` - there's no namespace-derivation page in the manual today, and a dedicated section for this niche knob felt disproportionate. Happy to add one if you'd like.

- [x] Tests pass (`eldev test`)
- [x] Linter clean (`eldev lint`)