### PR TITLE
Add cider-comment-style to control eval-to-comment formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+- [#3964](https://github.com/clojure-emacs/cider/pull/3964): Add `cider-comment-style` to control how the eval-to-comment commands format the inserted result (`line`, `ignore` or `comment`).
+
 ## 1.22.2 (2026-06-17)
 
 ### Bugs fixed

--- a/doc/modules/ROOT/pages/usage/code_evaluation.adoc
+++ b/doc/modules/ROOT/pages/usage/code_evaluation.adoc
@@ -302,6 +302,30 @@ prefix). By default the prefix is `=> `.
 
 To remove the prefix altogether, just set it to the empty string (`""`).
 
+=== Change the eval-to-comment style
+
+The eval-to-comment commands (e.g. `cider-eval-defun-to-comment` and
+`cider-pprint-eval-last-sexp-to-comment`) insert the evaluation result next to
+the form that produced it. The format is controlled by `cider-comment-style`:
+
+[source,lisp]
+----
+(setq cider-comment-style 'line) ;; the default
+----
+
+The available styles are:
+
+* `line` - a line comment, e.g. `+;; => 42+`. This is the default and honors the
+`cider-comment-prefix`, `cider-comment-continued-prefix` and
+`cider-comment-postfix` options.
+* `ignore` - a reader ignore form, e.g. `+#_42+`. Handy when the result is a data
+structure you want to keep as a navigable, editable Clojure datum rather than
+comment text.
+* `comment` - a `comment` form, e.g. `+(comment 42)+`.
+
+NOTE: The `ignore` and `comment` styles ignore the `cider-comment-*` prefix
+options and use their own fixed formatting.
+
 === Change the Output Destination
 
 By default CIDER will display the output produced by some evaluation in the REPL buffer, but you can also funnel the output to a dedicated buffer. You can configure this behavior via `cider-interactive-eval-output-destination`.

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -136,6 +136,37 @@ If t, save the file without confirmation."
   :group 'cider
   :package-version '(cider . "0.16.0"))
 
+(defcustom cider-comment-style 'line
+  "The style used by the eval-to-comment commands when inserting a result.
+
+The available styles are:
+
+  `line'    -- a line comment (e.g. \";; => 42\").  This is the default and
+               honors the `cider-comment-prefix', `cider-comment-continued-prefix'
+               and `cider-comment-postfix' options.
+  `ignore'  -- a reader ignore form (e.g. \"#_42\"), which keeps the result as a
+               navigable Clojure datum rather than comment text.
+  `comment' -- a `comment' form (e.g. \"(comment 42)\").
+
+The `ignore' and `comment' styles ignore the `cider-comment-*' prefix options
+and use their own fixed formatting."
+  :type '(choice (const :tag "Line comment (;; =>)" line)
+                 (const :tag "Reader ignore form (#_)" ignore)
+                 (const :tag "Comment form (comment ...)" comment))
+  :group 'cider
+  :package-version '(cider . "1.23.0"))
+
+(defun cider--comment-format ()
+  "Return the comment formatting for `cider-comment-style'.
+The return value is a list (PREFIX CONTINUED-PREFIX POSTFIX) suitable for
+the eval-to-comment handlers."
+  (pcase cider-comment-style
+    ('ignore  (list "#_" "" ""))
+    ('comment (list "(comment " "" ")"))
+    (_        (list cider-comment-prefix
+                    cider-comment-continued-prefix
+                    cider-comment-postfix))))
+
 (defcustom cider-eval-register ?e
   "The text register assigned to the most recent evaluation result.
 When non-nil, the return value of all CIDER eval commands are
@@ -355,10 +386,11 @@ Optional argument DONE-HANDLER lambda will be run once load is complete."
      :on-stdout #'cider-emit-interactive-eval-output
      :on-stderr #'cider-emit-interactive-eval-err-output)))
 
-(defun cider-eval-print-with-comment-handler (buffer location comment-prefix)
+(defun cider-eval-print-with-comment-handler (buffer location comment-prefix &optional comment-postfix)
   "Make a handler for evaluating and printing commented results in BUFFER.
 LOCATION is the location marker at which to insert.  COMMENT-PREFIX is the
-comment prefix to use."
+comment prefix to use and COMMENT-POSTFIX (if any) is appended after the
+result."
   (let ((res ""))
     (cider-make-eval-handler
      :buffer buffer
@@ -369,7 +401,7 @@ comment prefix to use."
                 (with-current-buffer buffer
                   (save-excursion
                     (goto-char (marker-position location))
-                    (insert (concat comment-prefix res "\n"))))
+                    (insert (concat comment-prefix res (or comment-postfix "") "\n"))))
                 (cider--maybe-set-eval-register res)))))
 
 (defun cider-maybe-insert-multiline-comment (result comment-prefix continued-prefix comment-postfix)
@@ -660,18 +692,20 @@ attempt to extract the context from parent let-bindings."
 (defun cider-eval-defun-to-comment (&optional insert-before)
   "Evaluate the \"top-level\" form and insert result as comment.
 
-The formatting of the comment is defined in `cider-comment-prefix'
-which, by default, is \";; => \" and can be customized.
+The comment style is controlled by `cider-comment-style' (by default a
+\";; => \" line comment; see also `cider-comment-prefix').
 
 With the prefix arg INSERT-BEFORE, insert before the form, otherwise afterwards."
   (interactive "P")
-  (let* ((bounds (cider-defun-at-point 'bounds))
-         (insertion-point (nth (if insert-before 0 1) bounds)))
+  (pcase-let* ((bounds (cider-defun-at-point 'bounds))
+               (insertion-point (nth (if insert-before 0 1) bounds))
+               (`(,prefix ,_ ,postfix) (cider--comment-format)))
     (cider-interactive-eval nil
                             (cider-eval-print-with-comment-handler
                              (current-buffer)
                              (set-marker (make-marker) insertion-point)
-                             cider-comment-prefix)
+                             prefix
+                             postfix)
                             bounds
                             (cider--nrepl-pr-request-plist))))
 
@@ -679,28 +713,24 @@ With the prefix arg INSERT-BEFORE, insert before the form, otherwise afterwards.
   "Evaluate the form selected by FORM-FN and insert result as comment.
 FORM-FN can be either `cider-last-sexp' or `cider-defun-at-point'.
 
-The formatting of the comment is controlled via three options:
-    `cider-comment-prefix'           \";; => \"
-    `cider-comment-continued-prefix' \";;    \"
-    `cider-comment-postfix'          \"\"
-
-so that with customization you can optionally wrap the output
-in the reader macro \"#_( .. )\", or \"(comment ... )\", or any
-other desired formatting.
+The comment style is controlled by `cider-comment-style'.  For the default
+`line' style the formatting is further controlled via the `cider-comment-prefix',
+`cider-comment-continued-prefix' and `cider-comment-postfix' options.
 
 If INSERT-BEFORE is non-nil, insert before the form, otherwise afterwards."
-  (let* ((bounds (funcall form-fn 'bounds))
-         (insertion-point (nth (if insert-before 0 1) bounds))
-         ;; when insert-before, we need a newline after the output to
-         ;; avoid commenting the first line of the form
-         (comment-postfix (concat cider-comment-postfix
-                                  (if insert-before "\n" ""))))
+  (pcase-let* ((bounds (funcall form-fn 'bounds))
+               (insertion-point (nth (if insert-before 0 1) bounds))
+               (`(,prefix ,continued ,postfix) (cider--comment-format))
+               ;; when insert-before, we need a newline after the output to
+               ;; avoid commenting the first line of the form
+               (comment-postfix (concat postfix
+                                        (if insert-before "\n" ""))))
     (cider-interactive-eval nil
                             (cider-eval-pprint-with-multiline-comment-handler
                              (current-buffer)
                              (set-marker (make-marker) insertion-point)
-                             cider-comment-prefix
-                             cider-comment-continued-prefix
+                             prefix
+                             continued
                              comment-postfix)
                             bounds
                             (cider--nrepl-print-request-plist fill-column))))
@@ -708,14 +738,7 @@ If INSERT-BEFORE is non-nil, insert before the form, otherwise afterwards."
 (defun cider-pprint-eval-last-sexp-to-comment (&optional insert-before)
   "Evaluate the last sexp and insert result as comment.
 
-The formatting of the comment is controlled via three options:
-    `cider-comment-prefix'           \";; => \"
-    `cider-comment-continued-prefix' \";;    \"
-    `cider-comment-postfix'          \"\"
-
-so that with customization you can optionally wrap the output
-in the reader macro \"#_( .. )\", or \"(comment ... )\", or any
-other desired formatting.
+The comment style is controlled by `cider-comment-style'.
 
 If INSERT-BEFORE is non-nil, insert before the form, otherwise afterwards."
   (interactive "P")
@@ -724,14 +747,7 @@ If INSERT-BEFORE is non-nil, insert before the form, otherwise afterwards."
 (defun cider-pprint-eval-defun-to-comment (&optional insert-before)
   "Evaluate the \"top-level\" form and insert result as comment.
 
-The formatting of the comment is controlled via three options:
-    `cider-comment-prefix'           \";; => \"
-    `cider-comment-continued-prefix' \";;    \"
-    `cider-comment-postfix'          \"\"
-
-so that with customization you can optionally wrap the output
-in the reader macro \"#_( .. )\", or \"(comment ... )\", or any
-other desired formatting.
+The comment style is controlled by `cider-comment-style'.
 
 If INSERT-BEFORE is non-nil, insert before the form, otherwise afterwards."
   (interactive "P")

--- a/test/cider-eval-tests.el
+++ b/test/cider-eval-tests.el
@@ -41,6 +41,48 @@
         (expect 'cider-emit-interactive-eval-output
                 :to-have-been-called-with "Elapsed time: 0.042 msecs\n")))))
 
+(describe "cider--comment-format"
+  (it "returns the configured prefixes for the `line' style"
+    (let ((cider-comment-style 'line)
+          (cider-comment-prefix ";; => ")
+          (cider-comment-continued-prefix ";;    ")
+          (cider-comment-postfix ""))
+      (expect (cider--comment-format) :to-equal '(";; => " ";;    " ""))))
+  (it "wraps results in a reader ignore form for the `ignore' style"
+    (let ((cider-comment-style 'ignore))
+      (expect (cider--comment-format) :to-equal '("#_" "" ""))))
+  (it "wraps results in a comment form for the `comment' style"
+    (let ((cider-comment-style 'comment))
+      (expect (cider--comment-format) :to-equal '("(comment " "" ")")))))
+
+(describe "cider-maybe-insert-multiline-comment"
+  ;; neutralize mode-specific indentation so the assertions are deterministic
+  (it "produces a line comment for the `line' style"
+    (with-temp-buffer
+      (let ((indent-line-function #'ignore))
+        (cider-maybe-insert-multiline-comment "42" ";; => " ";;    " ""))
+      (expect (buffer-string) :to-equal ";; => 42")))
+  (it "produces a reader ignore form for the `ignore' style"
+    (with-temp-buffer
+      (let ((indent-line-function #'ignore))
+        (cider-maybe-insert-multiline-comment "42" "#_" "" ""))
+      (expect (buffer-string) :to-equal "#_42")))
+  (it "produces a comment form for the `comment' style"
+    (with-temp-buffer
+      (let ((indent-line-function #'ignore))
+        (cider-maybe-insert-multiline-comment "42" "(comment " "" ")"))
+      (expect (buffer-string) :to-equal "(comment 42)")))
+  (it "keeps a multiline result as a single navigable datum for the `ignore' style"
+    (with-temp-buffer
+      (let ((indent-line-function #'ignore))
+        (cider-maybe-insert-multiline-comment "{:a 1\n :b 2}" "#_" "" ""))
+      (expect (buffer-string) :to-equal "#_{:a 1\n :b 2}")))
+  (it "balances the closing paren for a multiline `comment' style result"
+    (with-temp-buffer
+      (let ((indent-line-function #'ignore))
+        (cider-maybe-insert-multiline-comment "{:a 1\n :b 2}" "(comment " "" ")"))
+      (expect (buffer-string) :to-equal "(comment {:a 1\n :b 2})"))))
+
 (describe "cider-extract-error-info"
   (it "Matches Clojure compilation exceptions"
     (expect (cider-extract-error-info cider-compilation-regexp "Syntax error compiling clojure.core/let at (src/haystack/analyzer.clj:18:1).\n[1] - failed: even-number-of-forms? at: [:bindings] spec: :clojure.core.specs.alpha/bindings\n")


### PR DESCRIPTION
The eval-to-comment commands could already emit `#_` or `(comment ...)` wrappings, but only if you hand-configured `cider-comment-prefix`, `cider-comment-continued-prefix` and `cider-comment-postfix` just so. This exposes the common cases as a single `cider-comment-style` choice:

- `line` (default) - a `;; => 42` line comment; unchanged, and still honors the existing `cider-comment-*` options
- `ignore` - a `#_42` reader-ignore form, which keeps the result as a navigable Clojure datum instead of comment text
- `comment` - a `(comment 42)` form

The `#_` style is the genuinely useful new bit: for a structured result you get data you can navigate, copy and re-eval, rather than `;;`-prefixed text you'd have to clean up first.

Tests, docs and a CHANGELOG entry included.