### PR TITLE
Browse single-segment namespaces correctly

### DIFF
--- a/lisp/cider-browse-ns.el
+++ b/lisp/cider-browse-ns.el
@@ -470,7 +470,11 @@ var-meta map."
 Return a list of the type (`ns' or `var') and the value."
   (let ((ns-p (get-text-property (point) 'ns))
         (line (car (split-string (string-trim (thing-at-point 'line)) " "))))
-    (if (or ns-p (string-match "\\." line))
+    ;; In the "all namespaces" listing `cider-browse-ns-current-ns' is nil and
+    ;; every line is a namespace.  Relying on the `ns' text property alone fails
+    ;; when point sits on the leading whitespace, and the `.' heuristic misses
+    ;; single-segment namespaces like `user' (#3221).
+    (if (or ns-p (null cider-browse-ns-current-ns) (string-match "\\." line))
         `(ns ,line)
       `(var ,(format "%s/%s"
                      (or (get-text-property (point) 'cider-browse-ns-current-ns)

--- a/test/cider-browse-ns-tests.el
+++ b/test/cider-browse-ns-tests.el
@@ -68,6 +68,19 @@
       (goto-char (point-min))
       (expect (not (search-forward "blank" nil t))))))
 
+(describe "cider-browse-ns--thing-at-point"
+  :var (cider-browse-ns-buffer)
+  (it "treats single-segment namespaces in the all-namespaces listing as namespaces (#3221)"
+    (spy-on 'cider-sync-request:ns-list :and-return-value '("user" "clojure.core"))
+    (with-temp-buffer
+      (setq cider-browse-ns-buffer (buffer-name (current-buffer)))
+      (cider-browse-ns-all)
+      ;; point at the very start of the "user" line, on the leading whitespace
+      (goto-char (point-min))
+      (search-forward "user")
+      (beginning-of-line)
+      (expect (cider-browse-ns--thing-at-point) :to-equal '(ns "user")))))
+
 (describe "cider-browse-ns--first-doc-line"
   (it "returns Not documented if the doc string is missing"
     (expect (cider-browse-ns--first-doc-line nil)


### PR DESCRIPTION
In `cider-browse-ns-all`, pressing RET on a single-segment namespace like `user` opened its docs instead of browsing it. `cider-browse-ns--thing-at-point` decided "namespace vs var" from the `ns` text property (which isn't present when point sits on the leading whitespace of the line) plus a "does the name contain a `.`" heuristic, which dotless namespaces fail.

In the all-namespaces listing `cider-browse-ns-current-ns` is nil, so every line is unambiguously a namespace. Use that. Added a test.

Fixes #3221