### PR TITLE
Add cider-macrostep-expand-all for one-shot full expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [#3970](https://github.com/clojure-emacs/cider/pull/3970): Add `cider-macrostep-expand` for inline, in-place macro expansion with step-in/collapse (`cider-macrostep-mode`).
 - [#3976](https://github.com/clojure-emacs/cider/pull/3976): Underline the further-expandable sub-forms while inline macro stepping and move between them with `n`/`p` in `cider-macrostep-mode` (`cider-macrostep-highlight-expandable`).
 - [#3977](https://github.com/clojure-emacs/cider/pull/3977): Colorize the gensyms introduced by an inline macro expansion, each distinct gensym in its own color, so an introduced binding can be tracked (`cider-macrostep-color-gensyms`).
+- [#3978](https://github.com/clojure-emacs/cider/pull/3978): Add `cider-macrostep-expand-all` (`a` in `cider-macrostep-mode`) to fully expand the form at point inline in one step, instead of stepping level by level.
 
 ### Bugs fixed
 

--- a/doc/modules/ROOT/pages/debugging/macroexpansion.adoc
+++ b/doc/modules/ROOT/pages/debugging/macroexpansion.adoc
@@ -53,3 +53,60 @@ namespaces in the macroexpansion buffer. It can be set to one of the following:
 
 The option `cider-macroexpansion-print-metadata` controls whether to print the var metadata
 in the macroexpansion buffer. It's set to `nil` by default.
+
+== Inline macroexpansion
+
+As an alternative to the separate buffer, `cider-macrostep-expand` expands
+macros *in place* in the source buffer, in the spirit of the
+https://github.com/joddie/macrostep[macrostep] package. Place point right after
+a form (as with kbd:[C-x C-e]) and run `M-x cider-macrostep-expand`: the form is
+replaced by its one-step expansion and you enter a transient, read-only
+`cider-macrostep-mode` with these keybindings:
+
+|===
+| Keyboard shortcut | Description
+
+| kbd:[e] +
+kbd:[=] +
+kbd:[RET]
+| Expand the form before point one step further. Inside an existing expansion, put point after a nested form to step into it.
+
+| kbd:[a]
+| Fully expand the form before point in one step (`macroexpand-all`), instead of stepping level by level.
+
+| kbd:[c] +
+kbd:[u] +
+kbd:[DEL]
+| Collapse the innermost expansion at point, restoring the original form.
+
+| kbd:[n] +
+kbd:[p]
+| Move to the next/previous further-expandable sub-form.
+
+| kbd:[q]
+| Collapse every expansion and leave `cider-macrostep-mode`.
+|===
+
+Each expansion remembers the exact text it replaced, so collapsing restores the
+original verbatim and nested expansions peel back in order. The operators of
+sub-forms that can be expanded further (those that resolve to a macro) are
+underlined so you can see what's left to expand, and kbd:[n]/kbd:[p] jump
+between them. The gensyms a macro introduces (e.g. `x__42__auto__`) are each
+given their own color, so a binding can be tracked through the expansion.
+
+NOTE: The expandable-head highlighting and gensym coloring rely on the
+`cider/classify-symbols` nREPL op, available in cider-nrepl 0.60 and newer.
+Without it the stepping still works, just without those visual aids.
+
+=== Configuration
+
+* `cider-macrostep-display-namespaces` - how namespaces are displayed in the
+  expansion (`tidy`, `qualified` or `none`), as for the separate-buffer flow.
+* `cider-macrostep-highlight-expansion` - briefly pulse a freshly inserted
+  expansion (on by default).
+* `cider-macrostep-highlight-expandable` - underline the operators of
+  further-expandable sub-forms (on by default).
+* `cider-macrostep-color-gensyms` - colorize the gensyms introduced by an
+  expansion (on by default).
+* `cider-macrostep-gensym-colors` - the palette cycled through when coloring
+  gensyms.

--- a/lisp/cider-macrostep.el
+++ b/lisp/cider-macrostep.el
@@ -135,13 +135,15 @@ The sentinel `none' means there was no buffer-local value to restore.")
     (concat
      (propertize " CIDER Macrostep " 'face 'mode-line-emphasis)
      (format " %d expansion%s    " n (if (= n 1) "" "s"))
-     (propertize "[e]xpand [c]ollapse [n]ext [p]rev [q]uit" 'face 'shadow))))
+     (propertize "[e]xpand [a]ll [c]ollapse [n]ext [p]rev [q]uit" 'face 'shadow))))
 
-(defun cider-macrostep--expand-1 (code)
-  "Return the one-step macroexpansion of CODE in the current namespace."
+(defun cider-macrostep--expand (code expander)
+  "Return the macroexpansion of CODE in the current namespace.
+EXPANDER is a `cider/macroexpand' expander name, such as \"macroexpand-1\"
+\(one level) or \"macroexpand-all\" (fully, recursively)."
   (cider-ensure-op-supported "cider/macroexpand")
   (let ((result (thread-first `("op" "cider/macroexpand"
-                                "expander" "macroexpand-1"
+                                "expander" ,expander
                                 "code" ,code
                                 "ns" ,(cider-current-ns)
                                 "display-namespaces" ,(symbol-name cider-macrostep-display-namespaces))
@@ -388,6 +390,7 @@ colors from `cider-macrostep-gensym-colors'.  A no-op when disabled."
     (define-key map (kbd "e") #'cider-macrostep-expand)
     (define-key map (kbd "=") #'cider-macrostep-expand)
     (define-key map (kbd "RET") #'cider-macrostep-expand)
+    (define-key map (kbd "a") #'cider-macrostep-expand-all)
     (define-key map (kbd "c") #'cider-macrostep-collapse)
     (define-key map (kbd "u") #'cider-macrostep-collapse)
     (define-key map (kbd "DEL") #'cider-macrostep-collapse)
@@ -461,12 +464,39 @@ expansions and collapses then use that mode's key bindings."
                                   (user-error "No sexp before point to expand"))))
     (let ((operator (cider-macrostep--operator beg)))
       (cider-macrostep--ensure-macro operator)
-      (let ((expansion (cider-macrostep--expand-1
-                        (buffer-substring-no-properties beg end))))
+      (let ((expansion (cider-macrostep--expand
+                        (buffer-substring-no-properties beg end) "macroexpand-1")))
         (unless (and (stringp expansion) (not (string-blank-p expansion)))
           (user-error "No expansion returned for `%s'" operator))
         (cider-macrostep--expand-region beg end expansion)
         (cider-macrostep--refresh-overlays)))))
+
+;;;###autoload
+(defun cider-macrostep-expand-all ()
+  "Fully expand the form before point, inline.
+Unlike `cider-macrostep-expand', which expands one level at a time, this
+expands the form all the way (`macroexpand-all'), so you needn't step through
+every level.  Place point right after the form, as with
+`\\[cider-eval-last-sexp]'.
+
+Like `cider-macrostep-expand', this starts a `cider-macrostep-mode' session
+when one isn't active.  It does not require the form's head to be a macro,
+since a fully-recursive expansion can reach macros in nested sub-forms."
+  (interactive)
+  (cider-ensure-connected)
+  (pcase-let ((`(,beg . ,end) (or (cider-macrostep--form-bounds)
+                                  (user-error "No sexp before point to expand"))))
+    (let* ((code (buffer-substring-no-properties beg end))
+           (expansion (cider-macrostep--expand code "macroexpand-all")))
+      (unless (and (stringp expansion) (not (string-blank-p expansion)))
+        (user-error "No expansion returned"))
+      ;; Compare with whitespace normalized, so the printer merely reindenting
+      ;; an already-fully-expanded form still counts as "nothing to expand".
+      (when (string= (replace-regexp-in-string "[ \t\n]+" " " (string-trim expansion))
+                     (replace-regexp-in-string "[ \t\n]+" " " (string-trim code)))
+        (user-error "Nothing to expand"))
+      (cider-macrostep--expand-region beg end expansion)
+      (cider-macrostep--refresh-overlays))))
 
 (defun cider-macrostep-collapse ()
   "Collapse the innermost expansion at point."

--- a/test/cider-macrostep-tests.el
+++ b/test/cider-macrostep-tests.el
@@ -241,6 +241,32 @@
         (cider-macrostep--refresh-gensyms))
       (expect cider-macrostep--gensym-overlays :to-be nil))))
 
+(describe "cider-macrostep-expand-all"
+  (before-each
+    (spy-on 'cider-ensure-connected)
+    (spy-on 'cider-macrostep--refresh-overlays))
+
+  (it "fully expands the form before point inline via macroexpand-all"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(when x a)")
+      (goto-char (point-max))
+      (spy-on 'cider-macrostep--expand :and-return-value "(if x (do a))")
+      (cider-macrostep-expand-all)
+      (expect (string-search "(if x" (buffer-string)) :not :to-be nil)
+      (expect (length cider-macrostep--overlays) :to-equal 1)
+      (expect 'cider-macrostep--expand
+              :to-have-been-called-with "(when x a)" "macroexpand-all")))
+
+  (it "errors when the form has nothing to expand"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(+ 1 2)")
+      (goto-char (point-max))
+      (spy-on 'cider-macrostep--expand :and-return-value "(+ 1 2)")
+      (expect (cider-macrostep-expand-all) :to-throw 'user-error)
+      (expect cider-macrostep--overlays :to-be nil))))
+
 (provide 'cider-macrostep-tests)
 
 ;;; cider-macrostep-tests.el ends here


### PR DESCRIPTION
A small follow-up to the inline macrostep work: `cider-macrostep-expand-all` (bound to `a` in `cider-macrostep-mode`) fully expands the form before point in one step via `macroexpand-all`, for when you don't want to step down level by level to get to the bottom.

A couple of details:

- It deliberately doesn't require the form's head to be a macro (the stepwise `e` does), since a recursive expansion can reach macros nested under a non-macro head like `do` or `let`.
- "Nothing to expand" is reported (with whitespace normalized, so a mere reindent doesn't count as a change) when the form is already fully expanded.

Reuses the existing overlay/collapse machinery, so the result is a single collapsible expansion just like a stepwise one. The internal expander helper was generalized to take the expander name.

Also adds documentation for the inline macrostep flow as a whole - the manual only covered the separate-buffer commands until now, so the new section documents `cider-macrostep-expand`, the mode's keybindings (including `a`), the expandable-head highlighting/navigation and gensym coloring, and the relevant options.