### PR TITLE
Improve the macroexpansion module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,15 @@
 - [#3966](https://github.com/clojure-emacs/cider/pull/3966): Add `cider-set-eval-destination` and `cider-cycle-eval-destination` (`C-c C-M-d`) to override, per buffer, which REPL type (clj, cljs or multi) evaluations dispatch to.
 - [#3969](https://github.com/clojure-emacs/cider/pull/3969): Show ClojureDocs examples inline in the `*cider-doc*` buffer, toggled with `e` (`cider-docview-clojuredocs-examples`) or shown automatically when `cider-doc-show-clojuredocs-examples` is enabled.
 
+### Bugs fixed
+
+- [#3971](https://github.com/clojure-emacs/cider/pull/3971): Fix `cider-macroexpand-again` (`g` in the macroexpansion buffer) to actually re-expand the form instead of redisplaying the original input.
+
 ### Changes
 
 - [#3967](https://github.com/clojure-emacs/cider/pull/3967): Refresh the embedded Clojure cheatsheet with functions added since Clojure 1.11 (`partitionv`, `partitionv-all`, `splitv-at`, `clojure.repl.deps`, `clojure.java.process`, the `clojure.core` Java-stream helpers, and more `clojure.math` members).
 - [#3967](https://github.com/clojure-emacs/cider/pull/3967): Give the cheatsheet buffer a dedicated `cider-cheatsheet-mode` with fontified section headers and `TAB`/`S-TAB` navigation between entries.
+- [#3971](https://github.com/clojure-emacs/cider/pull/3971): Add `n` and `t` keys in the macroexpansion buffer to cycle namespace display (`cider-macroexpansion-display-namespaces`) and toggle metadata (`cider-macroexpansion-print-metadata`), re-expanding in place.
 - [#3968](https://github.com/clojure-emacs/cider/pull/3968): Add a menu and per-var key bindings to the cheatsheet buffer (`d` for docs, `c` for ClojureDocs, `w` for ClojureDocs in the browser).
 
 ## 1.22.2 (2026-06-17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [#3967](https://github.com/clojure-emacs/cider/pull/3967): Refresh the embedded Clojure cheatsheet with functions added since Clojure 1.11 (`partitionv`, `partitionv-all`, `splitv-at`, `clojure.repl.deps`, `clojure.java.process`, the `clojure.core` Java-stream helpers, and more `clojure.math` members).
 - [#3967](https://github.com/clojure-emacs/cider/pull/3967): Give the cheatsheet buffer a dedicated `cider-cheatsheet-mode` with fontified section headers and `TAB`/`S-TAB` navigation between entries.
 - [#3971](https://github.com/clojure-emacs/cider/pull/3971): Add `n` and `t` keys in the macroexpansion buffer to cycle namespace display (`cider-macroexpansion-display-namespaces`) and toggle metadata (`cider-macroexpansion-print-metadata`), re-expanding in place.
+- [#3971](https://github.com/clojure-emacs/cider/pull/3971): Show a header line in the macroexpansion buffer with the active expander, display options and key hints, and make the in-place expansion commands (`m`/`a`) target the form at point so you can drill into nested macro calls.
 - [#3968](https://github.com/clojure-emacs/cider/pull/3968): Add a menu and per-var key bindings to the cheatsheet buffer (`d` for docs, `c` for ClojureDocs, `w` for ClojureDocs in the browser).
 
 ## 1.22.2 (2026-06-17)

--- a/doc/modules/ROOT/pages/debugging/macroexpansion.adoc
+++ b/doc/modules/ROOT/pages/debugging/macroexpansion.adoc
@@ -1,10 +1,10 @@
 = Macroexpansion
 :experimental:
 
-Typing kbd:[C-c C-m] after some form in a source buffer or the
-REPL will show you the macro expansion of the form in a new
-buffer. You'll have access to additional keybindings in the macro
-expansion buffer (which is internally using
+Typing kbd:[C-c C-m] after some form in a source buffer or the REPL will show
+you the `macroexpand-1` expansion of the form in a new buffer; kbd:[C-c M-m]
+does the same with `macroexpand-all`. You'll have access to additional
+keybindings in the macro expansion buffer (which is internally using
 `cider-macroexpansion-mode`):
 
 |===
@@ -17,11 +17,26 @@ expansion buffer (which is internally using
 | Invoke `clojure.walk/macroexpand-all` on the form at point and replace the original form with its expansion.
 
 | kbd:[g]
-| The prior macro expansion is performed again and the current contents of the macro expansion buffer are replaced with the new expansion.
+| Re-expand the original form. This picks up the latest definition of the macro as well as any change to the display options below.
+
+| kbd:[n]
+| Cycle `cider-macroexpansion-display-namespaces` between `tidy`, `qualified` and `none`, then re-expand.
+
+| kbd:[t]
+| Toggle `cider-macroexpansion-print-metadata`, then re-expand.
 
 | kbd:[C-/] +
 kbd:[u]
 | Undo the last in-place expansion performed in the macroexpansion buffer.
+
+| kbd:[.]
+| Jump to the definition of the symbol at point.
+
+| kbd:[d]
+| Display documentation for the symbol at point.
+
+| kbd:[q]
+| Quit the macroexpansion buffer.
 |===
 
 == Configuration

--- a/lisp/cider-macroexpansion.el
+++ b/lisp/cider-macroexpansion.el
@@ -87,24 +87,35 @@ ARG is passed along to `undo-only'."
 (defvar cider-last-macroexpand-expression nil
   "Hold the last expression that was macroexpanded.")
 
+(defvar cider-last-macroexpand-expander nil
+  "Hold the expander used for the last macroexpansion.")
+
 (defun cider-macroexpand-expr (expander expr)
   "Macroexpand, use EXPANDER, the given EXPR."
   (when-let* ((expansion (cider-sync-request:macroexpand expander expr)))
-    (setq cider-last-macroexpand-expression expr)
+    (setq cider-last-macroexpand-expression expr
+          cider-last-macroexpand-expander expander)
     (cider-initialize-macroexpansion-buffer expansion (cider-current-ns))))
 
 (defun cider-macroexpand-expr-inplace (expander)
-  "Substitute the form preceding point with its macroexpansion using EXPANDER."
-  (interactive)
+  "Substitute the form preceding point with its macroexpansion using EXPANDER.
+This is a helper invoked by the in-place expansion commands; EXPANDER is
+required, so it is not meant to be called interactively."
   (let* ((expansion (cider-sync-request:macroexpand expander (cider-last-sexp)))
          (bounds (cons (save-excursion (clojure-backward-logical-sexp 1) (point)) (point))))
     (cider-redraw-macroexpansion-buffer
      expansion (current-buffer) (car bounds) (cdr bounds))))
 
 (defun cider-macroexpand-again ()
-  "Repeat the last macroexpansion."
+  "Repeat the last macroexpansion, re-expanding the original expression.
+This picks up the latest definition of the macro and the current value of the
+display options (see `cider-macroexpansion-display-namespaces' and
+`cider-macroexpansion-print-metadata')."
   (interactive)
-  (cider-initialize-macroexpansion-buffer cider-last-macroexpand-expression (cider-current-ns)))
+  (unless cider-last-macroexpand-expression
+    (user-error "Nothing has been macroexpanded yet"))
+  (cider-macroexpand-expr (or cider-last-macroexpand-expander "macroexpand-1")
+                          cider-last-macroexpand-expression))
 
 ;;;###autoload
 (defun cider-macroexpand-1 (&optional prefix)
@@ -168,6 +179,27 @@ and point is placed after the expanded form."
     (cider-macroexpansion-mode 1)
     (current-buffer)))
 
+(defun cider-macroexpansion-cycle-display-namespaces ()
+  "Cycle `cider-macroexpansion-display-namespaces' and re-expand.
+Cycles through `tidy', `qualified' and `none'."
+  (interactive)
+  (setq cider-macroexpansion-display-namespaces
+        (pcase cider-macroexpansion-display-namespaces
+          ('tidy 'qualified)
+          ('qualified 'none)
+          (_ 'tidy)))
+  (message "Macroexpansion namespaces: %s" cider-macroexpansion-display-namespaces)
+  (cider-macroexpand-again))
+
+(defun cider-macroexpansion-toggle-print-metadata ()
+  "Toggle `cider-macroexpansion-print-metadata' and re-expand."
+  (interactive)
+  (setq cider-macroexpansion-print-metadata
+        (not cider-macroexpansion-print-metadata))
+  (message "Macroexpansion metadata: %s"
+           (if cider-macroexpansion-print-metadata "on" "off"))
+  (cider-macroexpand-again))
+
 (declare-function cider-find-var "cider-find")
 
 (defvar cider-macroexpansion-mode-map
@@ -179,15 +211,22 @@ and point is placed after the expanded form."
     (define-key map (kbd ".") #'cider-find-var)
     (define-key map (kbd "m") #'cider-macroexpand-1-inplace)
     (define-key map (kbd "a") #'cider-macroexpand-all-inplace)
+    (define-key map (kbd "n") #'cider-macroexpansion-cycle-display-namespaces)
+    (define-key map (kbd "t") #'cider-macroexpansion-toggle-print-metadata)
     (define-key map (kbd "u") #'cider-macroexpand-undo)
     (define-key map [remap undo] #'cider-macroexpand-undo)
     (easy-menu-define cider-macroexpansion-mode-menu map
       "Menu for CIDER's macroexpansion mode"
       '("Macroexpansion"
-        ["Restart expansion" cider-macroexpand-again]
+        ["Re-expand" cider-macroexpand-again]
         ["Macroexpand-1" cider-macroexpand-1-inplace]
         ["Macroexpand-all" cider-macroexpand-all-inplace]
         ["Macroexpand-undo" cider-macroexpand-undo]
+        "--"
+        ["Cycle namespace display" cider-macroexpansion-cycle-display-namespaces]
+        ["Toggle metadata" cider-macroexpansion-toggle-print-metadata
+         :style toggle :selected cider-macroexpansion-print-metadata]
+        "--"
         ["Go to source" cider-find-var]
         ["Go to doc" cider-doc]
         ["Go to Javadoc" cider-javadoc]

--- a/lisp/cider-macroexpansion.el
+++ b/lisp/cider-macroexpansion.el
@@ -97,14 +97,28 @@ ARG is passed along to `undo-only'."
           cider-last-macroexpand-expander expander)
     (cider-initialize-macroexpansion-buffer expansion (cider-current-ns))))
 
+(defun cider-macroexpansion--sexp-at-point-bounds ()
+  "Return the bounds (BEG . END) of the list form at point, or nil."
+  (save-excursion
+    (ignore-errors
+      (unless (looking-at-p "(")
+        (backward-up-list))
+      (when (looking-at-p "(")
+        (cons (point) (save-excursion (forward-sexp) (point)))))))
+
 (defun cider-macroexpand-expr-inplace (expander)
-  "Substitute the form preceding point with its macroexpansion using EXPANDER.
+  "Substitute the form at point with its macroexpansion using EXPANDER.
 This is a helper invoked by the in-place expansion commands; EXPANDER is
-required, so it is not meant to be called interactively."
-  (let* ((expansion (cider-sync-request:macroexpand expander (cider-last-sexp)))
-         (bounds (cons (save-excursion (clojure-backward-logical-sexp 1) (point)) (point))))
-    (cider-redraw-macroexpansion-buffer
-     expansion (current-buffer) (car bounds) (cdr bounds))))
+required, so it is not meant to be called interactively.
+
+Targeting the form at point lets you drill into a nested macro call in the
+expansion: put point on it and expand just that node."
+  (pcase-let ((`(,beg . ,end) (or (cider-macroexpansion--sexp-at-point-bounds)
+                                  (user-error "No list form at point"))))
+    (let ((expansion (cider-sync-request:macroexpand
+                      expander
+                      (buffer-substring-no-properties beg end))))
+      (cider-redraw-macroexpansion-buffer expansion (current-buffer) beg end))))
 
 (defun cider-macroexpand-again ()
   "Repeat the last macroexpansion, re-expanding the original expression.
@@ -127,7 +141,7 @@ If invoked with a PREFIX argument, use \\=`macroexpand\\=` instead of
     (cider-macroexpand-expr expander (cider-last-sexp))))
 
 (defun cider-macroexpand-1-inplace (&optional prefix)
-  "Perform inplace \\=`macroexpand-1\\=` on the expression preceding point.
+  "Perform inplace \\=`macroexpand-1\\=` on the form at point.
 If invoked with a PREFIX argument, use \\=`macroexpand\\=` instead of
 \\=`macroexpand-1\\=`."
   (interactive "P")
@@ -141,7 +155,7 @@ If invoked with a PREFIX argument, use \\=`macroexpand\\=` instead of
   (cider-macroexpand-expr "macroexpand-all" (cider-last-sexp)))
 
 (defun cider-macroexpand-all-inplace ()
-  "Perform inplace \\=`macroexpand-all\\=` on the expression preceding point."
+  "Perform inplace \\=`macroexpand-all\\=` on the form at point."
   (interactive)
   (cider-macroexpand-expr-inplace "macroexpand-all"))
 

--- a/lisp/cider-macroexpansion.el
+++ b/lisp/cider-macroexpansion.el
@@ -200,6 +200,20 @@ Cycles through `tidy', `qualified' and `none'."
            (if cider-macroexpansion-print-metadata "on" "off"))
   (cider-macroexpand-again))
 
+(defun cider-macroexpansion--header-line ()
+  "Return the header line for the macroexpansion buffer.
+It shows the active expander and display options, plus a reminder of the
+buffer's key bindings."
+  (concat
+   (propertize (format " %s" (or cider-last-macroexpand-expander "macroexpand-1"))
+               'face 'mode-line-emphasis)
+   (format "  ns: %s  meta: %s"
+           cider-macroexpansion-display-namespaces
+           (if cider-macroexpansion-print-metadata "on" "off"))
+   "    "
+   (propertize "[g]re-expand [m/a]step [n]ns [t]meta [u]ndo [q]uit"
+               'face 'shadow)))
+
 (declare-function cider-find-var "cider-find")
 
 (defvar cider-macroexpansion-mode-map
@@ -237,7 +251,9 @@ Cycles through `tidy', `qualified' and `none'."
   "Minor mode for CIDER macroexpansion.
 
 \\{cider-macroexpansion-mode-map}"
-  :lighter " Macroexpand")
+  :lighter " Macroexpand"
+  (when cider-macroexpansion-mode
+    (setq-local header-line-format '(:eval (cider-macroexpansion--header-line)))))
 
 (provide 'cider-macroexpansion)
 

--- a/test/cider-macroexpansion-tests.el
+++ b/test/cider-macroexpansion-tests.el
@@ -1,0 +1,135 @@
+;;; cider-macroexpansion-tests.el  -*- lexical-binding: t; -*-
+
+;; Copyright © 2026 Bozhidar Batsov
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; Tests for the separate-buffer macroexpansion support.
+
+;;; Code:
+
+(require 'buttercup)
+(require 'cl-lib)
+(require 'clojure-mode)
+(require 'nrepl-dict)
+(require 'cider-macroexpansion)
+
+;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
+
+(describe "cider-sync-request:macroexpand"
+  (it "sends the expander, code and namespace and returns the expansion"
+    (let (captured)
+      (cl-letf (((symbol-function 'cider-ensure-op-supported) #'ignore)
+                ((symbol-function 'cider-current-ns) (lambda () "user"))
+                ((symbol-function 'cider-nrepl-send-sync-request)
+                 (lambda (request)
+                   (setq captured request)
+                   (nrepl-dict "expansion" "(if x (do y))" "status" '("done")))))
+        (let ((cider-macroexpansion-display-namespaces 'tidy)
+              (cider-macroexpansion-print-metadata nil))
+          (expect (cider-sync-request:macroexpand "macroexpand-1" "(when x y)")
+                  :to-equal "(if x (do y))")
+          (expect (cadr (member "op" captured)) :to-equal "cider/macroexpand")
+          (expect (cadr (member "expander" captured)) :to-equal "macroexpand-1")
+          (expect (cadr (member "code" captured)) :to-equal "(when x y)")
+          (expect (cadr (member "display-namespaces" captured)) :to-equal "tidy")
+          ;; metadata is off, so no print-meta is sent
+          (expect (member "print-meta" captured) :to-be nil)))))
+
+  (it "requests metadata when `cider-macroexpansion-print-metadata' is on"
+    (let (captured)
+      (cl-letf (((symbol-function 'cider-ensure-op-supported) #'ignore)
+                ((symbol-function 'cider-current-ns) (lambda () "user"))
+                ((symbol-function 'cider-nrepl-send-sync-request)
+                 (lambda (request)
+                   (setq captured request)
+                   (nrepl-dict "expansion" "x" "status" '("done")))))
+        (let ((cider-macroexpansion-print-metadata t))
+          (cider-sync-request:macroexpand "macroexpand-1" "x")
+          (expect (cadr (member "print-meta" captured)) :to-equal "true")))))
+
+  (it "signals a user-error when the middleware reports a macroexpand-error"
+    (cl-letf (((symbol-function 'cider-ensure-op-supported) #'ignore)
+              ((symbol-function 'cider-current-ns) (lambda () "user"))
+              ((symbol-function 'cider-nrepl-send-sync-request)
+               (lambda (_request) (nrepl-dict "status" '("macroexpand-error")))))
+      (expect (cider-sync-request:macroexpand "macroexpand-1" "(boom)")
+              :to-throw 'user-error))))
+
+(describe "cider-macroexpand-again"
+  (it "re-expands the stored expression instead of redisplaying the input"
+    (let (codes)
+      (cl-letf (((symbol-function 'cider-ensure-op-supported) #'ignore)
+                ((symbol-function 'cider-current-ns) (lambda () "user"))
+                ((symbol-function 'cider-initialize-macroexpansion-buffer) #'ignore)
+                ((symbol-function 'cider-nrepl-send-sync-request)
+                 (lambda (request)
+                   (push (cadr (member "code" request)) codes)
+                   (nrepl-dict "expansion" "EXPANDED" "status" '("done")))))
+        (cider-macroexpand-expr "macroexpand-1" "(when x y)")
+        (cider-macroexpand-again)
+        ;; both the initial expansion and the repeat sent the form to the middleware
+        (expect codes :to-equal '("(when x y)" "(when x y)")))))
+
+  (it "errors when there is nothing to repeat"
+    (let ((cider-last-macroexpand-expression nil))
+      (expect (cider-macroexpand-again) :to-throw 'user-error))))
+
+(describe "cider-macroexpansion-cycle-display-namespaces"
+  (it "cycles tidy -> qualified -> none -> tidy"
+    (cl-letf (((symbol-function 'cider-macroexpand-again) #'ignore))
+      (let ((cider-macroexpansion-display-namespaces 'tidy))
+        (cider-macroexpansion-cycle-display-namespaces)
+        (expect cider-macroexpansion-display-namespaces :to-equal 'qualified)
+        (cider-macroexpansion-cycle-display-namespaces)
+        (expect cider-macroexpansion-display-namespaces :to-equal 'none)
+        (cider-macroexpansion-cycle-display-namespaces)
+        (expect cider-macroexpansion-display-namespaces :to-equal 'tidy)))))
+
+(describe "cider-macroexpansion-toggle-print-metadata"
+  (it "flips the metadata flag"
+    (cl-letf (((symbol-function 'cider-macroexpand-again) #'ignore))
+      (let ((cider-macroexpansion-print-metadata nil))
+        (cider-macroexpansion-toggle-print-metadata)
+        (expect cider-macroexpansion-print-metadata :to-be t)
+        (cider-macroexpansion-toggle-print-metadata)
+        (expect cider-macroexpansion-print-metadata :to-be nil)))))
+
+(describe "cider-redraw-macroexpansion-buffer"
+  (it "replaces the region from START to END with the expansion"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(when x y)")
+      (cider-redraw-macroexpansion-buffer "(if x (do y))" (current-buffer)
+                                          (point-min) (point-max))
+      (expect (string-trim (buffer-string)) :to-equal "(if x (do y))"))))
+
+(describe "cider-macroexpansion-mode-map"
+  (it "binds the in-place expansion and display-toggle keys"
+    (expect (lookup-key cider-macroexpansion-mode-map "m")
+            :to-equal 'cider-macroexpand-1-inplace)
+    (expect (lookup-key cider-macroexpansion-mode-map "a")
+            :to-equal 'cider-macroexpand-all-inplace)
+    (expect (lookup-key cider-macroexpansion-mode-map "n")
+            :to-equal 'cider-macroexpansion-cycle-display-namespaces)
+    (expect (lookup-key cider-macroexpansion-mode-map "t")
+            :to-equal 'cider-macroexpansion-toggle-print-metadata)))
+
+(provide 'cider-macroexpansion-tests)
+
+;;; cider-macroexpansion-tests.el ends here

--- a/test/cider-macroexpansion-tests.el
+++ b/test/cider-macroexpansion-tests.el
@@ -110,6 +110,16 @@
         (cider-macroexpansion-toggle-print-metadata)
         (expect cider-macroexpansion-print-metadata :to-be nil)))))
 
+(describe "cider-macroexpansion--sexp-at-point-bounds"
+  (it "returns the bounds of the enclosing list at point"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(if x (do (println y)))")
+      (goto-char (point-min))
+      (search-forward "println")
+      (pcase-let ((`(,beg . ,end) (cider-macroexpansion--sexp-at-point-bounds)))
+        (expect (buffer-substring-no-properties beg end) :to-equal "(println y)")))))
+
 (describe "cider-redraw-macroexpansion-buffer"
   (it "replaces the region from START to END with the expansion"
     (with-temp-buffer


### PR DESCRIPTION
A pass over the separate-buffer macroexpansion module (`cider-macroexpansion.el`) - a real bug fix, a UX addition, its first tests, and doc updates. (The inline macrostep work in #3970 is kept entirely separate.)

**Bug fix**
- `cider-macroexpand-again` (`g` in the macroexpansion buffer) stored the *input* form and passed it to the buffer as if it were the expansion, so it redisplayed the original instead of re-expanding. It now remembers the expander and re-runs the expansion (picking up macro redefinitions and display-option changes), and errors cleanly when nothing has been expanded yet.

**UX**
- New `n` and `t` keys (and menu entries) in the macroexpansion buffer: cycle `cider-macroexpansion-display-namespaces` (`tidy` -> `qualified` -> `none`) and toggle `cider-macroexpansion-print-metadata`, re-expanding in place - so you can see the same expansion with/without namespaces or metadata without reconfiguring and re-running.

**Tidy**
- Removed a spurious `(interactive)` from the `cider-macroexpand-expr-inplace` helper (it requires an `expander` arg, so it was never validly interactive).

**Tests + docs**
- The module had no tests; added a basic suite (the `cider/macroexpand` request construction + error handling, the `again` re-expansion regression, the toggle/cycle commands, region redraw, keymap). Documented the new keys and clarified the `g` behavior in `macroexpansion.adoc`.