### PR TITLE
Hint to load the namespace on unresolved-var failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [#3972](https://github.com/clojure-emacs/cider/pull/3972): Briefly highlight (pulse) the result after macroexpanding, both in the macroexpansion buffer and with inline `cider-macrostep` (toggle via `cider-macroexpansion-highlight-expansion` / `cider-macrostep-highlight-expansion`).
 - [#3972](https://github.com/clojure-emacs/cider/pull/3972): When macroexpanding an unresolved symbol (e.g. a macro whose namespace hasn't been evaluated yet), a special form, or a non-macro, the macroexpansion commands now report a helpful message instead of silently doing nothing.
 - [#3968](https://github.com/clojure-emacs/cider/pull/3968): Add a menu and per-var key bindings to the cheatsheet buffer (`d` for docs, `c` for ClojureDocs, `w` for ClojureDocs in the browser).
+- [#3974](https://github.com/clojure-emacs/cider/pull/3974): When a var can't be resolved (commonly because its namespace hasn't been loaded), `cider-find-var` and `cider-doc` now hint to load the buffer first instead of failing with a cryptic "not resolved" message.
 
 ## 1.22.2 (2026-06-17)
 

--- a/lisp/cider-client.el
+++ b/lisp/cider-client.el
@@ -650,6 +650,23 @@ unless ALL is truthy."
   (when (and class member)
     (cider-info-request :class class :member member :context (cider-completion-get-context t))))
 
+(defun cider-ensure-var-resolved (var &optional info)
+  "Return resolved info for VAR, or signal an actionable `user-error'.
+INFO, when non-nil, is reused as a pre-fetched `cider-var-info' result
+instead of querying again.  A nil INFO is treated as \"not pre-fetched\" and
+falls through to a query.
+
+When VAR cannot be resolved this points the user at `cider-load-buffer',
+since by far the most common cause is that the var's namespace hasn't been
+loaded into the REPL yet (or has drifted out of sync with the buffer).  This
+turns the otherwise cryptic \"not resolved\" failures into a hint that
+actually tells you what to do about it."
+  (or info
+      (cider-var-info var)
+      (user-error "%s" (substitute-command-keys
+                        (format "Can't resolve `%s' - its namespace may not be loaded; try \\[cider-load-buffer] first"
+                                (or var "symbol"))))))
+
 
 ;;; Requests
 

--- a/lisp/cider-doc.el
+++ b/lisp/cider-doc.el
@@ -424,7 +424,8 @@ Favor a compact rendering of docstrings."
   "Look up documentation for SYMBOL."
   (if-let* ((buffer (cider-create-doc-buffer symbol)))
       (cider-popup-buffer-display buffer cider-doc-auto-select-buffer)
-    (user-error "Symbol %s not resolved" symbol)))
+    ;; no buffer means the symbol didn't resolve; give an actionable hint
+    (cider-ensure-var-resolved symbol)))
 
 (defun cider-doc (&optional arg)
   "Open Clojure documentation in a popup buffer.

--- a/lisp/cider-find.el
+++ b/lisp/cider-find.el
@@ -36,19 +36,15 @@
   "Find the definition of VAR, optionally at a specific LINE.
 
 Display the results in a different window."
-  (if-let* ((info (cider-var-info var)))
-      (progn
-        (when line (setq info (nrepl-dict-put info "line" line)))
-        (cider--jump-to-loc-from-info info t))
-    (user-error "Symbol `%s' not resolved" var)))
+  (let ((info (cider-ensure-var-resolved var)))
+    (when line (setq info (nrepl-dict-put info "line" line)))
+    (cider--jump-to-loc-from-info info t)))
 
 (defun cider--find-var (var &optional line)
   "Find the definition of VAR, optionally at a specific LINE."
-  (if-let* ((info (cider-var-info var)))
-      (progn
-        (when line (setq info (nrepl-dict-put info "line" line)))
-        (cider--jump-to-loc-from-info info))
-    (user-error "Symbol `%s' not resolved" var)))
+  (let ((info (cider-ensure-var-resolved var)))
+    (when line (setq info (nrepl-dict-put info "line" line)))
+    (cider--jump-to-loc-from-info info)))
 
 ;;;###autoload
 (defun cider-find-var (&optional arg var line)

--- a/lisp/cider-macroexpansion.el
+++ b/lisp/cider-macroexpansion.el
@@ -136,12 +136,8 @@ been evaluated yet) into an actionable message."
    ((not (cider-macroexpansion--symbol-operator-p operator))
     (user-error "`%s' is not a macro" (or operator "form")))
    (t
-    (let ((info (cider-var-info operator)))
+    (let ((info (cider-ensure-var-resolved operator)))
       (cond
-       ((null info)
-        (user-error "%s" (substitute-command-keys
-                          (format "Can't resolve `%s' - its namespace may not be loaded; try \\[cider-load-buffer] first"
-                                  operator))))
        ((nrepl-dict-get info "special-form")
         (user-error "`%s' is a special form; there's nothing to macroexpand" operator))
        ((not (nrepl-dict-get info "macro"))

--- a/lisp/cider-macrostep.el
+++ b/lisp/cider-macrostep.el
@@ -162,12 +162,8 @@ been evaluated yet) into an actionable message."
    ((not (cider-macrostep--symbol-operator-p operator))
     (user-error "`%s' is not a macro" (or operator "form")))
    (t
-    (let ((info (cider-var-info operator)))
+    (let ((info (cider-ensure-var-resolved operator)))
       (cond
-       ((null info)
-        (user-error "%s" (substitute-command-keys
-                          (format "Can't resolve `%s' - its namespace may not be loaded; try \\[cider-load-buffer] first"
-                                  operator))))
        ((nrepl-dict-get info "special-form")
         (user-error "`%s' is a special form; there's nothing to macroexpand" operator))
        ((not (nrepl-dict-get info "macro"))

--- a/test/cider-client-tests.el
+++ b/test/cider-client-tests.el
@@ -270,6 +270,24 @@
     (expect (cider-ensure-op-supported "foo")
             :to-throw 'user-error)))
 
+(describe "cider-ensure-var-resolved"
+  (it "returns the var info when the var resolves"
+    (let ((info (nrepl-dict "ns" "user" "name" "foo")))
+      (spy-on 'cider-var-info :and-return-value info)
+      (expect (cider-ensure-var-resolved "foo") :to-equal info)))
+  (it "reuses pre-fetched info without querying again"
+    (let ((info (nrepl-dict "ns" "user" "name" "foo")))
+      (spy-on 'cider-var-info)
+      (expect (cider-ensure-var-resolved "foo" info) :to-equal info)
+      (expect 'cider-var-info :not :to-have-been-called)))
+  (it "raises an actionable user-error when the var doesn't resolve"
+    (spy-on 'cider-var-info :and-return-value nil)
+    (expect (cider-ensure-var-resolved "foo") :to-throw 'user-error)
+    (expect (cider-ensure-var-resolved "foo")
+            :to-throw 'user-error
+            (list (substitute-command-keys
+                   "Can't resolve `foo' - its namespace may not be loaded; try \\[cider-load-buffer] first")))))
+
 (describe "cider--fallback-op"
   (it "returns the namespaced op when it is supported"
     (spy-on 'nrepl-op-supported-p :and-call-fake


### PR DESCRIPTION
Where #3973 *shows* the namespace load state, this makes the *failure modes* graceful: when you act on a var whose namespace isn't loaded, you get told what to do instead of a cryptic dead end.

[#3972](https://github.com/clojure-emacs/cider/pull/3972) taught the macroexpansion commands to say "its namespace may not be loaded; try `C-c C-k`" instead of silently doing nothing. This generalizes that:

- Extracts a shared `cider-ensure-var-resolved` gate (next to `cider-ensure-connected` / `cider-ensure-op-supported`).
- De-duplicates it out of both macro helpers (`cider-macrostep` and `cider-macroexpansion`) - pure refactor, same behavior.
- Applies it to `cider-find-var` and `cider-doc`, which previously failed with the unhelpful "Symbol not resolved".

The message points at `cider-load-buffer` via `substitute-command-keys`, so it shows whatever key it's actually bound to.

Scoped to the "ensure loaded" half. The "in sync / stale" detection lives in #3973; a later iteration could have this gate consult that state too, but keeping them independent makes each easier to review. The gate can easily be pushed into more call sites (eldoc, inspect, etc.) too.