### PR TITLE
Docstring and checkdoc cleanups across modules

### DIFF
--- a/lisp/cider-browse-spec.el
+++ b/lisp/cider-browse-spec.el
@@ -242,7 +242,7 @@ Display TITLE at the top and SPECS are indented underneath."
                      (string-join)))))
 
 (defun cider-browse-spec--pprint (form)
-  "Given a spec FORM builds a multi line string with a pretty render of that FORM."
+  "Build a multi-line string with a pretty render of the spec FORM."
   (cond ((stringp form)
          (if (cider--qualified-keyword-p form)
              (with-temp-buffer

--- a/lisp/cider-cheatsheet.el
+++ b/lisp/cider-cheatsheet.el
@@ -37,7 +37,8 @@
   :prefix "cider-cheatsheet-"
   :group 'cider)
 
-(defconst cider-cheatsheet-buffer "*cider-cheatsheet*")
+(defconst cider-cheatsheet-buffer "*cider-cheatsheet*"
+  "Name of the CIDER cheatsheet buffer.")
 
 (defcustom cider-cheatsheet-auto-select-buffer t
   "Whether to auto-select the cheatsheet popup buffer."
@@ -47,8 +48,8 @@
 (defcustom cider-cheatsheet-default-action-function #'cider-doc-lookup
   "Function to use on a var when it is selected.
 
-By default, documentation for a var is displayed using `cider-doc-lookup`,
-but it can also be set to `cider-clojuredocs-lookup` to show documentation
+By default, documentation for a var is displayed using `cider-doc-lookup',
+but it can also be set to `cider-clojuredocs-lookup' to show documentation
 from ClojureDocs or any other function accepting a var as an argument."
   :type '(choice (const cider-doc-lookup)
                  (const cider-clojuredocs-lookup)

--- a/lisp/cider-classpath.el
+++ b/lisp/cider-classpath.el
@@ -62,7 +62,7 @@
       (goto-char (point-min)))))
 
 (defun cider-classpath-properties (text)
-  "Decorate TEXT with a clickable keymap and function face."
+  "Decorate TEXT with a clickable keymap and a face based on its status."
   (let ((face (cond
                ((not (file-exists-p text)) 'font-lock-warning-face)
                ((file-directory-p text) 'dired-directory)

--- a/lisp/cider-common.el
+++ b/lisp/cider-common.el
@@ -149,8 +149,8 @@ so they keep tracking the current session."
 
 (defcustom cider-jump-to-pop-to-buffer-actions
   '((display-buffer-reuse-window display-buffer-same-window))
-  "Determines what window `cider-jump-to` uses.
-The value is passed as the `action` argument to `pop-to-buffer`.
+  "Determine what window `cider-jump-to' uses.
+The value is passed as the `action' argument to `pop-to-buffer'.
 
 The default value means:
 
@@ -252,10 +252,10 @@ create a valid path."
       filename)))
 
 (defun cider-make-tramp-prefix (method user host &optional port)
-  "Constructs a Tramp file prefix from METHOD, USER, HOST, PORT.
-It originated from Tramp's `tramp-make-tramp-file-name'.  The original be
-forced to make full file name with `with-parsed-tramp-file-name', not providing
-prefix only option."
+  "Construct a Tramp file prefix from METHOD, USER, HOST, PORT.
+It originated from Tramp's `tramp-make-tramp-file-name'.  The original was
+forced to make a full file name with `with-parsed-tramp-file-name', with no
+prefix-only option."
   (concat tramp-prefix-format
           (unless (zerop (length method))
             (concat method tramp-postfix-method-format))
@@ -331,7 +331,7 @@ whether DIRECTION is `from-nrepl' or `to-nrepl'."
         (seq-some f cider-path-translations)))))
 
 (defun cider--all-path-translations ()
-  "Returns `cider-path-translations' if non-empty, else seeks a present value."
+  "Return `cider-path-translations' if non-empty, else seek a present value."
   (or cider-path-translations
       ;; cider-path-translations often is defined as a directory-local variable,
       ;; so after jumping to a .jar file, its value can be lost,
@@ -364,6 +364,7 @@ whether DIRECTION is `from-nrepl' or `to-nrepl'."
 (defcustom cider-prefer-local-resources nil
   "Prefer local resources to remote (tramp) ones when both are available."
   :type 'boolean
+  :package-version '(cider . "0.7.0")
   :group 'cider)
 
 (defun cider--file-path (path)

--- a/lisp/cider-completion-context.el
+++ b/lisp/cider-completion-context.el
@@ -33,7 +33,7 @@
   :package-version '(cider . "0.7.0"))
 
 (defun cider-completion--bounds-of-non-string-symbol-at-point ()
-  "Returns the bounds of the symbol at point, unless it's inside a string."
+  "Return the bounds of the symbol at point, unless it's inside a string."
   (let ((sap (symbol-at-point)))
     (when (and sap (not (nth 3 (syntax-ppss))))
       (bounds-of-thing-at-point 'symbol))))
@@ -76,7 +76,7 @@ the current symbol at point."
 
 (defun cider-completion-get-context-at-point ()
   "Extract the context at point.
-If point is not inside the list, returns nil; otherwise return \"top-level\"
+If point is not inside the list, return nil; otherwise return \"top-level\"
 form, with symbol at point replaced by __prefix__."
   (when (save-mark-and-excursion
           (condition-case _

--- a/lisp/cider-completion.el
+++ b/lisp/cider-completion.el
@@ -115,7 +115,7 @@ if the candidate is not namespace-qualified."
 
 (defun cider-completion--parse-candidate-map (candidate-map)
   "Get \"candidate\" from CANDIDATE-MAP.
-Put type and ns properties on the candidate"
+Put type and ns properties on the candidate."
   (let ((candidate (nrepl-dict-get candidate-map "candidate"))
         (type (nrepl-dict-get candidate-map "type"))
         (ns (nrepl-dict-get candidate-map "ns")))
@@ -156,7 +156,7 @@ completion functionality."
     (get-text-property 0 'ns symbol)))
 
 (defun cider-default-annotate-completion-function (type ns)
-  "Get completion function based on TYPE and NS."
+  "Return an annotation string built from TYPE and NS."
   (concat (when ns (format " (%s)" ns))
           (when type (format " <%s>" type))))
 
@@ -277,14 +277,14 @@ in the buffer."
                "CIDER backend-driven completion style."))
 
 (defun cider-company-enable-fuzzy-completion ()
-  "Enables `cider' completion style for CIDER in all buffers.
+  "Enable `cider' completion style for CIDER in all buffers.
 
 DEPRECATED: please use `cider-enable-cider-completion-style' instead."
   (interactive)
   (cider-enable-cider-completion-style))
 
 (defun cider-enable-cider-completion-style (&optional arg)
-  "Enables or disables `cider' completion style for CIDER in all buffers.
+  "Enable or disable `cider' completion style for CIDER in all buffers.
 
 This style supports non-prefix completion candidates returned by the
 completion backend.  Only affects the `cider' completion category.  If ARG
@@ -312,9 +312,9 @@ is `1' or nil, enables the custom completion style; if `-1', disables it."
 (make-obsolete 'cider-company-enable-fuzzy-completion 'cider-enable-cider-completion-style "1.17.0")
 
 (defun cider-enable-flex-completion ()
-  "Enables `flex' (fuzzy) completion for CIDER in all buffers.
+  "Enable `flex' (fuzzy) completion for CIDER in all buffers.
 
-Only affects the `cider' completion category.`"
+Only affects the `cider' completion category."
   (interactive)
   (let ((found-styles (when-let ((cider (assq 'cider completion-category-overrides)))
                         (assq 'styles cider)))

--- a/lisp/cider-debug.el
+++ b/lisp/cider-debug.el
@@ -429,7 +429,7 @@ In order to work properly, this mode must be activated by
       (string-match "[[:upper:]]" (string last-command-event)))))
 
 (defun cider-debug-mode-send-reply (command &optional key force)
-  "Reply to the message that started current bufer's debugging session.
+  "Reply to the message that started current buffer's debugging session.
 COMMAND is sent as the input option.  KEY can be provided to reply to a
 specific message.  If FORCE is non-nil, send a \"force?\" argument in the
 message."

--- a/lisp/cider-doc.el
+++ b/lisp/cider-doc.el
@@ -52,7 +52,7 @@
   :group 'cider)
 
 (defcustom cider-doc-auto-select-buffer t
-  "Controls whether to auto-select the doc popup buffer."
+  "Control whether to auto-select the doc popup buffer."
   :type 'boolean
   :group 'cider-doc
   :package-version  '(cider . "0.15.0"))
@@ -261,15 +261,15 @@ opposite of what that option dictates."
 (defconst cider-doc-buffer "*cider-doc*")
 
 (defun cider-create-doc-buffer (symbol &optional compact)
-  "Populates *cider-doc* with the documentation for SYMBOL,
-favoring a COMPACT format if specified."
+  "Populate *cider-doc* with the documentation for SYMBOL.
+Favor a COMPACT format if specified."
   (when-let* ((info (cider-var-info symbol)))
     (cider-docview-render (cider-make-popup-buffer cider-doc-buffer nil 'ancillary) symbol info compact)))
 
 (defun cider-create-compact-doc-buffer (symbol)
-  "Populates *cider-doc* with the documentation for SYMBOL.
+  "Populate *cider-doc* with the documentation for SYMBOL.
 
-Favors a compact rendering of docstrings"
+Favor a compact rendering of docstrings."
   (cider-create-doc-buffer symbol :compact))
 
 (defun cider-doc-lookup (symbol)
@@ -402,8 +402,8 @@ Same for `jar:file:...!/' segments."
       result)))
 
 (defun cider-docview-render-info (buffer info &optional compact for-tooltip)
-  "Emit into BUFFER formatted INFO for the Clojure or Java symbol,
-in a COMPACT format is specified, FOR-TOOLTIP if specified."
+  "Emit into BUFFER formatted INFO for the Clojure or Java symbol.
+Use a COMPACT format if specified, and FOR-TOOLTIP if specified."
   (let* ((ns      (nrepl-dict-get info "ns"))
          (name    (nrepl-dict-get info "name"))
          (added   (nrepl-dict-get info "added"))

--- a/lisp/cider-docstring.el
+++ b/lisp/cider-docstring.el
@@ -32,7 +32,7 @@
 (require 'subr-x)
 
 (defsubst cider--render-pre* (dom)
-  "Render DOM nodes, formatting them them as Java if they are strings."
+  "Render DOM nodes, formatting them as Java if they are strings."
   (dolist (sub (dom-children dom))
     (if (stringp sub)
         (shr-insert (cider-font-lock-as 'java-mode sub))
@@ -106,7 +106,7 @@ Note that `cider-docstring' will trim thing smartly, for Java doc comments:
     (cider--fragments-to-s first-sentence-fragments)))
 
 (defun cider--render-docstring (eldoc-info)
-  "Renders the docstring from ELDOC-INFO based on its length and content.
+  "Render the docstring from ELDOC-INFO based on its length and content.
 Prioritize rendering as much as possible while staying within
 `cider-docstring-max-lines'."
   (let* ((first-sentence-fragments (cider-plist-get eldoc-info "doc-first-sentence-fragments"))

--- a/lisp/cider-eldoc.el
+++ b/lisp/cider-eldoc.el
@@ -131,8 +131,7 @@ mapping `cider-eldoc-ns-function' on it returns an empty list."
   "Format the eldoc subject defined by NS, SYMBOL, THING and TYPE.
 THING represents the thing at point which triggered eldoc.  Normally NS and
 SYMBOL are used (they are derived from THING), but when empty we fallback to
-THING (e.g. for Java methods).  Format it as a function, if FUNCTION-P
-is non-nil.  Else format it as a variable."
+THING (e.g. for Java methods).  TYPE is used to propertize the subject's name."
   (if-let* ((method-name (if (and symbol (not (string= symbol "")))
                              symbol
                            thing))
@@ -257,7 +256,7 @@ information."
             (cider-eldoc-format-arglist arglists pos))))
 
 (defun cider-highlight-args (arglist pos)
-  "Format the the function ARGLIST for eldoc.
+  "Format the function ARGLIST for eldoc.
 POS is the index of the currently highlighted argument."
   (let* ((rest-pos (cider--find-rest-args-position arglist))
          (i 0))
@@ -332,7 +331,7 @@ if the maximum number of sexps to skip is exceeded."
 
 (defun cider-eldoc-thing-type (eldoc-info)
   "Return the type of the ELDOC-INFO being displayed by eldoc.
-It can be a function or var now."
+It can be `fn', `special-form', `macro', `method' or `var'."
   (or (pcase (cider-plist-get eldoc-info "type")
         ("function" 'fn)
         ("special-form" 'special-form)

--- a/lisp/cider-jack-in.el
+++ b/lisp/cider-jack-in.el
@@ -352,7 +352,7 @@ specifying the artifact ID, and the second element the version number."
 
 (defvar-local cider-jack-in-cmd nil
   "The custom command used to start a nrepl server.
-This is used by `cider-jack-in`.
+This is used by `cider-jack-in'.
 
 If this variable is set, its value will be
 used as the command to start the nrepl server
@@ -440,14 +440,14 @@ returned by this function only contains strings."
                     spec)))))
 
 (defun cider--jack-in-required-dependencies ()
-  "Returns the required CIDER deps.
+  "Return the required CIDER deps.
 They are normally added to `cider-jack-in-dependencies',
 unless it's a Lein project."
   `(("nrepl/nrepl" ,cider-injected-nrepl-version)
     ("cider/cider-nrepl" ,cider-injected-middleware-version)))
 
 (defun cider--gradle-dependency-notation (dependency)
-  "Returns Gradle's GAV dependency syntax.
+  "Return Gradle's GAV dependency syntax.
 For a \"group/artifact\" \"version\") DEPENDENCY list
 return as group:artifact:version notation."
   (let ((group-artifact (replace-regexp-in-string "/" ":" (car dependency)))
@@ -455,9 +455,9 @@ return as group:artifact:version notation."
     (format "%s:%s" group-artifact version)))
 
 (defun cider--gradle-jack-in-property (dependencies)
-  "Returns Clojurephant's dependency jack-in property.
+  "Return Clojurephant's dependency jack-in property.
 For DEPENDENCIES, translates to Gradle's dependency notation
-using `cider--gradle-dependency-notation`.''"
+using `cider--gradle-dependency-notation'."
   (if (seq-empty-p dependencies)
       ""
     (shell-quote-argument
@@ -465,7 +465,7 @@ using `cider--gradle-dependency-notation`.''"
              (mapconcat #'cider--gradle-dependency-notation dependencies ",")))))
 
 (defun cider--gradle-middleware-params (middlewares)
-  "Returns Gradle-formatted middleware params.
+  "Return Gradle-formatted middleware params.
 Given a list of MIDDLEWARES symbols, this returns
 the Gradle parameters expected by Clojurephant's
 ClojureNRepl task."
@@ -528,16 +528,16 @@ removed, LEIN-PLUGINS, LEIN-MIDDLEWARES and finally PARAMS."
    params))
 
 (defun cider--dedupe-deps (deps)
-  "Removes the duplicates in DEPS."
+  "Remove the duplicates in DEPS."
   (cl-delete-duplicates deps :test 'equal))
 
 (defun cider--jack-in-cmd-powershell-p (command)
-  "Returns whether COMMAND is PowerShell."
+  "Return non-nil if COMMAND is PowerShell."
   (or (string-equal command "powershell")
       (string-equal command "pwsh")))
 
 (defun cider--shell-quote-argument (argument &optional command)
-  "Quotes ARGUMENT like `shell-quote-argument', suitable for use with COMMAND.
+  "Quote ARGUMENT like `shell-quote-argument', suitable for use with COMMAND.
 
 Uses `shell-quote-argument' to quote the ARGUMENT, unless COMMAND is given
 and refers to PowerShell, in which case it uses (some limited) PowerShell
@@ -559,7 +559,7 @@ rules to quote it."
 
 
 (defun cider--combined-aliases ()
-  "Creates the combined ailases as stringe separated by ':'."
+  "Create the combined aliases as a string separated by ':'."
   (let ((final-cider-clojure-cli-aliases
          (cond ((and cider-clojure-cli-global-aliases cider-clojure-cli-aliases)
                 (concat cider-clojure-cli-global-aliases ":" cider-clojure-cli-aliases))

--- a/lisp/cider-macroexpansion.el
+++ b/lisp/cider-macroexpansion.el
@@ -85,8 +85,7 @@ ARG is passed along to `undo-only'."
     (undo-only arg)))
 
 (defvar cider-last-macroexpand-expression nil
-  "Specify the last macroexpansion performed.
-This variable specifies both what was expanded and the expander.")
+  "Hold the last expression that was macroexpanded.")
 
 (defun cider-macroexpand-expr (expander expr)
   "Macroexpand, use EXPANDER, the given EXPR."
@@ -183,7 +182,7 @@ and point is placed after the expanded form."
     (define-key map (kbd "u") #'cider-macroexpand-undo)
     (define-key map [remap undo] #'cider-macroexpand-undo)
     (easy-menu-define cider-macroexpansion-mode-menu map
-      "Menu for CIDER's doc mode"
+      "Menu for CIDER's macroexpansion mode"
       '("Macroexpansion"
         ["Restart expansion" cider-macroexpand-again]
         ["Macroexpand-1" cider-macroexpand-1-inplace]

--- a/lisp/cider-ns.el
+++ b/lisp/cider-ns.el
@@ -127,9 +127,8 @@ Current options: tools.namespace and clj-reload."
   :package-version '(cider . "1.14.0"))
 
 (defun cider-ns--present-error (error)
-  "Render the `ERROR' stacktrace,
-and jump to the adequate file/line location,
-presenting the error message as an overlay."
+  "Render the ERROR stacktrace, jumping to the relevant file/line location.
+Present the error message as an overlay."
   (let* ((buf)
          (jump-args (seq-some (lambda (cause-dict) ;; a dict representing an exception cause
                                 (nrepl-dbind-response cause-dict (file-url line column)
@@ -236,7 +235,7 @@ Its behavior is controlled by `cider-ns-save-files-on-refresh' and
 
 (defun cider-ns--reload-op (op-name)
   "Return the reload operation to use.
-Based on OP-NAME and the value of cider-ns-code-reload-tool defcustom."
+Based on OP-NAME and the value of `cider-ns-code-reload-tool'."
   (if (eq cider-ns-code-reload-tool 'tools.namespace)
       (cond ((string= op-name "reload")       "cider/refresh")
             ((string= op-name "reload-all")   "cider/refresh-all")

--- a/lisp/cider-overlays.el
+++ b/lisp/cider-overlays.el
@@ -79,6 +79,7 @@ Only applies to evaluation commands.  To configure the debugger overlays,
 see `cider-debug-use-overlays'."
   :type '(choice (const :tag "Display using overlays" t)
                  (const :tag "Display in echo area" nil)
+                 (const :tag "Use overlays only for errors" errors-only)
                  (const :tag "Both" both))
   :group 'cider
   :package-version '(cider . "0.10.0"))
@@ -189,8 +190,6 @@ VALUE is used as the overlay's after-string property, meaning it is
 displayed at the end of the overlay.
 Return nil if the overlay was not placed or if it might not be visible, and
 return the overlay otherwise.
-
-Return the overlay if it was placed successfully, and nil if it failed.
 
 This function takes some optional keyword arguments:
 

--- a/lisp/cider-profile.el
+++ b/lisp/cider-profile.el
@@ -105,7 +105,7 @@ With prefix arg or no symbol at point, prompts for a var."
   query)
 
 (defun cider-profile--send-to-inspector (summary-response)
-  "Displays SUMMARY-RESPONSE using the inspector."
+  "Display SUMMARY-RESPONSE using the inspector."
   (let ((value (nrepl-dict-get summary-response "value")))
     (cider-inspector--render-value value)))
 

--- a/lisp/cider-selector.el
+++ b/lisp/cider-selector.el
@@ -94,7 +94,7 @@ See `def-cider-selector-method' for defining new methods."
            (cider-selector)))))
 
 (defmacro def-cider-selector-method (key description &rest body)
-  "Define a new `cider-select' buffer selection method.
+  "Define a new `cider-selector' buffer selection method.
 KEY is the key the user will enter to choose this method.
 
 DESCRIPTION is a one-line sentence describing how the method
@@ -149,8 +149,7 @@ is chosen.  The returned buffer is selected with
   (top-level))
 
 (def-cider-selector-method ?r
-  "Current REPL buffer or as a fallback, the most recently
-visited cider-repl-mode buffer."
+  "Current REPL buffer or most recently visited REPL buffer."
   (or (cider-current-repl)
       (cider-selector--recently-visited-buffer 'cider-repl-mode)))
 

--- a/lisp/cider-session.el
+++ b/lisp/cider-session.el
@@ -215,7 +215,7 @@ splits the version into separate fields rather than a `version-string`."
               (or (nrepl-dict-get lg "minor") "?")))))
 
 (defun cider-runtime ()
-  "Return the runtime of the nREPl server."
+  "Return the runtime of the nREPL server."
   (cond
    ((cider--clojure-version) 'clojure)
    ((cider--babashka-version) 'babashka)
@@ -305,7 +305,7 @@ Assume that the current buffer is a REPL."
 ;;; Connection Name Formatting
 
 (defun cider--ensure-spec-is-not-invokable (spec)
-  "Ensures SPEC cannot be invoked as a function.
+  "Ensure SPEC cannot be invoked as a function.
 
 Invokeable specs are an Emacs 29 feature
 that we don't intend to use in this context."

--- a/lisp/cider-stacktrace.el
+++ b/lisp/cider-stacktrace.el
@@ -366,8 +366,8 @@ filters for the resulting machinery."
 ;;; Internal/Middleware error suppression
 
 (defun cider-stacktrace-some-suppressed-errors-p (error-types)
-  "Return intersection of ERROR-TYPES and CIDER-STACKTRACE-SUPPRESSED-ERRORS.
-I.e, Return non-nil if the seq ERROR-TYPES shares any elements with
+  "Return non-nil if ERROR-TYPES has any suppressed error type.
+I.e, return non-nil if the seq ERROR-TYPES shares any elements with
 `cider-stacktrace-suppressed-errors'.  This means that even a
 well-behaved (ie, promoted) error type will be guilty by association if
 grouped with a suppressed error type."
@@ -845,8 +845,8 @@ If EX-DATA is true, inspect ex-data of the exception instead."
     map))
 
 (defun cider-stacktrace-render-cause (buffer cause num note &optional inspect-index)
-  "Emit into BUFFER the CAUSE NUM, exception class, message, data, and NOTE,
-make INSPECT-INDEX actionable if present."
+  "Emit into BUFFER the CAUSE NUM, exception class, message, data, and NOTE.
+Make INSPECT-INDEX actionable if present."
   (with-current-buffer buffer
     (nrepl-dbind-response cause (class message data spec triage stacktrace)
       (let ((indent "   ")

--- a/lisp/cider-util.el
+++ b/lisp/cider-util.el
@@ -165,8 +165,8 @@ Take into consideration current major mode."
 ;;; Thing at point
 
 (defun cider--text-or-limits (bounds start end)
-  "Returns the substring or the bounds of text.
-If BOUNDS is non-nil, returns the list (START END) of character
+  "Return the substring or the bounds of text.
+If BOUNDS is non-nil, return the list (START END) of character
 positions.  Else returns the substring from START to END."
   (funcall (if bounds #'list #'buffer-substring-no-properties)
            start end))
@@ -327,7 +327,7 @@ positions before and after executing BODY."
 (put 'cider-propertize-region 'lisp-indent-function 1)
 
 (defun cider-property-bounds (prop)
-  "Return the the positions of the previous and next change to PROP.
+  "Return the positions of the previous and next change to PROP.
 PROP is the name of a text property."
   (let ((end (next-single-char-property-change (point) prop)))
     (list (previous-single-char-property-change end prop) end)))
@@ -571,7 +571,7 @@ to."
   (browse-url cider-report-bug-url))
 
 (defun cider--project-name (dir)
-  "Extracts a project name from DIR, possibly nil.
+  "Extract a project name from DIR, possibly nil.
 The project name is the final component of DIR if not nil."
   (when dir
     (file-name-nondirectory (directory-file-name dir))))

--- a/lisp/cider-xref-backend.el
+++ b/lisp/cider-xref-backend.el
@@ -39,7 +39,7 @@
 ;; xref.el was introduced in Emacs 25.1.
 ;; CIDER's xref backend was added in CIDER 1.2.
 (defun cider--xref-backend ()
-  "Used for xref integration."
+  "Return `cider' when CIDER can serve as an xref backend."
   ;; Check if `cider-nrepl` middleware is loaded. Allows fallback to other xref
   ;; backends, if cider-nrepl is not loaded.
   (when (or
@@ -54,13 +54,13 @@
   (cider-symbol-at-point 'look-back))
 
 (defun cider--xref-extract-file (dict)
-  "Extracts the best possible file path from DICT."
+  "Extract the best possible file path from DICT."
   (or (nrepl-dict-get dict "file-url") ;; This is the primary choice, it has a protocol and indicates an absolute path
       ;; fall back in case it was absent or we're running an older cider-nrepl:
       (nrepl-dict-get dict "file")))
 
 (defun cider--xref-extract-friendly-file-name (dict)
-  "Extracts the best possible friendly file name from DICT.
+  "Extract the best possible friendly file name from DICT.
 These are used for presentation purposes."
   (let* ((s (or (nrepl-dict-get dict "file") ;; these are shorter and relative, which look better in UIs.
                 (nrepl-dict-get dict "file-url")))

--- a/lisp/cider-xref.el
+++ b/lisp/cider-xref.el
@@ -154,7 +154,7 @@ the symbol found by the xref search as argument."
 
 ;;;###autoload
 (defun cider-xref-fn-refs-select (&optional ns symbol)
-  "Displays the references for NS and SYMBOL using completing read."
+  "Display the references for NS and SYMBOL using completing read."
   (interactive)
   (cider-ensure-connected)
   (cider-ensure-op-supported "cider/fn-refs")
@@ -167,7 +167,7 @@ the symbol found by the xref search as argument."
 
 ;;;###autoload
 (defun cider-xref-fn-deps-select (&optional ns symbol)
-  "Displays the function dependencies for  NS and SYMBOL using completing read."
+  "Display the function dependencies for NS and SYMBOL using completing read."
   (interactive)
   (cider-ensure-connected)
   (cider-ensure-op-supported "cider/fn-deps")

--- a/lisp/nrepl-bencode.el
+++ b/lisp/nrepl-bencode.el
@@ -86,11 +86,12 @@ this list when inner object was completely decoded or grows it by one when
 new list or dict was encountered.
 
 The returned value is of the form (INFO . STACK) where INFO is
-:stub, nil, :end or :eob and STACK is either an incomplete parsing state as
-above (INFO is :stub, nil or :eob) or a list of one component representing
+:stub, nil, :e, :end or :eob and STACK is either an incomplete parsing state as
+above (INFO is :stub, nil, :e or :eob) or a list of one component representing
 the completely decoded message (INFO is :end).  INFO is nil when an
-elementary non-root object was successfully decoded.  INFO is :end when this
-object is a root list or dict."
+elementary non-root object was successfully decoded.  INFO is :e when a
+non-root list or dict was decoded.  INFO is :end when this object is a root
+list or dict."
   (cond
    ;; list
    ((eq (char-after) ?l)

--- a/lisp/nrepl-client.el
+++ b/lisp/nrepl-client.el
@@ -257,12 +257,12 @@ PARAMS is as in `nrepl-make-buffer-name'."
     (error nil)))
 
 (defun nrepl--port-string-to-number (s)
-  "Converts `S' from string to number when suitable."
+  "Convert S from string to number when suitable."
   (when (string-match "^\\([0-9]+\\)" s)
     (string-to-number (match-string 0 s))))
 
 (defun nrepl--port-from-file (file)
-  "Attempts to read port from a file named by FILE.
+  "Attempt to read port from a file named by FILE.
 
 Discards it if it can be determined that the port is not active."
   (when (file-exists-p file)
@@ -1023,7 +1023,7 @@ prefer the keyword-argument `nrepl-send-eval-request'."
   "Version of the nREPL client, sent in clone requests.")
 
 (defun nrepl-sync-request:clone (connection &optional tooling)
-  "Sent a :clone request to create a new client session.
+  "Send a :clone request to create a new client session.
 The request is dispatched via CONNECTION.
 Optional argument TOOLING Tooling is set to t if wanting the tooling session
 from CONNECTION."
@@ -1035,12 +1035,12 @@ from CONNECTION."
                       :tooling tooling))
 
 (defun nrepl-sync-request:close (connection)
-  "Sent a :close request to close CONNECTION's SESSION."
+  "Send a :close request to close CONNECTION's SESSION."
   (nrepl-sync-request '("op" "close") connection)
   (nrepl-sync-request '("op" "close") connection :tooling t)) ;; close tooling session
 
 (defun nrepl-sync-request:describe (connection)
-  "Perform :describe request for CONNECTION and SESSION."
+  "Perform a :describe request for CONNECTION."
   (nrepl-send-sync-request '("op" "describe")
                            connection))
 

--- a/lisp/nrepl-dict.el
+++ b/lisp/nrepl-dict.el
@@ -154,9 +154,10 @@ also always return a sequence (since the result will be flattened)."
     (apply #'append (nrepl-dict-map function dict))))
 
 (defun nrepl-dict-filter (function dict)
-  "For all key-values of DICT, return new dict where FUNCTION returns non-nil.
+  "Return a new dict of the key-values of DICT accepted by FUNCTION.
 
-FUNCTION should be a function taking two arguments, key and value."
+FUNCTION should be a function taking two arguments, key and value, that
+returns non-nil for the key-values to keep."
   (let ((new-map (nrepl-dict))
         (keys (nrepl-dict-keys dict)))
     (dolist (key keys)


### PR DESCRIPTION
Part of the per-module audit cleanups - the bundled docstring/checkdoc pass over the long tail of modules (24 files), so they don't each need their own PR.

All behavior-preserving. The changes:
- Non-imperative first verbs -> imperative (Returns/Displays/Extracts/Parses/Creates/Removes/Ensures/Populates/Controls/Converts/Sent/Determines...).
- Typos and duplicated words: "the the", "them them", "bufer", "ailases", "stringe", "nREPl", "beflore", "for  NS".
- Lisp-symbol quoting normalized to the `symbol'` convention (fixing paired-backtick and stray-backtick cases).
- First lines that ended in a comma / wrapped rephrased into self-contained sentences (checkdoc).
- Docstrings referencing phantom arguments (FUNCTION-P, SESSION, REPL-TYPE, etc.) corrected to match the actual arglists; a missing defconst docstring added; incomplete return-contract enumerations completed (`nrepl--bdecode-1`'s `:e`).

Two customize-metadata fixes rode along with the docstrings they sit next to: added the documented-and-honored `errors-only` value to `cider-use-overlays`'s `:type`, and a missing `:package-version` on `cider-prefer-local-resources`.

Compile is clean with `--warnings-as-errors`, the full test suite passes, and no new checkdoc warnings were introduced (remaining hits are pre-existing on untouched lines).

- [x] Tests pass (`eldev test`)
- [x] Linter clean (`eldev lint`)