### PR TITLE
Keep the jack-in command and cljs init form out of the REPL transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Changes
 
+- [#3984](https://github.com/clojure-emacs/cider/pull/3984): Stop dumping the full jack-in command and the ClojureScript REPL init form into the REPL transcript on startup (a ClojureScript REPL now just notes its type). The launch details are available on demand via `cider-repl-describe-startup` (the `,startup` REPL shortcut).
 - [#3983](https://github.com/clojure-emacs/cider/pull/3983): Slim down the REPL welcome banner - the long help banner is gone, replaced by a one-line hint, and the getting-started content now lives in a summonable `cider-repl-help` reference card (`C-c C-h`, or the `,refcard` REPL shortcut). `cider-repl-display-help-banner` now toggles the hint.
 - [#3980](https://github.com/clojure-emacs/cider/pull/3980): Keep the load-state indicators in sync across `cider-ns-reload`/`cider-ns-reload-all` and `cider-ns-refresh`: the reloaded namespaces' (unsaved-edit-free) buffers get their fringe and mode-line markers refreshed, instead of staying stale until the next `cider-load-buffer`. These commands now run `cider-file-loaded-hook` for the reloaded buffers, so `cider-auto-test-mode` re-runs their tests too (matching what `cider-load-buffer` already does).
 - [#3967](https://github.com/clojure-emacs/cider/pull/3967): Refresh the embedded Clojure cheatsheet with functions added since Clojure 1.11 (`partitionv`, `partitionv-all`, `splitv-at`, `clojure.repl.deps`, `clojure.java.process`, the `clojure.core` Java-stream helpers, and more `clojure.math` members).

--- a/doc/modules/ROOT/pages/repl/basic_usage.adoc
+++ b/doc/modules/ROOT/pages/repl/basic_usage.adoc
@@ -42,6 +42,13 @@ reference covering the common REPL interactions, loading code, switching
 namespaces and moving between the REPL and your source.  Set
 `cider-repl-display-help-banner` to nil to drop the hint from new REPLs.
 
+TIP: Since CIDER 1.23 the REPL transcript no longer dumps the full jack-in
+command or the ClojureScript REPL init form on startup (a ClojureScript REPL
+just notes its type).  Run `cider-repl-describe-startup` (the `,startup`
+shortcut) to see those launch details - project, endpoint, the jack-in command
+and the cljs init form - on demand, with buttons to copy a command or form or to
+customize the related options.
+
 == Interrupting Evaluations
 
 If you accidentally try to evaluate something that's going to take a lot of time (if it finishes at all), you

--- a/lisp/cider-repl.el
+++ b/lisp/cider-repl.el
@@ -333,29 +333,14 @@ fully initialized."
                  'cider-repl-help-banner t))))
 
 (defun cider-repl--insert-startup-commands ()
-  "Insert startup details from `cider-launch-params' as REPL comments.
-This shows the jack-in command and, for ClojureScript, the REPL type and
-init form, when those parameters are present."
-  (cl-flet
-      ((emit-comment
-        (contents)
-        (insert-before-markers
-         (propertize
-          (if (string-blank-p contents) ";;\n" (concat ";; " contents "\n"))
-          'font-lock-face 'font-lock-comment-face))))
-    (let ((jack-in-command (plist-get cider-launch-params :jack-in-cmd))
-          (cljs-repl-type (plist-get cider-launch-params :cljs-repl-type))
-          (cljs-init-form (plist-get cider-launch-params :repl-init-form)))
-      (when jack-in-command
-        ;; spaces to align with the banner
-        (emit-comment (concat " Startup: " jack-in-command)))
-      (when (or cljs-repl-type cljs-init-form)
-        (emit-comment "")
-        (when cljs-repl-type
-          (emit-comment (concat "ClojureScript REPL type: " (symbol-name cljs-repl-type))))
-        (when cljs-init-form
-          (emit-comment (concat "ClojureScript REPL init form: " cljs-init-form)))
-        (emit-comment "")))))
+  "Insert a compact startup note for ClojureScript REPLs.
+The full launch details - the jack-in command and the cljs init form - stay in
+`cider-launch-params' and are shown on demand by `cider-repl-describe-startup',
+rather than dumped into the REPL transcript."
+  (when-let* ((cljs-repl-type (plist-get cider-launch-params :cljs-repl-type)))
+    (insert-before-markers
+     (propertize (format ";; ClojureScript REPL: %s\n" cljs-repl-type)
+                 'font-lock-face 'font-lock-comment-face))))
 
 (defun cider-repl--banner ()
   "Generate the welcome REPL buffer banner."
@@ -523,6 +508,70 @@ code, switching namespaces and moving between the REPL and source."
       (insert (cider-repl--help-contents))
       (goto-char (point-min))))
   (pop-to-buffer cider-repl-help-buffer))
+
+(defconst cider-repl-startup-buffer "*cider-repl-startup*"
+  "Name of the buffer describing how a REPL was started.")
+
+;;;###autoload
+(defun cider-repl-describe-startup ()
+  "Describe how the current REPL was started.
+Shows the project, endpoint and REPL type, plus the jack-in command and (for
+ClojureScript) the init form used to upgrade the REPL - the launch details kept
+out of the transcript.  Offers buttons to copy a command or form to the kill
+ring (to paste into a shell or the REPL) and to customize the related options."
+  (interactive)
+  (let* ((repl (cider-current-repl 'infer 'ensure))
+         (params (buffer-local-value 'cider-launch-params repl))
+         (project (or (plist-get params :project-dir)
+                      (buffer-local-value 'nrepl-project-dir repl)))
+         (endpoint (buffer-local-value 'nrepl-endpoint repl))
+         (repl-type (buffer-local-value 'cider-repl-type repl))
+         (jack-in (plist-get params :jack-in-cmd))
+         (cljs-type (plist-get params :cljs-repl-type))
+         (cljs-form (plist-get params :repl-init-form)))
+    (unless (or project endpoint repl-type jack-in cljs-type cljs-form)
+      (user-error "No startup details available for this REPL"))
+    (with-current-buffer (get-buffer-create cider-repl-startup-buffer)
+      (cider-repl-help-mode)
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (insert (propertize "How this REPL started\n\n" 'face 'cider-repl-help-heading))
+        (when project
+          (insert (format "Project    %s\n" project)))
+        (when endpoint
+          (insert (format "Endpoint   %s:%s\n"
+                          (plist-get endpoint :host) (plist-get endpoint :port))))
+        (when repl-type
+          (insert (format "REPL type  %s\n" repl-type)))
+        (when jack-in
+          (insert "\n"
+                  (propertize "Jack-in command  " 'face 'cider-repl-help-heading)
+                  (cider-repl--help-button
+                   "[copy]"
+                   (lambda () (kill-new jack-in)
+                     (message "Jack-in command copied to the kill ring"))
+                   "Copy the jack-in command to the kill ring (paste it in a shell)")
+                  "\n  " jack-in "\n"))
+        (when (or cljs-type cljs-form)
+          (insert "\n"
+                  (propertize "ClojureScript REPL  " 'face 'cider-repl-help-heading)
+                  (cider-repl--help-button
+                   "[customize]"
+                   (lambda () (customize-variable 'cider-default-cljs-repl))
+                   "Customize cider-default-cljs-repl")
+                  "\n")
+          (when cljs-type
+            (insert (format "  type: %s\n" cljs-type)))
+          (when cljs-form
+            (insert "  init form  "
+                    (cider-repl--help-button
+                     "[copy]"
+                     (lambda () (kill-new cljs-form)
+                       (message "Init form copied to the kill ring"))
+                     "Copy the init form to the kill ring (paste it at the REPL)")
+                    "\n    " cljs-form "\n")))
+        (goto-char (point-min))))
+    (pop-to-buffer cider-repl-startup-buffer)))
 
 
 ;;; REPL interaction
@@ -1908,6 +1957,7 @@ the history file is rewritten if `cider-repl-history-file' is set."
 (cider-repl-add-shortcut "run" #'cider-run)
 (cider-repl-add-shortcut "conn-info" #'cider-describe-connection)
 (cider-repl-add-shortcut "refcard" #'cider-repl-help)
+(cider-repl-add-shortcut "startup" #'cider-repl-describe-startup)
 (cider-repl-add-shortcut "version" #'cider-version)
 (cider-repl-add-shortcut "require-repl-utils" #'cider-repl-require-repl-utils)
 ;; So many ways to quit :-)

--- a/test/cider-repl-tests.el
+++ b/test/cider-repl-tests.el
@@ -42,28 +42,61 @@
                                (setq output (format "%s%s" output (substring-no-properties arg)))))
       (cider-repl--insert-startup-commands)
       (expect output :to-be "")))
-  (it "puts jack-in-command in same style as banner"
+  (it "no longer dumps the jack-in command into the transcript"
     (let ((output "")
           (cider-launch-params '(:jack-in-cmd "lein command")))
       (spy-on 'insert-before-markers
               :and-call-fake (lambda (arg)
                                (setq output (format "%s%s" output (substring-no-properties arg)))))
       (cider-repl--insert-startup-commands)
-      (expect output :to-equal
-              ";;  Startup: lein command\n")))
-  (it "formats output if present"
+      (expect output :to-equal "")))
+  (it "prints a single compact line for a ClojureScript REPL"
     (let ((output "")
           (cider-launch-params '(:cljs-repl-type shadow :repl-init-form "(do)")))
       (spy-on 'insert-before-markers
               :and-call-fake (lambda (arg)
                                (setq output (format "%s%s" output (substring-no-properties arg)))))
       (cider-repl--insert-startup-commands)
-      (expect output :to-equal
-              ";;
-;; ClojureScript REPL type: shadow
-;; ClojureScript REPL init form: (do)
-;;
-"))))
+      (expect output :to-equal ";; ClojureScript REPL: shadow\n"))))
+
+(describe "cider-repl-describe-startup"
+  (it "errors when no startup details are available"
+    (let ((repl (generate-new-buffer " *repl*")))
+      (unwind-protect
+          (progn
+            (with-current-buffer repl
+              (setq-local cider-launch-params nil
+                          nrepl-endpoint nil
+                          nrepl-project-dir nil
+                          cider-repl-type nil))
+            (spy-on 'cider-current-repl :and-return-value repl)
+            (expect (cider-repl-describe-startup) :to-throw 'user-error))
+        (kill-buffer repl))))
+  (it "shows the project, jack-in command and cljs details, with a copy button"
+    (let ((repl (generate-new-buffer " *repl*")))
+      (unwind-protect
+          (progn
+            (with-current-buffer repl
+              (setq-local cider-launch-params
+                          '(:project-dir "/tmp/proj" :jack-in-cmd "lein repl"
+                            :cljs-repl-type shadow :repl-init-form "(do)")
+                          nrepl-endpoint nil
+                          nrepl-project-dir nil
+                          cider-repl-type 'cljs))
+            (spy-on 'cider-current-repl :and-return-value repl)
+            (spy-on 'pop-to-buffer)
+            (cider-repl-describe-startup)
+            (with-current-buffer cider-repl-startup-buffer
+              (let ((s (buffer-string)))
+                (expect (substring-no-properties s) :to-match "/tmp/proj")
+                (expect (substring-no-properties s) :to-match "lein repl")
+                (expect (substring-no-properties s) :to-match "shadow")
+                (expect (substring-no-properties s) :to-match "(do)")
+                ;; the jack-in [copy] is a real button
+                (expect (get-text-property (string-search "[copy]" s) 'action s)
+                        :to-be-truthy)))
+            (kill-buffer cider-repl-startup-buffer))
+        (kill-buffer repl)))))
 
 (describe "cider-repl--clojure-banner"
   :var (cider-version cider-codename)


### PR DESCRIPTION
Follow-up to #3983. On startup the REPL dumped the full jack-in shell command and, for ClojureScript, the upgrade init form as comments in the transcript - long, noisy lines you almost never need after the fact.

This drops them. A Clojure REPL adds nothing extra to the transcript now; a ClojureScript REPL just notes its type (`;; ClojureScript REPL: shadow`). The full launch details still live in `cider-launch-params`, and `cider-repl-describe-startup` (the new `,startup` REPL shortcut) shows them on demand in a small read-only buffer.

The ClojureScript upgrade form is still *evaluated* as before, so its output (build status, etc.) still shows - only the verbatim command/form comments are gone.

-----------------

- [x] The commits are consistent with our contribution guidelines
- [x] You've added tests to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`)
- [x] You've updated the changelog
- [x] You've updated the user manual