### PR TITLE
Add cider-send-to-comment to capture forms in a rich comment block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 - [#3964](https://github.com/clojure-emacs/cider/pull/3964): Add `cider-comment-style` to control how the eval-to-comment commands format the inserted result (`line`, `ignore` or `comment`).
+- [#3965](https://github.com/clojure-emacs/cider/pull/3965): Add `cider-send-to-comment` to copy the top-level form at point into the namespace's rich `comment` block (`C-c C-j c`), optionally evaluating it, and `cider-jump-to-comment` to visit the block (`C-c C-j v`).
 
 ## 1.22.2 (2026-06-17)
 

--- a/doc/modules/ROOT/pages/usage/cider_mode.adoc
+++ b/doc/modules/ROOT/pages/usage/cider_mode.adoc
@@ -80,6 +80,14 @@ kbd:[C-c C-e]
 | kbd:[C-u C-c M-p]
 | Load the form preceding point in the REPL buffer and eval.
 
+| `cider-send-to-comment`
+| kbd:[C-c C-j c]
+| Copy the top-level form at point into the namespace's rich `comment` block (creating one if needed). With a prefix argument, also eval the form and insert its result beneath it.
+
+| `cider-jump-to-comment`
+| kbd:[C-c C-j v]
+| Move point into the namespace's rich `comment` block (creating an empty one if needed), pushing the previous location onto the mark ring.
+
 | `cider-pprint-eval-last-sexp`
 | kbd:[C-c C-v C-f e]
 | Evaluate the form preceding point and pretty-print the result in a popup buffer. If invoked with a prefix argument, insert the result into the current buffer as a comment.

--- a/doc/modules/ROOT/pages/usage/code_evaluation.adoc
+++ b/doc/modules/ROOT/pages/usage/code_evaluation.adoc
@@ -414,6 +414,41 @@ With `cider-eval-defun-at-point` we get:
   *e)
 ----
 
+=== Sending forms to a rich comment block
+
+The `(comment ...)` form (often called a "rich comment" or RCF) is a popular
+place to keep throwaway experiments and usage examples that live with the code
+but never run when the namespace is loaded.
+
+`cider-send-to-comment` (kbd:[C-c C-j c]) copies the top-level form at point
+into the namespace's rich `comment` block, appending it to the last top-level
+`comment` form in the buffer (or creating one at the end of the buffer if there
+isn't any). Successive entries are separated by a blank line for readability.
+Point stays where it is, so filing away an experiment never interrupts your
+editing.
+
+With a prefix argument it also evaluates the form and inserts its result
+beneath it (honoring `cider-comment-style`), turning the block into a
+self-documenting record of what you tried:
+
+[source,clojure]
+----
+(comment
+  (add 1 2)
+  ;; => 3
+  )
+----
+
+To visit the block itself, use `cider-jump-to-comment` (kbd:[C-c C-j v]). It
+moves point into the last `comment` form (creating an empty one when there is
+none), pushing your previous location onto the mark ring so kbd:[C-u C-SPC]
+takes you back.
+
+NOTE: When a namespace has more than one top-level `comment` form, both commands
+operate on the last one (rich comment blocks live at the bottom of a file by
+convention).
+
+TIP: If the rich comment workflow is new to you, https://practical.li/clojure/clojure-cli/projects/rich-comments/[Practicalli's write-up] and https://betweentwoparens.com/blog/rich-comment-blocks/[Rich Comment Blocks] are good introductions.
 
 == Keybindings
 

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -753,6 +753,113 @@ If INSERT-BEFORE is non-nil, insert before the form, otherwise afterwards."
   (interactive "P")
   (cider-pprint-form-to-comment 'cider-defun-at-point insert-before))
 
+(defun cider--last-comment-form-bounds ()
+  "Return the bounds of the last top-level `comment' form in the buffer.
+The return value is a cons (BEG . END), or nil when the buffer has no
+top-level `comment' form."
+  (save-excursion
+    (goto-char (point-max))
+    (let (beg)
+      (while (and (not beg)
+                  (re-search-backward "^(comment\\_>" nil t))
+        ;; ignore matches that sit inside a string or a line comment
+        (unless (nth 8 (syntax-ppss))
+          (setq beg (point))))
+      (when beg
+        (goto-char beg)
+        (cons beg (progn (forward-sexp) (point)))))))
+
+(defun cider--insert-in-comment (form)
+  "Append FORM to the namespace's rich `comment' block.
+Create a `comment' block at the end of the buffer when there is none.  Return
+a cons (BEG . END) of the inserted form's bounds; END is a marker so it tracks
+later insertions (the eval-to-comment handler inserts the result there)."
+  (let ((trimmed (string-trim form))
+        (bounds (cider--last-comment-form-bounds))
+        (beg (make-marker))
+        (end (make-marker)))
+    (if bounds
+        ;; append just before the closing paren of the existing block,
+        ;; preserving whether that paren hugs the last form or sits alone
+        ;; (the marker tracks the closing paren across the insertion so the
+        ;; whole, grown block gets re-indented)
+        (let ((block-end (copy-marker (cdr bounds)))
+              (after-header (save-excursion
+                              (goto-char (car bounds))
+                              (forward-char)   ; past the opening paren
+                              (forward-sexp)   ; past the `comment' symbol
+                              (point))))
+          (goto-char (1- (cdr bounds)))
+          (skip-chars-backward " \t\n")
+          ;; separate entries with a blank line for readability, but don't add
+          ;; one right after the `comment' header (i.e. when the block is empty)
+          (insert (if (> (point) after-header) "\n\n" "\n"))
+          (set-marker beg (point))
+          (insert trimmed)
+          (set-marker end (point))
+          (indent-region (car bounds) block-end))
+      ;; no block yet: create one at the end of the buffer
+      (goto-char (point-max))
+      (skip-chars-backward " \t\n")
+      (delete-region (point) (point-max))
+      (insert "\n\n")
+      (let ((block-start (point)))
+        (insert "(comment\n")
+        (set-marker beg (point))
+        (insert trimmed ")")
+        (set-marker end (1- (point)))
+        (indent-region block-start (point))))
+    (cons (marker-position beg) end)))
+
+(defun cider-send-to-comment (&optional eval)
+  "Copy the top-level form at point into the namespace's rich `comment' block.
+The form is appended to the last top-level `comment' form in the buffer,
+creating one at the end of the buffer when none exists.  Point stays where it
+is; use `cider-jump-to-comment' to visit the block.
+
+With a prefix arg EVAL, also evaluate the form and insert its result beneath
+it, honoring `cider-comment-style'."
+  (interactive "P")
+  (let ((form (cider-defun-at-point)))
+    (when (or (null form) (string-blank-p form))
+      (user-error "No top-level form at point"))
+    ;; leave point undisturbed; the eval result lands via the END marker, not
+    ;; at point, so filing a form away never moves the user
+    (save-excursion
+      (pcase-let* ((`(,_beg . ,end) (cider--insert-in-comment form))
+                   (`(,prefix ,continued ,postfix) (cider--comment-format)))
+        (when eval
+          (cider-interactive-eval
+           (string-trim form)
+           (cider-eval-pprint-with-multiline-comment-handler
+            (current-buffer) end prefix continued postfix)
+           nil
+           (cider--nrepl-print-request-plist fill-column)))))))
+
+(defun cider-jump-to-comment ()
+  "Move point into the namespace's rich `comment' block.
+Jump to the last top-level `comment' form in the buffer, creating an empty one
+at the end of the buffer when there is none.  The previous location is pushed
+onto the mark ring, so \\[universal-argument] \\[set-mark-command] returns to it."
+  (interactive)
+  (let ((bounds (cider--last-comment-form-bounds)))
+    (push-mark)
+    (if bounds
+        ;; land at the end of the block's contents, where the next experiment
+        ;; would go
+        (progn
+          (goto-char (1- (cdr bounds)))
+          (skip-chars-backward " \t\n"))
+      ;; no block yet: create an empty one and land inside it (the inserted
+      ;; text is already correctly indented)
+      (goto-char (point-max))
+      (skip-chars-backward " \t\n")
+      (delete-region (point) (point-max))
+      (insert "\n\n(comment\n  )")
+      (search-backward ")"))
+    (when (get-buffer-window (current-buffer))
+      (recenter))))
+
 (declare-function cider-switch-to-repl-buffer "cider-mode")
 
 (defun cider--eval-last-sexp-to-repl (switch-to-repl request-map)

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -202,12 +202,16 @@ With a prefix argument, prompt for function to run instead of -main."
     (define-key map (kbd "d") #'cider-insert-defun-in-repl)
     (define-key map (kbd "r") #'cider-insert-region-in-repl)
     (define-key map (kbd "n") #'cider-insert-ns-form-in-repl)
+    (define-key map (kbd "c") #'cider-send-to-comment)
+    (define-key map (kbd "v") #'cider-jump-to-comment)
 
     ;; duplicates with C- for convenience
     (define-key map (kbd "C-e") #'cider-insert-last-sexp-in-repl)
     (define-key map (kbd "C-d") #'cider-insert-defun-in-repl)
     (define-key map (kbd "C-r") #'cider-insert-region-in-repl)
     (define-key map (kbd "C-n") #'cider-insert-ns-form-in-repl)
+    (define-key map (kbd "C-c") #'cider-send-to-comment)
+    (define-key map (kbd "C-v") #'cider-jump-to-comment)
     map))
 
 (defcustom cider-switch-to-repl-on-insert t
@@ -361,6 +365,10 @@ If invoked with a prefix ARG eval the expression after inserting it."
     ["Insert top-level sexp in REPL" cider-insert-defun-in-repl]
     ["Insert region in REPL" cider-insert-region-in-repl]
     ["Insert ns form in REPL" cider-insert-ns-form-in-repl]
+    ["Send top-level sexp to comment block" cider-send-to-comment]
+    ["Send top-level sexp to comment block and eval" (cider-send-to-comment t)
+     :keys "\\[universal-argument] \\[cider-send-to-comment]"]
+    ["Jump to comment block" cider-jump-to-comment]
     "--"
     ["Load this buffer" cider-load-buffer]
     ["Load this buffer and switch to REPL" cider-load-buffer-and-switch-to-repl-buffer]

--- a/test/cider-eval-tests.el
+++ b/test/cider-eval-tests.el
@@ -83,6 +83,106 @@
         (cider-maybe-insert-multiline-comment "{:a 1\n :b 2}" "(comment " "" ")"))
       (expect (buffer-string) :to-equal "(comment {:a 1\n :b 2})"))))
 
+(describe "cider--last-comment-form-bounds"
+  (it "returns nil when there is no top-level comment form"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(ns foo)\n\n(defn x [] 1)\n")
+      (expect (cider--last-comment-form-bounds) :to-be nil)))
+  (it "finds the last top-level comment form"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(comment (a))\n\n(defn x [] 1)\n\n(comment (b))\n")
+      (pcase-let ((`(,beg . ,end) (cider--last-comment-form-bounds)))
+        (expect (buffer-substring-no-properties beg end) :to-equal "(comment (b))"))))
+  (it "ignores a comment form that sits inside a string"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(def s \"x\n(comment y)\")\n")
+      (expect (cider--last-comment-form-bounds) :to-be nil))))
+
+(describe "cider--insert-in-comment"
+  ;; assert via `read' so the tests don't depend on clojure-mode indentation
+  (it "creates a comment block containing the form when none exists"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(ns foo)\n\n(defn x [] 1)\n")
+      (cider--insert-in-comment "(x)")
+      (pcase-let ((`(,beg . ,end) (cider--last-comment-form-bounds)))
+        (expect (car (read-from-string (buffer-substring-no-properties beg end)))
+                :to-equal '(comment (x))))
+      ;; the original code is left intact
+      (expect (string-search "(defn x [] 1)" (buffer-string)) :not :to-be nil)))
+  (it "appends the form as the last element of an existing comment block"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(ns foo)\n\n(comment\n  (a))\n")
+      (cider--insert-in-comment "(b)")
+      (pcase-let ((`(,beg . ,end) (cider--last-comment-form-bounds)))
+        (let ((forms (car (read-from-string (buffer-substring-no-properties beg end)))))
+          (expect (car forms) :to-equal 'comment)
+          (expect (car (last forms)) :to-equal '(b))))))
+  (it "separates appended entries with a blank line"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(comment\n  (a))\n")
+      (cider--insert-in-comment "(b)")
+      (goto-char (point-min))
+      (search-forward "(a)")
+      (forward-line 1)
+      ;; the line between the two entries is blank
+      (expect (looking-at-p "[ \t]*$") :to-be-truthy)))
+  (it "returns an end marker sitting just before the block's closing paren"
+    ;; this is where the eval result is inserted (inside the block, after the form)
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(ns foo)\n\n(comment\n  (a))\n")
+      (pcase-let ((`(,_beg . ,end) (cider--insert-in-comment "(b)")))
+        (goto-char end)
+        (skip-chars-forward " \t\n")
+        (expect (char-after) :to-equal ?\)))))
+  (it "appends to the last comment form when several are present"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(comment (a))\n\n(comment (b))\n")
+      (cider--insert-in-comment "(c)")
+      ;; the first block is untouched...
+      (expect (string-search "(comment (a))" (buffer-string)) :not :to-be nil)
+      ;; ...and the form lands in the last one
+      (pcase-let ((`(,beg . ,end) (cider--last-comment-form-bounds)))
+        (let ((forms (car (read-from-string (buffer-substring-no-properties beg end)))))
+          (expect (car (last forms)) :to-equal '(c)))))))
+
+(describe "cider-jump-to-comment"
+  (it "moves point into the last comment form when one exists"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(comment (a))\n\n(defn x [] 1)\n\n(comment (b))\n")
+      (goto-char (point-min))
+      (cider-jump-to-comment)
+      (pcase-let ((`(,beg . ,end) (cider--last-comment-form-bounds)))
+        (expect (<= beg (point) end) :to-be-truthy)
+        ;; it's the last block
+        (expect (buffer-substring-no-properties beg end) :to-equal "(comment (b))"))))
+  (it "creates a comment block and moves into it when none exists"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(ns foo)\n\n(defn x [] 1)\n")
+      (goto-char (point-min))
+      (cider-jump-to-comment)
+      (pcase-let ((bounds (cider--last-comment-form-bounds)))
+        (expect bounds :not :to-be nil)
+        (expect (<= (car bounds) (point) (cdr bounds)) :to-be-truthy))))
+  (it "pushes the original location onto the mark ring"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(ns foo)\n\n(defn x [] 1)\n\n(comment (a))\n")
+      (goto-char (point-min))
+      (forward-char 4)
+      (let ((start (point)))
+        (cider-jump-to-comment)
+        (expect (marker-position (mark-marker)) :to-equal start)))))
+
 (describe "cider-extract-error-info"
   (it "Matches Clojure compilation exceptions"
     (expect (cider-extract-error-info cider-compilation-regexp "Syntax error compiling clojure.core/let at (src/haystack/analyzer.clj:18:1).\n[1] - failed: even-number-of-forms? at: [:bindings] spec: :clojure.core.specs.alpha/bindings\n")


### PR DESCRIPTION
Follow-up to #3964. Adds two commands for working with rich `(comment ...)` blocks (RCFs).

**`cider-send-to-comment`** (`C-c C-j c`) copies the top-level form at point into the namespace's rich comment block - appending to the last such block, or creating one at the end of the buffer if there isn't any. Point stays where it is, so filing away an experiment never interrupts your editing. With a prefix arg it also evaluates the form and inserts the result beneath it (honoring `cider-comment-style` from #3964), so the block doubles as a self-documenting log:

```clojure
(comment
  (add 1 2)
  ;; => 3
  )
```

**`cider-jump-to-comment`** (`C-c C-j v`) visits the block - moves point into the last `comment` form (creating an empty one when there's none), pushing your previous location onto the mark ring so `C-u C-SPC` brings you back.

Both live alongside the insert-in-REPL family. When several `comment` forms exist, the last one wins (RCFs live at the bottom by convention). Tests, docs and a CHANGELOG entry included; the docs link out to a couple of rich-comment workflow write-ups.