### PR TITLE
Add a menu, per-var key bindings and tests to the cheatsheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - [#3967](https://github.com/clojure-emacs/cider/pull/3967): Refresh the embedded Clojure cheatsheet with functions added since Clojure 1.11 (`partitionv`, `partitionv-all`, `splitv-at`, `clojure.repl.deps`, `clojure.java.process`, the `clojure.core` Java-stream helpers, and more `clojure.math` members).
 - [#3967](https://github.com/clojure-emacs/cider/pull/3967): Give the cheatsheet buffer a dedicated `cider-cheatsheet-mode` with fontified section headers and `TAB`/`S-TAB` navigation between entries.
+- [#3968](https://github.com/clojure-emacs/cider/pull/3968): Add a menu and per-var key bindings to the cheatsheet buffer (`d` for docs, `c` for ClojureDocs, `w` for ClojureDocs in the browser).
 
 ## 1.22.2 (2026-06-17)
 

--- a/lisp/cider-cheatsheet.el
+++ b/lisp/cider-cheatsheet.el
@@ -27,9 +27,13 @@
 ;;; Code:
 
 (require 'cider-doc)
+(require 'easymenu)
 (require 'map)
 (require 'seq)
 (require 'subr-x)
+
+(declare-function cider-clojuredocs-lookup "cider-clojuredocs")
+(declare-function cider-clojuredocs-web-lookup "cider-clojuredocs")
 
 (defgroup cider-cheatsheet nil
   "Clojure cheatsheet in CIDER."
@@ -647,10 +651,52 @@ LEVEL defaults to 0."
     (cider-cheatsheet--insert-hierarchy cider-cheatsheet-hierarchy)
     (buffer-string)))
 
+(defun cider-cheatsheet--var-at-point ()
+  "Return the cheatsheet var on the button at point, or nil."
+  (when-let* ((button (button-at (point))))
+    (button-get button 'var)))
+
+(defun cider-cheatsheet-doc-at-point ()
+  "Display documentation for the var at point."
+  (interactive)
+  (if-let* ((var (cider-cheatsheet--var-at-point)))
+      (cider-doc-lookup var)
+    (user-error "No var at point")))
+
+(defun cider-cheatsheet-clojuredocs-at-point ()
+  "Display ClojureDocs documentation for the var at point."
+  (interactive)
+  (if-let* ((var (cider-cheatsheet--var-at-point)))
+      (cider-clojuredocs-lookup var)
+    (user-error "No var at point")))
+
+(defun cider-cheatsheet-clojuredocs-web-at-point ()
+  "Open the ClojureDocs page for the var at point in a browser."
+  (interactive)
+  (if-let* ((var (cider-cheatsheet--var-at-point)))
+      (cider-clojuredocs-web-lookup var)
+    (user-error "No var at point")))
+
 (defvar cider-cheatsheet-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "TAB") #'forward-button)
     (define-key map (kbd "<backtab>") #'backward-button)
+    (define-key map (kbd "d") #'cider-cheatsheet-doc-at-point)
+    (define-key map (kbd "c") #'cider-cheatsheet-clojuredocs-at-point)
+    (define-key map (kbd "w") #'cider-cheatsheet-clojuredocs-web-at-point)
+    (easy-menu-define cider-cheatsheet-mode-menu map
+      "Menu for CIDER's cheatsheet."
+      '("Cheatsheet"
+        ["Documentation for var" cider-cheatsheet-doc-at-point]
+        ["ClojureDocs for var" cider-cheatsheet-clojuredocs-at-point]
+        ["ClojureDocs (web) for var" cider-cheatsheet-clojuredocs-web-at-point]
+        "--"
+        ["Next entry" forward-button]
+        ["Previous entry" backward-button]
+        "--"
+        ["Search cheatsheet..." cider-cheatsheet-select]
+        "--"
+        ["Quit" quit-window]))
     map)
   "Keymap for `cider-cheatsheet-mode'.")
 

--- a/test/cider-cheatsheet-tests.el
+++ b/test/cider-cheatsheet-tests.el
@@ -1,0 +1,60 @@
+;;; cider-cheatsheet-tests.el  -*- lexical-binding: t; -*-
+
+;; Copyright © 2026 Bozhidar Batsov
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; Tests for the cheatsheet's data-processing helpers.
+
+;;; Code:
+
+(require 'buttercup)
+(require 'seq)
+(require 'cider-cheatsheet)
+
+;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
+
+(describe "cider-cheatsheet--expand-vars"
+  (it "qualifies vars with their namespace"
+    (expect (cider-cheatsheet--expand-vars '(clojure.core map filter))
+            :to-equal '("clojure.core/map" "clojure.core/filter")))
+  (it "leaves special forms unqualified"
+    (expect (cider-cheatsheet--expand-vars '(:special fn def))
+            :to-equal '("fn" "def"))))
+
+(describe "cider-cheatsheet--flatten-hierarchy"
+  (it "produces a section path followed by the qualified var"
+    (expect (cider-cheatsheet--flatten-hierarchy
+             '(("A" ("B" (clojure.core map filter)))))
+            :to-equal '(("A" "B" "clojure.core/map")
+                        ("A" "B" "clojure.core/filter")))))
+
+(describe "cider-cheatsheet-hierarchy"
+  (it "is well-formed: every flattened path is a section path ending in a var"
+    (let ((paths (cider-cheatsheet--flatten-hierarchy cider-cheatsheet-hierarchy)))
+      (expect (length paths) :to-be-greater-than 0)
+      (expect (seq-every-p (lambda (path)
+                             ;; at least one section plus a string var at the end
+                             (and (cdr path)
+                                  (stringp (car (last path)))))
+                           paths)
+              :to-be-truthy))))
+
+(provide 'cider-cheatsheet-tests)
+
+;;; cider-cheatsheet-tests.el ends here


### PR DESCRIPTION
Follow-up to #3967. Makes the cheatsheet buffer more useful and finally gives the module some tests.

- **Per-var actions**: on the var button at point, `d` looks it up via `cider-doc`, `c` via ClojureDocs, `w` opens ClojureDocs in the browser (mnemonics match the `C-c C-d` doc map). `RET` still runs the configured default action, and `TAB`/`S-TAB` still navigate.
- **Mode menu**: a Cheatsheet menu exposing those lookups, search (`cider-cheatsheet-select`), and quit.
- **Tests**: the module had none. Added `test/cider-cheatsheet-tests.el` covering `--expand-vars` (namespace qualification + `:special`), `--flatten-hierarchy`, and a hierarchy-integrity check that guards against a malformed entry slipping into the big data table.