### PR TITLE
Add commands to enlighten a single form and clear overlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- [#3988](https://github.com/clojure-emacs/cider/pull/3988): Add `cider-enlighten-defun-at-point` to enlighten a single top-level form without toggling the global `cider-enlighten-mode`, and `cider-enlighten-clear` to remove the enlighten overlays from a buffer.
 - [#3964](https://github.com/clojure-emacs/cider/pull/3964): Add `cider-comment-style` to control how the eval-to-comment commands format the inserted result (`line`, `ignore` or `comment`).
 - [#3965](https://github.com/clojure-emacs/cider/pull/3965): Add `cider-send-to-comment` to copy the top-level form at point into the namespace's rich `comment` block (`C-c C-j c`), optionally evaluating it, and `cider-jump-to-comment` to visit the block (`C-c C-j v`).
 - [#3963](https://github.com/clojure-emacs/cider/pull/3963): Attach `cider-scratch` buffers to a specific session (one scratchpad per session), with a configurable eval destination (cljc-style by default).

--- a/doc/modules/ROOT/pages/debugging/enlighten.adoc
+++ b/doc/modules/ROOT/pages/debugging/enlighten.adoc
@@ -20,8 +20,12 @@ into the brilliant show of lights on the right.
 |===
 
 To stop displaying the locals you'll have to disable `cider-enlighten-mode`
-and reevaluate the definitions you had instrumented previously.
+and reevaluate the definitions you had instrumented previously.  To clear the
+overlays from a buffer without re-evaluating anything, use
+`cider-enlighten-clear`.
 
-You can also trigger this on specific functions (without having to turn on the
-minor mode) by writing `#light` before the `(def` and re-evaluating
-it.
+If you only want to enlighten a single definition, you don't have to toggle the
+global mode at all.  Put point in the form and run
+`cider-enlighten-defun-at-point`: it evaluates just that top-level form with
+enlightenment enabled, leaving the global mode untouched.  You can also write
+`#light` before the `(def` and re-evaluate it.

--- a/lisp/cider-enlighten.el
+++ b/lisp/cider-enlighten.el
@@ -40,6 +40,7 @@
 
 (defvar cider-mode) ; for the lighter; the variable lives in cider-mode.el
 (declare-function cider--debug-find-source-position "cider-debug")
+(declare-function cider-eval-defun-at-point "cider-eval")
 
 (defface cider-enlightened-face
   '((((class color) (background light)) :inherit cider-result-overlay-face
@@ -93,6 +94,21 @@ displaying its value."
   :lighter (cider-mode " light")
   :global t
   :group 'cider)
+
+;;;###autoload
+(defun cider-enlighten-defun-at-point ()
+  "Evaluate the top-level form at point with enlightenment enabled.
+This is like enabling `cider-enlighten-mode' and evaluating the form, but
+scoped to this single evaluation, so you needn't toggle the global mode on
+and off (and re-evaluate everything) just to light up one definition."
+  (interactive)
+  (let ((cider-enlighten-mode t))
+    (cider-eval-defun-at-point)))
+
+(defun cider-enlighten-clear ()
+  "Remove all enlighten value overlays from the current buffer."
+  (interactive)
+  (remove-overlays nil nil 'category 'enlighten))
 
 (provide 'cider-enlighten)
 

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -446,6 +446,11 @@ If invoked with a prefix ARG eval the expression after inserting it."
       :keys "\\[universal-argument] \\[cider-eval-defun-at-point]"]
      ["List instrumented defs" cider-browse-instrumented-defs]
      "--"
+     ["Enlighten top-level form" cider-enlighten-defun-at-point]
+     ["Toggle Enlighten mode" cider-enlighten-mode
+      :style toggle :selected cider-enlighten-mode]
+     ["Clear enlighten overlays" cider-enlighten-clear]
+     "--"
      ["Configure the Debugger" (customize-group 'cider-debug)])
     ,cider-profile-menu
     ("Misc"

--- a/test/cider-enlighten-tests.el
+++ b/test/cider-enlighten-tests.el
@@ -56,6 +56,28 @@
         (expect ov :not :to-be nil)
         (expect (overlay-get ov 'face) :to-equal 'cider-enlightened-local-face)))))
 
+(describe "cider-enlighten-defun-at-point"
+  (it "evaluates the form with the enlighten mode bound on, then restores it"
+    (let ((mode-during 'unset))
+      (spy-on 'cider-eval-defun-at-point :and-call-fake
+              (lambda (&rest _) (setq mode-during cider-enlighten-mode)))
+      (let ((cider-enlighten-mode nil))
+        (cider-enlighten-defun-at-point)
+        (expect 'cider-eval-defun-at-point :to-have-been-called)
+        ;; the eval saw the mode enabled...
+        (expect mode-during :to-be t)
+        ;; ...but the global mode is left as it was afterwards
+        (expect cider-enlighten-mode :to-be nil)))))
+
+(describe "cider-enlighten-clear"
+  (it "removes enlighten overlays from the buffer"
+    (with-temp-buffer
+      (insert "(foo)")
+      (overlay-put (make-overlay (point-min) (point-max)) 'category 'enlighten)
+      (expect (length (cider-enlighten-tests--overlays)) :to-equal 1)
+      (cider-enlighten-clear)
+      (expect (cider-enlighten-tests--overlays) :to-be nil))))
+
 (provide 'cider-enlighten-tests)
 
 ;;; cider-enlighten-tests.el ends here


### PR DESCRIPTION
Next step in the enlighten/tracing audit, building on the freshly extracted `cider-enlighten.el`.

The only way to enlighten code was the global `cider-enlighten-mode`, whose activate/deactivate cycle is clunky (turn it on, re-eval each defn, turn it off and re-eval everything again to stop). This adds:

- `cider-enlighten-defun-at-point` - evaluate just the top-level form at point with enlightenment enabled, scoped to that one eval, leaving the global mode untouched.
- `cider-enlighten-clear` - drop the enlighten overlays from a buffer without re-evaluating.

Both, plus the mode toggle, now show up in the Debug menu - enlighten had no menu presence at all before. Kept to M-x + menu for now; any global key belongs to the keybinding reorg.
