### PR TITLE
Give actionable hints when a namespace isn't loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [#3971](https://github.com/clojure-emacs/cider/pull/3971): Show a header line in the macroexpansion buffer with the active expander, display options and key hints.
 - [#3972](https://github.com/clojure-emacs/cider/pull/3972): Briefly highlight (pulse) the result after macroexpanding, both in the macroexpansion buffer and with inline `cider-macrostep` (toggle via `cider-macroexpansion-highlight-expansion` / `cider-macrostep-highlight-expansion`).
 - [#3972](https://github.com/clojure-emacs/cider/pull/3972): When macroexpanding an unresolved symbol (e.g. a macro whose namespace hasn't been evaluated yet), a special form, or a non-macro, the macroexpansion commands now report a helpful message instead of silently doing nothing.
+- [#3979](https://github.com/clojure-emacs/cider/pull/3979): Extend those actionable resolution hints to `cider-find-var`, `cider-doc` and the ClojureDocs commands, and tell an unloaded namespace (evaluate the buffer first) apart from a genuinely unresolved symbol (a typo or a missing require).
 - [#3968](https://github.com/clojure-emacs/cider/pull/3968): Add a menu and per-var key bindings to the cheatsheet buffer (`d` for docs, `c` for ClojureDocs, `w` for ClojureDocs in the browser).
 
 ## 1.22.2 (2026-06-17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [#3972](https://github.com/clojure-emacs/cider/pull/3972): Briefly highlight (pulse) the result after macroexpanding, both in the macroexpansion buffer and with inline `cider-macrostep` (toggle via `cider-macroexpansion-highlight-expansion` / `cider-macrostep-highlight-expansion`).
 - [#3972](https://github.com/clojure-emacs/cider/pull/3972): When macroexpanding an unresolved symbol (e.g. a macro whose namespace hasn't been evaluated yet), a special form, or a non-macro, the macroexpansion commands now report a helpful message instead of silently doing nothing.
 - [#3979](https://github.com/clojure-emacs/cider/pull/3979): Extend those actionable resolution hints to `cider-find-var`, `cider-doc` and the ClojureDocs commands, and tell an unloaded namespace (evaluate the buffer first) apart from a genuinely unresolved symbol (a typo or a missing require).
+- [#3979](https://github.com/clojure-emacs/cider/pull/3979): Tell "no references/dependencies found" apart from an unresolved symbol in `cider-xref-fn-refs` and `cider-xref-fn-deps`, and warn instead of showing an empty buffer when `cider-browse-ns` is pointed at a namespace that isn't loaded.
 - [#3968](https://github.com/clojure-emacs/cider/pull/3968): Add a menu and per-var key bindings to the cheatsheet buffer (`d` for docs, `c` for ClojureDocs, `w` for ClojureDocs in the browser).
 
 ## 1.22.2 (2026-06-17)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -272,3 +272,10 @@ referenced var is unresolved - macroexpansion is one example, but the pattern
 is broad. We should detect these cases centrally and give an actionable hint
 (e.g. "evaluate the buffer first") instead of a silent no-op, ideally via a
 shared helper rather than ad-hoc checks scattered across commands.
+
+The shared helpers now exist in `cider-client.el` - `cider-ns-loaded-p`,
+`cider-resolution-failure-message` and `cider-ensure-macro` distinguish an
+unloaded namespace from a genuine typo/missing require, and the macroexpansion,
+`cider-find-var`, `cider-doc`, ClojureDocs, xref and `cider-browse-ns` commands
+route through them. The remaining work is to keep extending that coverage to the
+other commands that still fail quietly (e.g. inspector and completion paths).

--- a/lisp/cider-browse-ns.el
+++ b/lisp/cider-browse-ns.el
@@ -446,11 +446,14 @@ var-meta map."
 (defun cider-browse-ns (namespace)
   "List all NAMESPACE's vars."
   (interactive (list (completing-read "Browse namespace: " (cider-sync-request:ns-list))))
-  (with-current-buffer (cider-popup-buffer cider-browse-ns-buffer 'select nil 'ancillary)
-    (cider-browse-ns--list (current-buffer)
-                           namespace
-                           (cider-browse-ns--combined-vars-with-meta namespace)
-                           namespace)))
+  (let ((vars (cider-browse-ns--combined-vars-with-meta namespace)))
+    (when (and (nrepl-dict-empty-p vars)
+               (not (cider-ns-loaded-p namespace)))
+      (user-error "%s" (substitute-command-keys
+                        (format "The namespace `%s' isn't loaded yet; evaluate it (e.g. with \\[cider-load-buffer]) and try again"
+                                namespace))))
+    (with-current-buffer (cider-popup-buffer cider-browse-ns-buffer 'select nil 'ancillary)
+      (cider-browse-ns--list (current-buffer) namespace vars namespace))))
 
 ;;;###autoload
 (defun cider-browse-ns-all ()

--- a/lisp/cider-client.el
+++ b/lisp/cider-client.el
@@ -650,6 +650,74 @@ unless ALL is truthy."
   (when (and class member)
     (cider-info-request :class class :member member :context (cider-completion-get-context t))))
 
+
+;;; Namespace and symbol resolution diagnostics
+;;
+;; A lot of commands resolve a symbol (via `cider-var-info' and friends) and do
+;; nothing useful when it can't be resolved - typically because the buffer's
+;; namespace hasn't been evaluated into the REPL yet.  These helpers turn that
+;; silent no-op into an actionable message, distinguishing "the namespace isn't
+;; loaded" (load the buffer) from "the symbol doesn't exist" (a typo, a missing
+;; require, or a definition that hasn't been evaluated yet).  They're meant to be
+;; called only on the failure path, so they never slow down the common case.
+
+(defvar cider-repl-ns-cache) ; defined in cider-repl.el, populated by track-state
+
+(defun cider-ns-loaded-p (&optional ns)
+  "Return non-nil when NS is loaded in the connected runtime.
+NS defaults to the current namespace.  Consults the track-state namespace
+cache first - which is free, but only populated when cider-nrepl is present -
+and otherwise falls back to a `find-ns' eval, so it works against a vanilla
+nREPL server too.  Returns nil when the namespace can't be determined."
+  (when-let* ((ns (or ns (cider-current-ns 'no-default)))
+              (repl (cider-current-repl)))
+    (or
+     ;; Fast path: track-state already knows about this namespace.
+     (and (nrepl-dict-get (buffer-local-value 'cider-repl-ns-cache repl) ns) t)
+     ;; Fallback: ask the runtime directly (works without cider-nrepl).
+     (equal "true"
+            (nrepl-dict-get
+             (cider-sync-tooling-eval (format "(some? (find-ns '%s))" ns) nil repl)
+             "value")))))
+
+(defun cider-resolution-failure-message (sym)
+  "Return an actionable message explaining why SYM failed to resolve.
+When the current namespace isn't loaded in the REPL, point the user at
+evaluating the buffer.  When it is loaded, the likely causes are a typo, a
+missing require, or a definition that hasn't been (re-)evaluated yet - the
+last one being the out-of-sync case where the namespace is loaded but stale."
+  (let ((ns (cider-current-ns 'no-default)))
+    (if (and ns (not (cider-ns-loaded-p ns)))
+        (substitute-command-keys
+         (format "Can't resolve `%s' - the namespace `%s' isn't loaded yet; evaluate the buffer with \\[cider-load-buffer] and try again"
+                 sym ns))
+      (format "Can't resolve `%s'%s - check for a typo, a missing require, or a definition you haven't evaluated yet"
+              sym (if ns (format " in `%s'" ns) "")))))
+
+(defun cider--symbol-operator-p (operator)
+  "Return non-nil when OPERATOR could name a Clojure var (a plain symbol)."
+  (and (stringp operator)
+       (not (string-empty-p operator))
+       (not (string-match-p "\\`[][:\"(){}0-9]" operator))))
+
+(defun cider-ensure-macro (operator)
+  "Signal a helpful `user-error' unless OPERATOR names a resolvable macro.
+This turns the silent \"nothing happens\" case (e.g. the namespace hasn't
+been evaluated yet) into an actionable message, distinguishing an unresolved
+symbol from a special form or an ordinary (non-macro) var."
+  (cond
+   ((not (cider--symbol-operator-p operator))
+    (user-error "`%s' is not a macro" (or operator "form")))
+   (t
+    (let ((info (cider-var-info operator)))
+      (cond
+       ((null info)
+        (user-error "%s" (cider-resolution-failure-message operator)))
+       ((nrepl-dict-get info "special-form")
+        (user-error "`%s' is a special form; there's nothing to macroexpand" operator))
+       ((not (nrepl-dict-get info "macro"))
+        (user-error "`%s' is not a macro" operator)))))))
+
 
 ;;; Requests
 

--- a/lisp/cider-clojuredocs.el
+++ b/lisp/cider-clojuredocs.el
@@ -87,7 +87,7 @@ We need to handle \"?\", \".\", \"..\" and \"/\"."
       (let ((name (nrepl-dict-get var-info "name"))
             (ns (nrepl-dict-get var-info "ns")))
         (browse-url (cider-clojuredocs-url name ns)))
-    (error "Symbol %s not resolved" sym)))
+    (user-error "%s" (cider-resolution-failure-message sym))))
 
 ;;;###autoload
 (defun cider-clojuredocs-web (&optional arg)

--- a/lisp/cider-doc.el
+++ b/lisp/cider-doc.el
@@ -424,7 +424,7 @@ Favor a compact rendering of docstrings."
   "Look up documentation for SYMBOL."
   (if-let* ((buffer (cider-create-doc-buffer symbol)))
       (cider-popup-buffer-display buffer cider-doc-auto-select-buffer)
-    (user-error "Symbol %s not resolved" symbol)))
+    (user-error "%s" (cider-resolution-failure-message symbol))))
 
 (defun cider-doc (&optional arg)
   "Open Clojure documentation in a popup buffer.

--- a/lisp/cider-find.el
+++ b/lisp/cider-find.el
@@ -40,7 +40,7 @@ Display the results in a different window."
       (progn
         (when line (setq info (nrepl-dict-put info "line" line)))
         (cider--jump-to-loc-from-info info t))
-    (user-error "Symbol `%s' not resolved" var)))
+    (user-error "%s" (cider-resolution-failure-message var))))
 
 (defun cider--find-var (var &optional line)
   "Find the definition of VAR, optionally at a specific LINE."
@@ -48,7 +48,7 @@ Display the results in a different window."
       (progn
         (when line (setq info (nrepl-dict-put info "line" line)))
         (cider--jump-to-loc-from-info info))
-    (user-error "Symbol `%s' not resolved" var)))
+    (user-error "%s" (cider-resolution-failure-message var))))
 
 ;;;###autoload
 (defun cider-find-var (&optional arg var line)
@@ -89,7 +89,7 @@ Show results in a different window if OTHER-WINDOW is true."
                 (buffer (cider-find-file resource)))
           (cider-jump-to buffer 0 other-window)
         (if (cider--prompt-for-symbol-p current-prefix-arg)
-            (error "Resource or var %s not resolved" symbol-file)
+            (user-error "Resource or var %s not resolved" symbol-file)
           (let ((current-prefix-arg (if current-prefix-arg nil '(4))))
             (call-interactively callback)))))))
 

--- a/lisp/cider-macroexpansion.el
+++ b/lisp/cider-macroexpansion.el
@@ -31,6 +31,7 @@
 
 ;;; Code:
 
+(require 'cider-client)
 (require 'cider-mode)
 (require 'pulse)
 (require 'subr-x)
@@ -122,31 +123,6 @@ expansion, put point after that form and expand again."
   (when (and form (string-match "\\`(\\s-*\\([^][(){} \t\n]+\\)" form))
     (match-string 1 form)))
 
-(defun cider-macroexpansion--symbol-operator-p (operator)
-  "Return non-nil when OPERATOR could name a Clojure var (a plain symbol)."
-  (and (stringp operator)
-       (not (string-empty-p operator))
-       (not (string-match-p "\\`[][:\"(){}0-9]" operator))))
-
-(defun cider-macroexpansion--ensure-macro (operator)
-  "Signal a helpful `user-error' unless OPERATOR names a resolvable macro.
-This turns the silent \"nothing happens\" case (e.g. the namespace hasn't
-been evaluated yet) into an actionable message."
-  (cond
-   ((not (cider-macroexpansion--symbol-operator-p operator))
-    (user-error "`%s' is not a macro" (or operator "form")))
-   (t
-    (let ((info (cider-var-info operator)))
-      (cond
-       ((null info)
-        (user-error "%s" (substitute-command-keys
-                          (format "Can't resolve `%s' - its namespace may not be loaded; try \\[cider-load-buffer] first"
-                                  operator))))
-       ((nrepl-dict-get info "special-form")
-        (user-error "`%s' is a special form; there's nothing to macroexpand" operator))
-       ((not (nrepl-dict-get info "macro"))
-        (user-error "`%s' is not a macro" operator)))))))
-
 (defun cider-macroexpand-expr-inplace (expander)
   "Substitute the form before point with its macroexpansion using EXPANDER.
 This is a helper invoked by the in-place expansion commands; EXPANDER is
@@ -154,7 +130,7 @@ required, so it is not meant to be called interactively."
   (pcase-let ((`(,beg . ,end) (or (cider-macroexpansion--form-bounds)
                                   (user-error "No sexp before point to expand"))))
     (let ((code (buffer-substring-no-properties beg end)))
-      (cider-macroexpansion--ensure-macro (cider-macroexpansion--operator code))
+      (cider-ensure-macro (cider-macroexpansion--operator code))
       (cider-redraw-macroexpansion-buffer
        (cider-sync-request:macroexpand expander code)
        (current-buffer) beg end))))
@@ -178,7 +154,7 @@ If invoked with a PREFIX argument, use \\=`macroexpand\\=` instead of
   (interactive "P")
   (let ((form (cider-last-sexp))
         (expander (if prefix "macroexpand" "macroexpand-1")))
-    (cider-macroexpansion--ensure-macro (cider-macroexpansion--operator form))
+    (cider-ensure-macro (cider-macroexpansion--operator form))
     (cider-macroexpand-expr expander form)))
 
 (defun cider-macroexpand-1-inplace (&optional prefix)
@@ -194,7 +170,7 @@ If invoked with a PREFIX argument, use \\=`macroexpand\\=` instead of
   "Invoke \\=`macroexpand-all\\=` on the expression preceding point."
   (interactive)
   (let ((form (cider-last-sexp)))
-    (cider-macroexpansion--ensure-macro (cider-macroexpansion--operator form))
+    (cider-ensure-macro (cider-macroexpansion--operator form))
     (cider-macroexpand-expr "macroexpand-all" form)))
 
 (defun cider-macroexpand-all-inplace ()

--- a/lisp/cider-macrostep.el
+++ b/lisp/cider-macrostep.el
@@ -192,31 +192,6 @@ expansion, put point after the nested form to drill into it."
     (when (looking-at-p "[^][(){} \t\n]")
       (buffer-substring-no-properties (point) (progn (forward-sexp) (point))))))
 
-(defun cider-macrostep--symbol-operator-p (operator)
-  "Return non-nil when OPERATOR could name a Clojure var (a plain symbol)."
-  (and (stringp operator)
-       (not (string-empty-p operator))
-       (not (string-match-p "\\`[][:\"(){}0-9]" operator))))
-
-(defun cider-macrostep--ensure-macro (operator)
-  "Signal a helpful `user-error' unless OPERATOR names a resolvable macro.
-This turns the silent \"nothing happens\" case (e.g. the namespace hasn't
-been evaluated yet) into an actionable message."
-  (cond
-   ((not (cider-macrostep--symbol-operator-p operator))
-    (user-error "`%s' is not a macro" (or operator "form")))
-   (t
-    (let ((info (cider-var-info operator)))
-      (cond
-       ((null info)
-        (user-error "%s" (substitute-command-keys
-                          (format "Can't resolve `%s' - its namespace may not be loaded; try \\[cider-load-buffer] first"
-                                  operator))))
-       ((nrepl-dict-get info "special-form")
-        (user-error "`%s' is a special form; there's nothing to macroexpand" operator))
-       ((not (nrepl-dict-get info "macro"))
-        (user-error "`%s' is not a macro" operator)))))))
-
 (defun cider-macrostep--collapse-overlay (ov)
   "Collapse overlay OV, restoring the text it replaced.
 Overlays nested within OV are removed first; OV's saved text already contains
@@ -463,7 +438,7 @@ expansions and collapses then use that mode's key bindings."
   (pcase-let ((`(,beg . ,end) (or (cider-macrostep--form-bounds)
                                   (user-error "No sexp before point to expand"))))
     (let ((operator (cider-macrostep--operator beg)))
-      (cider-macrostep--ensure-macro operator)
+      (cider-ensure-macro operator)
       (let ((expansion (cider-macrostep--expand
                         (buffer-substring-no-properties beg end) "macroexpand-1")))
         (unless (and (stringp expansion) (not (string-blank-p expansion)))

--- a/lisp/cider-xref.el
+++ b/lisp/cider-xref.el
@@ -112,17 +112,26 @@ the symbol found by the xref search as argument."
         (cider-xref-result result))
       (goto-char (point-min)))))
 
+(defun cider-xref--report-no-results (symbol noun)
+  "Report that no NOUN (e.g. \"references\") were found for SYMBOL.
+When SYMBOL doesn't resolve, hint at why instead - a typo or an unloaded
+namespace is a likelier cause than a var that genuinely has none."
+  (if (cider-var-info symbol)
+      (message "No %s found for %S in currently loaded namespaces" noun symbol)
+    (user-error "%s" (cider-resolution-failure-message symbol))))
+
 ;;;###autoload
 (defun cider-xref-fn-refs (&optional ns symbol)
   "Show all functions that reference the var matching NS and SYMBOL."
   (interactive)
   (cider-ensure-connected)
   (cider-ensure-op-supported "cider/fn-refs")
-  (if-let* ((ns (or ns (cider-current-ns)))
-            (symbol (or symbol (cider-symbol-at-point)))
-            (results (cider-sync-request:fn-refs ns symbol)))
-      (cider-show-xref (format "Showing %d functions that reference %s in currently loaded namespaces" (length results) symbol) results)
-    (message "No references found for %S in currently loaded namespaces" symbol)))
+  (let ((ns (or ns (cider-current-ns)))
+        (symbol (or symbol (cider-symbol-at-point))))
+    (unless symbol (user-error "No symbol at point"))
+    (if-let* ((results (cider-sync-request:fn-refs ns symbol)))
+        (cider-show-xref (format "Showing %d functions that reference %s in currently loaded namespaces" (length results) symbol) results)
+      (cider-xref--report-no-results symbol "references"))))
 
 ;;;###autoload
 (defun cider-xref-fn-deps (&optional ns symbol)
@@ -130,11 +139,12 @@ the symbol found by the xref search as argument."
   (interactive)
   (cider-ensure-connected)
   (cider-ensure-op-supported "cider/fn-deps")
-  (if-let* ((ns (or ns (cider-current-ns)))
-            (symbol (or symbol (cider-symbol-at-point)))
-            (results (cider-sync-request:fn-deps ns symbol)))
-      (cider-show-xref (format "Showing %d function dependencies for %s" (length results) symbol) results)
-    (message "No dependencies found for %S" symbol)))
+  (let ((ns (or ns (cider-current-ns)))
+        (symbol (or symbol (cider-symbol-at-point))))
+    (unless symbol (user-error "No symbol at point"))
+    (if-let* ((results (cider-sync-request:fn-deps ns symbol)))
+        (cider-show-xref (format "Showing %d function dependencies for %s" (length results) symbol) results)
+      (cider-xref--report-no-results symbol "dependencies"))))
 
 (defun cider-xref-act-on-symbol (symbol)
   "Apply selected action on SYMBOL."
@@ -155,12 +165,13 @@ the symbol found by the xref search as argument."
   (interactive)
   (cider-ensure-connected)
   (cider-ensure-op-supported "cider/fn-refs")
-  (if-let* ((ns (or ns (cider-current-ns)))
-            (symbol (or symbol (cider-symbol-at-point)))
-            (results (mapcar (lambda (d) (nrepl-dict-get d "name")) (cider-sync-request:fn-refs ns symbol)))
-            (summary (format "References for %s" symbol)))
-      (cider-xref-act-on-symbol (completing-read (concat summary ": ") results))
-    (message "No references for %S found" symbol)))
+  (let ((ns (or ns (cider-current-ns)))
+        (symbol (or symbol (cider-symbol-at-point))))
+    (unless symbol (user-error "No symbol at point"))
+    (if-let* ((results (mapcar (lambda (d) (nrepl-dict-get d "name")) (cider-sync-request:fn-refs ns symbol)))
+              (summary (format "References for %s" symbol)))
+        (cider-xref-act-on-symbol (completing-read (concat summary ": ") results))
+      (cider-xref--report-no-results symbol "references"))))
 
 ;;;###autoload
 (defun cider-xref-fn-deps-select (&optional ns symbol)
@@ -168,12 +179,13 @@ the symbol found by the xref search as argument."
   (interactive)
   (cider-ensure-connected)
   (cider-ensure-op-supported "cider/fn-deps")
-  (if-let* ((ns (or ns (cider-current-ns)))
-            (symbol (or symbol (cider-symbol-at-point)))
-            (results (mapcar (lambda (d) (nrepl-dict-get d "name")) (cider-sync-request:fn-deps ns symbol)))
-            (summary (format "Dependencies for %s" symbol)))
-      (cider-xref-act-on-symbol (completing-read (concat summary ": ") results))
-    (message "No dependencies for %S found" symbol)))
+  (let ((ns (or ns (cider-current-ns)))
+        (symbol (or symbol (cider-symbol-at-point))))
+    (unless symbol (user-error "No symbol at point"))
+    (if-let* ((results (mapcar (lambda (d) (nrepl-dict-get d "name")) (cider-sync-request:fn-deps ns symbol)))
+              (summary (format "Dependencies for %s" symbol)))
+        (cider-xref-act-on-symbol (completing-read (concat summary ": ") results))
+      (cider-xref--report-no-results symbol "dependencies"))))
 
 (provide 'cider-xref)
 

--- a/test/cider-browse-ns-tests.el
+++ b/test/cider-browse-ns-tests.el
@@ -66,7 +66,13 @@
       ;; filter out the functions and ensure that blank? doesn't show up
       (cider-browse-ns-toggle-hide-function)
       (goto-char (point-min))
-      (expect (not (search-forward "blank" nil t))))))
+      (expect (not (search-forward "blank" nil t)))))
+
+  (it "hints to load the buffer when the namespace has no vars and isn't loaded"
+    (spy-on 'cider-sync-request:ns-vars-with-meta :and-return-value '(dict))
+    (spy-on 'cider-sync-request:private-ns-vars-with-meta :and-return-value '(dict))
+    (spy-on 'cider-ns-loaded-p :and-return-value nil)
+    (expect (cider-browse-ns "foo.bar") :to-throw 'user-error)))
 
 (describe "cider-browse-ns--thing-at-point"
   :var (cider-browse-ns-buffer)

--- a/test/cider-client-tests.el
+++ b/test/cider-client-tests.el
@@ -101,6 +101,71 @@
   (it "returns nil when member is nil"
     (expect (cider-member-info "java.lang.String" nil) :to-be nil)))
 
+(describe "cider--symbol-operator-p"
+  (it "accepts plain symbols and rejects keywords/literals"
+    (expect (cider--symbol-operator-p "when") :to-be-truthy)
+    (expect (cider--symbol-operator-p "->") :to-be-truthy)
+    (expect (cider--symbol-operator-p "%") :to-be-truthy)
+    (expect (cider--symbol-operator-p "my.ns/foo") :to-be-truthy)
+    (expect (cider--symbol-operator-p ":kw") :to-be nil)
+    (expect (cider--symbol-operator-p "1x") :to-be nil)
+    (expect (cider--symbol-operator-p "") :to-be nil)
+    (expect (cider--symbol-operator-p nil) :to-be nil)))
+
+(describe "cider-ns-loaded-p"
+  (it "uses the track-state cache as a free fast path"
+    (with-temp-buffer
+      (setq-local cider-repl-ns-cache (nrepl-dict "foo.bar" (nrepl-dict)))
+      (let ((repl (current-buffer)))
+        (spy-on 'cider-current-repl :and-return-value repl)
+        ;; The eval fallback must not be consulted when the cache hits.
+        (spy-on 'cider-sync-tooling-eval)
+        (expect (cider-ns-loaded-p "foo.bar") :to-be-truthy)
+        (expect 'cider-sync-tooling-eval :not :to-have-been-called))))
+  (it "falls back to a find-ns eval when the cache doesn't know (e.g. no cider-nrepl)"
+    (with-temp-buffer
+      (setq-local cider-repl-ns-cache nil)
+      (spy-on 'cider-current-repl :and-return-value (current-buffer))
+      (spy-on 'cider-sync-tooling-eval :and-return-value (nrepl-dict "value" "true"))
+      (expect (cider-ns-loaded-p "foo.bar") :to-be-truthy)
+      (spy-on 'cider-sync-tooling-eval :and-return-value (nrepl-dict "value" "false"))
+      (expect (cider-ns-loaded-p "missing.ns") :to-be nil)))
+  (it "returns nil when there's no connection"
+    (spy-on 'cider-current-repl :and-return-value nil)
+    (expect (cider-ns-loaded-p "foo.bar") :to-be nil))
+  (it "returns nil when the namespace can't be determined"
+    (spy-on 'cider-current-ns :and-return-value nil)
+    (expect (cider-ns-loaded-p) :to-be nil)))
+
+(describe "cider-resolution-failure-message"
+  (it "points at loading the buffer when the namespace isn't loaded"
+    (spy-on 'cider-current-ns :and-return-value "foo.bar")
+    (spy-on 'cider-ns-loaded-p :and-return-value nil)
+    (expect (cider-resolution-failure-message "x") :to-match "loaded yet"))
+  (it "covers typo, missing require and out-of-sync when the namespace is loaded"
+    (spy-on 'cider-current-ns :and-return-value "foo.bar")
+    (spy-on 'cider-ns-loaded-p :and-return-value t)
+    (expect (cider-resolution-failure-message "x") :to-match "haven't evaluated yet")))
+
+(describe "cider-ensure-macro"
+  (it "passes for a resolvable macro"
+    (spy-on 'cider-var-info :and-return-value (nrepl-dict "macro" "true"))
+    (expect (cider-ensure-macro "when") :not :to-throw))
+  (it "hints about resolution for an unresolved symbol"
+    (spy-on 'cider-var-info :and-return-value nil)
+    (spy-on 'cider-resolution-failure-message :and-return-value "nope")
+    (expect (cider-ensure-macro "my.ns/foo") :to-throw 'user-error))
+  (it "rejects special forms"
+    (spy-on 'cider-var-info :and-return-value (nrepl-dict "special-form" "true"))
+    (expect (cider-ensure-macro "if") :to-throw 'user-error))
+  (it "rejects ordinary (non-macro) vars"
+    (spy-on 'cider-var-info :and-return-value (nrepl-dict "arglists" "([coll])"))
+    (expect (cider-ensure-macro "map") :to-throw 'user-error))
+  (it "rejects non-symbol operators without consulting the runtime"
+    (spy-on 'cider-var-info)
+    (expect (cider-ensure-macro ":kw") :to-throw 'user-error)
+    (expect 'cider-var-info :not :to-have-been-called)))
+
 (describe "cider-classpath-entries"
   (it "uses the classpath op when available"
     (spy-on 'cider-nrepl-op-supported-p :and-return-value t)

--- a/test/cider-macroexpansion-tests.el
+++ b/test/cider-macroexpansion-tests.el
@@ -147,36 +147,6 @@
     (expect (cider-macroexpansion--operator "(defn- f [])") :to-equal "defn-")
     (expect (cider-macroexpansion--operator "(-> x f)") :to-equal "->")))
 
-(describe "cider-macroexpansion--symbol-operator-p"
-  (it "accepts plain symbols and rejects keywords/literals"
-    (expect (cider-macroexpansion--symbol-operator-p "when") :to-be-truthy)
-    (expect (cider-macroexpansion--symbol-operator-p "->") :to-be-truthy)
-    (expect (cider-macroexpansion--symbol-operator-p ":kw") :to-be nil)
-    (expect (cider-macroexpansion--symbol-operator-p "1x") :to-be nil)
-    (expect (cider-macroexpansion--symbol-operator-p "") :to-be nil)))
-
-(describe "cider-macroexpansion--ensure-macro"
-  (it "passes for a resolvable macro"
-    (cl-letf (((symbol-function 'cider-var-info)
-               (lambda (&rest _) (nrepl-dict "macro" "true"))))
-      (expect (cider-macroexpansion--ensure-macro "when") :not :to-throw)))
-  (it "hints about loading the namespace for an unresolved symbol"
-    (cl-letf (((symbol-function 'cider-var-info) (lambda (&rest _) nil)))
-      (expect (cider-macroexpansion--ensure-macro "my.ns/foo") :to-throw 'user-error)))
-  (it "rejects special forms"
-    (cl-letf (((symbol-function 'cider-var-info)
-               (lambda (&rest _) (nrepl-dict "special-form" "true"))))
-      (expect (cider-macroexpansion--ensure-macro "if") :to-throw 'user-error)))
-  (it "rejects ordinary (non-macro) vars"
-    (cl-letf (((symbol-function 'cider-var-info)
-               (lambda (&rest _) (nrepl-dict "arglists" "([coll])"))))
-      (expect (cider-macroexpansion--ensure-macro "map") :to-throw 'user-error)))
-  (it "rejects non-symbol operators without consulting the runtime"
-    (expect (cider-macroexpansion--ensure-macro ":kw") :to-throw 'user-error))
-  (it "handles an operator containing a percent sign"
-    (cl-letf (((symbol-function 'cider-var-info) (lambda (&rest _) nil)))
-      (expect (cider-macroexpansion--ensure-macro "%") :to-throw 'user-error))))
-
 (provide 'cider-macroexpansion-tests)
 
 ;;; cider-macroexpansion-tests.el ends here

--- a/test/cider-macrostep-tests.el
+++ b/test/cider-macrostep-tests.el
@@ -31,19 +31,6 @@
 
 ;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
 
-(describe "cider-macrostep--ensure-macro"
-  (it "passes for a resolvable macro"
-    (cl-letf (((symbol-function 'cider-var-info)
-               (lambda (&rest _) (nrepl-dict "macro" "true"))))
-      (expect (cider-macrostep--ensure-macro "when") :not :to-throw)))
-  (it "hints about loading the namespace for an unresolved symbol"
-    (cl-letf (((symbol-function 'cider-var-info) (lambda (&rest _) nil)))
-      (expect (cider-macrostep--ensure-macro "my.ns/foo") :to-throw 'user-error)))
-  (it "rejects non-macros"
-    (cl-letf (((symbol-function 'cider-var-info)
-               (lambda (&rest _) (nrepl-dict "arglists" "([coll])"))))
-      (expect (cider-macrostep--ensure-macro "map") :to-throw 'user-error))))
-
 (describe "cider-macrostep--form-bounds"
   (it "returns the bounds of the sexp before point"
     (with-temp-buffer

--- a/test/cider-xref-tests.el
+++ b/test/cider-xref-tests.el
@@ -1,0 +1,47 @@
+;;; cider-xref-tests.el  -*- lexical-binding: t; -*-
+
+;; Copyright © 2012-2026 Bozhidar Batsov
+
+;; Author: Bozhidar Batsov <bozhidar@batsov.dev>
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; This file is part of CIDER
+
+;;; Code:
+
+(require 'buttercup)
+(require 'nrepl-dict)
+(require 'cider-xref)
+
+;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
+
+(describe "cider-xref--report-no-results"
+  (it "reports an empty result set for a resolvable var"
+    (spy-on 'cider-var-info :and-return-value (nrepl-dict "name" "foo"))
+    (spy-on 'message)
+    (cider-xref--report-no-results "foo" "references")
+    (expect 'message :to-have-been-called))
+  (it "signals a resolution hint when the symbol doesn't resolve"
+    (spy-on 'cider-var-info :and-return-value nil)
+    (spy-on 'cider-resolution-failure-message :and-return-value "nope")
+    (expect (cider-xref--report-no-results "foo" "references") :to-throw 'user-error)))
+
+(provide 'cider-xref-tests)
+
+;;; cider-xref-tests.el ends here


### PR DESCRIPTION
A bunch of CIDER commands quietly do nothing (or show a vague "not resolved") when the buffer's namespace hasn't been evaluated into the REPL yet. The macroexpansion commands already grew a hint for this; this PR turns that into a shared mechanism and spreads it around.

The core of it lives in `cider-client.el` now: `cider-ns-loaded-p`, `cider-resolution-failure-message` and `cider-ensure-macro`. The interesting bit is that a resolution failure now tells two cases apart - the namespace genuinely isn't loaded (so it points you at `C-c C-k`) versus the symbol just doesn't exist (a typo or a missing require, where loading won't help). The extra round-trip to check that only happens on the failure path, so the common case is untouched.

It also dedups the two byte-for-byte `--ensure-macro` copies that lived in `cider-macroexpansion.el` and `cider-macrostep.el`, and routes `cider-find-var`, `cider-doc`, the ClojureDocs commands, the xref ref/dep commands and `cider-browse-ns` through the same helpers.

-----------------

- [x] The commits are consistent with our contribution guidelines
- [x] You've added tests to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`)
- [x] You've updated the changelog
- [ ] You've updated the user manual (n/a - no new commands or options, just better messaging)