### PR TITLE
Attach scratch buffers to a specific session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [#3964](https://github.com/clojure-emacs/cider/pull/3964): Add `cider-comment-style` to control how the eval-to-comment commands format the inserted result (`line`, `ignore` or `comment`).
 - [#3965](https://github.com/clojure-emacs/cider/pull/3965): Add `cider-send-to-comment` to copy the top-level form at point into the namespace's rich `comment` block (`C-c C-j c`), optionally evaluating it, and `cider-jump-to-comment` to visit the block (`C-c C-j v`).
+- [#3963](https://github.com/clojure-emacs/cider/pull/3963): Attach `cider-scratch` buffers to a specific session (one scratchpad per session), with a configurable eval destination (cljc-style by default) cyclable via `cider-scratch-cycle-eval-destination` (`C-c C-d`).
 
 ## 1.22.2 (2026-06-17)
 

--- a/doc/modules/ROOT/pages/usage/misc_features.adoc
+++ b/doc/modules/ROOT/pages/usage/misc_features.adoc
@@ -17,7 +17,26 @@ the REPL buffer and is very similar to Emacs's own `+*scratch*+` buffer.
 In the scratchpad, kbd:[C-j] (`cider-eval-print-last-sexp`) evaluates the
 expression before point and prints its value inline, advancing point;
 kbd:[C-u C-j] pretty-prints the result instead. `cider-scratch-reset`
-clears the buffer back to its initial state.
+clears the buffer back to its initial state (keeping its session and
+eval destination).
+
+=== Scratchpads and sessions
+
+Each CIDER session gets its own scratchpad, permanently attached to it, so
+your evaluations always go to a known session.  When you run `cider-scratch`
+from a buffer with a clear session, you land in that session's scratchpad
+(named `+*cider-scratch: SESSION*+`); when the context is ambiguous (or with
+a prefix argument), CIDER prompts you to pick one.  With no connections at
+all, you get a single, session-less `+*cider-scratch*+` buffer.  Use
+`cider-scratch-set-session` to re-attach a scratchpad to a different session.
+
+Because a scratchpad has no file extension to dispatch on, you choose where
+its evaluations go.  By default it follows `cider-clojurec-eval-destination`
+(like a `.cljc` file, i.e. both Clojure and ClojureScript REPLs of its
+session).  kbd:[C-c C-d] (`cider-scratch-cycle-eval-destination`) cycles
+between `clj`, `cljs`, and `multi`, and the current choice is shown in the
+mode line (e.g. `[multi]`).  You can also set it directly via
+`cider-scratch-set-eval-destination` or the mode menu.
 
 == Find References
 

--- a/lisp/cider-scratch.el
+++ b/lisp/cider-scratch.el
@@ -31,8 +31,10 @@
 ;;; Code:
 
 (require 'cider-eval)
+(require 'cider-session)
 (require 'clojure-mode)
 (require 'easymenu)
+(require 'sesman)
 
 (defcustom cider-scratch-initial-message
   ";; This buffer is for Clojure experiments and evaluation.\n
@@ -49,26 +51,68 @@
     (define-key map (kbd "C-j") #'cider-eval-print-last-sexp)
     (define-key map [remap paredit-newline] #'cider-eval-print-last-sexp)
     (define-key map [remap paredit-C-j] #'cider-eval-print-last-sexp)
+    (define-key map (kbd "C-c C-d") #'cider-scratch-cycle-eval-destination)
     (easy-menu-define cider-clojure-interaction-mode-menu map
       "Menu for Clojure Interaction mode"
       '("Clojure Interaction"
         ["Eval and print last sexp" cider-eval-print-last-sexp]
+        ["Eval and pretty-print last sexp" (cider-eval-print-last-sexp '(4))
+         :keys "C-u C-j"]
         "--"
+        ["Cycle eval destination" cider-scratch-cycle-eval-destination]
+        ("Eval destination"
+         ["Clojure" (cider-scratch-set-eval-destination 'clj)
+          :style radio :selected (eq cider-repl-type-override 'clj)]
+         ["ClojureScript" (cider-scratch-set-eval-destination 'cljs)
+          :style radio :selected (eq cider-repl-type-override 'cljs)]
+         ["Multi (Clojure + ClojureScript)" (cider-scratch-set-eval-destination 'multi)
+          :style radio :selected (eq cider-repl-type-override 'multi)])
+        "--"
+        ["Attach to session..." cider-scratch-set-session]
         ["Reset" cider-scratch-reset]))
     map))
 
-(defconst cider-scratch-buffer-name "*cider-scratch*")
+(defconst cider-scratch-buffer-name "*cider-scratch*"
+  "Name of the session-less scratch buffer.
+Per-session scratch buffers are named `*cider-scratch: SESSION*'.")
+
+(defconst cider-scratch--eval-destinations '(clj cljs multi)
+  "The dispatch modes a scratch buffer can cycle through.")
+
+(defun cider-scratch--buffer-name (session-name)
+  "Return the scratch buffer name for SESSION-NAME (nil for the session-less one)."
+  (if session-name
+      (format "*cider-scratch: %s*" session-name)
+    cider-scratch-buffer-name))
+
+(defun cider-scratch--ask-for-repl ()
+  "Prompt for a session and return one of its REPLs, or nil if there are none."
+  (when-let* ((sessions (cider-sessions)))
+    (let* ((name (completing-read "Attach scratch to CIDER session: "
+                                  (mapcar #'car sessions) nil t))
+           (session (assoc name sessions)))
+      (cadr session))))
 
 ;;;###autoload
-(defun cider-scratch ()
-  "Go to the scratch buffer named `cider-scratch-buffer-name'."
-  (interactive)
-  (pop-to-buffer (cider-scratch-find-or-create-buffer)))
+(defun cider-scratch (&optional ask)
+  "Go to the scratch buffer attached to the current session.
+Each session gets its own scratch buffer, permanently attached to it, so
+evaluations always target a known session.  When the current context has
+no clear session (or with a prefix ARG to force it), prompt for one.  With
+no connections at all, fall back to a single session-less scratch buffer."
+  (interactive "P")
+  (let ((repl (or (and (not ask) (cider-current-repl))
+                  (cider-scratch--ask-for-repl))))
+    (pop-to-buffer (cider-scratch-find-or-create-buffer repl))))
 
-(defun cider-scratch-find-or-create-buffer ()
-  "Find or create the scratch buffer."
-  (or (get-buffer cider-scratch-buffer-name)
-      (cider-scratch--create-buffer)))
+(defun cider-scratch-find-or-create-buffer (&optional repl)
+  "Find or create the scratch buffer attached to REPL's session.
+With no REPL, use the session-less scratch buffer."
+  (let* ((session-name (when (buffer-live-p repl)
+                         (sesman-session-name-for-object 'CIDER repl 'no-error)))
+         (name (cider-scratch--buffer-name session-name)))
+    (or (get-buffer name)
+        (cider-scratch--create-buffer name repl))))
 
 (define-derived-mode cider-clojure-interaction-mode clojure-mode "Clojure Interaction"
   "Major mode for typing and evaluating Clojure forms.
@@ -82,12 +126,66 @@ before point, and prints its value into the buffer, advancing point.
   "Insert the welcome message for the scratch buffer."
   (insert cider-scratch-initial-message))
 
-(defun cider-scratch--create-buffer ()
-  "Create a new scratch buffer."
-  (with-current-buffer (get-buffer-create cider-scratch-buffer-name)
+(defun cider-scratch--update-mode-line ()
+  "Reflect the current eval destination in the mode line."
+  (setq-local mode-line-process
+              (format " [%s]" (or cider-repl-type-override 'clj)))
+  (force-mode-line-update))
+
+(defun cider-scratch--attach (repl)
+  "Associate the current scratch buffer with REPL's session.
+When REPL is a live buffer, pin the scratch to it (via
+`cider--ancillary-buffer-repl') and adopt its project directory, so that
+evaluations and project-aware commands target REPL's session.  The eval
+destination defaults to `cider-clojurec-eval-destination', unless one has
+already been chosen for this buffer."
+  (when (buffer-live-p repl)
+    (setq-local cider--ancillary-buffer-repl repl)
+    ;; Adopt the session's project dir so project-aware commands behave.
+    (setq-local default-directory (buffer-local-value 'default-directory repl)))
+  (unless cider-repl-type-override
+    ;; cljc-style dispatch by default; the user can cycle it per buffer.
+    (setq-local cider-repl-type-override cider-clojurec-eval-destination))
+  (cider-scratch--update-mode-line))
+
+(defun cider-scratch--create-buffer (name repl)
+  "Create scratch buffer NAME and attach it to REPL's session."
+  (with-current-buffer (get-buffer-create name)
     (cider-clojure-interaction-mode)
+    (cider-scratch--attach repl)
     (cider-scratch--insert-welcome-message)
     (current-buffer)))
+
+(defun cider-scratch-set-eval-destination (type)
+  "Set this scratch buffer's eval dispatch to TYPE (clj, cljs or multi)."
+  (interactive (list (intern (completing-read
+                              "Scratch eval destination: "
+                              (mapcar #'symbol-name cider-scratch--eval-destinations)
+                              nil t))))
+  (setq-local cider-repl-type-override type)
+  (cider-scratch--update-mode-line)
+  (message "Scratch eval destination set to `%s'" type))
+
+(defun cider-scratch-cycle-eval-destination ()
+  "Cycle this scratch buffer's eval dispatch through clj, cljs and multi."
+  (interactive)
+  (let* ((current (or cider-repl-type-override (car cider-scratch--eval-destinations)))
+         (tail (cdr (memq current cider-scratch--eval-destinations)))
+         (next (or (car tail) (car cider-scratch--eval-destinations))))
+    (cider-scratch-set-eval-destination next)))
+
+(defun cider-scratch-set-session ()
+  "Attach the current scratch buffer to an explicitly chosen session.
+Also renames the buffer to match, so its name keeps reflecting its session."
+  (interactive)
+  (if-let* ((repl (cider-scratch--ask-for-repl)))
+      (progn
+        (cider-scratch--attach repl)
+        (rename-buffer
+         (cider-scratch--buffer-name
+          (sesman-session-name-for-object 'CIDER repl 'no-error))
+         'unique))
+    (user-error "No CIDER sessions to attach to")))
 
 (defun cider-scratch-reset ()
   "Reset the current scratch buffer."

--- a/lisp/cider-session.el
+++ b/lisp/cider-session.el
@@ -268,13 +268,21 @@ By default it assumes the connection buffer is current."
   "Return non-nil when REPL-BUFFER is currently a pending cljs repl."
   (buffer-local-value 'cider-repl-cljs-upgrade-pending repl-buffer))
 
+(defvar-local cider-repl-type-override nil
+  "When non-nil, the connection type (clj, cljs or multi) used for this buffer.
+Overrides the major-mode-based inference in `cider-repl-type-for-buffer'.
+Buffers with no inherent file type - e.g. `*cider-scratch*' - set this to
+control where their evaluations are dispatched.")
+
 (defun cider-repl-type-for-buffer (&optional buffer)
   "Return the matching connection type (clj or cljs) for BUFFER.
 BUFFER defaults to the `current-buffer'.  In cljc buffers return
-multi.  This function infers connection type based on the major mode.
+multi.  This function infers connection type based on the major mode,
+unless `cider-repl-type-override' is set.
 For the REPL type use the function `cider-repl-type'."
   (with-current-buffer (or buffer (current-buffer))
     (cond
+     (cider-repl-type-override cider-repl-type-override)
      ((cider-clojurescript-major-mode-p) 'cljs)
      ((cider-clojurec-major-mode-p) cider-clojurec-eval-destination)
      ((cider-clojure-major-mode-p) 'clj)

--- a/test/cider-scratch-tests.el
+++ b/test/cider-scratch-tests.el
@@ -1,0 +1,90 @@
+;;; cider-scratch-tests.el  -*- lexical-binding: t; -*-
+
+;; Copyright © 2026 Bozhidar Batsov
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; Tests for per-session scratch buffers and their eval-destination dispatch.
+
+;;; Code:
+
+(require 'buttercup)
+(require 'sesman)
+(require 'cider-scratch)
+(require 'cider-connection-test-utils "test/utils/cider-connection-test-utils")
+
+;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
+
+(describe "cider-repl-type-for-buffer override"
+  (it "honors a buffer-local cider-repl-type-override"
+    (with-temp-buffer
+      (cider-clojure-interaction-mode)
+      ;; a plain Clojure-interaction buffer would otherwise infer `clj'
+      (expect (cider-repl-type-for-buffer) :to-equal 'clj)
+      (setq-local cider-repl-type-override 'multi)
+      (expect (cider-repl-type-for-buffer) :to-equal 'multi))))
+
+(describe "cider-scratch--buffer-name"
+  (it "is session-less without a session name"
+    (expect (cider-scratch--buffer-name nil) :to-equal cider-scratch-buffer-name))
+  (it "embeds the session name when given one"
+    (expect (cider-scratch--buffer-name "proj@host") :to-equal "*cider-scratch: proj@host*")))
+
+(describe "cider-scratch-cycle-eval-destination"
+  (it "cycles clj -> cljs -> multi -> clj and reflects it in the mode line"
+    (with-temp-buffer
+      (cider-clojure-interaction-mode)
+      (setq-local cider-repl-type-override 'clj)
+      (cider-scratch-cycle-eval-destination)
+      (expect cider-repl-type-override :to-equal 'cljs)
+      (cider-scratch-cycle-eval-destination)
+      (expect cider-repl-type-override :to-equal 'multi)
+      (expect mode-line-process :to-equal " [multi]")
+      (cider-scratch-cycle-eval-destination)
+      (expect cider-repl-type-override :to-equal 'clj))))
+
+(describe "cider-scratch per-session attachment"
+  :var (sesman-sessions-hashmap sesman-links-alist)
+  (before-each
+    (setq sesman-sessions-hashmap (make-hash-table :test #'equal)
+          sesman-links-alist nil))
+
+  (it "pins the buffer to its session's REPL and defaults to cljc-style dispatch"
+    (let ((default-directory (expand-file-name "/tmp/a-dir/"))
+          (cider-clojurec-eval-destination 'multi))
+      (with-repl-buffer "scratch-ses" 'clj repl
+        (let ((buf (cider-scratch-find-or-create-buffer repl)))
+          (unwind-protect
+              (with-current-buffer buf
+                (expect (buffer-name) :to-equal "*cider-scratch: scratch-ses*")
+                (expect cider--ancillary-buffer-repl :to-equal repl)
+                (expect cider-repl-type-override :to-equal 'multi))
+            (kill-buffer buf)))))))
+
+(describe "cider-scratch-reset"
+  (it "preserves the chosen eval destination"
+    (with-temp-buffer
+      (cider-clojure-interaction-mode)
+      (setq-local cider-repl-type-override 'cljs)
+      (insert "(+ 1 2)")
+      (cider-scratch-reset)
+      (expect cider-repl-type-override :to-equal 'cljs))))
+
+(provide 'cider-scratch-tests)
+
+;;; cider-scratch-tests.el ends here


### PR DESCRIPTION
`*cider-scratch*` was a single global buffer that always dispatched to a clj REPL, so in a clj+cljs session (or when juggling projects) evaluations went somewhere surprising and ignored the "current REPL" rules.

This gives each session its own scratchpad, permanently attached to it:

- `cider-scratch` resolves the current session and lands in (or creates) `*cider-scratch: SESSION*`, pinned via `cider--ancillary-buffer-repl` (building on the popup-session work in #3962) and carrying that session's project dir. Ambiguous context (or a prefix arg) prompts for a session; with no connections you get the session-less `*cider-scratch*`. `cider-scratch-set-session` re-attaches an existing scratchpad.
- Since a scratchpad has no file extension to dispatch on, its eval destination is configurable: defaults to `cider-clojurec-eval-destination` (cljc-style, i.e. both REPLs of the session), and `cider-scratch-cycle-eval-destination` (`C-c C-d`) cycles clj/cljs/multi, reflected in the mode line. Implemented via a new general `cider-repl-type-override` buffer-local that `cider-repl-type-for-buffer` consults.

Also fleshed out the Clojure Interaction mode menu (adds the pretty-print eval and the destination commands), and documented all of it in the manual.

Fixes #2742