### PR TITLE
Fix Emacs 31+ byte-compiler warnings

### DIFF
--- a/Eldev
+++ b/Eldev
@@ -1,6 +1,6 @@
 ; -*- mode: emacs-lisp; lexical-binding: t -*-
 
-(eldev-require-version "1.8.2")
+(eldev-require-version "1.11.2")
 
 (setf eldev-project-source-dirs '("lisp/"))
 (setf eldev-project-main-file "cider.el")

--- a/lisp/cider-cljs.el
+++ b/lisp/cider-cljs.el
@@ -206,7 +206,7 @@ Figwheel for details."
 (defun cider--figwheel-main-get-builds ()
   "Extract build names from the <build-id>.cljs.edn config files.
 Fetches them in the project root."
-  (when-let ((project-dir (cider-project-dir)))
+  (when-let* ((project-dir (cider-project-dir)))
     (let ((builds (directory-files project-dir nil ".*\\.cljs\\.edn")))
       (mapcar (lambda (f) (string-match "^\\(.*\\)\\.cljs\\.edn" f)
                 (match-string 1 f))
@@ -342,7 +342,7 @@ DEFAULT is the default ClojureScript REPL to offer in completion."
 (defun cider-cljs-repl-form (repl-type)
   "Get the cljs REPL form for REPL-TYPE, if any."
   (if-let* ((repl-type-info (cider--cljs-repl-type-entry repl-type)))
-      (when-let ((repl-form (cadr repl-type-info)))
+      (when-let* ((repl-form (cadr repl-type-info)))
         ;; repl-form can be either a string or a function producing a string
         (if (symbolp repl-form)
             (funcall repl-form)

--- a/lisp/cider-clojuredocs.el
+++ b/lisp/cider-clojuredocs.el
@@ -114,7 +114,7 @@ opposite of what that option dictates."
                   (nrepl-dict-get dict "ns")
                   (nrepl-dict-get dict "name")))
   (newline)
-  (when-let ((arglists (nrepl-dict-get dict "arglists")))
+  (when-let* ((arglists (nrepl-dict-get dict "arglists")))
     (dolist (arglist arglists)
       (insert (format " [%s]\n" arglist)))
     (newline))
@@ -127,7 +127,7 @@ opposite of what that option dictates."
   "Insert \"See Also\" section based on data from DICT."
   (insert "== See Also\n")
   (newline)
-  (if-let ((see-alsos (nrepl-dict-get dict "see-alsos")))
+  (if-let* ((see-alsos (nrepl-dict-get dict "see-alsos")))
       (dolist (see-also see-alsos)
         (insert "* ")
         (insert-text-button see-also
@@ -143,7 +143,7 @@ opposite of what that option dictates."
   "Insert \"Examples\" section based on data from DICT."
   (insert "== Examples\n")
   (newline)
-  (if-let ((examples (nrepl-dict-get dict "examples")))
+  (if-let* ((examples (nrepl-dict-get dict "examples")))
       (dolist (example examples)
         (insert (cider-font-lock-as-clojure example) "\n")
         (insert "-------------------------------------------------\n"))
@@ -154,7 +154,7 @@ opposite of what that option dictates."
   "Insert \"Notes\" section based on data from DICT."
   (insert "== Notes\n")
   (newline)
-  (if-let ((notes (nrepl-dict-get dict "notes")))
+  (if-let* ((notes (nrepl-dict-get dict "notes")))
       (dolist (note notes)
         (insert note "\n")
         (insert "-------------------------------------------------\n"))
@@ -176,7 +176,7 @@ opposite of what that option dictates."
 
 (defun cider-clojuredocs-lookup (sym)
   "Look up the ClojureDocs documentation for SYM."
-  (if-let ((docs (cider-sync-request:clojuredocs-lookup (cider-current-ns) sym)))
+  (if-let* ((docs (cider-sync-request:clojuredocs-lookup (cider-current-ns) sym)))
       (progn
         (pop-to-buffer (cider-create-clojuredocs-buffer (cider-clojuredocs--content docs)))
         ;; highlight the symbol in question in the docs buffer

--- a/lisp/cider-completion.el
+++ b/lisp/cider-completion.el
@@ -248,7 +248,7 @@ in the buffer."
 
 (defun cider-company-docsig (thing)
   "Return signature for THING."
-  (when-let ((eldoc-info (cider-eldoc-info thing)))
+  (when-let* ((eldoc-info (cider-eldoc-info thing)))
     (let* ((ns (cider-plist-get eldoc-info "ns"))
            (symbol (cider-plist-get eldoc-info "symbol"))
            (arglists (cider-plist-get eldoc-info "arglists")))
@@ -316,9 +316,9 @@ is `1' or nil, enables the custom completion style; if `-1', disables it."
 
 Only affects the `cider' completion category."
   (interactive)
-  (let ((found-styles (when-let ((cider (assq 'cider completion-category-overrides)))
+  (let ((found-styles (when-let* ((cider (assq 'cider completion-category-overrides)))
                         (assq 'styles cider)))
-        (found-cycle (when-let ((cider (assq 'cider completion-category-overrides)))
+        (found-cycle (when-let* ((cider (assq 'cider completion-category-overrides)))
                        (assq 'cycle cider))))
     (setq completion-category-overrides (seq-remove (lambda (x)
                                                       (equal 'cider (car x)))

--- a/lisp/cider-connection.el
+++ b/lisp/cider-connection.el
@@ -623,7 +623,7 @@ function with the repl buffer set as current."
             ;; ran at the end of cider--connected-handler
             cider-repl-init-function (plist-get params :repl-init-function)
             cider-launch-params params)
-      (when-let ((type (plist-get params :cljs-repl-type)))
+      (when-let* ((type (plist-get params :cljs-repl-type)))
         (setq cider-cljs-repl-type type))
       (cider-repl-reset-markers)
       (add-hook 'nrepl-response-handler-functions #'cider-repl--state-handler nil 'local)

--- a/lisp/cider-docstring.el
+++ b/lisp/cider-docstring.el
@@ -99,7 +99,7 @@ Note that `cider-docstring' will trim thing smartly, for Java doc comments:
 
 (defun cider--render-docstring-first-sentence (eldoc-info)
   "Render the first sentence of the docstring extracted from ELDOC-INFO."
-  (when-let ((first-sentence-fragments (cider-plist-get eldoc-info "doc-first-sentence-fragments")))
+  (when-let* ((first-sentence-fragments (cider-plist-get eldoc-info "doc-first-sentence-fragments")))
     (cider--fragments-to-s first-sentence-fragments)))
 
 (defun cider--render-docstring (eldoc-info)

--- a/lisp/cider-eldoc.el
+++ b/lisp/cider-eldoc.el
@@ -217,7 +217,7 @@ information."
          (symbol (cider-plist-get eldoc-info "symbol"))
          (docstring (or (cider--render-docstring-first-sentence eldoc-info)
                         (cider--render-docstring eldoc-info)
-                        (when-let (docstring (cider-plist-get eldoc-info "docstring"))
+                        (when-let* ((docstring (cider-plist-get eldoc-info "docstring")))
                           (cider-docstring--trim
                            (cider-docstring--format docstring)))))
          ;; if it's a single class (and not multiple class candidates), that's it

--- a/lisp/cider-endpoint.el
+++ b/lisp/cider-endpoint.el
@@ -225,7 +225,7 @@ Necessary since we run some OS-specific commands that may fail."
 When DIR is non-nil also look for nREPL port files in DIR.  Return a list
 of list of the form (project-dir port)."
   (let* ((pairs (cider--running-nrepl-paths))
-         (pairs (if-let (c (and dir (cider-project-dir dir)))
+         (pairs (if-let* ((c (and dir (cider-project-dir dir))))
                     (append (cider--path->path-port-pairs c) pairs)
                   pairs)))
     (thread-last pairs

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -924,7 +924,7 @@ buffer, else display in a popup buffer."
   "Evaluate the current buffer's namespace form.
 When UNDEF-ALL is non-nil, unmap all symbols and aliases first."
   (interactive "P")
-  (when-let ((ns (cider-get-ns-name)))
+  (when-let* ((ns (cider-get-ns-name)))
     (save-excursion
       (goto-char (match-beginning 0))
       (when undef-all

--- a/lisp/cider-inspector.el
+++ b/lisp/cider-inspector.el
@@ -133,9 +133,9 @@ by clicking or navigating to them by other means."
 (defun cider-inspector-open-thing-at-point ()
   "Opens the thing at point if found, without prompting."
   (interactive)
-  (if-let ((url (thing-at-point 'url)))
+  (if-let* ((url (thing-at-point 'url)))
       (browse-url url)
-    (if-let ((filename (thing-at-point 'filename)))
+    (if-let* ((filename (thing-at-point 'filename)))
         (find-file filename))))
 
 (defvar cider-inspector-mode-map
@@ -282,6 +282,8 @@ current buffer's namespace."
     (when (nrepl-dict-get result "value")
       (setq cider-inspector-location-stack nil)
       (cider-inspector--render-value result :next-inspectable))))
+
+(defvar cider-repl-prompt-function)
 
 (defun cider-inspect-expr-from-inspector ()
   "Run `cider-inspect-expr' in a way that's suitable from the Inspector itself.

--- a/lisp/cider-log.el
+++ b/lisp/cider-log.el
@@ -158,7 +158,7 @@ It will not be used if the package hasn't been installed."
 
 (defun cider-log-buffer-clear-p (&optional buffer)
   "Return non-nil if BUFFER is not empty, otherwise nil."
-  (when-let (buffer (get-buffer (or buffer cider-log-buffer)))
+  (when-let* ((buffer (get-buffer (or buffer cider-log-buffer))))
     (> (buffer-size buffer) 0)))
 
 (defun cider-log--description-clear-events-buffer ()
@@ -362,7 +362,7 @@ It will not be used if the package hasn't been installed."
 The KEYS are used to lookup the values and are joined by SEPARATOR."
   `(:annotation-function
     ,(lambda (identifier)
-       (when-let (dict (cadr (assoc identifier minibuffer-completion-table)))
+       (when-let* ((dict (cadr (assoc identifier minibuffer-completion-table))))
          (let ((annotation (string-join (seq-map (lambda (key) (nrepl-dict-get dict key)) keys)
                                         (or separator " "))))
            (unless (string-blank-p annotation)
@@ -372,7 +372,7 @@ The KEYS are used to lookup the values and are joined by SEPARATOR."
 (defun cider-log--read-appender-id (prompt initial-input history)
   "Read a appender from the minibuffer using PROMPT, INITIAL-INPUT and HISTORY."
   (let ((table (when cider-log-framework
-                 (when-let (framework (cider-log-framework-reload cider-log-framework))
+                 (when-let* ((framework (cider-log-framework-reload cider-log-framework)))
                    (seq-map #'cider-log-appender-id (cider-log-framework-appenders framework))))))
     (completing-read (or prompt "Log appender: ") table nil nil
                      (or initial-input cider-log-appender-id)
@@ -416,12 +416,12 @@ The KEYS are used to lookup the values and are joined by SEPARATOR."
 
 (defun cider-log--read-number-N0 (&optional prompt initial-input history)
   "Read a natural number (including zero) using PROMPT, INITIAL-INPUT and HISTORY."
-  (when-let (value (transient-read-number-N0 (or prompt "Number: ") initial-input history))
+  (when-let* ((value (transient-read-number-N0 (or prompt "Number: ") initial-input history)))
     (string-to-number value)))
 
 (defun cider-log--read-number-N+ (&optional prompt initial-input history)
   "Read a natural number (excluding zero) using PROMPT, INITIAL-INPUT and HISTORY."
-  (when-let (value (transient-read-number-N+ (or prompt "Number: ") initial-input history))
+  (when-let* ((value (transient-read-number-N+ (or prompt "Number: ") initial-input history)))
     (string-to-number value)))
 
 (defun cider-log--read-threads (&optional prompt initial-input history)
@@ -493,13 +493,13 @@ The KEYS are used to lookup the values and are joined by SEPARATOR."
 
 (defun cider-log-appender-attached-p (&optional framework appender)
   "Return non-nil if the log APPENDER is attached to FRAMEWORK, otherwise nil."
-  (when-let ((framework (or framework
-                            (cider-log-framework-by-name
-                             (cider-sync-request:log-frameworks)
-                             cider-log-framework-name)))
-             (appender-id (if appender
-                              (cider-log-appender-id appender)
-                            cider-log-appender-id)))
+  (when-let* ((framework (or framework
+                             (cider-log-framework-by-name
+                              (cider-sync-request:log-frameworks)
+                              cider-log-framework-name)))
+              (appender-id (if appender
+                               (cider-log-appender-id appender)
+                             cider-log-appender-id)))
     (cider-log-framework-appender framework appender-id)))
 
 (defun cider-log-appender-consumers (appender)
@@ -534,16 +534,16 @@ The KEYS are used to lookup the values and are joined by SEPARATOR."
 
 (defun cider-log-appender-reload (framework appender)
   "Reload the APPENDER of the log FRAMEWORK."
-  (when-let (framework (cider-log-framework-reload framework))
+  (when-let* ((framework (cider-log-framework-reload framework)))
     (cider-log-framework-appender framework (cider-log-appender-id appender))))
 
 ;; Log Consumer
 
 (defun cider-log-consumer-attached-p (&optional framework appender consumer)
   "Return non-nil if the CONSUMER is attached to the APPENDER of FRAMEWORK."
-  (when-let ((framework (or framework cider-log-framework))
-             (appender (or appender cider-log-appender))
-             (consumer (or consumer cider-log-consumer)))
+  (when-let* ((framework (or framework cider-log-framework))
+              (appender (or appender cider-log-appender))
+              (consumer (or consumer cider-log-consumer)))
     (cider-log-consumer-reload framework appender consumer)))
 
 (defun cider-log-consumer-id (consumer)
@@ -569,7 +569,7 @@ The KEYS are used to lookup the values and are joined by SEPARATOR."
 
 (defun cider-log-consumer-reload (framework appender consumer)
   "Reload the CONSUMER attached to APPENDER of the log FRAMEWORK."
-  (when-let (appender (cider-log-appender-reload framework appender))
+  (when-let* ((appender (cider-log-appender-reload framework appender)))
     (cider-log-appender-consumer appender consumer)))
 
 (declare-function cider-log-mode "cider-log")
@@ -619,11 +619,11 @@ The KEYS are used to lookup the values and are joined by SEPARATOR."
 
 (defun cider-log--remove-current-buffer-consumer ()
   "Cleanup the log consumer of the current buffer."
-  (when-let ((framework cider-log-framework)
-             (appender cider-log-appender)
-             (consumer cider-log-consumer))
+  (when-let* ((framework cider-log-framework)
+              (appender cider-log-appender)
+              (consumer cider-log-consumer))
     (setq-local cider-log-consumer nil)
-    (when-let (consumer (cider-log-consumer-reload framework appender consumer))
+    (when-let* ((consumer (cider-log-consumer-reload framework appender consumer)))
       (cider-sync-request:log-remove-consumer framework appender consumer)
       consumer)))
 
@@ -655,7 +655,7 @@ The KEYS are used to lookup the values and are joined by SEPARATOR."
 
 (defun cider-log-event--pretty-print (framework appender event)
   "Format the log EVENT of FRAMEWORK and APPENDER."
-  (when-let (event (cider-sync-request:log-format-event framework appender event))
+  (when-let* ((event (cider-sync-request:log-format-event framework appender event)))
     (cider-popup-buffer cider-log-event-buffer cider-auto-select-error-buffer
                         'clojure-mode 'ancillary)
     (with-current-buffer cider-log-event-buffer
@@ -688,9 +688,9 @@ The KEYS are used to lookup the values and are joined by SEPARATOR."
   (let ((n (or n 1)))
     (forward-line n)
     (beginning-of-line)
-    (when-let ((framework cider-log-framework)
-               (appender cider-log-appender)
-               (event (cider-log-event-at-point)))
+    (when-let* ((framework cider-log-framework)
+                (appender cider-log-appender)
+                (event (cider-log-event-at-point)))
       (let ((cider-auto-select-error-buffer nil))
         (save-window-excursion
           (when (get-buffer-window cider-inspector-buffer)
@@ -735,9 +735,9 @@ The KEYS are used to lookup the values and are joined by SEPARATOR."
 (defun cider-log-kill-buffer-hook-handler ()
   "Called from `kill-buffer-hook' to remove the consumer."
   (when (eq 'cider-log-mode major-mode)
-    (when-let ((framework cider-log-framework)
-               (appender cider-log-appender)
-               (consumer cider-log-consumer))
+    (when-let* ((framework cider-log-framework)
+                (appender cider-log-appender)
+                (consumer cider-log-consumer))
       (cider-log--remove-current-buffer-consumer)
       (message "Removed %s event consumer %s from appender %s."
                (cider-log-framework-display-name framework)
@@ -810,7 +810,7 @@ The KEYS are used to lookup the values and are joined by SEPARATOR."
                     (format "Framework: %s" (cider-log--bold cider-log-framework-name)))
                   (when cider-log-appender-id
                     (format "Appender: %s" (cider-log--bold cider-log-appender-id)))
-                  (when-let (id (and cider-log-consumer (cider-log-consumer-id cider-log-consumer)))
+                  (when-let* ((id (and cider-log-consumer (cider-log-consumer-id cider-log-consumer))))
                     (format "Consumer: %s" (cider-log--bold id))))
             " ")))
 

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -42,6 +42,7 @@
 (require 'cider-completion)
 (require 'cider-completion-context)
 (require 'cider-inspector)
+(require 'cider-repl)
 (require 'cider-find)
 (require 'cider-xref-backend)
 (require 'subr-x)

--- a/lisp/cider-ns.el
+++ b/lisp/cider-ns.el
@@ -141,9 +141,9 @@ Present the error message as an overlay."
                               error)))
     (when jump-args
       (apply #'cider-jump-to jump-args)
-      (when-let ((message (seq-some (lambda (cause-dict)
-                                      (nrepl-dbind-response cause-dict (message)
-                                        message))
+      (when-let* ((message (seq-some (lambda (cause-dict)
+                                       (nrepl-dbind-response cause-dict (message)
+                                         message))
                                     ;; `reverse' the causes as the first one typically is a CompilerException, which the second one is the actual exception:
                                     (reverse error))))
         (with-current-buffer buf
@@ -255,9 +255,9 @@ org.clojure/tools.namespace.  See Commentary of this file for a longer list
 of differences.  From the Clojure doc: \":reload forces loading of all the
 identified libs even if they are already loaded\"."
   (interactive "P")
-  (when-let ((ns (if prompt
-                     (string-remove-prefix "'" (read-from-minibuffer "Namespace: " (cider-get-ns-name)))
-                   (cider-get-ns-name))))
+  (when-let* ((ns (if prompt
+                      (string-remove-prefix "'" (read-from-minibuffer "Namespace: " (cider-get-ns-name)))
+                    (cider-get-ns-name))))
     (cider-interactive-eval (format "(require '%s :reload)" ns))))
 
 ;;;###autoload
@@ -271,9 +271,9 @@ of differences.  From the Clojure doc: \":reload-all implies :reload and
 also forces loading of all libs that the identified libs directly or
 indirectly load via require\"."
   (interactive "P")
-  (when-let ((ns (if prompt
-                     (string-remove-prefix "'" (read-from-minibuffer "Namespace: " (cider-get-ns-name)))
-                   (cider-get-ns-name))))
+  (when-let* ((ns (if prompt
+                      (string-remove-prefix "'" (read-from-minibuffer "Namespace: " (cider-get-ns-name)))
+                    (cider-get-ns-name))))
     (cider-interactive-eval (format "(require '%s :reload-all)" ns))))
 
 ;;;###autoload

--- a/lisp/cider-popup.el
+++ b/lisp/cider-popup.el
@@ -72,7 +72,7 @@ by adding BUFFER-NAME to the `special-display-buffer-names' list."
         (progn
           (display-buffer buffer-name)
           (when select
-            (when-let ((window (get-buffer-window buffer-name)))
+            (when-let* ((window (get-buffer-window buffer-name)))
               (select-window window))))
       (let ((window (get-buffer-window buffer-name 'visible)))
         (when window

--- a/lisp/cider-repl.el
+++ b/lisp/cider-repl.el
@@ -619,7 +619,7 @@ the input stream may block the whole colorization process."
          ;; sequence (aka SGR seq) though then flush it out and appended it to
          ;; the result.
          (fragment-flush?
-          (when-let (fragment (and ansi-color-context (cadr ansi-color-context)))
+          (when-let* ((fragment (and ansi-color-context (cadr ansi-color-context))))
             (save-match-data
               ;; Check if fragment is indeed an SGR seq in the making. The SGR
               ;; seq is defined as starting with ESC followed by [ followed by
@@ -978,7 +978,7 @@ nREPL ops, it may be convenient to prevent inserting a prompt.")
 
 (defun cider--maybe-get-state-cljs ()
   "Invokes `cider/get-state' when it's possible to do so."
-  (when-let ((conn (cider-current-repl 'cljs)))
+  (when-let* ((conn (cider-current-repl 'cljs)))
     (when (cider-nrepl-op-supported-p "cider/get-state" conn)
       ;; Per-response side effects happen via the global
       ;; `cider-repl--state-handler' on `nrepl-response-handler-functions',
@@ -1609,7 +1609,7 @@ The value of `cider-repl-input-history' is set by this function."
    (filename (setq cider-repl-history-file filename))
    ((equal 'per-project cider-repl-history-file)
     (make-local-variable 'cider-repl-input-history)
-    (when-let ((dir (cider-repl--find-dir-for-history)))
+    (when-let* ((dir (cider-repl--find-dir-for-history)))
       (setq-local
        cider-repl-history-file (expand-file-name ".cider-history" dir)))))
   (when cider-repl-history-file
@@ -1921,7 +1921,7 @@ The project directory is cached at connection time by
 `cider--cache-session-project-dir', so this function does not block on
 any nREPL requests."
   (setcdr session (seq-filter #'buffer-live-p (cdr session)))
-  (when-let ((repl (cadr session)))
+  (when-let* ((repl (cadr session)))
     (cond
      ;; If a default session is set and still exists, only that session is
      ;; friendly.  If the named session no longer exists we fall through to
@@ -1943,11 +1943,11 @@ any nREPL requests."
      (t
       (when-let* ((proc (get-buffer-process repl))
                   (file (file-truename (or (buffer-file-name) default-directory))))
-        (when-let ((tp (cider-tramp-prefix (current-buffer))))
+        (when-let* ((tp (cider-tramp-prefix (current-buffer))))
           (setq file (string-remove-prefix tp file)))
         (when (process-live-p proc)
           (let ((proj-dir (or (process-get proc :cached-project-dir)
-                              (when-let ((pd (buffer-local-value 'nrepl-project-dir repl)))
+                              (when-let* ((pd (buffer-local-value 'nrepl-project-dir repl)))
                                 (file-name-as-directory (file-truename pd))))))
             ;; The project dir is cached as a truename-resolved directory (with
             ;; a trailing slash), so a plain `string-prefix-p' is both a correct

--- a/lisp/cider-stacktrace.el
+++ b/lisp/cider-stacktrace.el
@@ -808,7 +808,7 @@ If EX-DATA is true, inspect ex-data of the exception instead."
   "Keyboard handler.
 If EX-DATA is true, inspect ex-data of the exception instead."
   (interactive)
-  (when-let ((inspect-index (get-text-property (point) 'inspect-index)))
+  (when-let* ((inspect-index (get-text-property (point) 'inspect-index)))
     (cider-inspector-inspect-last-exception inspect-index ex-data)))
 
 (defun cider-stacktrace--inspect-ex-data-mouse (event)
@@ -915,7 +915,7 @@ Make INSPECT-INDEX actionable if present."
               (goto-char (next-single-property-change (point) 'compile-error))
             (progn
               (while (cider-stacktrace-next-cause))
-              (when-let (position (next-single-property-change (point) 'flags))
+              (when-let* ((position (next-single-property-change (point) 'flags)))
                 (goto-char position)))))))))
 
 (defun cider-stacktrace-render (buffer causes &optional error-types)

--- a/lisp/cider-test.el
+++ b/lisp/cider-test.el
@@ -510,7 +510,7 @@ timing data for the overall run, per-namespace, and per-var respectively."
                     "")
                 "\n")
         (when var-elapsed-time
-          (when-let ((pairs (nrepl-dict-get var-elapsed-time ns)))
+          (when-let* ((pairs (nrepl-dict-get var-elapsed-time ns)))
             (nrepl-dict-map (lambda (var meta)
                               (insert "  " ;; indentation - we're showing a var within a ns
                                       (cider-propertize var 'font-lock-function-name-face)

--- a/lisp/cider-util.el
+++ b/lisp/cider-util.el
@@ -37,6 +37,7 @@
 (require 'seq)
 (require 'subr-x)
 (require 'thingatpt)
+(require 'project)
 
 ;; Third-party
 (require 'compat)

--- a/lisp/cider-xref.el
+++ b/lisp/cider-xref.el
@@ -66,7 +66,7 @@ the symbol found by the xref search as argument."
                                    'action #'cider-xref-doc
                                    'help-echo "Display doc")
       (insert-text-button var-name 'type 'apropos-symbol))
-    (when-let ((doc (nrepl-dict-get result "doc")))
+    (when-let* ((doc (nrepl-dict-get result "doc")))
       (unless (string-equal "(not documented)" doc)
         (insert "\n  ")
         (let ((beg (point)))

--- a/lisp/nrepl-client.el
+++ b/lisp/nrepl-client.el
@@ -1126,7 +1126,7 @@ been determined."
        (and "nREPL server started on port " (group-n 1 (+ (any "0-9"))))
        ;; babashka
        (and "Started nREPL server at "
-            (group-n 2 (+? any)) ":" (group-n 1 (+ (any "0-9"))))))
+            (group-n 2 (+? not-newline)) ":" (group-n 1 (+ (any "0-9"))))))
   "A regexp to search an nREPL's stdout for the address it is listening on.
 
 If it matches, the address components can be extracted using the following


### PR DESCRIPTION
- Replace obsolete `when-let`/`if-let` macros
- Replace obsolete `any` keyword with `non-newline` in nREPL address rx
- Add missing requires/forward-decl where the byte-compiler complained
- Bump Eldev version to 1.11.2

No functional changes.