### PR TITLE
Promote the eval-destination commands to cider-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 - [#3964](https://github.com/clojure-emacs/cider/pull/3964): Add `cider-comment-style` to control how the eval-to-comment commands format the inserted result (`line`, `ignore` or `comment`).
 - [#3965](https://github.com/clojure-emacs/cider/pull/3965): Add `cider-send-to-comment` to copy the top-level form at point into the namespace's rich `comment` block (`C-c C-j c`), optionally evaluating it, and `cider-jump-to-comment` to visit the block (`C-c C-j v`).
-- [#3963](https://github.com/clojure-emacs/cider/pull/3963): Attach `cider-scratch` buffers to a specific session (one scratchpad per session), with a configurable eval destination (cljc-style by default) cyclable via `cider-scratch-cycle-eval-destination` (`C-c C-d`).
+- [#3963](https://github.com/clojure-emacs/cider/pull/3963): Attach `cider-scratch` buffers to a specific session (one scratchpad per session), with a configurable eval destination (cljc-style by default).
+- [#3966](https://github.com/clojure-emacs/cider/pull/3966): Add `cider-set-eval-destination` and `cider-cycle-eval-destination` (`C-c C-M-d`) to override, per buffer, which REPL type (clj, cljs or multi) evaluations dispatch to.
 
 ## 1.22.2 (2026-06-17)
 

--- a/doc/modules/ROOT/pages/usage/misc_features.adoc
+++ b/doc/modules/ROOT/pages/usage/misc_features.adoc
@@ -33,10 +33,15 @@ all, you get a single, session-less `+*cider-scratch*+` buffer.  Use
 Because a scratchpad has no file extension to dispatch on, you choose where
 its evaluations go.  By default it follows `cider-clojurec-eval-destination`
 (like a `.cljc` file, i.e. both Clojure and ClojureScript REPLs of its
-session).  kbd:[C-c C-d] (`cider-scratch-cycle-eval-destination`) cycles
-between `clj`, `cljs`, and `multi`, and the current choice is shown in the
-mode line (e.g. `[multi]`).  You can also set it directly via
-`cider-scratch-set-eval-destination` or the mode menu.
+session).  kbd:[C-c C-M-d] (`cider-cycle-eval-destination`) cycles between
+`clj`, `cljs`, `multi`, and `auto` (infer from the major mode), and the
+current choice is shown in the mode line (e.g. `[multi]`).  You can also set it
+directly via `cider-set-eval-destination` or the mode menu.
+
+TIP: `cider-set-eval-destination` and `cider-cycle-eval-destination` work in any
+buffer, not just the scratchpad - they are handy in `.cljc` buffers too, when
+you want to pin evaluations to a specific REPL instead of the
+`cider-clojurec-eval-destination` default.
 
 == Find References
 

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -388,6 +388,7 @@ If invoked with a prefix ARG eval the expression after inserting it."
     ("REPL"
      ["Set REPL to this ns" cider-repl-set-ns]
      ["Switch to REPL" cider-switch-to-repl-buffer]
+     ["Switch to scratchpad" cider-scratch]
      ["REPL Pretty Print" cider-repl-toggle-pretty-printing
       :style toggle :selected cider-repl-use-pretty-printing]
      ["Clear latest output" cider-find-and-clear-repl-output]
@@ -395,6 +396,17 @@ If invoked with a prefix ARG eval the expression after inserting it."
       :keys "\\[universal-argument] \\[cider-find-and-clear-repl-output]"]
      "--"
      ["Configure the REPL" (customize-group 'cider-repl)])
+    ("Eval destination"
+     ["Auto (infer from major mode)" (cider-set-eval-destination 'auto)
+      :style radio :selected (null cider-repl-type-override)]
+     ["Clojure" (cider-set-eval-destination 'clj)
+      :style radio :selected (eq cider-repl-type-override 'clj)]
+     ["ClojureScript" (cider-set-eval-destination 'cljs)
+      :style radio :selected (eq cider-repl-type-override 'cljs)]
+     ["Multi (Clojure + ClojureScript)" (cider-set-eval-destination 'multi)
+      :style radio :selected (eq cider-repl-type-override 'multi)]
+     "--"
+     ["Cycle eval destination" cider-cycle-eval-destination :keys "C-c C-M-d"])
     ,cider-doc-menu
     ("Find (jump to)"
      ["Find definition" cider-find-var]
@@ -546,6 +558,7 @@ higher precedence."
     (define-key map (kbd "C-c C-t") 'cider-test-commands-map)
     (define-key map (kbd "C-c M-s") #'cider-selector)
     (define-key map (kbd "C-c M-d") #'cider-describe-connection)
+    (define-key map (kbd "C-c C-M-d") #'cider-cycle-eval-destination)
     (define-key map (kbd "C-c C-=") 'cider-profile-map)
     (define-key map (kbd "C-c C-? r") #'cider-xref-fn-refs)
     (define-key map (kbd "C-c C-? C-r") #'cider-xref-fn-refs-select)

--- a/lisp/cider-scratch.el
+++ b/lisp/cider-scratch.el
@@ -37,9 +37,16 @@
 (require 'sesman)
 
 (defcustom cider-scratch-initial-message
-  ";; This buffer is for Clojure experiments and evaluation.\n
-;; Press C-j to evaluate the last expression.\n
-;; You can also press C-u C-j to evaluate the expression and pretty-print its result.\n\n"
+  ";; This buffer is for Clojure experiments and evaluation.
+;; It is attached to a specific CIDER session, so evaluations always
+;; target a known REPL.
+;;
+;; Press C-j to evaluate the expression before point and print its value;
+;; C-u C-j pretty-prints the result instead.
+;;
+;; Evaluations dispatch like a .cljc file by default.  Use the Clojure
+;; Interaction menu, or C-c C-M-d (`cider-cycle-eval-destination'), to send
+;; them to the Clojure, ClojureScript or both REPLs of the session.\n\n"
   "The initial message displayed in new scratch buffers."
   :type 'string
   :group 'cider
@@ -51,7 +58,6 @@
     (define-key map (kbd "C-j") #'cider-eval-print-last-sexp)
     (define-key map [remap paredit-newline] #'cider-eval-print-last-sexp)
     (define-key map [remap paredit-C-j] #'cider-eval-print-last-sexp)
-    (define-key map (kbd "C-c C-d") #'cider-scratch-cycle-eval-destination)
     (easy-menu-define cider-clojure-interaction-mode-menu map
       "Menu for Clojure Interaction mode"
       '("Clojure Interaction"
@@ -59,14 +65,17 @@
         ["Eval and pretty-print last sexp" (cider-eval-print-last-sexp '(4))
          :keys "C-u C-j"]
         "--"
-        ["Cycle eval destination" cider-scratch-cycle-eval-destination]
         ("Eval destination"
-         ["Clojure" (cider-scratch-set-eval-destination 'clj)
+         ["Auto (infer from major mode)" (cider-set-eval-destination 'auto)
+          :style radio :selected (null cider-repl-type-override)]
+         ["Clojure" (cider-set-eval-destination 'clj)
           :style radio :selected (eq cider-repl-type-override 'clj)]
-         ["ClojureScript" (cider-scratch-set-eval-destination 'cljs)
+         ["ClojureScript" (cider-set-eval-destination 'cljs)
           :style radio :selected (eq cider-repl-type-override 'cljs)]
-         ["Multi (Clojure + ClojureScript)" (cider-scratch-set-eval-destination 'multi)
-          :style radio :selected (eq cider-repl-type-override 'multi)])
+         ["Multi (Clojure + ClojureScript)" (cider-set-eval-destination 'multi)
+          :style radio :selected (eq cider-repl-type-override 'multi)]
+         "--"
+         ["Cycle eval destination" cider-cycle-eval-destination :keys "C-c C-M-d"])
         "--"
         ["Attach to session..." cider-scratch-set-session]
         ["Reset" cider-scratch-reset]))
@@ -75,9 +84,6 @@
 (defconst cider-scratch-buffer-name "*cider-scratch*"
   "Name of the session-less scratch buffer.
 Per-session scratch buffers are named `*cider-scratch: SESSION*'.")
-
-(defconst cider-scratch--eval-destinations '(clj cljs multi)
-  "The dispatch modes a scratch buffer can cycle through.")
 
 (defun cider-scratch--buffer-name (session-name)
   "Return the scratch buffer name for SESSION-NAME (nil for the session-less one)."
@@ -126,12 +132,6 @@ before point, and prints its value into the buffer, advancing point.
   "Insert the welcome message for the scratch buffer."
   (insert cider-scratch-initial-message))
 
-(defun cider-scratch--update-mode-line ()
-  "Reflect the current eval destination in the mode line."
-  (setq-local mode-line-process
-              (format " [%s]" (or cider-repl-type-override 'clj)))
-  (force-mode-line-update))
-
 (defun cider-scratch--attach (repl)
   "Associate the current scratch buffer with REPL's session.
 When REPL is a live buffer, pin the scratch to it (via
@@ -146,7 +146,7 @@ already been chosen for this buffer."
   (unless cider-repl-type-override
     ;; cljc-style dispatch by default; the user can cycle it per buffer.
     (setq-local cider-repl-type-override cider-clojurec-eval-destination))
-  (cider-scratch--update-mode-line))
+  (cider--reflect-eval-destination-in-mode-line))
 
 (defun cider-scratch--create-buffer (name repl)
   "Create scratch buffer NAME and attach it to REPL's session."
@@ -155,24 +155,6 @@ already been chosen for this buffer."
     (cider-scratch--attach repl)
     (cider-scratch--insert-welcome-message)
     (current-buffer)))
-
-(defun cider-scratch-set-eval-destination (type)
-  "Set this scratch buffer's eval dispatch to TYPE (clj, cljs or multi)."
-  (interactive (list (intern (completing-read
-                              "Scratch eval destination: "
-                              (mapcar #'symbol-name cider-scratch--eval-destinations)
-                              nil t))))
-  (setq-local cider-repl-type-override type)
-  (cider-scratch--update-mode-line)
-  (message "Scratch eval destination set to `%s'" type))
-
-(defun cider-scratch-cycle-eval-destination ()
-  "Cycle this scratch buffer's eval dispatch through clj, cljs and multi."
-  (interactive)
-  (let* ((current (or cider-repl-type-override (car cider-scratch--eval-destinations)))
-         (tail (cdr (memq current cider-scratch--eval-destinations)))
-         (next (or (car tail) (car cider-scratch--eval-destinations))))
-    (cider-scratch-set-eval-destination next)))
 
 (defun cider-scratch-set-session ()
   "Attach the current scratch buffer to an explicitly chosen session.

--- a/lisp/cider-session.el
+++ b/lisp/cider-session.el
@@ -288,6 +288,46 @@ For the REPL type use the function `cider-repl-type'."
      ((cider-clojure-major-mode-p) 'clj)
      (cider-repl-type))))
 
+(defconst cider-eval-destinations '(clj cljs multi auto)
+  "The eval dispatch types `cider-cycle-eval-destination' cycles through.
+The `auto' entry clears `cider-repl-type-override', reverting to the
+major-mode-based inference of `cider-repl-type-for-buffer'.")
+
+(defun cider--reflect-eval-destination-in-mode-line ()
+  "Show the buffer's `cider-repl-type-override' in the mode line, if any."
+  (setq-local mode-line-process
+              (when cider-repl-type-override
+                (format " [%s]" cider-repl-type-override)))
+  (force-mode-line-update))
+
+(defun cider-set-eval-destination (type)
+  "Set the current buffer's eval dispatch (REPL type) to TYPE.
+TYPE is one of `clj', `cljs', `multi', or `auto'.  All but `auto' set
+`cider-repl-type-override' for this buffer, overriding the major-mode-based
+inference of `cider-repl-type-for-buffer' so that evaluations target the
+chosen REPL of the buffer's session; `auto' clears the override.  The choice
+is reflected in the mode line.
+
+This is handy in buffers with no inherent file type to dispatch on (e.g. the
+scratch buffer) and in `.cljc' buffers where you want to pin evaluations to a
+specific REPL."
+  (interactive (list (intern (completing-read
+                              "Eval destination: "
+                              (mapcar #'symbol-name cider-eval-destinations)
+                              nil t))))
+  (setq-local cider-repl-type-override (unless (eq type 'auto) type))
+  (cider--reflect-eval-destination-in-mode-line)
+  (message "Buffer eval destination set to `%s'" type))
+
+(defun cider-cycle-eval-destination ()
+  "Cycle the current buffer's eval dispatch through `cider-eval-destinations'.
+See `cider-set-eval-destination'."
+  (interactive)
+  (let* ((current (or cider-repl-type-override 'auto))
+         (tail (cdr (memq current cider-eval-destinations)))
+         (next (or (car tail) (car cider-eval-destinations))))
+    (cider-set-eval-destination next)))
+
 (defun cider-set-repl-type (&optional type)
   "Set REPL TYPE to clj or cljs.
 Assume that the current buffer is a REPL."

--- a/test/cider-scratch-tests.el
+++ b/test/cider-scratch-tests.el
@@ -30,33 +30,11 @@
 
 ;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
 
-(describe "cider-repl-type-for-buffer override"
-  (it "honors a buffer-local cider-repl-type-override"
-    (with-temp-buffer
-      (cider-clojure-interaction-mode)
-      ;; a plain Clojure-interaction buffer would otherwise infer `clj'
-      (expect (cider-repl-type-for-buffer) :to-equal 'clj)
-      (setq-local cider-repl-type-override 'multi)
-      (expect (cider-repl-type-for-buffer) :to-equal 'multi))))
-
 (describe "cider-scratch--buffer-name"
   (it "is session-less without a session name"
     (expect (cider-scratch--buffer-name nil) :to-equal cider-scratch-buffer-name))
   (it "embeds the session name when given one"
     (expect (cider-scratch--buffer-name "proj@host") :to-equal "*cider-scratch: proj@host*")))
-
-(describe "cider-scratch-cycle-eval-destination"
-  (it "cycles clj -> cljs -> multi -> clj and reflects it in the mode line"
-    (with-temp-buffer
-      (cider-clojure-interaction-mode)
-      (setq-local cider-repl-type-override 'clj)
-      (cider-scratch-cycle-eval-destination)
-      (expect cider-repl-type-override :to-equal 'cljs)
-      (cider-scratch-cycle-eval-destination)
-      (expect cider-repl-type-override :to-equal 'multi)
-      (expect mode-line-process :to-equal " [multi]")
-      (cider-scratch-cycle-eval-destination)
-      (expect cider-repl-type-override :to-equal 'clj))))
 
 (describe "cider-scratch per-session attachment"
   :var (sesman-sessions-hashmap sesman-links-alist)

--- a/test/cider-session-tests.el
+++ b/test/cider-session-tests.el
@@ -1,0 +1,75 @@
+;;; cider-session-tests.el  -*- lexical-binding: t; -*-
+
+;; Copyright © 2026 Bozhidar Batsov
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; Tests for session-level helpers, including the per-buffer eval-destination
+;; override.
+
+;;; Code:
+
+(require 'buttercup)
+(require 'clojure-mode)
+(require 'cider-session)
+
+;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
+
+(describe "cider-repl-type-for-buffer"
+  (it "honors a buffer-local cider-repl-type-override"
+    (with-temp-buffer
+      (clojure-mode)
+      ;; a plain Clojure buffer would otherwise infer `clj'
+      (expect (cider-repl-type-for-buffer) :to-equal 'clj)
+      (setq-local cider-repl-type-override 'multi)
+      (expect (cider-repl-type-for-buffer) :to-equal 'multi))))
+
+(describe "cider-cycle-eval-destination"
+  (it "cycles clj -> cljs -> multi -> auto and reflects it in the mode line"
+    (with-temp-buffer
+      (clojure-mode)
+      (setq-local cider-repl-type-override 'clj)
+      (cider-cycle-eval-destination)
+      (expect cider-repl-type-override :to-equal 'cljs)
+      (cider-cycle-eval-destination)
+      (expect cider-repl-type-override :to-equal 'multi)
+      (expect mode-line-process :to-equal " [multi]")
+      (cider-cycle-eval-destination)    ; multi -> auto (clears the override)
+      (expect cider-repl-type-override :to-be nil)
+      (expect mode-line-process :to-be nil)
+      (cider-cycle-eval-destination)    ; auto -> clj
+      (expect cider-repl-type-override :to-equal 'clj))))
+
+(describe "cider-set-eval-destination"
+  (it "sets the override and reflects it in the mode line"
+    (with-temp-buffer
+      (clojure-mode)
+      (cider-set-eval-destination 'cljs)
+      (expect cider-repl-type-override :to-equal 'cljs)
+      (expect mode-line-process :to-equal " [cljs]")))
+  (it "clears the override for the `auto' destination"
+    (with-temp-buffer
+      (clojure-mode)
+      (setq-local cider-repl-type-override 'multi)
+      (cider-set-eval-destination 'auto)
+      (expect cider-repl-type-override :to-be nil)
+      (expect mode-line-process :to-be nil))))
+
+(provide 'cider-session-tests)
+
+;;; cider-session-tests.el ends here


### PR DESCRIPTION
Follow-up to the per-session scratch work (#3963). The scratch module's "cycle which REPL type evaluations dispatch to" command was bound to `C-c C-d` in the scratch major-mode map - but `cider-mode`'s doc prefix shadows that once you're connected, so the key was effectively dead. The underlying mechanism (`cider-repl-type-override`) was never scratch-specific, so the fix is to promote it.

- `cider-set-eval-destination` and `cider-cycle-eval-destination` (`C-c C-M-d`, in `cider-mode-map` where nothing shadows it) let any buffer override which REPL type (clj/cljs/multi) its evaluations target, plus an `auto` state that clears the override and reverts to major-mode inference. The current choice shows in the mode line when set.
- Genuinely useful beyond scratch - in a `.cljc` buffer you can now pin evals to one REPL instead of the `cider-clojurec-eval-destination` default.
- The scratch buffer drops its private `cider-scratch-{set,cycle}-eval-destination` copies and reuses these.
- Tidies a couple of long-standing scratch gaps too: a "Switch to scratchpad" menu item (it was `M-x`-only before) and a refreshed welcome message that mentions the dispatch commands.

Tests live in a new `test/cider-session-tests.el`. The removed scratch commands were only ever on master (unreleased), so no deprecation needed.