### PR TITLE
Emit stdout when pprint-eval-ing to a comment

### DIFF
--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -401,6 +401,9 @@ COMMENT-POSTFIX is the text to output after the last line."
     (cider-make-eval-handler
      :buffer buffer
      :on-value (lambda (value) (setq res (concat res value)))
+     ;; Forward stdout to the usual interactive sink so output like the
+     ;; `time' macro's "Elapsed time" line isn't silently dropped (#3732).
+     :on-stdout #'cider-emit-interactive-eval-output
      :on-stderr (lambda (err) (setq res (concat res err)))
      :on-done (lambda ()
                 (with-current-buffer buffer

--- a/test/cider-eval-tests.el
+++ b/test/cider-eval-tests.el
@@ -31,6 +31,16 @@
 
 ;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
 
+(describe "cider-eval-pprint-with-multiline-comment-handler"
+  (it "forwards stdout to the interactive eval output sink (#3732)"
+    (spy-on 'cider-emit-interactive-eval-output)
+    (with-temp-buffer
+      (let ((handler (cider-eval-pprint-with-multiline-comment-handler
+                      (current-buffer) (point-marker) ";; => " ";;    " "")))
+        (funcall handler (nrepl-dict "out" "Elapsed time: 0.042 msecs\n"))
+        (expect 'cider-emit-interactive-eval-output
+                :to-have-been-called-with "Elapsed time: 0.042 msecs\n")))))
+
 (describe "cider-extract-error-info"
   (it "Matches Clojure compilation exceptions"
     (expect (cider-extract-error-info cider-compilation-regexp "Syntax error compiling clojure.core/let at (src/haystack/analyzer.clj:18:1).\n[1] - failed: even-number-of-forms? at: [:bindings] spec: :clojure.core.specs.alpha/bindings\n")


### PR DESCRIPTION
`cider-pprint-eval-last-sexp-to-comment` on something like `(time (+ 1 2))` would drop the "Elapsed time" line entirely. The culprit: `cider-eval-pprint-with-multiline-comment-handler` defines no `:on-stdout` handler, so stdout chunks go nowhere. The non-pprint sibling handler and `C-x C-e`'s handler both forward stdout via `cider-emit-interactive-eval-output`, so this just brings the pprint variant in line. Added a test.

Fixes #3732