### PR TITLE
Don't crash rendering ClojureScript stacktraces

### DIFF
--- a/lisp/cider-stacktrace.el
+++ b/lisp/cider-stacktrace.el
@@ -857,7 +857,10 @@ Make INSPECT-INDEX actionable if present."
                                      ,cider-stacktrace-exception-map)
             (insert (format "%d. " num)
                     (propertize note 'font-lock-face 'font-lock-comment-face) " "
-                    (propertize class 'font-lock-face class-face 'mouse-face 'highlight)
+                    ;; ClojureScript error causes can lack a class (it's only
+                    ;; meaningful for JVM exceptions), so guard against nil.
+                    (propertize (or class "(Unknown exception type)")
+                                'font-lock-face class-face 'mouse-face 'highlight)
                     "\n"))
           ;; Detail level 1: message + ex-data
           (cider-propertize-region '(detail 1)

--- a/test/cider-stacktrace-tests.el
+++ b/test/cider-stacktrace-tests.el
@@ -246,6 +246,16 @@
       (goto-char (point-min))
       (expect (cider-stacktrace-frame-p) :to-be nil))))
 
+(describe "cider-stacktrace-render-cause"
+  (it "renders a cause without a class (e.g. ClojureScript errors) instead of erroring"
+    (with-temp-buffer
+      (cider-stacktrace-render-cause
+       (current-buffer)
+       (nrepl-dict "message" "Some ClojureScript error")
+       1 "")
+      (expect (buffer-string) :to-match "Some ClojureScript error")
+      (expect (buffer-string) :to-match "Unknown exception type"))))
+
 (describe "cider-stacktrace--should-hide-p-tests"
   (it "should hide when members of the neg filters"
     (let ((hidden1 (cider-stacktrace--should-hide-p '(a b c) '() '(a)))


### PR DESCRIPTION
ClojureScript error causes can come back without a `class` (it's only meaningful for JVM exceptions), and `cider-stacktrace-render-cause` passed it straight to `propertize`, which throws `wrong-type-argument stringp nil`. That blows up the whole stacktrace buffer for CLJS errors.

Guard the class with a fallback so the cause renders instead of erroring. Added a regression test.

Note: the deeper question of whether the stacktrace window should pop up for CLJS errors at all is a separate, larger change (server-side); this just stops the crash.

Fixes #3821