### PR TITLE
Extract enlighten into its own cider-enlighten.el module

### DIFF
--- a/lisp/cider-debug.el
+++ b/lisp/cider-debug.el
@@ -32,6 +32,7 @@
 (require 'cider-browse-ns)
 (require 'cider-client)
 (require 'cider-eval)
+(require 'cider-enlighten) ; the enlighten handler dispatched below lives there
 (require 'cider-inspector)
 (require 'cider-util)
 (require 'cider-common)
@@ -56,21 +57,6 @@
   '((t :underline t :inherit font-lock-builtin-face))
   "Face used to highlight keys in the debug prompt."
   :package-version '(cider . "0.10.0"))
-
-(defface cider-enlightened-face
-  '((((class color) (background light)) :inherit cider-result-overlay-face
-     :box (:color "darkorange" :line-width -1))
-    (((class color) (background dark))  :inherit cider-result-overlay-face
-     ;; "#dd0" is a dimmer yellow.
-     :box (:color "#990" :line-width -1)))
-  "Face used to mark enlightened sexps and their return values."
-  :package-version '(cider . "0.11.0"))
-
-(defface cider-enlightened-local-face
-  '((((class color) (background light)) :weight bold :foreground "darkorange")
-    (((class color) (background dark))  :weight bold :foreground "yellow"))
-  "Face used to mark enlightened locals (not their values)."
-  :package-version '(cider . "0.11.0"))
 
 (defcustom cider-debug-prompt 'overlay
   "If and where to show the keys while debugging.
@@ -685,37 +671,6 @@ needed.  It is expected to contain at least \"key\", \"input-type\", and
       (error (cider-debug-mode-send-reply ":quit" key)
              (message "Error encountered while handling the debug message: %S" e)))))
 
-(defun cider--handle-enlighten (response)
-  "Handle an enlighten notification.
-RESPONSE is a message received from the nrepl describing the value and
-coordinates of a sexp.  Create an overlay after the specified sexp
-displaying its value."
-  (when-let* ((marker (cider--debug-find-source-position response)))
-    (with-current-buffer (marker-buffer marker)
-      (save-excursion
-        (goto-char marker)
-        (clojure-backward-logical-sexp 1)
-        (nrepl-dbind-response response (debug-value erase-previous)
-          (when erase-previous
-            (remove-overlays (point) marker 'category 'enlighten))
-          (when debug-value
-            (if (memq (char-before marker) '(?\) ?\] ?}))
-                ;; Enlightening a sexp looks like a regular return value, except
-                ;; for a different border.
-                (cider--make-result-overlay (cider-font-lock-as-clojure debug-value)
-                  :where (cons marker marker)
-                  :type 'enlighten
-                  :prepend-face 'cider-enlightened-face)
-              ;; Enlightening a symbol uses a more abbreviated format. The
-              ;; result face is the same as a regular result, but we also color
-              ;; the symbol with `cider-enlightened-local-face'.
-              (cider--make-result-overlay (cider-font-lock-as-clojure debug-value)
-                :format "%s"
-                :where (cons (point) marker)
-                :type 'enlighten
-                'face 'cider-enlightened-local-face))))))))
-
-
 ;;; Move here command
 ;; This is the inverse of `cider--debug-move-point'.  However, that algorithm is
 ;; complicated, and trying to code its inverse would probably be insane.

--- a/lisp/cider-enlighten.el
+++ b/lisp/cider-enlighten.el
@@ -1,0 +1,99 @@
+;;; cider-enlighten.el --- Inline display of running code values -*- lexical-binding: t -*-
+
+;; Copyright © 2015-2026 Artur Malabarba, Bozhidar Batsov and CIDER contributors
+;;
+;; Author: Artur Malabarba <bruce.connor.am@gmail.com>
+;;         Bozhidar Batsov <bozhidar@batsov.dev>
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+
+;; Enlighten mode displays the value of each sub-expression inline, in place,
+;; as instrumented code runs - similar to a feature of the Light Table editor.
+;;
+;; It is built on top of the debugger middleware: enabling `cider-enlighten-mode'
+;; makes evaluations request instrumentation, and the values streamed back are
+;; rendered as overlays by `cider--handle-enlighten'.  The debug-specific
+;; navigation (`cider--debug-find-source-position') is therefore shared with
+;; the debugger, which is why this file is loaded alongside `cider-debug'.
+
+;;; Code:
+
+(require 'clojure-mode) ; for `clojure-backward-logical-sexp'
+(require 'cider-overlays) ; for `cider--make-result-overlay'
+(require 'cider-util) ; for `cider-font-lock-as-clojure'
+(require 'nrepl-dict)
+
+(defvar cider-mode) ; for the lighter; the variable lives in cider-mode.el
+(declare-function cider--debug-find-source-position "cider-debug")
+
+(defface cider-enlightened-face
+  '((((class color) (background light)) :inherit cider-result-overlay-face
+     :box (:color "darkorange" :line-width -1))
+    (((class color) (background dark))  :inherit cider-result-overlay-face
+     ;; "#dd0" is a dimmer yellow.
+     :box (:color "#990" :line-width -1)))
+  "Face used to mark enlightened sexps and their return values."
+  :group 'cider
+  :package-version '(cider . "0.11.0"))
+
+(defface cider-enlightened-local-face
+  '((((class color) (background light)) :weight bold :foreground "darkorange")
+    (((class color) (background dark))  :weight bold :foreground "yellow"))
+  "Face used to mark enlightened locals (not their values)."
+  :group 'cider
+  :package-version '(cider . "0.11.0"))
+
+(defun cider--handle-enlighten (response)
+  "Handle an enlighten notification.
+RESPONSE is a message received from the nrepl describing the value and
+coordinates of a sexp.  Create an overlay after the specified sexp
+displaying its value."
+  (when-let* ((marker (cider--debug-find-source-position response)))
+    (with-current-buffer (marker-buffer marker)
+      (save-excursion
+        (goto-char marker)
+        (clojure-backward-logical-sexp 1)
+        (nrepl-dbind-response response (debug-value erase-previous)
+          (when erase-previous
+            (remove-overlays (point) marker 'category 'enlighten))
+          (when debug-value
+            (if (memq (char-before marker) '(?\) ?\] ?}))
+                ;; Enlightening a sexp looks like a regular return value, except
+                ;; for a different border.
+                (cider--make-result-overlay (cider-font-lock-as-clojure debug-value)
+                  :where (cons marker marker)
+                  :type 'enlighten
+                  :prepend-face 'cider-enlightened-face)
+              ;; Enlightening a symbol uses a more abbreviated format. The
+              ;; result face is the same as a regular result, but we also color
+              ;; the symbol with `cider-enlightened-local-face'.
+              (cider--make-result-overlay (cider-font-lock-as-clojure debug-value)
+                :format "%s"
+                :where (cons (point) marker)
+                :type 'enlighten
+                'face 'cider-enlightened-local-face))))))))
+
+(define-minor-mode cider-enlighten-mode
+  "Minor mode for displaying locals in debugger-instrumented evaluations."
+  :lighter (cider-mode " light")
+  :global t
+  :group 'cider)
+
+(provide 'cider-enlighten)
+
+;;; cider-enlighten.el ends here

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -1172,16 +1172,9 @@ property."
   (when (or cider-mode (derived-mode-p 'cider-repl-mode))
     (cider-refresh-dynamic-font-lock ns)))
 
-;; Enlighten is a cross-cutting feature: the mode toggle and the font-lock
-;; integration for enlightened var references live here, the debug middleware
-;; response handler (`cider--handle-enlighten') and the faces
-;; (`cider-enlightened-face', `cider-enlightened-local-face') live in
-;; cider-debug.el, and the param/eval wiring lives in cider-connection.el.
-(define-minor-mode cider-enlighten-mode
-  "Minor mode for displaying locals in debugger-instrumented evaluations."
-  :lighter (cider-mode " light")
-  :global t
-  :group 'cider)
+;; `cider-enlighten-mode' and its faces now live in cider-enlighten.el.  Only
+;; the font-lock that marks enlightened var references (see above) stays here,
+;; since it is part of cider-mode's dynamic font-locking machinery.
 
 (provide 'cider-mode)
 

--- a/test/cider-debug-tests.el
+++ b/test/cider-debug-tests.el
@@ -178,28 +178,3 @@
       (save-excursion (insert "(defn a [] (let [x 1] #break ^{foo (foo x)} (inc x))"))
       (cider--debug-move-point '(3 2 1))
       (expect (thing-at-point 'symbol) :to-equal "x"))))
-
-(defun cider-debug-tests--enlighten-overlays ()
-  "Return the `enlighten' overlays in the current buffer."
-  (seq-filter (lambda (o) (eq (overlay-get o 'category) 'enlighten))
-              (overlays-in (point-min) (point-max))))
-
-(describe "cider--handle-enlighten"
-  (it "overlays the value after an enlightened sexp"
-    (with-temp-buffer
-      (clojure-mode)
-      (insert "(+ 1 2)")
-      ;; point (and the marker) sit right after the closing paren
-      (spy-on 'cider--debug-find-source-position :and-return-value (point-marker))
-      (cider--handle-enlighten (nrepl-dict "debug-value" "3"))
-      (expect (length (cider-debug-tests--enlighten-overlays)) :to-be-greater-than 0)))
-
-  (it "marks an enlightened local with the local face"
-    (with-temp-buffer
-      (clojure-mode)
-      (insert "x")
-      (spy-on 'cider--debug-find-source-position :and-return-value (point-marker))
-      (cider--handle-enlighten (nrepl-dict "debug-value" "42"))
-      (let ((ov (car (cider-debug-tests--enlighten-overlays))))
-        (expect ov :not :to-be nil)
-        (expect (overlay-get ov 'face) :to-equal 'cider-enlightened-local-face)))))

--- a/test/cider-enlighten-tests.el
+++ b/test/cider-enlighten-tests.el
@@ -1,0 +1,61 @@
+;;; cider-enlighten-tests.el  -*- lexical-binding: t; -*-
+
+;; Copyright © 2026 Bozhidar Batsov
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; Tests for the enlighten overlay handler.
+
+;;; Code:
+
+(require 'buttercup)
+(require 'clojure-mode)
+(require 'nrepl-dict)
+(require 'cider-debug) ; provides `cider--debug-find-source-position', which the handler calls
+(require 'cider-enlighten)
+
+;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
+
+(defun cider-enlighten-tests--overlays ()
+  "Return the `enlighten' overlays in the current buffer."
+  (seq-filter (lambda (o) (eq (overlay-get o 'category) 'enlighten))
+              (overlays-in (point-min) (point-max))))
+
+(describe "cider--handle-enlighten"
+  (it "overlays the value after an enlightened sexp"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(+ 1 2)")
+      ;; point (and the marker) sit right after the closing paren
+      (spy-on 'cider--debug-find-source-position :and-return-value (point-marker))
+      (cider--handle-enlighten (nrepl-dict "debug-value" "3"))
+      (expect (length (cider-enlighten-tests--overlays)) :to-be-greater-than 0)))
+
+  (it "marks an enlightened local with the local face"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "x")
+      (spy-on 'cider--debug-find-source-position :and-return-value (point-marker))
+      (cider--handle-enlighten (nrepl-dict "debug-value" "42"))
+      (let ((ov (car (cider-enlighten-tests--overlays))))
+        (expect ov :not :to-be nil)
+        (expect (overlay-get ov 'face) :to-equal 'cider-enlightened-local-face)))))
+
+(provide 'cider-enlighten-tests)
+
+;;; cider-enlighten-tests.el ends here


### PR DESCRIPTION
The structural opening move of the enlighten/tracing audit. Enlighten was scattered across three files (the mode in `cider-mode.el`, the faces and overlay handler in `cider-debug.el`, the eval wiring in `cider-connection.el`); this pulls the mode, faces, and `cider--handle-enlighten` into a dedicated `cider-enlighten.el` so the feature has a home to grow in (binding, menu, `cider-enlighten-defun-at-point`, etc. coming next).

Since the handler both calls `cider--debug-find-source-position` and is dispatched from `cider-debug`'s response handler, `cider-debug` now requires `cider-enlighten` while `cider-enlighten` forward-declares the debug helper, keeping the dependency one-directional. The enlighten font-lock stays in `cider-mode.el` as part of its dynamic font-locking machinery.

No behavior change; the handler tests move alongside the code.
