### PR TITLE
Macroexpansion polish: consistency, flash, and graceful unresolved handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [#3967](https://github.com/clojure-emacs/cider/pull/3967): Give the cheatsheet buffer a dedicated `cider-cheatsheet-mode` with fontified section headers and `TAB`/`S-TAB` navigation between entries.
 - [#3971](https://github.com/clojure-emacs/cider/pull/3971): Add `n` and `t` keys in the macroexpansion buffer to cycle namespace display (`cider-macroexpansion-display-namespaces`) and toggle metadata (`cider-macroexpansion-print-metadata`), re-expanding in place.
 - [#3971](https://github.com/clojure-emacs/cider/pull/3971): Show a header line in the macroexpansion buffer with the active expander, display options and key hints.
+- [#3972](https://github.com/clojure-emacs/cider/pull/3972): Briefly highlight (pulse) the result after macroexpanding, both in the macroexpansion buffer and with inline `cider-macrostep` (toggle via `cider-macroexpansion-highlight-expansion` / `cider-macrostep-highlight-expansion`).
 - [#3968](https://github.com/clojure-emacs/cider/pull/3968): Add a menu and per-var key bindings to the cheatsheet buffer (`d` for docs, `c` for ClojureDocs, `w` for ClojureDocs in the browser).
 
 ## 1.22.2 (2026-06-17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [#3971](https://github.com/clojure-emacs/cider/pull/3971): Add `n` and `t` keys in the macroexpansion buffer to cycle namespace display (`cider-macroexpansion-display-namespaces`) and toggle metadata (`cider-macroexpansion-print-metadata`), re-expanding in place.
 - [#3971](https://github.com/clojure-emacs/cider/pull/3971): Show a header line in the macroexpansion buffer with the active expander, display options and key hints.
 - [#3972](https://github.com/clojure-emacs/cider/pull/3972): Briefly highlight (pulse) the result after macroexpanding, both in the macroexpansion buffer and with inline `cider-macrostep` (toggle via `cider-macroexpansion-highlight-expansion` / `cider-macrostep-highlight-expansion`).
+- [#3972](https://github.com/clojure-emacs/cider/pull/3972): When macroexpanding an unresolved symbol (e.g. a macro whose namespace hasn't been evaluated yet), a special form, or a non-macro, the macroexpansion commands now report a helpful message instead of silently doing nothing.
 - [#3968](https://github.com/clojure-emacs/cider/pull/3968): Add a menu and per-var key bindings to the cheatsheet buffer (`d` for docs, `c` for ClojureDocs, `w` for ClojureDocs in the browser).
 
 ## 1.22.2 (2026-06-17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - [#3967](https://github.com/clojure-emacs/cider/pull/3967): Refresh the embedded Clojure cheatsheet with functions added since Clojure 1.11 (`partitionv`, `partitionv-all`, `splitv-at`, `clojure.repl.deps`, `clojure.java.process`, the `clojure.core` Java-stream helpers, and more `clojure.math` members).
 - [#3967](https://github.com/clojure-emacs/cider/pull/3967): Give the cheatsheet buffer a dedicated `cider-cheatsheet-mode` with fontified section headers and `TAB`/`S-TAB` navigation between entries.
 - [#3971](https://github.com/clojure-emacs/cider/pull/3971): Add `n` and `t` keys in the macroexpansion buffer to cycle namespace display (`cider-macroexpansion-display-namespaces`) and toggle metadata (`cider-macroexpansion-print-metadata`), re-expanding in place.
-- [#3971](https://github.com/clojure-emacs/cider/pull/3971): Show a header line in the macroexpansion buffer with the active expander, display options and key hints, and make the in-place expansion commands (`m`/`a`) target the form at point so you can drill into nested macro calls.
+- [#3971](https://github.com/clojure-emacs/cider/pull/3971): Show a header line in the macroexpansion buffer with the active expander, display options and key hints.
 - [#3968](https://github.com/clojure-emacs/cider/pull/3968): Add a menu and per-var key bindings to the cheatsheet buffer (`d` for docs, `c` for ClojureDocs, `w` for ClojureDocs in the browser).
 
 ## 1.22.2 (2026-06-17)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -249,3 +249,12 @@ keep that momentum - finishing the decoupling odds and ends, tightening up
 callback handling
 ([#1099](https://github.com/clojure-emacs/cider/issues/1099)), and continuing
 to prefer built-ins and shed dead code as we touch each module.
+
+### Graceful handling of unloaded namespaces
+
+A lot of CIDER commands silently do nothing (or behave confusingly) when the
+current namespace hasn't been evaluated/loaded into the REPL, or when a
+referenced var is unresolved - macroexpansion is one example, but the pattern
+is broad. We should detect these cases centrally and give an actionable hint
+(e.g. "evaluate the buffer first") instead of a silent no-op, ideally via a
+shared helper rather than ad-hoc checks scattered across commands.

--- a/doc/modules/ROOT/pages/debugging/macroexpansion.adoc
+++ b/doc/modules/ROOT/pages/debugging/macroexpansion.adoc
@@ -11,10 +11,10 @@ keybindings in the macro expansion buffer (which is internally using
 | Keyboard shortcut | Description
 
 | kbd:[m]
-| Invoke `macroexpand-1` on the form at point and replace the original form with its expansion.  If invoked with a prefix argument, `macroexpand` is used instead of `macroexpand-1`.
+| Invoke `macroexpand-1` on the form before point and replace the original form with its expansion.  If invoked with a prefix argument, `macroexpand` is used instead of `macroexpand-1`.
 
 | kbd:[a]
-| Invoke `clojure.walk/macroexpand-all` on the form at point and replace the original form with its expansion.
+| Invoke `clojure.walk/macroexpand-all` on the form before point and replace the original form with its expansion.
 
 | kbd:[g]
 | Re-expand the original form. This picks up the latest definition of the macro as well as any change to the display options below.

--- a/lisp/cider-macroexpansion.el
+++ b/lisp/cider-macroexpansion.el
@@ -117,16 +117,47 @@ expansion, put point after that form and expand again."
         (when (< beg end)
           (cons beg end))))))
 
+(defun cider-macroexpansion--operator (form)
+  "Return the operator (leading symbol) of the Clojure FORM string, or nil."
+  (when (and form (string-match "\\`(\\s-*\\([^][(){} \t\n]+\\)" form))
+    (match-string 1 form)))
+
+(defun cider-macroexpansion--symbol-operator-p (operator)
+  "Return non-nil when OPERATOR could name a Clojure var (a plain symbol)."
+  (and (stringp operator)
+       (not (string-empty-p operator))
+       (not (string-match-p "\\`[][:\"(){}0-9]" operator))))
+
+(defun cider-macroexpansion--ensure-macro (operator)
+  "Signal a helpful `user-error' unless OPERATOR names a resolvable macro.
+This turns the silent \"nothing happens\" case (e.g. the namespace hasn't
+been evaluated yet) into an actionable message."
+  (cond
+   ((not (cider-macroexpansion--symbol-operator-p operator))
+    (user-error "`%s' is not a macro" (or operator "form")))
+   (t
+    (let ((info (cider-var-info operator)))
+      (cond
+       ((null info)
+        (user-error "%s" (substitute-command-keys
+                          (format "Can't resolve `%s' - its namespace may not be loaded; try \\[cider-load-buffer] first"
+                                  operator))))
+       ((nrepl-dict-get info "special-form")
+        (user-error "`%s' is a special form; there's nothing to macroexpand" operator))
+       ((not (nrepl-dict-get info "macro"))
+        (user-error "`%s' is not a macro" operator)))))))
+
 (defun cider-macroexpand-expr-inplace (expander)
   "Substitute the form before point with its macroexpansion using EXPANDER.
 This is a helper invoked by the in-place expansion commands; EXPANDER is
 required, so it is not meant to be called interactively."
   (pcase-let ((`(,beg . ,end) (or (cider-macroexpansion--form-bounds)
                                   (user-error "No sexp before point to expand"))))
-    (let ((expansion (cider-sync-request:macroexpand
-                      expander
-                      (buffer-substring-no-properties beg end))))
-      (cider-redraw-macroexpansion-buffer expansion (current-buffer) beg end))))
+    (let ((code (buffer-substring-no-properties beg end)))
+      (cider-macroexpansion--ensure-macro (cider-macroexpansion--operator code))
+      (cider-redraw-macroexpansion-buffer
+       (cider-sync-request:macroexpand expander code)
+       (current-buffer) beg end))))
 
 (defun cider-macroexpand-again ()
   "Repeat the last macroexpansion, re-expanding the original expression.
@@ -145,8 +176,10 @@ display options (see `cider-macroexpansion-display-namespaces' and
 If invoked with a PREFIX argument, use \\=`macroexpand\\=` instead of
 \\=`macroexpand-1\\=`."
   (interactive "P")
-  (let ((expander (if prefix "macroexpand" "macroexpand-1")))
-    (cider-macroexpand-expr expander (cider-last-sexp))))
+  (let ((form (cider-last-sexp))
+        (expander (if prefix "macroexpand" "macroexpand-1")))
+    (cider-macroexpansion--ensure-macro (cider-macroexpansion--operator form))
+    (cider-macroexpand-expr expander form)))
 
 (defun cider-macroexpand-1-inplace (&optional prefix)
   "Perform inplace \\=`macroexpand-1\\=` on the form before point.
@@ -160,7 +193,9 @@ If invoked with a PREFIX argument, use \\=`macroexpand\\=` instead of
 (defun cider-macroexpand-all ()
   "Invoke \\=`macroexpand-all\\=` on the expression preceding point."
   (interactive)
-  (cider-macroexpand-expr "macroexpand-all" (cider-last-sexp)))
+  (let ((form (cider-last-sexp)))
+    (cider-macroexpansion--ensure-macro (cider-macroexpansion--operator form))
+    (cider-macroexpand-expr "macroexpand-all" form)))
 
 (defun cider-macroexpand-all-inplace ()
   "Perform inplace \\=`macroexpand-all\\=` on the form before point."

--- a/lisp/cider-macroexpansion.el
+++ b/lisp/cider-macroexpansion.el
@@ -32,9 +32,17 @@
 ;;; Code:
 
 (require 'cider-mode)
+(require 'pulse)
 (require 'subr-x)
 
 (defconst cider-macroexpansion-buffer "*cider-macroexpansion*")
+
+(defcustom cider-macroexpansion-highlight-expansion t
+  "Whether to briefly highlight (pulse) the expansion after expanding.
+This makes it more obvious that the buffer's contents changed."
+  :type 'boolean
+  :group 'cider
+  :package-version '(cider . "1.23.0"))
 
 (defcustom cider-macroexpansion-display-namespaces 'tidy
   "Determines if namespaces are displayed in the macroexpansion buffer.
@@ -169,7 +177,9 @@ If invoked with a PREFIX argument, use \\=`macroexpand\\=` instead of
     (erase-buffer)
     (insert (format "%s" expansion))
     (goto-char (point-max))
-    (font-lock-ensure)))
+    (font-lock-ensure))
+  (when cider-macroexpansion-highlight-expansion
+    (pulse-momentary-highlight-region (point-min) (point-max))))
 
 (defun cider-redraw-macroexpansion-buffer (expansion buffer start end)
   "Redraw the macroexpansion with new EXPANSION.
@@ -182,7 +192,9 @@ and point is placed after the expanded form."
       (insert (format "%s" expansion))
       (goto-char start)
       (indent-sexp)
-      (forward-sexp))))
+      (forward-sexp)
+      (when cider-macroexpansion-highlight-expansion
+        (pulse-momentary-highlight-region start (point))))))
 
 (declare-function cider-mode "cider-mode")
 

--- a/lisp/cider-macroexpansion.el
+++ b/lisp/cider-macroexpansion.el
@@ -97,24 +97,24 @@ ARG is passed along to `undo-only'."
           cider-last-macroexpand-expander expander)
     (cider-initialize-macroexpansion-buffer expansion (cider-current-ns))))
 
-(defun cider-macroexpansion--sexp-at-point-bounds ()
-  "Return the bounds (BEG . END) of the list form at point, or nil."
+(defun cider-macroexpansion--form-bounds ()
+  "Return the bounds (BEG . END) of the sexp before point, or nil.
+This follows CIDER's usual convention (like `\\[cider-eval-last-sexp]'): place
+point right after the form.  To drill into a nested macro call in an
+expansion, put point after that form and expand again."
   (save-excursion
     (ignore-errors
-      (unless (looking-at-p "(")
-        (backward-up-list))
-      (when (looking-at-p "(")
-        (cons (point) (save-excursion (forward-sexp) (point)))))))
+      (let ((beg (progn (clojure-backward-logical-sexp 1) (point)))
+            (end (progn (clojure-forward-logical-sexp 1) (point))))
+        (when (< beg end)
+          (cons beg end))))))
 
 (defun cider-macroexpand-expr-inplace (expander)
-  "Substitute the form at point with its macroexpansion using EXPANDER.
+  "Substitute the form before point with its macroexpansion using EXPANDER.
 This is a helper invoked by the in-place expansion commands; EXPANDER is
-required, so it is not meant to be called interactively.
-
-Targeting the form at point lets you drill into a nested macro call in the
-expansion: put point on it and expand just that node."
-  (pcase-let ((`(,beg . ,end) (or (cider-macroexpansion--sexp-at-point-bounds)
-                                  (user-error "No list form at point"))))
+required, so it is not meant to be called interactively."
+  (pcase-let ((`(,beg . ,end) (or (cider-macroexpansion--form-bounds)
+                                  (user-error "No sexp before point to expand"))))
     (let ((expansion (cider-sync-request:macroexpand
                       expander
                       (buffer-substring-no-properties beg end))))
@@ -141,7 +141,7 @@ If invoked with a PREFIX argument, use \\=`macroexpand\\=` instead of
     (cider-macroexpand-expr expander (cider-last-sexp))))
 
 (defun cider-macroexpand-1-inplace (&optional prefix)
-  "Perform inplace \\=`macroexpand-1\\=` on the form at point.
+  "Perform inplace \\=`macroexpand-1\\=` on the form before point.
 If invoked with a PREFIX argument, use \\=`macroexpand\\=` instead of
 \\=`macroexpand-1\\=`."
   (interactive "P")
@@ -155,7 +155,7 @@ If invoked with a PREFIX argument, use \\=`macroexpand\\=` instead of
   (cider-macroexpand-expr "macroexpand-all" (cider-last-sexp)))
 
 (defun cider-macroexpand-all-inplace ()
-  "Perform inplace \\=`macroexpand-all\\=` on the form at point."
+  "Perform inplace \\=`macroexpand-all\\=` on the form before point."
   (interactive)
   (cider-macroexpand-expr-inplace "macroexpand-all"))
 

--- a/lisp/cider-macrostep.el
+++ b/lisp/cider-macrostep.el
@@ -34,6 +34,7 @@
 
 ;;; Code:
 
+(require 'pulse)
 (require 'seq)
 (require 'subr-x)
 
@@ -55,6 +56,12 @@ Possible values are:
   :type '(choice (const :tag "Suppress namespaces" none)
                  (const :tag "Show fully-qualified namespaces" qualified)
                  (const :tag "Show namespace aliases" tidy))
+  :group 'cider
+  :package-version '(cider . "1.23.0"))
+
+(defcustom cider-macrostep-highlight-expansion t
+  "Whether to briefly highlight (pulse) a freshly inserted inline expansion."
+  :type 'boolean
   :group 'cider
   :package-version '(cider . "1.23.0"))
 
@@ -233,7 +240,9 @@ Enter `cider-macrostep-mode' when it isn't already active."
                                           1))
               (overlay-put ov 'face 'cider-macrostep-expansion-face)
               (push ov cider-macrostep--overlays))
-            (goto-char ins-beg)))))))
+            (goto-char ins-beg)
+            (when cider-macrostep-highlight-expansion
+              (pulse-momentary-highlight-region ins-beg ins-end))))))))
 
 ;;;###autoload
 (defun cider-macrostep-expand ()

--- a/lisp/cider-macrostep.el
+++ b/lisp/cider-macrostep.el
@@ -148,11 +148,30 @@ expansion, put point after the nested form to drill into it."
     (when (looking-at-p "[^][(){} \t\n]")
       (buffer-substring-no-properties (point) (progn (forward-sexp) (point))))))
 
-(defun cider-macrostep--macro-p (operator)
-  "Return non-nil when OPERATOR names a macro in the current namespace."
-  (when operator
-    (when-let* ((info (cider-var-info operator)))
-      (nrepl-dict-get info "macro"))))
+(defun cider-macrostep--symbol-operator-p (operator)
+  "Return non-nil when OPERATOR could name a Clojure var (a plain symbol)."
+  (and (stringp operator)
+       (not (string-empty-p operator))
+       (not (string-match-p "\\`[][:\"(){}0-9]" operator))))
+
+(defun cider-macrostep--ensure-macro (operator)
+  "Signal a helpful `user-error' unless OPERATOR names a resolvable macro.
+This turns the silent \"nothing happens\" case (e.g. the namespace hasn't
+been evaluated yet) into an actionable message."
+  (cond
+   ((not (cider-macrostep--symbol-operator-p operator))
+    (user-error "`%s' is not a macro" (or operator "form")))
+   (t
+    (let ((info (cider-var-info operator)))
+      (cond
+       ((null info)
+        (user-error "%s" (substitute-command-keys
+                          (format "Can't resolve `%s' - its namespace may not be loaded; try \\[cider-load-buffer] first"
+                                  operator))))
+       ((nrepl-dict-get info "special-form")
+        (user-error "`%s' is a special form; there's nothing to macroexpand" operator))
+       ((not (nrepl-dict-get info "macro"))
+        (user-error "`%s' is not a macro" operator)))))))
 
 (defun cider-macrostep--collapse-overlay (ov)
   "Collapse overlay OV, restoring the text it replaced.
@@ -256,8 +275,7 @@ expansions and collapses then use that mode's key bindings."
   (pcase-let ((`(,beg . ,end) (or (cider-macrostep--form-bounds)
                                   (user-error "No sexp before point to expand"))))
     (let ((operator (cider-macrostep--operator beg)))
-      (unless (cider-macrostep--macro-p operator)
-        (user-error "`%s' is not a macro" (or operator "form")))
+      (cider-macrostep--ensure-macro operator)
       (let ((expansion (cider-macrostep--expand-1
                         (buffer-substring-no-properties beg end))))
         (unless (and (stringp expansion) (not (string-blank-p expansion)))

--- a/test/cider-macroexpansion-tests.el
+++ b/test/cider-macroexpansion-tests.el
@@ -110,14 +110,15 @@
         (cider-macroexpansion-toggle-print-metadata)
         (expect cider-macroexpansion-print-metadata :to-be nil)))))
 
-(describe "cider-macroexpansion--sexp-at-point-bounds"
-  (it "returns the bounds of the enclosing list at point"
+(describe "cider-macroexpansion--form-bounds"
+  (it "returns the bounds of the sexp before point"
     (with-temp-buffer
       (clojure-mode)
       (insert "(if x (do (println y)))")
+      ;; point right after the nested form
       (goto-char (point-min))
-      (search-forward "println")
-      (pcase-let ((`(,beg . ,end) (cider-macroexpansion--sexp-at-point-bounds)))
+      (search-forward "(println y)")
+      (pcase-let ((`(,beg . ,end) (cider-macroexpansion--form-bounds)))
         (expect (buffer-substring-no-properties beg end) :to-equal "(println y)")))))
 
 (describe "cider-redraw-macroexpansion-buffer"

--- a/test/cider-macroexpansion-tests.el
+++ b/test/cider-macroexpansion-tests.el
@@ -141,6 +141,42 @@
     (expect (lookup-key cider-macroexpansion-mode-map "t")
             :to-equal 'cider-macroexpansion-toggle-print-metadata)))
 
+(describe "cider-macroexpansion--operator"
+  (it "returns the leading symbol of a form"
+    (expect (cider-macroexpansion--operator "(when x y)") :to-equal "when")
+    (expect (cider-macroexpansion--operator "(defn- f [])") :to-equal "defn-")
+    (expect (cider-macroexpansion--operator "(-> x f)") :to-equal "->")))
+
+(describe "cider-macroexpansion--symbol-operator-p"
+  (it "accepts plain symbols and rejects keywords/literals"
+    (expect (cider-macroexpansion--symbol-operator-p "when") :to-be-truthy)
+    (expect (cider-macroexpansion--symbol-operator-p "->") :to-be-truthy)
+    (expect (cider-macroexpansion--symbol-operator-p ":kw") :to-be nil)
+    (expect (cider-macroexpansion--symbol-operator-p "1x") :to-be nil)
+    (expect (cider-macroexpansion--symbol-operator-p "") :to-be nil)))
+
+(describe "cider-macroexpansion--ensure-macro"
+  (it "passes for a resolvable macro"
+    (cl-letf (((symbol-function 'cider-var-info)
+               (lambda (&rest _) (nrepl-dict "macro" "true"))))
+      (expect (cider-macroexpansion--ensure-macro "when") :not :to-throw)))
+  (it "hints about loading the namespace for an unresolved symbol"
+    (cl-letf (((symbol-function 'cider-var-info) (lambda (&rest _) nil)))
+      (expect (cider-macroexpansion--ensure-macro "my.ns/foo") :to-throw 'user-error)))
+  (it "rejects special forms"
+    (cl-letf (((symbol-function 'cider-var-info)
+               (lambda (&rest _) (nrepl-dict "special-form" "true"))))
+      (expect (cider-macroexpansion--ensure-macro "if") :to-throw 'user-error)))
+  (it "rejects ordinary (non-macro) vars"
+    (cl-letf (((symbol-function 'cider-var-info)
+               (lambda (&rest _) (nrepl-dict "arglists" "([coll])"))))
+      (expect (cider-macroexpansion--ensure-macro "map") :to-throw 'user-error)))
+  (it "rejects non-symbol operators without consulting the runtime"
+    (expect (cider-macroexpansion--ensure-macro ":kw") :to-throw 'user-error))
+  (it "handles an operator containing a percent sign"
+    (cl-letf (((symbol-function 'cider-var-info) (lambda (&rest _) nil)))
+      (expect (cider-macroexpansion--ensure-macro "%") :to-throw 'user-error))))
+
 (provide 'cider-macroexpansion-tests)
 
 ;;; cider-macroexpansion-tests.el ends here

--- a/test/cider-macrostep-tests.el
+++ b/test/cider-macrostep-tests.el
@@ -24,10 +24,25 @@
 ;;; Code:
 
 (require 'buttercup)
+(require 'cl-lib)
 (require 'clojure-mode)
+(require 'nrepl-dict)
 (require 'cider-macrostep)
 
 ;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
+
+(describe "cider-macrostep--ensure-macro"
+  (it "passes for a resolvable macro"
+    (cl-letf (((symbol-function 'cider-var-info)
+               (lambda (&rest _) (nrepl-dict "macro" "true"))))
+      (expect (cider-macrostep--ensure-macro "when") :not :to-throw)))
+  (it "hints about loading the namespace for an unresolved symbol"
+    (cl-letf (((symbol-function 'cider-var-info) (lambda (&rest _) nil)))
+      (expect (cider-macrostep--ensure-macro "my.ns/foo") :to-throw 'user-error)))
+  (it "rejects non-macros"
+    (cl-letf (((symbol-function 'cider-var-info)
+               (lambda (&rest _) (nrepl-dict "arglists" "([coll])"))))
+      (expect (cider-macrostep--ensure-macro "map") :to-throw 'user-error))))
 
 (describe "cider-macrostep--form-bounds"
   (it "returns the bounds of the sexp before point"


### PR DESCRIPTION
A few small improvements across both macroexpansion modules (separate-buffer `cider-macroexpansion` and inline `cider-macrostep`).

**1. Consistent form selection.** The legacy in-place commands (`m`/`a`) targeted the form *at* point; they now target the sexp *before* point, like the entry commands and `cider-macrostep`. So all macroexpansion entry points follow the same CIDER convention (this undoes the inconsistent at-point variant from #3971; the header line from #3971 stays).

**2. Flash the result.** After expanding, the result is briefly pulsed (`pulse-momentary-highlight-region`, already used elsewhere in CIDER) so it's obvious something changed - in the macroexpansion buffer and inline. Toggle via `cider-macroexpansion-highlight-expansion` / `cider-macrostep-highlight-expansion` (on by default).

**3. Graceful unresolved/unloaded handling.** Macroexpanding a macro whose namespace hasn't been evaluated yet used to silently do nothing. Both modules now resolve the operator first and give an actionable message: an unresolved symbol hints to load the buffer (`C-c C-k`), a special form / non-macro says so plainly. Noted in the roadmap as a targeted instance of the broader "commands silently no-op when the namespace isn't loaded" problem.

Tests added for the operator/macro-resolution helpers (including a `%`-in-operator guard); compile `--warnings-as-errors`, checkdoc, and the suite all clean.