### PR TITLE
Add cider-trace streaming buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- [#3990](https://github.com/clojure-emacs/cider/pull/3990): Add `cider-trace`, opening a dedicated `*cider-trace*` buffer that streams the calls and return values of traced functions live, instead of interleaving them into the REPL (requires a recent enough `cider-nrepl`).
 - [#3989](https://github.com/clojure-emacs/cider/pull/3989): Add `cider-list-traced` to show the vars and namespaces that are currently traced, and `cider-untrace-all` to clear all tracing at once (both require a recent enough `cider-nrepl`).
 - [#3988](https://github.com/clojure-emacs/cider/pull/3988): Add `cider-enlighten-defun-at-point` to enlighten a single top-level form without toggling the global `cider-enlighten-mode`, and `cider-enlighten-clear` to remove the enlighten overlays from a buffer.
 - [#3964](https://github.com/clojure-emacs/cider/pull/3964): Add `cider-comment-style` to control how the eval-to-comment commands format the inserted result (`line`, `ignore` or `comment`).

--- a/doc/modules/ROOT/pages/debugging/tracing.adoc
+++ b/doc/modules/ROOT/pages/debugging/tracing.adoc
@@ -16,5 +16,11 @@ an entire namespace.
 
 Since it's easy to lose track of what you've traced, `cider-list-traced`
 displays all the currently traced vars and namespaces in a buffer, and
-`cider-untrace-all` clears every trace at once.  Both require a recent enough
-`cider-nrepl`.
+`cider-untrace-all` clears every trace at once.
+
+By default the trace output lands in the REPL, mixed in with everything else.
+`cider-trace` opens a dedicated `+*cider-trace*+` buffer instead: trace some
+functions, call them, and their calls and return values stream into that buffer
+live, indented to show the call nesting.  Kill the buffer to stop streaming.
+
+All of these require a recent enough `cider-nrepl`.

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -443,6 +443,7 @@ If invoked with a prefix ARG eval the expression after inserting it."
      ["Toggle ns tracing" cider-toggle-trace-ns]
      ["List traced" cider-list-traced]
      ["Untrace all" cider-untrace-all]
+     ["Trace events buffer" cider-trace]
      "--"
      ["Debug top-level form" cider-debug-defun-at-point
       :keys "\\[universal-argument] \\[cider-eval-defun-at-point]"]

--- a/lisp/cider-tracing.el
+++ b/lisp/cider-tracing.el
@@ -131,5 +131,105 @@ Defaults to the current ns.  With prefix arg QUERY, prompts for a ns."
          (count (or (nrepl-dict-get response "untraced-count") 0)))
     (message "Untraced %d var%s" count (if (= count 1) "" "s"))))
 
+;;; Streaming trace buffer
+
+(defconst cider-trace-buffer "*cider-trace*"
+  "The name of the buffer streaming trace events.")
+
+(defvar-local cider-trace--subscription nil
+  "Id of this buffer's active trace subscription, or nil.")
+
+(defvar-local cider-trace--connection nil
+  "The REPL connection this trace buffer is subscribed through.")
+
+(defun cider-trace--indent (depth)
+  "Return the nesting indentation string for DEPTH."
+  (apply #'concat (make-list (or depth 0) "│ ")))
+
+(defun cider-trace--render-event (event)
+  "Append the trace EVENT to the current buffer, following the tail."
+  (nrepl-dbind-response event (phase name depth args value)
+    (let ((inhibit-read-only t)
+          (indent (cider-trace--indent depth))
+          (at-end (= (point) (point-max))))
+      (save-excursion
+        (goto-char (point-max))
+        (pcase phase
+          ("call"
+           (insert indent
+                   (cider-font-lock-as-clojure
+                    (format "(%s%s)" name
+                            (if args (concat " " (mapconcat #'identity args " ")) "")))
+                   "\n"))
+          ("return"
+           (insert indent "└─→ "
+                   (cider-font-lock-as-clojure (or value "nil"))
+                   "\n"))))
+      (when at-end (goto-char (point-max))))))
+
+(defun cider-trace--handle (buffer msg)
+  "Handle a trace subscription response MSG, rendering into BUFFER."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (nrepl-dbind-response msg (cider/trace-subscribe cider/trace-event)
+        (cond (cider/trace-event
+               (cider-trace--render-event cider/trace-event))
+              (cider/trace-subscribe
+               (setq cider-trace--subscription cider/trace-subscribe)))))))
+
+(defun cider-trace--unsubscribe ()
+  "Tear down this buffer's trace subscription, if any.
+Fires a best-effort async request, since this runs from `kill-buffer-hook'."
+  (when (and cider-trace--subscription
+             (buffer-live-p cider-trace--connection))
+    (ignore-errors
+      (cider-nrepl-send-request
+       (list "op" "cider/trace-unsubscribe"
+             "subscription" cider-trace--subscription)
+       #'ignore
+       cider-trace--connection))
+    (setq cider-trace--subscription nil)))
+
+(defun cider-trace-clear ()
+  "Clear the trace buffer."
+  (interactive)
+  (let ((inhibit-read-only t))
+    (erase-buffer)))
+
+(defvar cider-trace-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "c") #'cider-trace-clear)
+    (define-key map (kbd "q") #'quit-window)
+    map)
+  "Keymap for `cider-trace-mode'.")
+
+(define-derived-mode cider-trace-mode special-mode "cider-trace"
+  "Major mode for viewing streamed trace events.
+
+\\{cider-trace-mode-map}"
+  (setq-local truncate-lines nil)
+  (add-hook 'kill-buffer-hook #'cider-trace--unsubscribe nil 'local))
+
+;;;###autoload
+(defun cider-trace ()
+  "Open a buffer that streams trace events for traced functions.
+Trace functions with `cider-toggle-trace-var' or `cider-toggle-trace-ns'
+and call them; their calls and return values stream here instead of
+cluttering the REPL.  Killing the buffer stops the streaming."
+  (interactive)
+  (cider-ensure-op-supported "cider/trace-subscribe")
+  (let ((connection (cider-current-repl nil 'ensure))
+        (buffer (get-buffer-create cider-trace-buffer)))
+    (with-current-buffer buffer
+      (unless (eq major-mode 'cider-trace-mode)
+        (cider-trace-mode))
+      (setq cider-trace--connection connection)
+      (unless cider-trace--subscription
+        (cider-nrepl-send-request
+         '("op" "cider/trace-subscribe")
+         (lambda (msg) (cider-trace--handle buffer msg))
+         connection)))
+    (pop-to-buffer buffer)))
+
 (provide 'cider-tracing)
 ;;; cider-tracing.el ends here

--- a/test/cider-tracing-tests.el
+++ b/test/cider-tracing-tests.el
@@ -79,6 +79,38 @@
       (expect (string-search "#'foo/bar" (buffer-string)) :not :to-be nil)
       (expect (string-search "baz.ns" (buffer-string)) :not :to-be nil))))
 
+(describe "cider-trace--render-event"
+  (it "renders a call event indented by depth"
+    (with-temp-buffer
+      (cider-trace--render-event
+       (nrepl-dict "phase" "call" "name" "user/foo" "depth" 1 "args" '("1" "2")))
+      (expect (string-search "foo" (buffer-string)) :not :to-be nil)
+      (expect (string-search "│ " (buffer-string)) :not :to-be nil)))
+
+  (it "renders a return event with its value"
+    (with-temp-buffer
+      (cider-trace--render-event
+       (nrepl-dict "phase" "return" "name" "user/foo" "depth" 0 "value" "42"))
+      (expect (string-search "└─→" (buffer-string)) :not :to-be nil)
+      (expect (string-search "42" (buffer-string)) :not :to-be nil))))
+
+(describe "cider-trace--handle"
+  (it "stores the subscription id from the initial reply"
+    (with-temp-buffer
+      (cider-trace-mode)
+      (cider-trace--handle (current-buffer)
+                           (nrepl-dict "cider/trace-subscribe" "sub-1"))
+      (expect cider-trace--subscription :to-equal "sub-1")))
+
+  (it "renders streamed trace events into the buffer"
+    (with-temp-buffer
+      (cider-trace-mode)
+      (cider-trace--handle
+       (current-buffer)
+       (nrepl-dict "cider/trace-event"
+                   (nrepl-dict "phase" "call" "name" "user/foo" "depth" 0 "args" nil)))
+      (expect (string-search "foo" (buffer-string)) :not :to-be nil))))
+
 (provide 'cider-tracing-tests)
 
 ;;; cider-tracing-tests.el ends here


### PR DESCRIPTION
The final piece of the trace output buffer (Tier 2 of the enlighten/tracing audit), on top of orchard#400 and cider-nrepl#982.

Trace output went into the REPL, interleaved with everything else and hard to follow. `cider-trace` opens a dedicated `*cider-trace*` buffer and subscribes to the new `cider/trace-subscribe` op: each traced call and return streams in live, indented by call depth, with the form font-locked. Killing the buffer unsubscribes and restores REPL output.

Guarded by `cider-ensure-op-supported` and surfaced in the Debug menu. Needs a `cider-nrepl` with the trace-subscribe op (and thus `orchard` 0.43.0). M-x + menu for now; any global key belongs to the keybinding reorg.

This is a solid v1; foldable nodes and click-to-inspect on args/values are natural follow-ups.
