### PR TITLE
Associate popup buffers with their originating session

### DIFF
--- a/lisp/cider-inspector.el
+++ b/lisp/cider-inspector.el
@@ -548,7 +548,6 @@ from stack), `:next-inspectable' (move point to next inspectable object)."
          (truncate-lines-p (when-let* ((b (get-buffer cider-inspector-buffer))
                                        (continue truncate-lines-defined))
                              (buffer-local-value 'truncate-lines b)))
-         (repl (cider-current-repl))
          (current-point (point)))
     (cider-make-popup-buffer cider-inspector-buffer 'cider-inspector-mode 'ancillary)
     (cider-inspector-render cider-inspector-buffer value
@@ -558,7 +557,7 @@ from stack), `:next-inspectable' (move point to next inspectable object)."
     (cider-popup-buffer-display cider-inspector-buffer cider-inspector-auto-select-buffer)
     (when cider-inspector-fill-frame (delete-other-windows))
     (with-current-buffer cider-inspector-buffer
-      (setq cider--ancillary-buffer-repl repl)
+      ;; The pin to the originating REPL is set by `cider-make-popup-buffer'.
       (cider-set-buffer-ns ns)
       (cond ((eq point-action nil) (goto-char current-point))
             ((eq point-action :next-inspectable) (ignore-errors (cider-inspector-next-inspectable-object 1)))

--- a/lisp/cider-popup.el
+++ b/lisp/cider-popup.el
@@ -27,6 +27,9 @@
 
 (require 'subr-x)
 
+(declare-function cider-current-repl "cider-session")
+(defvar cider--ancillary-buffer-repl)
+
 (define-minor-mode cider-popup-buffer-mode
   "Mode for CIDER popup buffers."
   :lighter (" cider-tmp")
@@ -114,23 +117,36 @@ We track them mostly to be able to clean them up on quit.")
   "Create a temporary buffer called NAME using major MODE (if specified).
 If ANCILLARY is non-nil, the buffer is added to `cider-ancillary-buffers'
 and automatically removed when killed."
-  (with-current-buffer (get-buffer-create name)
-    (kill-all-local-variables)
-    (setq buffer-read-only nil)
-    (erase-buffer)
-    (when mode
-      (funcall mode))
-    (cider-popup-buffer-mode 1)
-    (setq cider-popup-output-marker (point-marker))
-    (setq buffer-read-only t)
-    (when ancillary
-      (add-to-list 'cider-ancillary-buffers name)
-      (add-hook 'kill-buffer-hook
-                (lambda ()
-                  (setq cider-ancillary-buffers
-                        (remove name cider-ancillary-buffers)))
-                nil 'local))
-    (current-buffer)))
+  ;; Resolve the originating REPL in the *calling* buffer's context (typically
+  ;; the connection buffer, since popups are usually created inside async
+  ;; response handlers).  We use it below to pin the popup to the session that
+  ;; produced it and to adopt that session's project directory.
+  (let ((repl (ignore-errors (cider-current-repl))))
+    (with-current-buffer (get-buffer-create name)
+      (kill-all-local-variables)
+      (setq buffer-read-only nil)
+      (erase-buffer)
+      (when mode
+        (funcall mode))
+      (cider-popup-buffer-mode 1)
+      (setq cider-popup-output-marker (point-marker))
+      (setq buffer-read-only t)
+      ;; Associate the popup with its originating session explicitly, instead of
+      ;; relying on sesman re-resolution from `default-directory'.  This pins
+      ;; `cider-current-repl' (see its definition) and makes project-aware
+      ;; commands (project.el, magit) operate on the session's project.
+      (when (buffer-live-p repl)
+        (setq-local cider--ancillary-buffer-repl repl)
+        (setq-local default-directory
+                    (buffer-local-value 'default-directory repl)))
+      (when ancillary
+        (add-to-list 'cider-ancillary-buffers name)
+        (add-hook 'kill-buffer-hook
+                  (lambda ()
+                    (setq cider-ancillary-buffers
+                          (remove name cider-ancillary-buffers)))
+                  nil 'local))
+      (current-buffer))))
 
 (defun cider-emit-into-popup-buffer (buffer value &optional face inhibit-indent)
   "Emit into BUFFER the provided VALUE optionally using FACE.

--- a/lisp/cider-repl.el
+++ b/lisp/cider-repl.el
@@ -1905,16 +1905,14 @@ under the session's project directory.  The checking is done as follows:
   exists, only that session is considered friendly (it serves every
   buffer, regardless of project context).  When the named session has
   been quit/killed, fall through to the normal matching logic.
-* If the current buffer's name equals the value of `cider-test-report-buffer',
-  only accept the given session's repl if it equals `cider-test--current-repl'.
 * Consider if the buffer belongs to `cider-ancillary-buffers'.
 * Consider the buffer's filename, strip any Docker/TRAMP details from it.
 * Check whether that filename lives under the connection's project
   directory.
 
-Buffers outside the project directory (e.g. a dependency's source jumped
-to via `cider-find-var') are associated with their originating session
-explicitly through `cider--ancillary-buffer-repl', so they don't rely on
+Buffers associated with their originating session explicitly through
+`cider--ancillary-buffer-repl' (e.g. popups, or a dependency's source
+jumped to via `cider-find-var') resolve via that pin and don't rely on
 this matcher.
 
 The project directory is cached at connection time by
@@ -1929,13 +1927,6 @@ any nREPL requests."
      ((and cider-default-session
            (sesman-session 'CIDER cider-default-session))
       (equal (car session) cider-default-session))
-
-     ((equal (buffer-name)
-             cider-test-report-buffer)
-      (or (not cider-test--current-repl)
-          (not (buffer-live-p cider-test--current-repl))
-          (equal repl
-                 cider-test--current-repl)))
 
      ((member (buffer-name) cider-ancillary-buffers)
       t)

--- a/lisp/cider-session.el
+++ b/lisp/cider-session.el
@@ -539,33 +539,46 @@ If TYPE is nil or multi, return all REPLs.  If TYPE is a list of types,
 return only REPLs of type contained in the list.  If ENSURE is non-nil,
 throw an error if no linked session exists.  If REQUIRED-OPS is non-nil,
 filters out all the REPLs that do not support the designated ops."
-  (let ((type (cond
-               ((listp type)
-                (mapcar #'cider-maybe-intern type))
-               ((cider-maybe-intern type))))
-        ;; Gather the candidate REPLs for the current buffer.  Each branch
-        ;; produces the raw list without an `ensure' check; the single check
-        ;; below reports the absence of any linked session uniformly.
-        (repls (if cider-default-session
-                   ;; A pinned default session bypasses sesman entirely and
-                   ;; serves every buffer.  If it has been quit since being
-                   ;; pinned, warn and treat it as having no REPLs, so the
-                   ;; `ensure' check below reports the missing session.
-                   (if-let* ((session (sesman-session 'CIDER cider-default-session)))
-                       (cdr session)
-                     (message "Default CIDER session '%s' no longer exists, ignoring" cider-default-session)
-                     nil)
-                 (pcase cider-merge-sessions
-                   ;; Merge every linked session sharing the current session's
-                   ;; host into one pool of REPLs.
-                   ('host (cider--extract-connections
-                           (cider--get-sessions-with-same-host
-                            (sesman-current-session 'CIDER)
-                            (sesman-current-sessions 'CIDER))))
-                   ;; Merge all sessions linked to the current project.
-                   ('project (cider--extract-connections (sesman-current-sessions 'CIDER)))
-                   ;; No merging: use only the most relevant linked session.
-                   (_ (cdr (sesman-current-session 'CIDER)))))))
+  (let* ((type (cond
+                ((listp type)
+                 (mapcar #'cider-maybe-intern type))
+                ((cider-maybe-intern type))))
+         ;; Gather the candidate REPLs for the current buffer.  Each branch
+         ;; produces the raw list without an `ensure' check; the single check
+         ;; below reports the absence of any linked session uniformly.
+         ;; A buffer explicitly pinned to a REPL (e.g. a popup created from a
+         ;; given session) resolves against that REPL's *session*, independent
+         ;; of sesman/`default-directory'.  We resolve the session - not just the
+         ;; lone REPL - so type filtering and multi (clj+cljs) dispatch keep
+         ;; working.  Takes precedence over `cider-default-session', matching
+         ;; `cider-current-repl', which checks the pin first.  A stale pin (its
+         ;; session has been quit) falls through to normal resolution.
+         (pinned-session (and (buffer-live-p cider--ancillary-buffer-repl)
+                              (sesman-session-for-object
+                               'CIDER cider--ancillary-buffer-repl 'no-error)))
+         (repls (cond
+                 (pinned-session (cdr pinned-session))
+                 ;; A pinned default session bypasses sesman entirely and serves
+                 ;; every buffer.  If it has been quit since being pinned, warn
+                 ;; and treat it as having no REPLs, so the `ensure' check below
+                 ;; reports the missing session.
+                 (cider-default-session
+                  (if-let* ((session (sesman-session 'CIDER cider-default-session)))
+                      (cdr session)
+                    (message "Default CIDER session '%s' no longer exists, ignoring" cider-default-session)
+                    nil))
+                 (t
+                  (pcase cider-merge-sessions
+                    ;; Merge every linked session sharing the current session's
+                    ;; host into one pool of REPLs.
+                    ('host (cider--extract-connections
+                            (cider--get-sessions-with-same-host
+                             (sesman-current-session 'CIDER)
+                             (sesman-current-sessions 'CIDER))))
+                    ;; Merge all sessions linked to the current project.
+                    ('project (cider--extract-connections (sesman-current-sessions 'CIDER)))
+                    ;; No merging: use only the most relevant linked session.
+                    (_ (cdr (sesman-current-session 'CIDER))))))))
     ;; `ensure' has two distinct failure modes: no linked session at all
     ;; (reported here, matching `sesman-ensure-session') and a session that
     ;; has no REPL of the requested TYPE (reported after filtering below).

--- a/lisp/cider-test.el
+++ b/lisp/cider-test.el
@@ -799,10 +799,10 @@ running them."
                             (let ((b (cider-popup-buffer
                                       cider-test-report-buffer
                                       cider-auto-select-test-report-buffer)))
-                              (with-current-buffer b
-                                ;; Change the default-directory so that it doesn't affect `sesman--linked-sessions` logic:
-                                (setq-local default-directory
-                                            (with-current-buffer "*Messages*" default-directory)))
+                              ;; `cider-make-popup-buffer' now pins the report to
+                              ;; its originating REPL and adopts that session's
+                              ;; project dir, so no `default-directory' override
+                              ;; is needed here anymore.
                               (cider-test-render-report
                                b
                                summary

--- a/test/cider-popup-tests.el
+++ b/test/cider-popup-tests.el
@@ -1,0 +1,92 @@
+;;; cider-popup-tests.el  -*- lexical-binding: t; -*-
+
+;; Copyright © 2026 Bozhidar Batsov
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; Harness exploring how CIDER popup/special buffers associate with a session.
+
+;;; Code:
+
+(require 'buttercup)
+(require 'sesman)
+(require 'cider-popup)
+(require 'cider-connection)
+(require 'cider-connection-test-utils "test/utils/cider-connection-test-utils")
+
+;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
+
+(describe "cider-make-popup-buffer session association"
+  :var (sesman-sessions-hashmap sesman-links-alist ses-name)
+
+  (before-each
+    (setq sesman-sessions-hashmap (make-hash-table :test #'equal)
+          sesman-links-alist nil
+          ses-name "a-session"))
+
+  (it "pins the popup to the originating REPL and adopts its project dir"
+    (let ((default-directory (expand-file-name "/tmp/a-dir/")))
+      (with-repl-buffer ses-name 'clj repl
+        (with-current-buffer repl
+          (setq-local default-directory (expand-file-name "/tmp/proj/"))
+          ;; Popups are created in the connection buffer's context (async handler).
+          (let ((popup (cider-make-popup-buffer "*cider-proto-test*" nil 'ancillary)))
+            (unwind-protect
+                (with-current-buffer popup
+                  ;; (1) project-awareness: default-directory follows the session
+                  (expect default-directory :to-equal (expand-file-name "/tmp/proj/"))
+                  ;; (2) explicit session pin
+                  (expect cider--ancillary-buffer-repl :to-equal repl)
+                  ;; (3) resolution uses the pin even with a bogus default-directory,
+                  ;; i.e. it no longer depends on sesman re-resolution at all
+                  (setq-local default-directory (expand-file-name "/tmp/elsewhere/"))
+                  (expect (cider-current-repl) :to-equal repl))
+              (kill-buffer popup)))))))
+
+  (it "degrades gracefully when there is no session"
+    (let ((default-directory (expand-file-name "/tmp/a-dir/")))
+      (let ((popup (cider-make-popup-buffer "*cider-proto-test-2*" nil 'ancillary)))
+        (unwind-protect
+            (with-current-buffer popup
+              (expect cider--ancillary-buffer-repl :to-be nil))
+          (kill-buffer popup)))))
+
+  ;; The pin identifies a *session*, not a lone REPL: `cider-repls' must still
+  ;; honor the type argument and `multi' dispatch within the pinned session.
+  (it "resolves the pinned REPL's whole session for cider-repls (type + multi)"
+    (let ((default-directory (expand-file-name "/tmp/a-dir/")))
+      (with-repl-buffer ses-name 'clj clj-repl
+        (with-repl-buffer ses-name 'cljs cljs-repl
+          (with-current-buffer clj-repl
+            (let ((popup (cider-make-popup-buffer "*cider-proto-test-3*" nil 'ancillary)))
+              (unwind-protect
+                  (with-current-buffer popup
+                    ;; pinned to the clj REPL...
+                    (expect cider--ancillary-buffer-repl :to-equal clj-repl)
+                    ;; ...yet the cljs sibling in the same session is still reachable
+                    (expect (cider-repls 'clj) :to-equal (list clj-repl))
+                    (expect (cider-repls 'cljs) :to-equal (list cljs-repl))
+                    (expect (sort (mapcar #'buffer-name (cider-repls 'multi)) #'string<)
+                            :to-equal (sort (list (buffer-name clj-repl)
+                                                  (buffer-name cljs-repl))
+                                            #'string<)))
+                (kill-buffer popup)))))))))
+
+(provide 'cider-popup-tests)
+
+;;; cider-popup-tests.el ends here


### PR DESCRIPTION
Supersedes #3932, and credit to @Zzull for surfacing the underlying problem there.

While looking at #3932 (which sets `default-directory` in the test-report buffer so `magit`/`project.el` commands work from it), it became clear the test-report buffer isn't special - it's just the messiest case of a more general gap: CIDER's popup/special buffers have no consistent notion of which session they belong to. Most inherit `default-directory` incidentally; the test report overrode it to `*Messages*`' dir, which both disconnected it from project-based session resolution and broke project-aware commands invoked from it.

So instead of patching the one buffer, this fixes it centrally:

- `cider-make-popup-buffer` pins every popup to its originating REPL (`cider--ancillary-buffer-repl`) and adopts that session's project `default-directory`. That gives project-awareness *and* deterministic session resolution that no longer depends on sesman re-resolving from `default-directory`.
- `cider-repls` now honors the pin too, resolving the pinned REPL's **session** (not the lone REPL), so type filtering and `multi` (clj+cljs) dispatch keep working. It takes precedence over `cider-default-session`, and a stale pin (its session quit) falls through to normal resolution.
- The test report's `*Messages*` hack is removed.

Second commit drops two work-arounds the pin makes redundant: the `cider-test-report-buffer` branch in `cider-sesman-friendly-session-p`, and the inspector's manual pin. `cider-test--current-repl` and the compilation buffer's explicit (caller-provided) pin stay - they're not redundant.

New `test/cider-popup-tests.el` covers the pin + project dir, the no-session degradation, and the session-resolution-for-`cider-repls` behavior (type + multi).