### PR TITLE
Namespace load-state indicator in the mode line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [#3976](https://github.com/clojure-emacs/cider/pull/3976): Underline the further-expandable sub-forms while inline macro stepping and move between them with `n`/`p` in `cider-macrostep-mode` (`cider-macrostep-highlight-expandable`).
 - [#3977](https://github.com/clojure-emacs/cider/pull/3977): Colorize the gensyms introduced by an inline macro expansion, each distinct gensym in its own color, so an introduced binding can be tracked (`cider-macrostep-color-gensyms`).
 - [#3978](https://github.com/clojure-emacs/cider/pull/3978): Add `cider-macrostep-expand-all` (`a` in `cider-macrostep-mode`) to fully expand the form at point inline in one step, instead of stepping level by level.
+- [#3973](https://github.com/clojure-emacs/cider/pull/3973): Indicate namespace load-state: a `cider-mode` lighter (and optional fringe) marker showing when the current buffer's namespace isn't loaded into the REPL or is stale (`cider-ns-load-state-display`), and a per-form fringe marker that turns from green to amber when you edit an evaluated form (`cider-mark-stale-after-edit`).
 
 ### Bugs fixed
 

--- a/doc/modules/ROOT/pages/usage/code_evaluation.adoc
+++ b/doc/modules/ROOT/pages/usage/code_evaluation.adoc
@@ -270,6 +270,61 @@ next change to the buffer contents.
 (setq cider-eval-result-duration 'change)
 ----
 
+=== Evaluation and Load-State Indicators
+
+Beyond the result overlays, CIDER can show, at a glance, which code is in sync
+with the REPL.
+
+==== Per-form fringe indicators
+
+When you evaluate a top-level form, CIDER places a small green marker in the
+left fringe next to it (`cider-fringe-good-face`).  Editing a form you've already
+evaluated turns its marker amber (`cider-fringe-stale-face`) to flag that the
+form is now out of sync with what the REPL has; re-evaluating it restores the
+green marker.
+
+This is on by default.  To turn the indicators off entirely:
+
+[source,lisp]
+----
+(setq cider-use-fringe-indicators nil)
+----
+
+To keep the indicators but restore the older behavior, where editing an
+evaluated form simply removes its marker instead of marking it stale:
+
+[source,lisp]
+----
+(setq cider-mark-stale-after-edit nil)
+----
+
+==== Namespace load-state indicator
+
+CIDER can also show whether the *whole* namespace of the current buffer is
+loaded into the REPL.  By default a marker appears in the `cider-mode` mode-line
+lighter: ` not-loaded` when the runtime doesn't know the namespace yet, and
+` stale` once you've edited the buffer since it was last loaded.  Both clear once
+you load the buffer with kbd:[C-c C-k].
+
+The state comes from the same namespace tracking CIDER already maintains, so it
+costs no extra requests; it simply stays blank until the runtime has reported
+in (and when cider-nrepl isn't present).  Choose where it's shown with
+`cider-ns-load-state-display` - a list of `mode-line` and/or `fringe`:
+
+[source,lisp]
+----
+;; default: just the mode-line marker
+(setq cider-ns-load-state-display '(mode-line))
+
+;; also mark the ns form in the fringe when the namespace isn't loaded
+(setq cider-ns-load-state-display '(mode-line fringe))
+
+;; disable it entirely
+(setq cider-ns-load-state-display nil)
+----
+
+`cider-ns-refresh-load-state` re-checks the current buffer on demand.
+
 === Auto-Save Clojure Buffers on Load
 
 Normally, CIDER prompts you to save a modified Clojure buffer when you

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -33,6 +33,7 @@
 
 (require 'clojure-mode)
 (require 'cider-eval)
+(require 'cider-ns-state)
 (require 'cider-inspiration)
 (require 'cider-test) ; required only for the menu
 (require 'cider-eldoc)
@@ -71,7 +72,8 @@ Info contains the connection type, project name and host:port endpoint."
 
 ;;;###autoload
 (defcustom cider-mode-line
-  '(:eval (format " cider[%s]" (cider--modeline-info)))
+  '(:eval (concat (format " cider[%s]" (cider--modeline-info))
+                  (cider-ns-state--lighter)))
   "Mode line lighter for cider mode.
 
 The value of this variable is a mode line template as in
@@ -1125,6 +1127,7 @@ property."
       (progn
         (setq-local sesman-system 'CIDER)
         (cider-eldoc-setup)
+        (cider-ns-state-setup)
         (add-hook 'completion-at-point-functions #'cider-complete-at-point nil t)
         (font-lock-add-keywords nil cider--static-font-lock-keywords)
         (cider-refresh-dynamic-font-lock)
@@ -1148,6 +1151,7 @@ property."
         (cider-enable-cider-completion-style 1)
         (setq next-error-function #'cider-jump-to-compilation-error))
     ;; Mode cleanup
+    (cider-ns-state-teardown)
     (mapc #'kill-local-variable '(next-error-function
                                   x-gtk-use-system-tooltips
                                   font-lock-fontify-region-function

--- a/lisp/cider-ns-state.el
+++ b/lisp/cider-ns-state.el
@@ -1,0 +1,219 @@
+;;; cider-ns-state.el --- Namespace load-state tracking -*- lexical-binding: t -*-
+
+;; Copyright © 2026  Bozhidar Batsov and CIDER contributors
+
+;; Author: Bozhidar Batsov <bozhidar@batsov.dev>
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+
+;; Track whether a source buffer's namespace has been loaded into the running
+;; REPL, and whether the buffer has been edited since it was last loaded.  The
+;; state is surfaced via the `cider-mode' mode-line lighter and/or a fringe
+;; marker (see `cider-ns-load-state-display'), so it's obvious when you're about
+;; to operate on a namespace that the runtime doesn't know about (or that is out
+;; of sync).  Loadedness is read from the track-state namespace cache, so it
+;; costs no extra requests.
+;;
+;; This is the coarse, namespace-level view.  The complementary per-form view
+;; lives with the evaluation fringe indicators in cider-overlays.el (a form goes
+;; stale when you edit it after evaluating it).
+
+;;; Code:
+
+(require 'subr-x)
+
+(require 'cider-client)
+(require 'cider-eval)
+(require 'nrepl-dict)
+
+(defvar cider-repl-ns-cache) ; defined in cider-repl.el, populated by track-state
+
+(defcustom cider-ns-load-state-display '(mode-line)
+  "Where to surface the current buffer's namespace load-state.
+A list of presentations to enable (an empty list disables the indicator):
+
+  `mode-line' - a marker in the `cider-mode' lighter: ` not-loaded' when the
+                namespace isn't loaded, ` stale' once the buffer is edited
+                after loading.
+  `fringe'    - a marker in the left fringe on the namespace form when the
+                namespace isn't loaded.
+
+For per-form staleness, use the evaluation fringe indicators instead (see
+`cider-use-fringe-indicators' and `cider-mark-stale-after-edit')."
+  :type '(set (const :tag "Mode-line marker" mode-line)
+              (const :tag "Fringe marker" fringe))
+  :group 'cider
+  :package-version '(cider . "1.23.0"))
+
+(defface cider-ns-load-state-face
+  '((t :inherit warning))
+  "Face for the namespace load-state marker (mode line and fringe)."
+  :group 'cider
+  :package-version '(cider . "1.23.0"))
+
+(defconst cider-ns-state--fringe-marker
+  (propertize " " 'display '(left-fringe empty-line cider-ns-load-state-face))
+  "The before-string that adds a namespace load-state marker on the fringe.")
+
+(defvar-local cider-ns-state--loaded nil
+  "Cached load state of the current buffer's namespace.
+One of nil (unknown / not checked yet), t (loaded), or the symbol
+`not-loaded'.  Refreshed from the track-state namespace cache by
+`cider-ns-state--refresh' and on `cider-file-loaded-hook'.")
+
+(defvar-local cider-ns-state--loaded-tick nil
+  "Value of `buffer-chars-modified-tick' when the buffer was last loaded.
+Used to detect that the buffer has been edited since (out of sync).  Only set
+when CIDER itself loaded the buffer, since otherwise there is no reliable sync
+baseline.")
+
+(defvar-local cider-ns-state--fringe-overlay nil
+  "Overlay holding the namespace-level fringe marker, when shown.")
+
+(defun cider-ns-load-state ()
+  "Return the load/sync state of the current buffer's namespace.
+One of `loaded', `not-loaded', `out-of-sync', or nil when the state is unknown
+or not applicable (no connection, not a Clojure source buffer, or no
+namespace).
+
+Cheap enough for the mode line: it never sends a request to the REPL, and when
+the state hasn't been determined yet `cider-ns-state--loaded' is nil so it bails
+out before the connection check."
+  (when (and cider-ns-state--loaded
+             (derived-mode-p 'clojure-mode 'clojure-ts-mode)
+             (cider-connected-p))
+    (cond
+     ((eq cider-ns-state--loaded 'not-loaded) 'not-loaded)
+     ((and cider-ns-state--loaded-tick
+           (/= cider-ns-state--loaded-tick (buffer-chars-modified-tick)))
+      'out-of-sync)
+     (t 'loaded))))
+
+(defun cider-ns-state--lighter ()
+  "Return the mode-line marker for the current buffer's namespace state.
+Empty unless the namespace is not loaded or is out of sync.  Any error is
+swallowed and rendered as an empty marker, since this runs during redisplay."
+  (if (not (memq 'mode-line cider-ns-load-state-display))
+      ""
+    (pcase (ignore-errors (cider-ns-load-state))
+      ('not-loaded
+       (propertize " not-loaded" 'face 'cider-ns-load-state-face
+                   'help-echo "This namespace has not been loaded into the REPL.
+Load the buffer with `cider-load-buffer' (C-c C-k)."))
+      ('out-of-sync
+       (propertize " stale" 'face 'cider-ns-load-state-face
+                   'help-echo "This buffer has been edited since it was last loaded.
+Reload it with `cider-load-buffer' (C-c C-k)."))
+      (_ ""))))
+
+(defun cider-ns-state--ns-form-bounds ()
+  "Return (BEG . END) of the leading ns/in-ns form, or nil."
+  (save-excursion
+    (goto-char (point-min))
+    (when (re-search-forward "^[ \t]*(\\(?:ns\\|in-ns\\)\\_>" nil t)
+      (goto-char (match-beginning 0))
+      (skip-chars-forward " \t")
+      (let ((beg (point)))
+        (ignore-errors
+          (forward-sexp)
+          (cons beg (point)))))))
+
+(defun cider-ns-state--update-fringe ()
+  "Place or remove the namespace-level fringe marker.
+Shown on the ns form only when `fringe' is enabled in
+`cider-ns-load-state-display' and the namespace isn't loaded.  Per-form
+staleness is surfaced separately, by the evaluation fringe indicators."
+  (when cider-ns-state--fringe-overlay
+    (delete-overlay cider-ns-state--fringe-overlay)
+    (setq cider-ns-state--fringe-overlay nil))
+  (when (and (memq 'fringe cider-ns-load-state-display)
+             (eq (ignore-errors (cider-ns-load-state)) 'not-loaded))
+    (when-let* ((bounds (cider-ns-state--ns-form-bounds)))
+      (let ((ov (make-overlay (car bounds) (cdr bounds))))
+        (overlay-put ov 'before-string cider-ns-state--fringe-marker)
+        (overlay-put ov 'cider-temporary t)
+        (setq cider-ns-state--fringe-overlay ov)))))
+
+(defun cider-ns-state--refresh (&optional buffer)
+  "Refresh the cached namespace load-state for BUFFER from track-state.
+BUFFER defaults to the current buffer.  Reads `cider-repl-ns-cache', which the
+track-state middleware keeps up to date, so it issues no request of its own.
+An empty cache means \"not yet reported\" (left unknown), not \"nothing
+loaded\".  Does nothing without a connection or a namespace."
+  (with-current-buffer (or buffer (current-buffer))
+    (when-let* ((repl (and (cider-connected-p) (cider-current-repl)))
+                (ns (cider-current-ns 'no-default))
+                (cache (buffer-local-value 'cider-repl-ns-cache repl)))
+      (unless (nrepl-dict-empty-p cache)
+        (setq-local cider-ns-state--loaded
+                    (if (nrepl-dict-get cache ns) t 'not-loaded))
+        (cider-ns-state--update-fringe)))))
+
+(defun cider-ns-refresh-load-state ()
+  "Re-check whether the current buffer's namespace is loaded in the REPL."
+  (interactive)
+  (cider-ns-state--refresh))
+
+(defun cider-ns-state--refresh-on-focus (&optional _frame)
+  "Refresh the load-state of the focused Clojure buffer if it's unknown.
+Intended for `window-selection-change-functions': when you select a connected
+Clojure buffer whose state hasn't been determined yet, check it once.  This
+deliberately avoids querying at connection time (which is fragile)."
+  (when cider-ns-load-state-display
+    (ignore-errors
+      (let ((buf (window-buffer (selected-window))))
+        (with-current-buffer buf
+          (when (and (derived-mode-p 'clojure-mode 'clojure-ts-mode)
+                     (null cider-ns-state--loaded)
+                     (cider-connected-p))
+            (cider-ns-state--refresh buf)))))))
+
+(defun cider-ns-state--mark-loaded ()
+  "Mark the current buffer's namespace as loaded and in sync.
+Intended for `cider-file-loaded-hook'."
+  (when (derived-mode-p 'clojure-mode 'clojure-ts-mode)
+    (setq-local cider-ns-state--loaded t
+                cider-ns-state--loaded-tick (buffer-chars-modified-tick))
+    (cider-ns-state--update-fringe)))
+
+(defun cider-ns-state-setup ()
+  "Enable namespace load-state tracking in the current buffer.
+Registers a buffer-local focus hook so the state is checked when you switch
+to the buffer.  Intended to be called when `cider-mode' is enabled."
+  (add-hook 'window-selection-change-functions
+            #'cider-ns-state--refresh-on-focus nil 'local))
+
+(defun cider-ns-state-teardown ()
+  "Disable namespace load-state tracking in the current buffer.
+Intended to be called when `cider-mode' is disabled."
+  (remove-hook 'window-selection-change-functions
+               #'cider-ns-state--refresh-on-focus 'local)
+  (when cider-ns-state--fringe-overlay
+    (delete-overlay cider-ns-state--fringe-overlay))
+  (kill-local-variable 'cider-ns-state--fringe-overlay)
+  (kill-local-variable 'cider-ns-state--loaded)
+  (kill-local-variable 'cider-ns-state--loaded-tick))
+
+;; `cider-file-loaded-hook' is cheap and only fires on CIDER loads, so it stays
+;; global; the focus hook is per-buffer (see `cider-ns-state-setup') to avoid
+;; running on every window selection change in unrelated buffers.
+(add-hook 'cider-file-loaded-hook #'cider-ns-state--mark-loaded)
+
+(provide 'cider-ns-state)
+
+;;; cider-ns-state.el ends here

--- a/lisp/cider-overlays.el
+++ b/lisp/cider-overlays.el
@@ -154,9 +154,20 @@ This function also removes itself from `post-command-hook'."
   "Face used on the fringe indicator for successful evaluation."
   :group 'cider)
 
+(defface cider-fringe-stale-face
+  '((((class color) (background light)) :foreground "orange3")
+    (((class color) (background dark)) :foreground "orange"))
+  "Face used on the fringe indicator for a form edited since it was evaluated."
+  :group 'cider
+  :package-version '(cider . "1.23.0"))
+
 (defconst cider--fringe-overlay-good
   (propertize " " 'display '(left-fringe empty-line cider-fringe-good-face))
   "The before-string property that adds a green indicator on the fringe.")
+
+(defconst cider--fringe-overlay-stale
+  (propertize " " 'display '(left-fringe empty-line cider-fringe-stale-face))
+  "The before-string property that adds a stale indicator on the fringe.")
 
 (defcustom cider-use-fringe-indicators t
   "Whether to display evaluation indicators on the left fringe."
@@ -164,6 +175,26 @@ This function also removes itself from `post-command-hook'."
   :group 'cider
   :type 'boolean
   :package-version '(cider . "0.13.0"))
+
+(defcustom cider-mark-stale-after-edit t
+  "Whether editing an evaluated form marks its fringe indicator stale.
+When non-nil, editing a top-level form that carries an evaluation fringe
+indicator recolors it (`cider-fringe-stale-face') to show the form is out of
+sync with the REPL, instead of removing the indicator outright.  Re-evaluating
+the form restores the in-sync indicator."
+  :safe #'booleanp
+  :group 'cider
+  :type 'boolean
+  :package-version '(cider . "1.23.0"))
+
+(defun cider--fringe-overlay-mark-stale (ov after-p _beg _end &optional _len)
+  "Recolor fringe indicator overlay OV to the stale face once its form is edited.
+Installed on OV's `modification-hooks': it acts only after the change (when
+AFTER-P is non-nil), then stops reacting, since the form stays stale until it
+is re-evaluated."
+  (when after-p
+    (overlay-put ov 'before-string cider--fringe-overlay-stale)
+    (overlay-put ov 'modification-hooks nil)))
 
 (defun cider--make-fringe-overlay (&optional end)
   "Place an eval indicator at the fringe before a sexp.
@@ -177,9 +208,20 @@ END is the position where the sexp ends, and defaults to point."
             (goto-char end)
           (setq end (point)))
         (clojure-forward-logical-sexp -1)
+        ;; Drop any prior indicator on this form (e.g. a stale one) so a
+        ;; re-evaluation replaces it with a fresh in-sync indicator.
+        (remove-overlays (point) end 'category 'cider-fringe-indicator)
         ;; Create the green-circle overlay.
-        (cider--make-overlay (point) end 'cider-fringe-indicator
-                             'before-string cider--fringe-overlay-good)))))
+        (let ((ov (cider--make-overlay (point) end 'cider-fringe-indicator
+                                       'before-string cider--fringe-overlay-good)))
+          (when cider-mark-stale-after-edit
+            ;; `cider--make-overlay' installs a delete-on-edit hook; swap just
+            ;; that one out for mark-stale, leaving any other hooks intact.
+            (overlay-put ov 'modification-hooks
+                         (cons #'cider--fringe-overlay-mark-stale
+                               (remq #'cider--delete-overlay
+                                     (overlay-get ov 'modification-hooks)))))
+          ov)))))
 
 (cl-defun cider--make-result-overlay (value &rest props &key where duration (type 'result)
                                             (format (concat " " cider-eval-result-prefix "%s "))

--- a/test/cider-ns-state-tests.el
+++ b/test/cider-ns-state-tests.el
@@ -1,0 +1,147 @@
+;;; cider-ns-state-tests.el  -*- lexical-binding: t; -*-
+
+;; Copyright © 2026 Bozhidar Batsov
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; Tests for the namespace load-state tracking.
+
+;;; Code:
+
+(require 'buttercup)
+(require 'cl-lib)
+(require 'clojure-mode)
+(require 'nrepl-dict)
+(require 'cider-ns-state)
+
+;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
+
+(describe "cider-ns-load-state"
+  ;; stub the connection check so the logic runs offline
+  (before-each (spy-on 'cider-connected-p :and-return-value t))
+
+  (it "is nil when the load state hasn't been determined"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(ns foo)")
+      (expect (cider-ns-load-state) :to-be nil)))
+  (it "is not-loaded when the namespace is absent from the REPL"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(ns foo)")
+      (setq-local cider-ns-state--loaded 'not-loaded)
+      (expect (cider-ns-load-state) :to-equal 'not-loaded)))
+  (it "is loaded when loaded and unchanged since"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(ns foo)")
+      (setq-local cider-ns-state--loaded t
+                  cider-ns-state--loaded-tick (buffer-chars-modified-tick))
+      (expect (cider-ns-load-state) :to-equal 'loaded)))
+  (it "is out-of-sync when the buffer was edited since loading"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(ns foo)")
+      (setq-local cider-ns-state--loaded t
+                  cider-ns-state--loaded-tick (buffer-chars-modified-tick))
+      (insert " ;; edit")
+      (expect (cider-ns-load-state) :to-equal 'out-of-sync)))
+  (it "is nil in non-Clojure buffers"
+    (with-temp-buffer
+      (fundamental-mode)
+      (setq-local cider-ns-state--loaded 'not-loaded)
+      (expect (cider-ns-load-state) :to-be nil))))
+
+(describe "cider-ns-state--lighter"
+  (before-each (spy-on 'cider-connected-p :and-return-value t))
+
+  (it "marks not-loaded and stale, and is empty when loaded/unknown"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(ns foo)")
+      (expect (cider-ns-state--lighter) :to-equal "")            ; unknown
+      (setq-local cider-ns-state--loaded 'not-loaded)
+      (expect (string-trim (cider-ns-state--lighter)) :to-equal "not-loaded")
+      (setq-local cider-ns-state--loaded t
+                  cider-ns-state--loaded-tick (buffer-chars-modified-tick))
+      (expect (cider-ns-state--lighter) :to-equal "")            ; loaded
+      (insert " x")
+      (expect (string-trim (cider-ns-state--lighter)) :to-equal "stale")))
+  (it "is empty when `mode-line' isn't in `cider-ns-load-state-display'"
+    (let ((cider-ns-load-state-display '(fringe)))
+      (with-temp-buffer
+        (clojure-mode)
+        (setq-local cider-ns-state--loaded 'not-loaded)
+        (expect (cider-ns-state--lighter) :to-equal "")))))
+
+(describe "cider-ns-state--refresh"
+  (before-each (spy-on 'cider-connected-p :and-return-value t))
+
+  ;; Run BODY with a stub REPL whose `cider-repl-ns-cache' is CACHE.
+  (cl-macrolet ((with-repl-cache (cache &rest body)
+                  `(let ((repl (generate-new-buffer " *ns-state-repl*")))
+                     (unwind-protect
+                         (progn
+                           (with-current-buffer repl (setq-local cider-repl-ns-cache ,cache))
+                           (spy-on 'cider-current-repl :and-return-value repl)
+                           ,@body)
+                       (kill-buffer repl)))))
+
+    (it "marks loaded when the ns is in the track-state cache"
+      (with-repl-cache (nrepl-dict "foo" (nrepl-dict))
+        (with-temp-buffer
+          (clojure-mode)
+          (insert "(ns foo)")
+          (cider-ns-state--refresh)
+          (expect cider-ns-state--loaded :to-be t))))
+
+    (it "marks not-loaded when the ns is absent from a populated cache"
+      (with-repl-cache (nrepl-dict "other" (nrepl-dict))
+        (with-temp-buffer
+          (clojure-mode)
+          (insert "(ns foo)")
+          (cider-ns-state--refresh)
+          (expect cider-ns-state--loaded :to-equal 'not-loaded))))
+
+    (it "leaves the state unknown when track-state hasn't reported yet"
+      ;; An empty cache means \"not reported\", not \"nothing loaded\".
+      (with-repl-cache nil
+        (with-temp-buffer
+          (clojure-mode)
+          (insert "(ns foo)")
+          (cider-ns-state--refresh)
+          (expect cider-ns-state--loaded :to-be nil))))))
+
+(describe "cider-ns-state setup/teardown"
+  (it "adds a buffer-local focus hook and tears it down with the cached state"
+    (with-temp-buffer
+      (clojure-mode)
+      (cider-ns-state-setup)
+      (expect (memq #'cider-ns-state--refresh-on-focus
+                    window-selection-change-functions)
+              :to-be-truthy)
+      (setq-local cider-ns-state--loaded t)
+      (cider-ns-state-teardown)
+      (expect (memq #'cider-ns-state--refresh-on-focus
+                    window-selection-change-functions)
+              :to-be nil)
+      (expect (local-variable-p 'cider-ns-state--loaded) :to-be nil))))
+
+(provide 'cider-ns-state-tests)
+
+;;; cider-ns-state-tests.el ends here

--- a/test/cider-overlay-tests.el
+++ b/test/cider-overlay-tests.el
@@ -221,6 +221,49 @@ being set that way"
         (insert "Hello")
         (expect (overlay-count) :to-be 0)))))
 
+(describe "cider--make-fringe-overlay"
+  (it "flips the indicator to stale when the evaluated form is edited"
+    (let ((cider-use-fringe-indicators t)
+          (cider-mark-stale-after-edit t))
+      (with-temp-buffer
+        (clojure-mode)
+        (insert "(def x 1)")
+        (cider--make-fringe-overlay (point))
+        (let ((ov (car (overlays-in (point-min) (point-max)))))
+          (expect (overlay-get ov 'before-string) :to-equal cider--fringe-overlay-good)
+          (goto-char (1- (point-max)))
+          (insert "0")                  ; edit inside the form
+          (expect (overlay-get ov 'before-string) :to-equal cider--fringe-overlay-stale)
+          (expect (overlay-buffer ov) :not :to-be nil)))))   ; kept, not deleted
+
+  (it "keeps the old delete-on-edit behavior when `cider-mark-stale-after-edit' is nil"
+    (let ((cider-use-fringe-indicators t)
+          (cider-mark-stale-after-edit nil))
+      (with-temp-buffer
+        (clojure-mode)
+        (insert "(def x 1)")
+        (cider--make-fringe-overlay (point))
+        (let ((ov (car (overlays-in (point-min) (point-max)))))
+          (goto-char (1- (point-max)))
+          (insert "0")
+          (expect (overlay-buffer ov) :to-be nil)))))       ; deleted
+
+  (it "replaces a prior (stale) indicator when the form is re-evaluated"
+    (let ((cider-use-fringe-indicators t)
+          (cider-mark-stale-after-edit t))
+      (with-temp-buffer
+        (clojure-mode)
+        (insert "(def x 1)")
+        (cider--make-fringe-overlay (point))
+        (goto-char (1- (point-max)))
+        (insert "0")                    ; now stale
+        (goto-char (point-max))
+        (cider--make-fringe-overlay (point))   ; re-eval
+        (let ((ovs (overlays-in (point-min) (point-max))))
+          (expect (length ovs) :to-equal 1)
+          (expect (overlay-get (car ovs) 'before-string)
+                  :to-equal cider--fringe-overlay-good))))))
+
 (describe "cider--delete-overlay"
   :var (overlay-position)
   (it "deletes overlays"


### PR DESCRIPTION
Make it obvious, without running anything, whether the buffer you're looking at is actually loaded into the REPL.

The `cider-mode` lighter grows a small marker:

- ` not-loaded` - this namespace isn't loaded in the running REPL (operating on it will likely misbehave).
- ` stale` - the buffer has been edited since it was last loaded via CIDER.

How it works:

- State is cached buffer-locally (`cider--ns-loaded` plus a `buffer-chars-modified-tick` baseline) and the lighter only reads that cache, so redisplay never touches the network.
- It's refreshed when CIDER loads a file (`cider-file-loaded-hook`), on demand via `M-x cider-ns-refresh-load-state`, and once per buffer when you first focus it (`window-selection-change-functions`).
- No query on connect: a `cider/ns-list` request fired during the connection dance breaks the mock-server tests, and focus-driven refresh is nicer UX anyway.
- Toggle the whole thing with `cider-show-ns-load-state`.

Known limitations (intentional for now):

- `stale` only works for namespaces CIDER itself loaded - if a namespace was loaded outside CIDER (or before it attached) there's no reliable sync baseline, so it shows as loaded and never goes stale.
- Granularity is the whole namespace, not per-form. Per-form staleness (extending the fringe indicators) is a separate effort.

Opening this as a draft to gather feedback - the markers, triggers and defaults are all up for discussion.