### PR TITLE
Fill documentation gaps for several commands and options

### DIFF
--- a/doc/modules/ROOT/pages/config/basic_config.adoc
+++ b/doc/modules/ROOT/pages/config/basic_config.adoc
@@ -154,6 +154,9 @@ you can tweak easily yourselves:
 
 Of course, it goes without saying that you can do the same with `cider-tips`.
 
+You can summon an inspirational message any time with kbd:[M-x]
+`cider-inspire-me` (and a tip with `cider-drink-a-sip`).
+
 IMPORTANT: This is probably one of the most important CIDER features. Disable
 those amazing messages at your own risk!
 

--- a/doc/modules/ROOT/pages/usage/code_reloading.adoc
+++ b/doc/modules/ROOT/pages/usage/code_reloading.adoc
@@ -63,7 +63,7 @@ will be displayed in the echo area after you call
 `cider-ns-refresh`. The same information will also be recorded in the
 `+*cider-ns-refresh-log*+` buffer, along with anything printed to
 `+*out*+` or `+*err*+` by `cider-ns-refresh-before-fn` and
-`cider-ns-refresh-start-fn`.
+`cider-ns-refresh-after-fn`.
 
 You can make the `+*cider-ns-refresh-log*+` buffer display automatically
 after you call `cider-ns-refresh` by setting the

--- a/doc/modules/ROOT/pages/usage/misc_features.adoc
+++ b/doc/modules/ROOT/pages/usage/misc_features.adoc
@@ -133,7 +133,9 @@ Here you can see it in action:
 
 image::classpath_browser.png[Classpath Browser]
 
-Press kbd:[RET] on a classpath entry to navigate into it.
+Press kbd:[RET] on a classpath entry to navigate into it.  You can also
+jump straight to a classpath entry, selected via completion, with
+kbd:[M-x] `cider-open-classpath-entry`.
 
 == Browsing Namespaces
 
@@ -307,7 +309,7 @@ shelling out.
 Similarly to the `cljfmt` integration, CIDER also provides a convenient interface
 to format EDN using `clojure.tools.reader.edn`. The following commands are provided:
 
-* `cider-format-edn-defun`
+* `cider-format-edn-last-sexp`
 * `cider-format-edn-region`
 * `cider-format-edn-buffer`
 
@@ -354,3 +356,5 @@ By using a prefix argument when calling `cider-cheatsheet-select`, we can change
 image::cider-cheatsheet-select-3.png[Selecting path in cheatsheet]
 
 It is possible to control which function is used on a var when it is selected by customizing `cider-cheatsheet-default-action-function`. By default, documentation for a var is displayed using `cider-doc-lookup`, but it can also be set to `cider-clojuredocs-lookup` to show documentation from ClojureDocs or any other function accepting a var as an argument.
+
+By default the cheatsheet buffer is selected when it pops up.  Set `cider-cheatsheet-auto-select-buffer` to nil if you'd rather keep focus in the current buffer.


### PR DESCRIPTION
Final part of the per-module audit - the bundled documentation-gap fixes. Doc-only, no code changes.

Stale names corrected:
- `cider-format-edn-defun` -> `cider-format-edn-last-sexp` (the actual command; the old name exists nowhere in the code).
- `cider-ns-refresh-start-fn` -> `cider-ns-refresh-after-fn` (there's no `-start-fn`; the sibling line already documents `-before-fn`).

Missing commands/options now documented:
- `cider-open-classpath-entry` (classpath section).
- `cider-cheatsheet-auto-select-buffer` (cheatsheet section).
- `cider-inspire-me` / `cider-drink-a-sip` (next to the inspiration/tips config).

- [x] Manual updated; adoc parses cleanly