### PR TITLE
Small simplifications across modules (+ two bugfixes)

### DIFF
--- a/lisp/cider-apropos.el
+++ b/lisp/cider-apropos.el
@@ -119,12 +119,22 @@ and be case-sensitive (based on CASE-SENSITIVE-P)."
   "Show SUMMARY and RESULTS for QUERY in a pop-up buffer, formatted for DOCS-P."
   (with-current-buffer (cider-popup-buffer cider-apropos-buffer 'select 'apropos-mode 'ancillary)
     (let ((inhibit-read-only t))
-      (if (boundp 'header-line-format)
-          (setq-local header-line-format summary)
-        (insert summary "\n\n"))
+      (setq-local header-line-format summary)
       (dolist (result results)
         (cider-apropos-result result query docs-p))
       (goto-char (point-min)))))
+
+(defun cider-apropos--read-args ()
+  "Read the arguments for `cider-apropos' and `cider-apropos-select'.
+With a prefix argument, also prompt for the namespace, whether to search
+doc strings, include private symbols, and be case-sensitive."
+  (cons (read-string "Search for Clojure symbol (a regular expression): ")
+        (when current-prefix-arg
+          (list (let ((ns (completing-read "Namespace (default is all): " (cider-sync-request:ns-list))))
+                  (if (string= ns "") nil ns))
+                (y-or-n-p "Search doc strings? ")
+                (y-or-n-p "Include private symbols? ")
+                (y-or-n-p "Case-sensitive? ")))))
 
 ;;;###autoload
 (defun cider-apropos (query &optional ns docs-p privates-p case-sensitive-p)
@@ -134,14 +144,7 @@ will be converted to a regular expression (like take.+while) automatically
 behind the scenes.  The search may be limited to the namespace NS, and may
 optionally search doc strings (based on DOCS-P), include private vars
 \(based on PRIVATES-P), and be case-sensitive (based on CASE-SENSITIVE-P)."
-  (interactive
-   (cons (read-string "Search for Clojure symbol (a regular expression): ")
-         (when current-prefix-arg
-           (list (let ((ns (completing-read "Namespace (default is all): " (cider-sync-request:ns-list))))
-                   (if (string= ns "") nil ns))
-                 (y-or-n-p "Search doc strings? ")
-                 (y-or-n-p "Include private symbols? ")
-                 (y-or-n-p "Case-sensitive? ")))))
+  (interactive (cider-apropos--read-args))
   (cider-ensure-connected)
   (cider-ensure-op-supported "cider/apropos")
   (if-let* ((summary (cider-apropos-summary
@@ -184,14 +187,7 @@ will be converted to a regular expression (like take.+while) automatically
 behind the scenes.  The search may be limited to the namespace NS, and may
 optionally search doc strings (based on DOCS-P), include private vars
 \(based on PRIVATES-P), and be case-sensitive (based on CASE-SENSITIVE-P)."
-  (interactive
-   (cons (read-string "Search for Clojure symbol (a regular expression): ")
-         (when current-prefix-arg
-           (list (let ((ns (completing-read "Namespace (default is all): " (cider-sync-request:ns-list))))
-                   (if (string= ns "") nil ns))
-                 (y-or-n-p "Search doc strings? ")
-                 (y-or-n-p "Include private symbols? ")
-                 (y-or-n-p "Case-sensitive? ")))))
+  (interactive (cider-apropos--read-args))
   (cider-ensure-connected)
   (cider-ensure-op-supported "cider/apropos")
   (if-let* ((summary (cider-apropos-summary

--- a/lisp/cider-browse-spec.el
+++ b/lisp/cider-browse-spec.el
@@ -196,11 +196,12 @@ Display TITLE at the top and SPECS are indented underneath."
         (cider-browse-spec--render-schema-map spec-form)
       (cider-browse-spec--render-schema-vector spec-form))))
 
-(defun cider-browse-spec--render-select (spec-form)
-  "Render the s/select SPEC-FORM."
+(defun cider-browse-spec--render-keyset-op (op spec-form)
+  "Render the keyset-based OP (e.g. \"s/select\") for SPEC-FORM."
   (let ((keyset (cadr spec-form))
         (selection (caddr spec-form)))
-    (format "(s/select\n %s\n [%s])"
+    (format "(%s\n %s\n [%s])"
+            op
             (cider-browse-spec--pprint keyset)
             (string-join
              (thread-last
@@ -208,17 +209,13 @@ Display TITLE at the top and SPECS are indented underneath."
                (mapcar (lambda (s) (cider-browse-spec--pprint s))))
              "\n  "))))
 
+(defun cider-browse-spec--render-select (spec-form)
+  "Render the s/select SPEC-FORM."
+  (cider-browse-spec--render-keyset-op "s/select" spec-form))
+
 (defun cider-browse-spec--render-union (spec-form)
   "Render the s/union SPEC-FORM."
-  (let ((keyset (cadr spec-form))
-        (selection (caddr spec-form)))
-    (format "(s/union\n %s\n [%s])"
-            (cider-browse-spec--pprint keyset)
-            (string-join
-             (thread-last
-               selection
-               (mapcar (lambda (s) (cider-browse-spec--pprint s))))
-             "\n  "))))
+  (cider-browse-spec--render-keyset-op "s/union" spec-form))
 
 (defun cider-browse-spec--render-vector (spec-form)
   "Render SPEC-FORM as a vector."
@@ -434,8 +431,8 @@ property."
               (insert "\n\n")
               (insert (cider-font-lock-as-clojure example))
               (goto-char (point-min))))
-        (error (format "No example for spec %s" spec)))
-    (error "No current spec")))
+        (user-error "No example for spec %s" spec))
+    (user-error "No current spec")))
 
 (defun cider-browse-spec--example-revert-buffer-function (&rest _)
   "`revert-buffer' function for `cider-browse-spec-example-mode'.

--- a/lisp/cider-cheatsheet.el
+++ b/lisp/cider-cheatsheet.el
@@ -27,7 +27,6 @@
 ;;; Code:
 
 (require 'cider-doc)
-(require 'cl-lib)
 (require 'map)
 (require 'seq)
 (require 'subr-x)
@@ -602,22 +601,24 @@ With a prefix argument FLAT, represent each candidate as a full path to var."
              (var (completing-read "Select var: " vars)))
         (funcall cider-cheatsheet-default-action-function var)))))
 
-(cl-defun cider-cheatsheet--insert-hierarchy (hierarchy &optional (level 0))
-  "Insert HIERARCHY with visual indentation for LEVEL."
-  (dolist (node hierarchy)
-    (if (stringp (car node))
-        (progn
-          (insert (make-string (* level 2) ?\s) (car node) "\n")
-          (cider-cheatsheet--insert-hierarchy (cdr node) (1+ level)))
-      (dolist (var (cider-cheatsheet--expand-vars node))
-        (insert (make-string (* level 2) ?\s))
-        (insert-text-button var
-                            'var var
-                            'action (lambda (btn)
-                                      (funcall cider-cheatsheet-default-action-function
-                                               (button-get btn 'var)))
-                            'help-echo (format "Show documentation for %s" var))
-        (insert "\n")))))
+(defun cider-cheatsheet--insert-hierarchy (hierarchy &optional level)
+  "Insert HIERARCHY with visual indentation for LEVEL.
+LEVEL defaults to 0."
+  (let ((level (or level 0)))
+    (dolist (node hierarchy)
+      (if (stringp (car node))
+          (progn
+            (insert (make-string (* level 2) ?\s) (car node) "\n")
+            (cider-cheatsheet--insert-hierarchy (cdr node) (1+ level)))
+        (dolist (var (cider-cheatsheet--expand-vars node))
+          (insert (make-string (* level 2) ?\s))
+          (insert-text-button var
+                              'var var
+                              'action (lambda (btn)
+                                        (funcall cider-cheatsheet-default-action-function
+                                                 (button-get btn 'var)))
+                              'help-echo (format "Show documentation for %s" var))
+          (insert "\n"))))))
 
 (defun cider-cheatsheet--buffer-contents ()
   "Generate cheatsheet buffer contents based on the cheatsheet hierarchy."

--- a/lisp/cider-completion-context.el
+++ b/lisp/cider-completion-context.el
@@ -46,19 +46,24 @@
   "Find the end position of the symbol at point, unless inside a string."
   (cdr (cider-completion--bounds-of-non-string-symbol-at-point)))
 
+(defun cider-completion--point-in-balanced-list-p ()
+  "Return non-nil if point is inside a balanced list.
+Point is left unchanged."
+  (save-mark-and-excursion
+    (condition-case _
+        (progn
+          (up-list)
+          (check-parens)
+          t)
+      (scan-error nil)
+      (user-error nil))))
+
 (defun cider-completion-get-info-context-at-point ()
   "Extract a context at point that is suitable for eldoc and info ops.
 Note that this context is slightly different than that of
 `cider-completion-get-context-at-point': this one does not include
 the current symbol at point."
-  (when (save-mark-and-excursion
-          (condition-case _
-              (progn
-                (up-list)
-                (check-parens)
-                t)
-            (scan-error nil)
-            (user-error nil)))
+  (when (cider-completion--point-in-balanced-list-p)
     (save-excursion
       (let* ((pref-start (cider-completion-symbol-start-pos))
              (context (cider-defun-at-point))
@@ -78,14 +83,7 @@ the current symbol at point."
   "Extract the context at point.
 If point is not inside the list, return nil; otherwise return \"top-level\"
 form, with symbol at point replaced by __prefix__."
-  (when (save-mark-and-excursion
-          (condition-case _
-              (progn
-                (up-list)
-                (check-parens)
-                t)
-            (scan-error nil)
-            (user-error nil)))
+  (when (cider-completion--point-in-balanced-list-p)
     (save-excursion
       (let* ((pref-end (point))
              (pref-start (cider-completion-symbol-start-pos))

--- a/lisp/cider-debug.el
+++ b/lisp/cider-debug.el
@@ -403,7 +403,7 @@ In order to work properly, this mode must be activated by
     ["Continue" (cider-debug-mode-send-reply ":continue") :keys "c"]
     ["Continue non-stop" (cider-debug-mode-send-reply ":continue-all") :keys "C"]
     ["Move out of sexp" (cider-debug-mode-send-reply ":out") :keys "o"]
-    ["Forced move out of sexp" (cider-debug-mode-send-reply ":out" nil true) :keys "O"]
+    ["Forced move out of sexp" (cider-debug-mode-send-reply ":out" nil t) :keys "O"]
     ["Move to current position" (cider-debug-mode-send-reply ":here") :keys "h"]
     ["Quit" (cider-debug-mode-send-reply ":quit") :keys "q"]
     "--"

--- a/lisp/cider-docstring.el
+++ b/lisp/cider-docstring.el
@@ -64,9 +64,7 @@
   "Convert FRAGMENTS into a concatenated string representation.
 If a given fragment is of html type, it's converted to a propertized string;
 otherwise, it's included as-is."
-  (when (and fragments
-             (> (length fragments)
-                0))
+  (when fragments
     (string-trim (seq-reduce (lambda (new-s fragment)
                                (let* ((html? (equal "html" (nrepl-dict-get fragment "type")))
                                       (v (nrepl-dict-get fragment "content")))
@@ -96,9 +94,8 @@ Note that `cider-docstring' will trim thing smartly, for Java doc comments:
 (defun cider--attempt-invalid? (attempt)
   "Check if ATTEMPT is nil or has more lines than `cider-docstring-max-lines'."
   (or (not attempt)
-      (and attempt
-           (> (length (split-string attempt "\n"))
-              cider-docstring-max-lines))))
+      (> (length (split-string attempt "\n"))
+         cider-docstring-max-lines)))
 
 (defun cider--render-docstring-first-sentence (eldoc-info)
   "Render the first sentence of the docstring extracted from ELDOC-INFO."

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -191,6 +191,11 @@ as in `nrepl-make-eval-handler'."
    :on-eval-error (or on-eval-error
                       (lambda () (cider-default-err-handler buffer)))))
 
+(defun cider--maybe-set-eval-register (res)
+  "Set the value of `cider-eval-register' to RES when the register is set."
+  (when cider-eval-register
+    (set-register cider-eval-register res)))
+
 (defun cider-insert-eval-handler (&optional buffer _bounds source-buffer on-success-callback)
   "Make an nREPL evaluation handler for the BUFFER,
 _BOUNDS representing the buffer bounds of the evaled input,
@@ -214,8 +219,7 @@ The handler simply inserts the result value in BUFFER."
                   ;; Don't jump
                   (cider-handle-compilation-errors err eval-buffer t))
      :on-done (lambda ()
-                (when cider-eval-register
-                  (set-register cider-eval-register res))
+                (cider--maybe-set-eval-register res)
                 (when (and (not failed) on-success-callback)
                   (funcall on-success-callback)))
      :on-eval-error (lambda ()
@@ -308,8 +312,7 @@ when `cider-auto-inspect-after-eval' is non-nil."
                              (windowp (get-buffer-window cider-inspector-buffer 'visible)))
                     (cider-inspect-last-result)
                     (select-window (get-buffer-window target))))
-                (when cider-eval-register
-                  (set-register cider-eval-register res))))))
+                (cider--maybe-set-eval-register res)))))
 
 
 (defun cider-load-file-handler (&optional buffer done-handler)
@@ -333,8 +336,7 @@ Optional argument DONE-HANDLER lambda will be run once load is complete."
                   (cider-emit-interactive-eval-err-output err)
                   (cider-handle-compilation-errors err eval-buffer))
      :on-done (lambda ()
-                (when cider-eval-register
-                  (set-register cider-eval-register res))
+                (cider--maybe-set-eval-register res)
                 (when done-handler
                   (funcall done-handler target))))))
 
@@ -368,8 +370,7 @@ comment prefix to use."
                   (save-excursion
                     (goto-char (marker-position location))
                     (insert (concat comment-prefix res "\n"))))
-                (when cider-eval-register
-                  (set-register cider-eval-register res))))))
+                (cider--maybe-set-eval-register res)))))
 
 (defun cider-maybe-insert-multiline-comment (result comment-prefix continued-prefix comment-postfix)
   "Insert eval RESULT at current location if RESULT is not empty.
@@ -409,12 +410,7 @@ COMMENT-POSTFIX is the text to output after the last line."
                     (unless (bolp) (insert "\n"))
                     (cider-maybe-insert-multiline-comment
                      res comment-prefix continued-prefix comment-postfix)))
-                (when cider-eval-register
-                  (set-register cider-eval-register res)))
-     :on-truncated (lambda ()
-                     ;; Preserve the (incidentally nil) warning the legacy
-                     ;; truncated-handler form passed through.
-                     (setq res (concat res nil))))))
+                (cider--maybe-set-eval-register res)))))
 
 (defun cider-popup-eval-handler (&optional buffer _bounds source-buffer)
   "Make a handler for printing evaluation results in popup BUFFER,

--- a/lisp/cider-inspiration.el
+++ b/lisp/cider-inspiration.el
@@ -134,7 +134,7 @@
 (defun cider-inspire-me ()
   "Display a random inspiration message."
   (interactive)
-  (message (cider-random-words-of-inspiration)))
+  (message "%s" (cider-random-words-of-inspiration)))
 
 (defvar cider-tips
   '(;; Connection / session
@@ -237,7 +237,7 @@
 (defun cider-drink-a-sip ()
   "Show a random tip."
   (interactive)
-  (message (cider-random-tip)))
+  (message "%s" (cider-random-tip)))
 
 (provide 'cider-inspiration)
 

--- a/lisp/cider-jack-in.el
+++ b/lisp/cider-jack-in.el
@@ -269,7 +269,7 @@ The repl dependendcies are most likely to be nREPL middlewares."
   :type 'boolean
   :group 'cider
   :safe #'booleanp
-  :version '(cider . "0.11.0"))
+  :package-version '(cider . "0.11.0"))
 
 (defcustom cider-enable-nrepl-jvmti-agent nil
   "When t, add `-Djdk.attach.allowAttachSelf' to the command line arguments.
@@ -281,7 +281,7 @@ some hardened environments forbid self-attach."
   :type 'boolean
   :group 'cider
   :safe #'booleanp
-  :version '(cider . "1.15.0"))
+  :package-version '(cider . "1.15.0"))
 
 
 ;;; Jack-in dependencies

--- a/lisp/cider-macroexpansion.el
+++ b/lisp/cider-macroexpansion.el
@@ -80,7 +80,7 @@ The default for DISPLAY-NAMESPACES is taken from
 (defun cider-macroexpand-undo (&optional arg)
   "Undo the last macroexpansion, using `undo-only'.
 ARG is passed along to `undo-only'."
-  (interactive)
+  (interactive "*P")
   (let ((inhibit-read-only t))
     (undo-only arg)))
 

--- a/lisp/cider-profile.el
+++ b/lisp/cider-profile.el
@@ -79,12 +79,11 @@ current ns."
       (lambda (value)
         (pcase value
           ("profiled" (message "Profiling enabled for %s" ns))
-          ("unprofiled" (message "Profiling disabled for %s" ns)))))))
-  query)
+          ("unprofiled" (message "Profiling disabled for %s" ns))))))))
 
 ;;;###autoload
-(defun cider-profile-toggle (query)
-  "Toggle profiling for the given QUERY.
+(defun cider-profile-toggle (_query)
+  "Toggle profiling for a var.
 Defaults to the symbol at point.
 With prefix arg or no symbol at point, prompts for a var."
   (interactive "P")
@@ -101,13 +100,7 @@ With prefix arg or no symbol at point, prompts for a var."
          (lambda (value)
            (pcase value
              ("profiled" (message "Profiling enabled for %s/%s" ns sym))
-             ("unprofiled" (message "Profiling disabled for %s/%s" ns sym)))))))))
-  query)
-
-(defun cider-profile--send-to-inspector (summary-response)
-  "Display SUMMARY-RESPONSE using the inspector."
-  (let ((value (nrepl-dict-get summary-response "value")))
-    (cider-inspector--render-value value)))
+             ("unprofiled" (message "Profiling disabled for %s/%s" ns sym))))))))))
 
 ;;;###autoload
 (defun cider-profile-summary ()

--- a/lisp/cider-session.el
+++ b/lisp/cider-session.el
@@ -509,9 +509,7 @@ no linked session or there is no REPL of TYPE within the current session."
            (or (string= type buffer-repl-type)
                (let ((capabilities
                       (buffer-local-value 'cider-connection-capabilities buffer)))
-                 (cond ((listp type)
-                        (seq-some (lambda (it) (member it capabilities)) type))
-                       (t (member type capabilities)))))))))
+                 (member type capabilities)))))))
 
 (defun cider--get-host-from-session (session)
   "Return the host associated with SESSION."

--- a/lisp/cider-stacktrace.el
+++ b/lisp/cider-stacktrace.el
@@ -283,8 +283,7 @@ Argument FLAGS are the flags set on the stackframe, ie: clj dup, etc."
         (pos (seq-intersection pos-filters flags))
         (all (memq 'all pos-filters)))
     (cond (all nil) ;; if all filter is on then we should not hide
-          ((and pos neg) nil) ;; if hidden and "resurrected" we should not hide
-          (pos nil)
+          (pos nil) ;; if shown (even when also hidden, ie "resurrected") we should not hide
           (neg t)
           (t nil))))
 
@@ -613,27 +612,21 @@ length given by `current-column'."
 SPECIAL-FILTERS are filters that show stack certain stack frames, hiding
 others."
   (with-current-buffer buffer
-    (insert "  Show: ")
-    (dolist (filter special-filters)
-      (insert-text-button (car filter)
-                          'filter (cadr filter)
-                          'follow-link t
-                          'action #'cider-stacktrace-filter
-                          'help-echo (cider-stacktrace-tooltip
-                                      (format "Toggle %s stack frames"
-                                              (car filter))))
-      (insert " "))
-    (insert "\n")
-    (insert "  Hide: ")
-    (dolist (filter filters)
-      (insert-text-button (car filter)
-                          'filter (cadr filter)
-                          'follow-link t
-                          'action #'cider-stacktrace-filter
-                          'help-echo (cider-stacktrace-tooltip
-                                      (format "Toggle %s stack frames"
-                                              (car filter))))
-      (insert " "))
+    (cl-flet ((insert-filter-buttons (filters)
+                (dolist (filter filters)
+                  (insert-text-button (car filter)
+                                      'filter (cadr filter)
+                                      'follow-link t
+                                      'action #'cider-stacktrace-filter
+                                      'help-echo (cider-stacktrace-tooltip
+                                                  (format "Toggle %s stack frames"
+                                                          (car filter))))
+                  (insert " "))))
+      (insert "  Show: ")
+      (insert-filter-buttons special-filters)
+      (insert "\n")
+      (insert "  Hide: ")
+      (insert-filter-buttons filters))
 
     (let ((hidden (copy-sequence "(0 frames hidden)")))
       (put-text-property 0 (length hidden) 'hidden-count t hidden)

--- a/lisp/cider-util.el
+++ b/lisp/cider-util.el
@@ -50,7 +50,7 @@
 
 Setting this to nil removes the fontification restriction."
   :group 'cider
-  :type 'boolean
+  :type '(choice (const :tag "No limit" nil) (integer))
   :package-version '(cider . "0.10.0"))
 
 (defun cider-util--hash-keys (hashtable)
@@ -107,7 +107,7 @@ file, walking up from the current buffer."
   :group 'cider
   :safe (lambda (value)
           (and (listp value)
-               (cl-every #'stringp value))))
+               (seq-every-p #'stringp value))))
 
 (defun cider-project-dir (&optional dir)
   "Return the absolute path of the current Clojure project root, or nil.
@@ -591,10 +591,10 @@ Any other value is just returned."
 Modern specs are lists of rules like ((:block N)) or ((:inner D))."
   (and (listp spec)
        spec
-       (cl-every (lambda (rule)
-                   (and (listp rule)
-                        (memq (car rule) '(:block :inner))))
-                 spec)))
+       (seq-every-p (lambda (rule)
+                      (and (listp rule)
+                           (memq (car rule) '(:block :inner))))
+                    spec)))
 
 (defun cider--indent-spec-to-legacy (spec)
   "Convert a modern indent SPEC to legacy format for older clojure-mode.

--- a/lisp/cider-xref-backend.el
+++ b/lisp/cider-xref-backend.el
@@ -101,9 +101,8 @@ These are used for presentation purposes."
 (cl-defmethod xref-backend-identifier-completion-table ((_backend (eql cider)))
   "Return the completion table for identifiers."
   (cider-ensure-connected)
-  (when-let* ((ns (cider-current-ns))
-              (results (cider-sync-request:ns-vars ns)))
-    results))
+  (when-let* ((ns (cider-current-ns)))
+    (cider-sync-request:ns-vars ns)))
 
 (cl-defmethod xref-backend-references ((_backend (eql cider)) var)
   "Find references of VAR."
@@ -128,7 +127,7 @@ These are used for presentation purposes."
                                            (xref-make-buffer-location buf (with-current-buffer buf
                                                                             (save-excursion
                                                                               (goto-char 0)
-                                                                              (forward-line line)
+                                                                              (forward-line (1- line))
                                                                               (move-to-column (or column 0))
                                                                               (point)))))))
                                   (should-be-closed (and

--- a/lisp/cider-xref.el
+++ b/lisp/cider-xref.el
@@ -91,7 +91,6 @@ the symbol found by the xref search as argument."
 
 (defun cider-xref-source (file-url line name)
   "Find source for FILE-URL, LINE and NAME."
-  (interactive)
   (if file-url
       (if-let* ((buffer (and (not (cider--tooling-file-p file-url))
                              (cider-find-file file-url))))
@@ -108,9 +107,7 @@ the symbol found by the xref search as argument."
   "Show SUMMARY and RESULTS in a pop-up buffer."
   (with-current-buffer (cider-popup-buffer cider-xref-buffer 'select 'apropos-mode 'ancillary)
     (let ((inhibit-read-only t))
-      (if (boundp 'header-line-format)
-          (setq-local header-line-format summary)
-        (insert summary "\n\n"))
+      (setq-local header-line-format summary)
       (dolist (result results)
         (cider-xref-result result))
       (goto-char (point-min)))))

--- a/lisp/nrepl-bencode.el
+++ b/lisp/nrepl-bencode.el
@@ -117,7 +117,9 @@ list or dict."
         (goto-char end)
         ;; normalise any platform-specific newlines
         (let* ((original (buffer-substring-no-properties beg end))
-               (result (replace-regexp-in-string "\r\n\\|\n\r\\|\r" "\n" original)))
+               (result (if (string-search "\r" original)
+                           (replace-regexp-in-string "\r\n\\|\n\r\\|\r" "\n" original)
+                         original)))
           (cons nil (nrepl--push result stack))))))
    ;; integer
    ((looking-at "i\\(-?[0-9]+\\)e")

--- a/lisp/nrepl-client.el
+++ b/lisp/nrepl-client.el
@@ -1197,13 +1197,6 @@ up."
               (when nrepl-on-port-callback
                 (funcall nrepl-on-port-callback (process-buffer process))))))))))
 
-(defmacro emacs-bug-46284/when-27.1-windows-nt (&rest body)
-  "Only evaluate BODY when Emacs bug #46284 has been detected."
-  (when (and (eq system-type 'windows-nt)
-             (string= emacs-version "27.1"))
-    (cons 'progn body)))
-
-
 (defvar nrepl-close-connection-handler-function nil
   "Function to call to close a client connection buffer.
 Called with one argument: the REPL buffer to close.
@@ -1216,18 +1209,6 @@ signal, raise an `error'.  Additionally, if the EVENT signal is SIGHUP,
 close any existing client connections."
   ;; only interested on fatal signals.
   (unless (process-live-p process)
-    (emacs-bug-46284/when-27.1-windows-nt
-     ;; There is a bug in emacs 27.1 (since fixed) that sets all EVENT
-     ;; descriptions for signals to "unknown signal". We correct this by
-     ;; resetting it back to its canonical value.
-     (when (eq (process-status process) 'signal)
-       (pcase (process-exit-status process)
-         ;; SIGHUP==1 emacs nt/inc/ms-w32.h
-         (1 (setq event "Hangup"))
-         ;; SIGINT==2 x86_64-w64-mingw32/include/signal.h
-         (2 (setq event "Interrupt"))
-         ;; SIGKILL==9 emacs nt/inc/ms-w32.h
-         (9 (setq event "Killed")))))
     (let* ((server-buffer (process-buffer process))
            (clients (seq-filter (lambda (b)
                                   (eq (buffer-local-value 'nrepl-server-buffer b)

--- a/lisp/nrepl-dict.el
+++ b/lisp/nrepl-dict.el
@@ -32,7 +32,6 @@
 ;; comparison of string keys.
 
 ;;; Code:
-(require 'cl-lib)
 (require 'compat)
 
 
@@ -53,7 +52,7 @@
 
 (defun nrepl-dict (&rest key-vals)
   "Create nREPL dict from KEY-VALS."
-  (if (cl-evenp (length key-vals))
+  (if (zerop (% (length key-vals) 2))
       (cons 'dict key-vals)
     (error "An even number of KEY-VALS is needed to build a dict object")))
 


### PR DESCRIPTION
Part of the per-module audit cleanups - the bundled simplification pass over the long tail (19 files), so they don't each need their own PR. All behavior-preserving except two small bugfixes called out below.

Highlights:
- **Dead code**: dropped the Emacs-27.1-only `emacs-bug-46284/when-27.1-windows-nt` macro + its only use site (we require Emacs 28+), an always-true `(boundp 'header-line-format)` guard, an unreachable `cond` branch in `cider--match-repl-type`, redundant length/re-tests, and the never-referenced `cider-profile--send-to-inspector`.
- **Idioms**: `when`/`unless` for one-armed `if`/`(when (not ...))`, removed a `format` with no directives and meaningless trailing return values from side-effect commands, `(message "%s" ...)` for the user-extensible inspiration/tips strings, and a `(string-search "\r" ...)` fast path around the unconditional CR-normalization in the bencode decode hot loop.
- **Shed cl-lib where a built-in works**: `cl-every`→`seq-every-p`, `cl-evenp`→`(zerop (% ...))`, a one-default `cl-defun`→plain `defun`; dropped the now-unused `(require 'cl-lib)` in those files.
- **De-duplication**: extracted small prefixed helpers (apropos read-args, browse-spec keyset-op renderer, completion-context balance guard, eval register-write, stacktrace filter buttons).
- **defcustom metadata/types**: `:version`→`:package-version` (two in cider-jack-in), and `cider-font-lock-max-length` `:type` boolean→`(choice (const nil) integer)` to match its real value.

**Bugfixes (worth a look):**
- `cider-debug` menu entry "Forced move out of sexp" called `(cider-debug-mode-send-reply ":out" nil true)` - `true` is unbound in Elisp, so the menu item errored with void-variable. Changed to `t`.
- `cider-xref-backend`'s no-backing-file references fallback used `(forward-line line)` with a 1-based `line`, landing one line past the target; changed to `(forward-line (1- line))` to match the sibling helper.

I deliberately left out two riskier items from this bundle: the `cider-resolve` hot-path threading (coming as its own focused PR) and the `cider-xref` refs/deps command-scaffolding extraction (no tests for that module).

Compile clean with `--warnings-as-errors`, full suite passes, no new checkdoc warnings.

- [x] Tests pass (`eldev test`)
- [x] Linter clean (`eldev lint`)