### PR TITLE
Add cider-macrostep-expand-in-buffer for out-of-place stepping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [#3976](https://github.com/clojure-emacs/cider/pull/3976): Underline the further-expandable sub-forms while inline macro stepping and move between them with `n`/`p` in `cider-macrostep-mode` (`cider-macrostep-highlight-expandable`).
 - [#3977](https://github.com/clojure-emacs/cider/pull/3977): Colorize the gensyms introduced by an inline macro expansion, each distinct gensym in its own color, so an introduced binding can be tracked (`cider-macrostep-color-gensyms`).
 - [#3978](https://github.com/clojure-emacs/cider/pull/3978): Add `cider-macrostep-expand-all` (`a` in `cider-macrostep-mode`) to fully expand the form at point inline in one step, instead of stepping level by level.
+- [#3985](https://github.com/clojure-emacs/cider/pull/3985): Add `cider-macrostep-expand-in-buffer` to run a macro-stepping session in a dedicated `*cider-macrostep*` popup, leaving the source buffer untouched.
 - [#3973](https://github.com/clojure-emacs/cider/pull/3973): Indicate namespace load-state: a `cider-mode` lighter (and optional fringe) marker showing when the current buffer's namespace isn't loaded into the REPL or is stale (`cider-ns-load-state-display`), and a per-form fringe marker that turns from green to amber when you edit an evaluated form (`cider-mark-stale-after-edit`).
 
 ### Bugs fixed

--- a/doc/modules/ROOT/pages/debugging/macroexpansion.adoc
+++ b/doc/modules/ROOT/pages/debugging/macroexpansion.adoc
@@ -160,6 +160,12 @@ NOTE: The expandable-head highlighting and gensym coloring rely on the
 `cider/classify-symbols` nREPL op, available in cider-nrepl 0.60 and newer.
 Without it the stepping still works, just without those visual aids.
 
+If you'd rather not touch the source buffer, `cider-macrostep-expand-in-buffer`
+runs the same stepping session in a dedicated `+*cider-macrostep*+` popup: it
+copies the form before point there and you step through it exactly as above,
+with the source left untouched. In the popup kbd:[q] dismisses the whole buffer
+in one step.
+
 === Configuration
 
 * `cider-macrostep-display-namespaces` - how namespaces are displayed in the

--- a/lisp/cider-macrostep.el
+++ b/lisp/cider-macrostep.el
@@ -41,6 +41,7 @@
 (require 'clojure-mode)
 (require 'cider-client)
 (require 'cider-common)
+(require 'cider-popup)
 (require 'nrepl-dict)
 
 (defcustom cider-macrostep-display-namespaces 'tidy
@@ -128,6 +129,11 @@ Refreshed after every expansion and collapse; cleared on mode exit.")
 (defvar-local cider-macrostep--saved-header-line 'none
   "Saved `header-line-format' from before `cider-macrostep-mode'.
 The sentinel `none' means there was no buffer-local value to restore.")
+
+(defvar-local cider-macrostep--popup nil
+  "Non-nil when the current buffer is a dedicated macrostep popup.
+Set by `cider-macrostep-expand-in-buffer'; it makes `q' dismiss the whole
+popup rather than merely leave `cider-macrostep-mode' as it does inline.")
 
 (defun cider-macrostep--header-line ()
   "Return the header line shown while `cider-macrostep-mode' is active."
@@ -473,6 +479,46 @@ since a fully-recursive expansion can reach macros in nested sub-forms."
       (cider-macrostep--expand-region beg end expansion)
       (cider-macrostep--refresh-overlays))))
 
+(defconst cider-macrostep-buffer "*cider-macrostep*"
+  "Name of the dedicated buffer for out-of-place macro stepping.")
+
+(defun cider-macrostep--popup-buffer (code ns)
+  "Pop to the macrostep buffer seeded with CODE, expanded in namespace NS.
+The buffer is a `clojure-mode' popup whose `cider-buffer-ns' is NS so the
+expander resolves vars as it would in the originating buffer.  Point is left
+right after the inserted form, ready for `cider-macrostep-expand'."
+  (with-current-buffer
+      (cider-popup-buffer cider-macrostep-buffer 'select 'clojure-mode 'ancillary)
+    (setq cider-buffer-ns ns
+          cider-macrostep--popup t)
+    (let ((inhibit-read-only t))
+      (erase-buffer)
+      (insert code)
+      (indent-region (point-min) (point-max))
+      (goto-char (point-max)))
+    (current-buffer)))
+
+;;;###autoload
+(defun cider-macrostep-expand-in-buffer ()
+  "Step through the macro before point in a dedicated buffer.
+Like `cider-macrostep-expand', but instead of rewriting the form in place it
+copies it into a separate `cider-macrostep-buffer' and starts the stepping
+session there, leaving the source buffer untouched.  Place point right after
+the form, as with `\\[cider-eval-last-sexp]'.
+
+The session uses the same overlay engine and key bindings as the inline
+flow, except that `q' dismisses the whole popup in one step."
+  (interactive)
+  (cider-ensure-connected)
+  (pcase-let ((`(,beg . ,end) (or (cider-macrostep--form-bounds)
+                                  (user-error "No sexp before point to expand"))))
+    (let ((operator (cider-macrostep--operator beg)))
+      (cider-ensure-macro operator)
+      (with-current-buffer (cider-macrostep--popup-buffer
+                            (buffer-substring-no-properties beg end)
+                            (cider-current-ns))
+        (cider-macrostep-expand)))))
+
 (defun cider-macrostep-collapse ()
   "Collapse the innermost expansion at point."
   (interactive)
@@ -495,9 +541,13 @@ since a fully-recursive expansion can reach macros in nested sub-forms."
   (cider-macrostep--move-to-expandable -1))
 
 (defun cider-macrostep-collapse-all ()
-  "Collapse all expansions and leave `cider-macrostep-mode'."
+  "Collapse all expansions and leave `cider-macrostep-mode'.
+In a dedicated macrostep popup (see `cider-macrostep-expand-in-buffer') this
+dismisses the popup instead, since its buffer is disposable."
   (interactive)
-  (cider-macrostep-mode -1))
+  (if cider-macrostep--popup
+      (cider-popup-buffer-quit-function 'kill)
+    (cider-macrostep-mode -1)))
 
 (provide 'cider-macrostep)
 

--- a/test/cider-macrostep-tests.el
+++ b/test/cider-macrostep-tests.el
@@ -254,6 +254,54 @@
       (expect (cider-macrostep-expand-all) :to-throw 'user-error)
       (expect cider-macrostep--overlays :to-be nil))))
 
+(describe "cider-macrostep-expand-in-buffer"
+  (after-each
+    (when (get-buffer cider-macrostep-buffer)
+      (kill-buffer cider-macrostep-buffer)))
+
+  (it "seeds a dedicated popup with the form and the originating namespace"
+    (with-current-buffer (cider-macrostep--popup-buffer "(when x a)" "fancy.ns")
+      (expect (buffer-name) :to-equal cider-macrostep-buffer)
+      (expect (string-search "(when x a)" (buffer-string)) :not :to-be nil)
+      (expect cider-buffer-ns :to-equal "fancy.ns")
+      (expect (point) :to-equal (point-max))))
+
+  (it "runs the stepping session in the popup, leaving the source untouched"
+    (spy-on 'cider-ensure-connected)
+    (spy-on 'cider-ensure-macro)
+    (spy-on 'cider-current-ns :and-return-value "user")
+    (spy-on 'cider-macrostep--expand :and-return-value "(if x (do a))")
+    (spy-on 'cider-macrostep--refresh-overlays)
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(when x a)")
+      (goto-char (point-max))
+      (cider-macrostep-expand-in-buffer)
+      ;; the source buffer is never modified
+      (expect (buffer-string) :to-equal "(when x a)")
+      (expect cider-macrostep--overlays :to-be nil))
+    ;; the expansion and its overlay live in the popup instead
+    (with-current-buffer cider-macrostep-buffer
+      (expect (string-search "(if x" (buffer-string)) :not :to-be nil)
+      (expect (length cider-macrostep--overlays) :to-equal 1)))
+
+  (it "dismisses the popup in one step via collapse-all"
+    (cider-macrostep--popup-buffer "(when x a)" "user")
+    (cider-macrostep-mode 1)
+    (with-current-buffer cider-macrostep-buffer
+      (cider-macrostep-collapse-all))
+    (expect (get-buffer cider-macrostep-buffer) :to-be nil))
+
+  (it "leaves collapse-all non-destructive inline (no popup flag)"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(when x a)")
+      (cider-macrostep-mode 1)
+      (cider-macrostep-collapse-all)
+      ;; inline: the mode exits but the buffer survives
+      (expect cider-macrostep-mode :to-be nil)
+      (expect (buffer-live-p (current-buffer)) :to-be t))))
+
 (provide 'cider-macrostep-tests)
 
 ;;; cider-macrostep-tests.el ends here

--- a/test/cider-repl-tests.el
+++ b/test/cider-repl-tests.el
@@ -288,11 +288,12 @@ PROPERTY should be a symbol of either 'text, 'ansi-context or
               :to-equal
               '(:type warning :highlight (22 . 100) :var nil :file "cider/inlined_deps/toolsreader/v1v2v2/clojure/tools/reader/impl/utils.clj" :line 18))))
   (it "works with compilation exceptions"
-    (insert "\nCompilerException java.lang.RuntimeException: Unable to resolve symbol: pp in this context, compiling:(/path/to/a/file.clj:575:16)")
-    (move-to-column 20)
-    (expect (cider-locref-at-point)
-            :to-equal
-            '(:type compilation :highlight (2 . 132) :var nil :file "/path/to/a/file.clj" :line 575))))
+    (with-temp-buffer
+      (insert "\nCompilerException java.lang.RuntimeException: Unable to resolve symbol: pp in this context, compiling:(/path/to/a/file.clj:575:16)")
+      (move-to-column 20)
+      (expect (cider-locref-at-point)
+              :to-equal
+              '(:type compilation :highlight (2 . 132) :var nil :file "/path/to/a/file.clj" :line 575)))))
 
 (describe "cider-repl-require-repl-utils"
   (before-each


### PR DESCRIPTION
Follow-up to the inline macrostep work. This adds `cider-macrostep-expand-in-buffer`, which runs a full stepping session in a disposable `*cider-macrostep*` popup instead of rewriting the form in your source buffer. The popup is seeded with the form and the originating namespace, then driven by the exact same overlay engine as the inline flow - so you get stepping, nested collapse, gensym coloring and expandable-head highlighting, but your source is never touched.

In the popup `q` dismisses the whole buffer in one step; the inline flow keeps its non-destructive `q` (just leaves `cider-macrostep-mode`).

M-x-only for now, matching the inline `cider-macrostep-expand` - no new keybinding, deferring that to the keybinding reorg.
