### PR TITLE
Show ClojureDocs examples inline in the doc buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#3965](https://github.com/clojure-emacs/cider/pull/3965): Add `cider-send-to-comment` to copy the top-level form at point into the namespace's rich `comment` block (`C-c C-j c`), optionally evaluating it, and `cider-jump-to-comment` to visit the block (`C-c C-j v`).
 - [#3963](https://github.com/clojure-emacs/cider/pull/3963): Attach `cider-scratch` buffers to a specific session (one scratchpad per session), with a configurable eval destination (cljc-style by default).
 - [#3966](https://github.com/clojure-emacs/cider/pull/3966): Add `cider-set-eval-destination` and `cider-cycle-eval-destination` (`C-c C-M-d`) to override, per buffer, which REPL type (clj, cljs or multi) evaluations dispatch to.
+- [#3969](https://github.com/clojure-emacs/cider/pull/3969): Show ClojureDocs examples inline in the `*cider-doc*` buffer, toggled with `e` (`cider-docview-clojuredocs-examples`) or shown automatically when `cider-doc-show-clojuredocs-examples` is enabled.
 
 ### Changes
 

--- a/doc/modules/ROOT/pages/usage/working_with_documentation.adoc
+++ b/doc/modules/ROOT/pages/usage/working_with_documentation.adoc
@@ -86,10 +86,19 @@ results as a list in the minibuffer, so you can quickly select what you need (es
 == ClojureDocs
 
 CIDER provides integration with the popular https://clojuredocs.org/[ClojureDocs service].
-You've got two main ways of interacting with ClojureDocs:
+You've got a few ways of interacting with ClojureDocs:
 
 * displaying the documentation in a dedicated buffer in Emacs via `cider-clojuredocs` (kbd:[C-c C-d C-c])
 * opening the documentation in your default browser via `cider-clojuredocs-web` (kbd:[C-c C-d C-w])
+* showing the crowd-sourced examples right inside the `*cider-doc*` buffer
+
+In a `*cider-doc*` buffer, press kbd:[e] (`cider-docview-clojuredocs-examples`), or
+click the button at the bottom of the buffer, to toggle the ClojureDocs examples
+for the symbol you're looking at. They're fetched on first use and cached, so
+toggling them on and off is instant. Set `cider-doc-show-clojuredocs-examples` to a
+non-nil value to have them shown automatically whenever you open the doc buffer,
+and `cider-doc-clojuredocs-max-examples` to control how many are shown inline (a
+link to the full ClojureDocs entry is shown when there are more).
 
 The documentation is bundled with `cider-nrepl` as an EDN resource (or more
 precisely - with `orchard`, which is dependency of `cider-nrepl`) and it's a

--- a/lisp/cider-clojuredocs.el
+++ b/lisp/cider-clojuredocs.el
@@ -52,6 +52,20 @@
                 (cider-nrepl-send-sync-request)
                 (nrepl-dict-get "status")))
 
+(defun cider-clojuredocs--lookup-async (ns sym callback)
+  "Asynchronously perform a \"clojuredocs-lookup\" for SYM in NS.
+CALLBACK is invoked with the resulting dict, or nil when there is none (e.g.
+the symbol has no ClojureDocs entry, or the middleware is unavailable)."
+  (let (result)
+    (cider-nrepl-send-request
+     `("op" "cider/clojuredocs-lookup" "ns" ,ns "sym" ,sym)
+     (lambda (response)
+       (nrepl-dbind-response response (clojuredocs status)
+         (when clojuredocs
+           (setq result clojuredocs))
+         (when (member "done" status)
+           (funcall callback result)))))))
+
 (defun cider-clojuredocs-replace-special (name)
   "Convert the dashes in NAME to a ClojureDocs friendly format.
 We need to handle \"?\", \".\", \"..\" and \"/\"."

--- a/lisp/cider-doc.el
+++ b/lisp/cider-doc.el
@@ -57,6 +57,22 @@
   :group 'cider-doc
   :package-version  '(cider . "0.15.0"))
 
+(defcustom cider-doc-show-clojuredocs-examples nil
+  "Whether to show ClojureDocs examples in the doc buffer automatically.
+When non-nil, `cider-doc' fetches ClojureDocs examples for the symbol and
+appends them to the `*cider-doc*' buffer.  When nil, the buffer instead shows
+a button (and the \\`e' key) to fetch them on demand."
+  :type 'boolean
+  :group 'cider-doc
+  :package-version '(cider . "1.23.0"))
+
+(defcustom cider-doc-clojuredocs-max-examples 3
+  "Maximum number of ClojureDocs examples to show inline in the doc buffer.
+A link to the full ClojureDocs entry is shown when more examples exist."
+  :type 'integer
+  :group 'cider-doc
+  :package-version '(cider . "1.23.0"))
+
 (declare-function cider-apropos "cider-apropos")
 (declare-function cider-apropos-select "cider-apropos")
 (declare-function cider-apropos-documentation "cider-apropos")
@@ -156,6 +172,7 @@
     (define-key map "q" #'cider-popup-buffer-quit-function)
     (define-key map "g" #'cider-docview-clojuredocs)
     (define-key map "G" #'cider-docview-clojuredocs-web)
+    (define-key map "e" #'cider-docview-clojuredocs-examples)
     (define-key map "j" #'cider-docview-javadoc)
     (define-key map "s" #'cider-docview-source)
     (define-key map (kbd "<backtab>") #'backward-button)
@@ -163,6 +180,7 @@
     (easy-menu-define cider-docview-mode-menu map
       "Menu for CIDER's doc mode"
       `("CiderDoc"
+        ["Toggle ClojureDocs examples" cider-docview-clojuredocs-examples]
         ["Look up in Clojuredocs" cider-docview-clojuredocs]
         ["Look up in Clojuredocs (browser)" cider-docview-clojuredocs-web]
         ["JavaDoc in browser" cider-docview-javadoc]
@@ -176,6 +194,19 @@
 (defvar cider-docview-javadoc-url)
 (defvar cider-docview-file)
 (defvar cider-docview-line)
+
+(defvar-local cider-docview--clojuredocs-beg nil
+  "Marker at the start of the ClojureDocs footer in the doc buffer.
+Everything from this marker to the end of the buffer is managed by the
+ClojureDocs-examples machinery and rewritten as examples are toggled.")
+
+(defvar-local cider-docview--clojuredocs-data nil
+  "Cached ClojureDocs lookup result for the doc buffer's symbol.
+Nil until the examples have been fetched once; afterwards it holds the
+result dict (possibly empty), so toggling visibility never re-fetches.")
+
+(defvar-local cider-docview--clojuredocs-shown nil
+  "Whether the ClojureDocs examples are currently expanded in the doc buffer.")
 
 (define-derived-mode cider-docview-mode help-mode "Doc"
   "Major mode for displaying CIDER documentation.
@@ -257,6 +288,123 @@ opposite of what that option dictates."
   (if cider-buffer-ns
       (cider-clojuredocs-web-lookup cider-docview-symbol)
     (error "%s cannot be looked up on ClojureDocs" cider-docview-symbol)))
+
+(declare-function cider-clojuredocs--lookup-async "cider-clojuredocs")
+
+(defun cider-docview--insert-clojuredocs-toggle (label)
+  "Insert a button labeled LABEL that toggles the ClojureDocs examples."
+  (insert-text-button label
+                      'follow-link t
+                      'action (lambda (_) (cider-docview-clojuredocs-examples)))
+  (insert "\n"))
+
+(defun cider-docview--insert-clojuredocs-examples (dict)
+  "Insert the ClojureDocs examples from DICT at point.
+Show at most `cider-doc-clojuredocs-max-examples', with a link to the full
+ClojureDocs entry when more exist.  Insert nothing when DICT has no examples."
+  (when-let* ((examples (nrepl-dict-get dict "examples")))
+    (let ((shown (seq-take examples cider-doc-clojuredocs-max-examples)))
+      (insert (propertize "ClojureDocs Examples" 'font-lock-face 'font-lock-function-name-face)
+              "\n\n")
+      (dolist (example shown)
+        (insert (cider-font-lock-as-clojure example) "\n")
+        (insert (propertize (make-string 60 ?-) 'font-lock-face 'cider-docview-table-border-face)
+                "\n"))
+      (when (> (length examples) (length shown))
+        (insert-text-button (format "%d more example(s) on ClojureDocs"
+                                    (- (length examples) (length shown)))
+                            'follow-link t
+                            'action (lambda (_) (cider-docview-clojuredocs)))
+        (insert "\n")))))
+
+(defun cider-docview--refresh-clojuredocs-footer ()
+  "Redraw the ClojureDocs footer from the buffer-local shown/cache state.
+Show the examples (with a \"Hide\" toggle) when expanded, otherwise just a
+\"Show\" toggle."
+  (when (and cider-docview--clojuredocs-beg
+             (marker-position cider-docview--clojuredocs-beg))
+    (let ((inhibit-read-only t))
+      (delete-region cider-docview--clojuredocs-beg (point-max))
+      (save-excursion
+        (goto-char (point-max))
+        (if (and cider-docview--clojuredocs-shown
+                 cider-docview--clojuredocs-data
+                 (nrepl-dict-get cider-docview--clojuredocs-data "examples"))
+            (progn
+              (cider-docview--insert-clojuredocs-toggle "[ Hide ClojureDocs examples ]")
+              (insert "\n")
+              (cider-docview--insert-clojuredocs-examples cider-docview--clojuredocs-data))
+          (cider-docview--insert-clojuredocs-toggle "[ Show ClojureDocs examples ]"))))))
+
+(defun cider-docview--fetch-clojuredocs-examples ()
+  "Fetch ClojureDocs examples for the current symbol, then show them.
+Cache the result so subsequent toggles don't re-fetch."
+  (let ((buffer (current-buffer))
+        (symbol cider-docview-symbol))
+    (when (and cider-docview--clojuredocs-beg
+               (marker-position cider-docview--clojuredocs-beg))
+      (let ((inhibit-read-only t))
+        (delete-region cider-docview--clojuredocs-beg (point-max))
+        (save-excursion
+          (goto-char (point-max))
+          (insert (propertize "Fetching ClojureDocs examples..."
+                              'font-lock-face 'font-lock-comment-face)
+                  "\n"))))
+    (cider-clojuredocs--lookup-async
+     (cider-current-ns) symbol
+     (lambda (dict)
+       (when (buffer-live-p buffer)
+         (with-current-buffer buffer
+           ;; remember the result (even when empty) so we never re-fetch
+           (setq-local cider-docview--clojuredocs-data (or dict (nrepl-dict)))
+           (if (nrepl-dict-get cider-docview--clojuredocs-data "examples")
+               (setq-local cider-docview--clojuredocs-shown t)
+             (setq-local cider-docview--clojuredocs-shown nil)
+             (message "No ClojureDocs examples for %s" symbol))
+           (cider-docview--refresh-clojuredocs-footer)))))))
+
+(defun cider-docview-clojuredocs-examples ()
+  "Toggle the display of ClojureDocs examples for the current symbol.
+The examples are fetched on first use (and cached), then shown beneath the
+documentation; invoking this again hides them.  The footer's button toggles
+them too."
+  (interactive)
+  (unless cider-docview-symbol
+    (user-error "No symbol associated with this buffer"))
+  (cond
+   ;; currently expanded -> collapse
+   (cider-docview--clojuredocs-shown
+    (setq-local cider-docview--clojuredocs-shown nil)
+    (cider-docview--refresh-clojuredocs-footer))
+   ;; already fetched -> just expand (or report there's nothing to show)
+   (cider-docview--clojuredocs-data
+    (if (nrepl-dict-get cider-docview--clojuredocs-data "examples")
+        (progn
+          (setq-local cider-docview--clojuredocs-shown t)
+          (cider-docview--refresh-clojuredocs-footer))
+      (message "No ClojureDocs examples for %s" cider-docview-symbol)))
+   ;; not fetched yet -> fetch, then show
+   (t
+    (cider-docview--fetch-clojuredocs-examples))))
+
+(defun cider-docview--setup-clojuredocs-footer (info)
+  "Set up the ClojureDocs-examples footer for INFO in the current doc buffer.
+Only applies to Clojure vars (not Java members) when the ClojureDocs
+middleware is available.  When `cider-doc-show-clojuredocs-examples' is non-nil
+the examples are fetched and shown right away; otherwise the footer starts
+collapsed with a button to reveal them."
+  (when (and (nrepl-dict-get info "ns")
+             (not (nrepl-dict-get info "class"))
+             (cider-nrepl-op-supported-p "cider/clojuredocs-lookup" nil 'skip-ensure))
+    (let ((inhibit-read-only t))
+      (goto-char (point-max))
+      (insert "\n")
+      (setq-local cider-docview--clojuredocs-beg (point-marker))
+      (setq-local cider-docview--clojuredocs-data nil)
+      (setq-local cider-docview--clojuredocs-shown nil)
+      (if cider-doc-show-clojuredocs-examples
+          (cider-docview--fetch-clojuredocs-examples)
+        (cider-docview--refresh-clojuredocs-footer)))))
 
 (defconst cider-doc-buffer "*cider-doc*")
 
@@ -568,6 +716,9 @@ favoring a COMPACT format if specified, FOR-TOOLTIP if specified."
 
       (remove-overlays)
       (cider-docview-render-info buffer info compact for-tooltip)
+
+      (unless (or compact for-tooltip)
+        (cider-docview--setup-clojuredocs-footer info))
 
       (goto-char (point-min))
       (current-buffer))))

--- a/test/cider-doc-tests.el
+++ b/test/cider-doc-tests.el
@@ -27,8 +27,45 @@
 
 (require 'buttercup)
 (require 'cider-doc)
+(require 'nrepl-dict)
 
 ;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
+
+(describe "cider-docview--insert-clojuredocs-examples"
+  (it "inserts the examples capped at `cider-doc-clojuredocs-max-examples'"
+    (with-temp-buffer
+      (let ((cider-doc-clojuredocs-max-examples 2))
+        (cider-docview--insert-clojuredocs-examples
+         (nrepl-dict "examples" '("(ex-a)" "(ex-b)" "(ex-c)"))))
+      (let ((contents (buffer-string)))
+        (expect (string-search "ClojureDocs Examples" contents) :not :to-be nil)
+        (expect (string-search "(ex-a)" contents) :not :to-be nil)
+        (expect (string-search "(ex-b)" contents) :not :to-be nil)
+        ;; the third example is over the cap, so only the link to the rest shows
+        (expect (string-search "(ex-c)" contents) :to-be nil)
+        (expect (string-search "1 more example" contents) :not :to-be nil))))
+  (it "inserts nothing when the symbol has no examples"
+    (with-temp-buffer
+      (cider-docview--insert-clojuredocs-examples (nrepl-dict "examples" nil))
+      (expect (buffer-string) :to-equal ""))))
+
+(describe "cider-docview--refresh-clojuredocs-footer"
+  (it "expands examples with a Hide toggle, and collapses to a Show toggle"
+    (with-temp-buffer
+      (setq-local cider-docview--clojuredocs-beg (point-marker))
+      (setq-local cider-docview--clojuredocs-data (nrepl-dict "examples" '("(ex)")))
+      ;; expanded
+      (setq-local cider-docview--clojuredocs-shown t)
+      (cider-docview--refresh-clojuredocs-footer)
+      (let ((contents (buffer-string)))
+        (expect (string-search "Hide ClojureDocs examples" contents) :not :to-be nil)
+        (expect (string-search "(ex)" contents) :not :to-be nil))
+      ;; collapsed
+      (setq-local cider-docview--clojuredocs-shown nil)
+      (cider-docview--refresh-clojuredocs-footer)
+      (let ((contents (buffer-string)))
+        (expect (string-search "Show ClojureDocs examples" contents) :not :to-be nil)
+        (expect (string-search "(ex)" contents) :to-be nil)))))
 
 (describe "cider--abbreviate-file-protocol"
   (it "Removes the file or jar part"


### PR DESCRIPTION
Implements #3744. Brings ClojureDocs examples into the standard `*cider-doc*` buffer instead of requiring the separate `cider-clojuredocs` view.

Built as a configurable approach:

- **On-demand by default**: the doc buffer shows a `[ Show ClojureDocs examples ]` button (and binds `e` / a menu item) that fetches and appends the examples for the symbol.
- **Opt-in eager**: set `cider-doc-clojuredocs-examples` to fetch them automatically on every doc lookup.
- Fetched **asynchronously** (new `cider-clojuredocs--lookup-async`) so the doc renders immediately and examples pop in when they arrive (with a "Fetching…" placeholder).
- Capped at `cider-doc-clojuredocs-max-examples` (default 3) with a link to the full ClojureDocs entry for the rest.
- **Suppressed when empty** - no noise for the many vars without examples.
- Limited to Clojure vars (not Java members) and only when the clojuredocs middleware is available, so it degrades cleanly.

The first lookup may download the ClojureDocs EDN export (as today with `cider-clojuredocs`); subsequent lookups are cheap.

Tests cover the rendering (cap, empty, replace-not-append); the async/integration paths are exercised the way the rest of `cider-doc.el` is.