### PR TITLE
Recognize ?/! in cider-find-dwim symbols

### DIFF
--- a/lisp/cider-find.el
+++ b/lisp/cider-find.el
@@ -93,12 +93,22 @@ Show results in a different window if OTHER-WINDOW is true."
           (let ((current-prefix-arg (if current-prefix-arg nil '(4))))
             (call-interactively callback)))))))
 
+(defun cider--find-dwim-thing-at-point ()
+  "Return the var or resource path at point for `cider-find-dwim'.
+Inside a string we assume a resource path and use `thing-at-point'.
+Otherwise we use `cider-symbol-at-point', which recognizes Clojure symbol
+characters such as `?' and `!' that `thing-at-point' filename mode drops
+\(see #2876)."
+  (if (nth 3 (syntax-ppss))
+      (thing-at-point 'filename)
+    (or (cider-symbol-at-point) (thing-at-point 'filename))))
+
 (defun cider--find-dwim-interactive (prompt)
   "Get interactive arguments for jump-to functions using PROMPT as needed."
-  (if (cider--prompt-for-symbol-p current-prefix-arg)
-      (list
-       (cider-read-from-minibuffer prompt (thing-at-point 'filename)))
-    (list (or (thing-at-point 'filename) ""))))  ; No prompt.
+  (let ((thing (cider--find-dwim-thing-at-point)))
+    (if (cider--prompt-for-symbol-p current-prefix-arg)
+        (list (cider-read-from-minibuffer prompt thing))
+      (list (or thing "")))))  ; No prompt.
 
 (defun cider-find-dwim-other-window (symbol-file)
   "Jump to SYMBOL-FILE at point, place results in other window."

--- a/test/cider-find-tests.el
+++ b/test/cider-find-tests.el
@@ -31,6 +31,17 @@
 
 ;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
 
+(describe "cider--find-dwim-thing-at-point"
+  (it "captures Clojure symbols ending in ! or ? (#2876)"
+    (with-clojure-buffer "(teardown!|)"
+      (expect (cider--find-dwim-thing-at-point) :to-equal "teardown!"))
+    (with-clojure-buffer "(empty?| coll)"
+      (expect (cider--find-dwim-thing-at-point) :to-equal "empty?")))
+
+  (it "uses the filename inside a string, for resource paths"
+    (with-clojure-buffer "(io/resource \"foo/bar.e|dn\")"
+      (expect (cider--find-dwim-thing-at-point) :to-equal "foo/bar.edn"))))
+
 (describe "cider-find-ns"
   (it "raises a user error if cider is not connected"
     (spy-on 'cider-connected-p :and-return-value nil)


### PR DESCRIPTION
`cider-find-dwim` (`M-.`) on a symbol like `teardown!` or `empty?` jumped to the wrong place (or nowhere): `cider--find-dwim-interactive` read the thing at point via `thing-at-point` in filename mode, and that char set excludes `?` and `!`, truncating the symbol.

Prefer `cider-symbol-at-point`, which respects Clojure symbol syntax, and only fall back to the filename when point is inside a string (resource paths like `(io/resource "foo/bar.edn")`). Added tests for both.

Fixes #2876