### PR TITLE
Refresh and modernize the Clojure cheatsheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changes
 
 - [#3967](https://github.com/clojure-emacs/cider/pull/3967): Refresh the embedded Clojure cheatsheet with functions added since Clojure 1.11 (`partitionv`, `partitionv-all`, `splitv-at`, `clojure.repl.deps`, `clojure.java.process`, the `clojure.core` Java-stream helpers, and more `clojure.math` members).
+- [#3967](https://github.com/clojure-emacs/cider/pull/3967): Give the cheatsheet buffer a dedicated `cider-cheatsheet-mode` with fontified section headers and `TAB`/`S-TAB` navigation between entries.
 
 ## 1.22.2 (2026-06-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - [#3963](https://github.com/clojure-emacs/cider/pull/3963): Attach `cider-scratch` buffers to a specific session (one scratchpad per session), with a configurable eval destination (cljc-style by default).
 - [#3966](https://github.com/clojure-emacs/cider/pull/3966): Add `cider-set-eval-destination` and `cider-cycle-eval-destination` (`C-c C-M-d`) to override, per buffer, which REPL type (clj, cljs or multi) evaluations dispatch to.
 
+### Changes
+
+- [#3967](https://github.com/clojure-emacs/cider/pull/3967): Refresh the embedded Clojure cheatsheet with functions added since Clojure 1.11 (`partitionv`, `partitionv-all`, `splitv-at`, `clojure.repl.deps`, `clojure.java.process`, the `clojure.core` Java-stream helpers, and more `clojure.math` members).
+
 ## 1.22.2 (2026-06-17)
 
 ### Bugs fixed

--- a/lisp/cider-cheatsheet.el
+++ b/lisp/cider-cheatsheet.el
@@ -64,7 +64,7 @@ from ClojureDocs or any other function accepting a var as an argument."
      ("Numbers"
       ("Arithmetic"
        (clojure.core + - * / quot rem mod inc dec max min abs)
-       (clojure.math floor-div floor-mod ceil floor rint round pow sqrt cbrt E exp expm1 log log10 log1p PI sin cos tan asin acos atan atan2))
+       (clojure.math floor-div floor-mod ceil floor rint round pow sqrt cbrt E exp expm1 log log10 log1p PI sin cos tan asin acos atan atan2 sinh cosh tanh to-degrees to-radians hypot signum add-exact subtract-exact multiply-exact increment-exact decrement-exact negate-exact))
       ("Arbitrary Precision Arithmetic"
        (clojure.core +\' -\' *\' inc\' dec\'))
       ("Compare"
@@ -214,7 +214,7 @@ from ClojureDocs or any other function accepting a var as an argument."
       ("Head-items"
        (clojure.core take take-while butlast drop-last for))
       ("Change"
-       (clojure.core conj concat distinct flatten group-by partition partition-all partition-by split-at split-with filter remove replace shuffle))
+       (clojure.core conj concat distinct flatten group-by partition partitionv partition-all partitionv-all partition-by split-at splitv-at split-with filter remove replace shuffle))
       ("Rearrange"
        (clojure.core reverse sort sort-by compare))
       ("Process items"
@@ -409,7 +409,9 @@ from ClojureDocs or any other function accepting a var as an argument."
      ("List loaded"
       (clojure.core loaded-libs))
      ("Load misc"
-      (clojure.core load load-file load-reader load-string)))
+      (clojure.core load load-file load-reader load-string))
+     ("Hotload deps"
+      (clojure.repl.deps add-lib add-libs sync-deps)))
     ("Concurrency"
      ("Atoms"
       (clojure.core atom swap! reset! compare-and-set! swap-vals! reset-vals!))
@@ -457,6 +459,8 @@ from ClojureDocs or any other function accepting a var as an argument."
      ("General"
       (clojure.core .. doto bean comparator enumeration-seq import iterator-seq memfn class class? bases supers type gen-class gen-interface definterface)
       (:special new set!))
+     ("Java Streams"
+      (clojure.core stream-seq! stream-reduce! stream-transduce! stream-into!))
      ("Cast"
       (clojure.core boolean byte short char int long float double bigdec bigint num cast biginteger))
      ("Exceptions"
@@ -496,7 +500,7 @@ from ClojureDocs or any other function accepting a var as an argument."
       (clojure.xml parse)
       (clojure.core xml-seq))
      ("REPL"
-      (clojure.core *1 *2 *3 *e *print-dup* *print-length* *print-level* *print-meta* *print-readably*))
+      (clojure.core *1 *2 *3 *e *repl* *print-dup* *print-length* *print-level* *print-meta* *print-readably*))
      ("Code"
       (clojure.core *compile-files* *compile-path* *file* *warn-on-reflection* compile loaded-libs test))
      ("Misc"
@@ -504,6 +508,8 @@ from ClojureDocs or any other function accepting a var as an argument."
      ("Browser / Shell"
       (clojure.java.browse browse-url)
       (clojure.java.shell sh with-sh-dir with-sh-env))
+     ("Processes"
+      (clojure.java.process start exec))
      ("EDN"
       (clojure.edn read read-string))
      ("Pretty Printing"

--- a/lisp/cider-cheatsheet.el
+++ b/lisp/cider-cheatsheet.el
@@ -55,6 +55,16 @@ from ClojureDocs or any other function accepting a var as an argument."
                  function)
   :package-version '(cider . "1.15.0"))
 
+(defface cider-cheatsheet-section
+  '((t (:inherit font-lock-keyword-face :weight bold)))
+  "Face for top-level sections in the cheatsheet buffer."
+  :package-version '(cider . "1.23.0"))
+
+(defface cider-cheatsheet-subsection
+  '((t (:weight bold)))
+  "Face for nested sections in the cheatsheet buffer."
+  :package-version '(cider . "1.23.0"))
+
 (defconst cider-cheatsheet-hierarchy
   '(("Documentation"
      ("REPL"
@@ -614,7 +624,12 @@ LEVEL defaults to 0."
     (dolist (node hierarchy)
       (if (stringp (car node))
           (progn
-            (insert (make-string (* level 2) ?\s) (car node) "\n")
+            (insert (make-string (* level 2) ?\s)
+                    (propertize (car node)
+                                'face (if (zerop level)
+                                          'cider-cheatsheet-section
+                                        'cider-cheatsheet-subsection))
+                    "\n")
             (cider-cheatsheet--insert-hierarchy (cdr node) (1+ level)))
         (dolist (var (cider-cheatsheet--expand-vars node))
           (insert (make-string (* level 2) ?\s))
@@ -632,15 +647,27 @@ LEVEL defaults to 0."
     (cider-cheatsheet--insert-hierarchy cider-cheatsheet-hierarchy)
     (buffer-string)))
 
+(defvar cider-cheatsheet-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "TAB") #'forward-button)
+    (define-key map (kbd "<backtab>") #'backward-button)
+    map)
+  "Keymap for `cider-cheatsheet-mode'.")
+
+(define-derived-mode cider-cheatsheet-mode special-mode "Cheatsheet"
+  "Major mode for displaying the Clojure cheatsheet.
+
+\\{cider-cheatsheet-mode-map}")
+
 ;;;###autoload
 (defun cider-cheatsheet ()
   "Display cheatsheet in a popup buffer."
   (interactive)
   (with-current-buffer (cider-popup-buffer cider-cheatsheet-buffer
-                                           cider-cheatsheet-auto-select-buffer)
-    (read-only-mode -1)
-    (insert (cider-cheatsheet--buffer-contents))
-    (read-only-mode 1)
+                                           cider-cheatsheet-auto-select-buffer
+                                           #'cider-cheatsheet-mode)
+    (let ((inhibit-read-only t))
+      (insert (cider-cheatsheet--buffer-contents)))
     (goto-char (point-min))))
 
 (provide 'cider-cheatsheet)


### PR DESCRIPTION
The embedded cheatsheet hadn't kept up with recent Clojure, and the display was a bit dated. Two commits:

**Data refresh** - add the commonly useful functions introduced since Clojure 1.11 (1.11 itself was already fully covered): `partitionv`, `partitionv-all`, `splitv-at`, `*repl*`, the `clojure.core` Java-stream reducers, the `clojure.repl.deps` hotload commands, `clojure.java.process`, and a fuller set of `clojure.math` members (hyperbolic trig, angle conversion, exact arithmetic, `hypot`, `signum`). Kept it curated - skipped the obscure FP bit-twiddling and tools.deps internals.

**UX** - give the cheatsheet buffer a dedicated `cider-cheatsheet-mode` (deriving `special-mode`) with fontified section headers (distinct faces per nesting level) and `TAB`/`S-TAB` navigation between the var buttons. The buffer used to be same-weight text with no way to jump between entries.

Verified against the official Clojure changelog so no made-up vars crept in.