### PR TITLE
Add cider-list-traced and cider-untrace-all commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- [#3989](https://github.com/clojure-emacs/cider/pull/3989): Add `cider-list-traced` to show the vars and namespaces that are currently traced, and `cider-untrace-all` to clear all tracing at once (both require a recent enough `cider-nrepl`).
 - [#3988](https://github.com/clojure-emacs/cider/pull/3988): Add `cider-enlighten-defun-at-point` to enlighten a single top-level form without toggling the global `cider-enlighten-mode`, and `cider-enlighten-clear` to remove the enlighten overlays from a buffer.
 - [#3964](https://github.com/clojure-emacs/cider/pull/3964): Add `cider-comment-style` to control how the eval-to-comment commands format the inserted result (`line`, `ignore` or `comment`).
 - [#3965](https://github.com/clojure-emacs/cider/pull/3965): Add `cider-send-to-comment` to copy the top-level form at point into the namespace's rich `comment` block (`C-c C-j c`), optionally evaluating it, and `cider-jump-to-comment` to visit the block (`C-c C-j v`).

--- a/doc/modules/ROOT/pages/debugging/tracing.adoc
+++ b/doc/modules/ROOT/pages/debugging/tracing.adoc
@@ -13,3 +13,8 @@ in the function being untraced.
 
 You can also use kbd:[C-c M-t n] to toggle tracing on and off for
 an entire namespace.
+
+Since it's easy to lose track of what you've traced, `cider-list-traced`
+displays all the currently traced vars and namespaces in a buffer, and
+`cider-untrace-all` clears every trace at once.  Both require a recent enough
+`cider-nrepl`.

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -441,6 +441,8 @@ If invoked with a prefix ARG eval the expression after inserting it."
      ["Inspect" cider-inspect]
      ["Toggle var tracing" cider-toggle-trace-var]
      ["Toggle ns tracing" cider-toggle-trace-ns]
+     ["List traced" cider-list-traced]
+     ["Untrace all" cider-untrace-all]
      "--"
      ["Debug top-level form" cider-debug-defun-at-point
       :keys "\\[universal-argument] \\[cider-eval-defun-at-point]"]

--- a/lisp/cider-tracing.el
+++ b/lisp/cider-tracing.el
@@ -28,6 +28,7 @@
 
 (require 'cider-client)
 (require 'cider-common) ; for `cider-prompt-for-symbol-function'
+(require 'cider-popup) ; for `cider-popup-buffer'
 (require 'cider-util) ; for `cider-propertize'
 (require 'cider-session) ; for `cider-map-repls'
 (require 'nrepl-dict)
@@ -84,6 +85,51 @@ Defaults to the current ns.  With prefix arg QUERY, prompts for a ns."
             (pcase ns-status
               ("not-found" (user-error "Namespace %s not found" (cider-propertize ns 'ns)))
               (_ (message "Namespace %s %s" (cider-propertize ns 'ns) ns-status)))))))))
+
+(defconst cider-traced-buffer "*cider-traced*"
+  "The name of the buffer listing the currently traced vars and namespaces.")
+
+(defun cider-sync-request:list-traced ()
+  "Return the vars and namespaces that are currently traced."
+  (thread-first `("op" "cider/list-traced")
+                (cider-nrepl-send-sync-request)))
+
+(defun cider-list-traced--render (nses vars)
+  "Render the traced NSES and VARS in `cider-traced-buffer'."
+  (with-current-buffer (cider-popup-buffer cider-traced-buffer 'select 'clojure-mode)
+    (let ((inhibit-read-only t))
+      (erase-buffer)
+      (when nses
+        (insert ";; Traced namespaces\n")
+        (dolist (ns (sort (copy-sequence nses) #'string<))
+          (insert ns "\n"))
+        (insert "\n"))
+      (when vars
+        (insert ";; Traced vars\n")
+        (dolist (var (sort (copy-sequence vars) #'string<))
+          (insert var "\n")))
+      (goto-char (point-min)))))
+
+;;;###autoload
+(defun cider-list-traced ()
+  "Display the vars and namespaces that are currently traced."
+  (interactive)
+  (cider-ensure-op-supported "cider/list-traced")
+  (let* ((response (cider-sync-request:list-traced))
+         (vars (nrepl-dict-get response "traced-vars"))
+         (nses (nrepl-dict-get response "traced-nses")))
+    (if (and (null vars) (null nses))
+        (message "Nothing is currently traced")
+      (cider-list-traced--render nses vars))))
+
+;;;###autoload
+(defun cider-untrace-all ()
+  "Untrace all currently traced vars and namespaces."
+  (interactive)
+  (cider-ensure-op-supported "cider/untrace-all")
+  (let* ((response (cider-nrepl-send-sync-request '("op" "cider/untrace-all")))
+         (count (or (nrepl-dict-get response "untraced-count") 0)))
+    (message "Untraced %d var%s" count (if (= count 1) "" "s"))))
 
 (provide 'cider-tracing)
 ;;; cider-tracing.el ends here

--- a/test/cider-tracing-tests.el
+++ b/test/cider-tracing-tests.el
@@ -47,6 +47,38 @@
             (nrepl-dict "var-name" "user/foo" "var-status" "not-traceable"))
     (expect (cider--toggle-trace-var "foo") :to-throw 'user-error)))
 
+(describe "cider-untrace-all"
+  (it "reports the number of untraced vars"
+    (spy-on 'cider-ensure-op-supported)
+    (spy-on 'cider-nrepl-send-sync-request :and-return-value
+            (nrepl-dict "untraced-count" 3))
+    (spy-on 'message)
+    (cider-untrace-all)
+    (expect 'message :to-have-been-called-with "Untraced %d var%s" 3 "s")))
+
+(describe "cider-list-traced"
+  (after-each
+    (when (get-buffer cider-traced-buffer)
+      (kill-buffer cider-traced-buffer)))
+
+  (it "reports when nothing is traced"
+    (spy-on 'cider-ensure-op-supported)
+    (spy-on 'cider-sync-request:list-traced :and-return-value
+            (nrepl-dict "traced-vars" nil "traced-nses" nil))
+    (spy-on 'message)
+    (cider-list-traced)
+    (expect 'message :to-have-been-called)
+    (expect (get-buffer cider-traced-buffer) :to-be nil))
+
+  (it "renders the traced vars and namespaces in a buffer"
+    (spy-on 'cider-ensure-op-supported)
+    (spy-on 'cider-sync-request:list-traced :and-return-value
+            (nrepl-dict "traced-vars" '("#'foo/bar") "traced-nses" '("baz.ns")))
+    (cider-list-traced)
+    (with-current-buffer cider-traced-buffer
+      (expect (string-search "#'foo/bar" (buffer-string)) :not :to-be nil)
+      (expect (string-search "baz.ns" (buffer-string)) :not :to-be nil))))
+
 (provide 'cider-tracing-tests)
 
 ;;; cider-tracing-tests.el ends here


### PR DESCRIPTION
The tracing side of the enlighten/tracing audit, building on the new cider-nrepl ops (clojure-emacs/cider-nrepl#981).

Tracing was fire-and-forget: you could toggle individual vars and namespaces but had no way to see what was traced or to clear it all. This adds:

- `cider-list-traced` - shows the currently traced vars and namespaces in a buffer.
- `cider-untrace-all` - clears every trace at once and reports the count.

Both are guarded by `cider-ensure-op-supported` and surfaced in the Debug menu. M-x + menu for now; any global key belongs to the keybinding reorg.
