### PR TITLE
Add a test/robustness foundation for tracing and enlighten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Bugs fixed
 
 - [#3971](https://github.com/clojure-emacs/cider/pull/3971): Fix `cider-macroexpand-again` (`g` in the macroexpansion buffer) to actually re-expand the form instead of redisplaying the original input.
+- [#3986](https://github.com/clojure-emacs/cider/pull/3986): Signal a `user-error` (instead of a generic `error`) when a var to trace isn't found or isn't traceable, so the failure no longer triggers a backtrace under `debug-on-error`.
 
 ### Changes
 

--- a/lisp/cider-tracing.el
+++ b/lisp/cider-tracing.el
@@ -45,8 +45,8 @@
          (var-name (nrepl-dict-get trace-response "var-name"))
          (var-status (nrepl-dict-get trace-response "var-status")))
     (pcase var-status
-      ("not-found" (error "Var %s not found" (cider-propertize sym 'fn)))
-      ("not-traceable" (error "Var %s can't be traced because it's not bound to a function" (cider-propertize var-name 'fn)))
+      ("not-found" (user-error "Var %s not found" (cider-propertize sym 'fn)))
+      ("not-traceable" (user-error "Var %s can't be traced because it's not bound to a function" (cider-propertize var-name 'fn)))
       (_ (message "Var %s %s" (cider-propertize var-name 'fn) var-status)))))
 
 ;;;###autoload
@@ -82,7 +82,7 @@ Defaults to the current ns.  With prefix arg QUERY, prompts for a ns."
           (let* ((trace-response (cider-sync-request:toggle-trace-ns ns))
                  (ns-status (nrepl-dict-get trace-response "ns-status")))
             (pcase ns-status
-              ("not-found" (error "Namespace %s not found" (cider-propertize ns 'ns)))
+              ("not-found" (user-error "Namespace %s not found" (cider-propertize ns 'ns)))
               (_ (message "Namespace %s %s" (cider-propertize ns 'ns) ns-status)))))))))
 
 (provide 'cider-tracing)

--- a/test/cider-debug-tests.el
+++ b/test/cider-debug-tests.el
@@ -178,3 +178,28 @@
       (save-excursion (insert "(defn a [] (let [x 1] #break ^{foo (foo x)} (inc x))"))
       (cider--debug-move-point '(3 2 1))
       (expect (thing-at-point 'symbol) :to-equal "x"))))
+
+(defun cider-debug-tests--enlighten-overlays ()
+  "Return the `enlighten' overlays in the current buffer."
+  (seq-filter (lambda (o) (eq (overlay-get o 'category) 'enlighten))
+              (overlays-in (point-min) (point-max))))
+
+(describe "cider--handle-enlighten"
+  (it "overlays the value after an enlightened sexp"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(+ 1 2)")
+      ;; point (and the marker) sit right after the closing paren
+      (spy-on 'cider--debug-find-source-position :and-return-value (point-marker))
+      (cider--handle-enlighten (nrepl-dict "debug-value" "3"))
+      (expect (length (cider-debug-tests--enlighten-overlays)) :to-be-greater-than 0)))
+
+  (it "marks an enlightened local with the local face"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "x")
+      (spy-on 'cider--debug-find-source-position :and-return-value (point-marker))
+      (cider--handle-enlighten (nrepl-dict "debug-value" "42"))
+      (let ((ov (car (cider-debug-tests--enlighten-overlays))))
+        (expect ov :not :to-be nil)
+        (expect (overlay-get ov 'face) :to-equal 'cider-enlightened-local-face)))))

--- a/test/cider-tracing-tests.el
+++ b/test/cider-tracing-tests.el
@@ -1,0 +1,52 @@
+;;; cider-tracing-tests.el  -*- lexical-binding: t; -*-
+
+;; Copyright © 2026 Bozhidar Batsov
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; Tests for the var/ns tracing commands.
+
+;;; Code:
+
+(require 'buttercup)
+(require 'nrepl-dict)
+(require 'cider-tracing)
+
+;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
+
+(describe "cider--toggle-trace-var"
+  (it "reports the new trace status on success"
+    (spy-on 'cider-sync-request:toggle-trace-var :and-return-value
+            (nrepl-dict "var-name" "user/foo" "var-status" "traced"))
+    (spy-on 'message)
+    (cider--toggle-trace-var "foo")
+    (expect 'message :to-have-been-called))
+
+  (it "signals a user-error when the var is not found"
+    (spy-on 'cider-sync-request:toggle-trace-var :and-return-value
+            (nrepl-dict "var-name" "user/foo" "var-status" "not-found"))
+    (expect (cider--toggle-trace-var "foo") :to-throw 'user-error))
+
+  (it "signals a user-error when the var is not bound to a function"
+    (spy-on 'cider-sync-request:toggle-trace-var :and-return-value
+            (nrepl-dict "var-name" "user/foo" "var-status" "not-traceable"))
+    (expect (cider--toggle-trace-var "foo") :to-throw 'user-error)))
+
+(provide 'cider-tracing-tests)
+
+;;; cider-tracing-tests.el ends here


### PR DESCRIPTION
First pass of a deeper audit of the enlighten and tracing features, in the same spirit as the recent macroexpansion work: start by getting a robustness and test foundation under both before adding features.

- Trace failures (var not found / not traceable / namespace not found) now signal `user-error` instead of a generic `error`, so they no longer pop the backtrace under `debug-on-error`.
- Adds a first `cider-tracing` test suite (the var-toggle status dispatch had no coverage at all).
- Adds the first tests for the enlighten overlay handler, covering both render paths.
