### PR TITLE
Add cider-enlighten-stop to quiet enlightenment without re-evaluating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- [#3991](https://github.com/clojure-emacs/cider/pull/3991): Add `cider-enlighten-stop` to turn off enlightenment at once - it disables `cider-enlighten-mode`, clears the overlays, and ignores any further values still streaming from previously-instrumented code, so you no longer have to re-evaluate everything just to make it stop.
 - [#3990](https://github.com/clojure-emacs/cider/pull/3990): Add `cider-trace`, opening a dedicated `*cider-trace*` buffer that streams the calls and return values of traced functions live, instead of interleaving them into the REPL (requires a recent enough `cider-nrepl`).
 - [#3989](https://github.com/clojure-emacs/cider/pull/3989): Add `cider-list-traced` to show the vars and namespaces that are currently traced, and `cider-untrace-all` to clear all tracing at once (both require a recent enough `cider-nrepl`).
 - [#3988](https://github.com/clojure-emacs/cider/pull/3988): Add `cider-enlighten-defun-at-point` to enlighten a single top-level form without toggling the global `cider-enlighten-mode`, and `cider-enlighten-clear` to remove the enlighten overlays from a buffer.

--- a/doc/modules/ROOT/pages/debugging/enlighten.adoc
+++ b/doc/modules/ROOT/pages/debugging/enlighten.adoc
@@ -19,10 +19,13 @@ into the brilliant show of lights on the right.
 | image:enlighten_enabled.png[Enabled]
 |===
 
-To stop displaying the locals you'll have to disable `cider-enlighten-mode`
-and reevaluate the definitions you had instrumented previously.  To clear the
-overlays from a buffer without re-evaluating anything, use
-`cider-enlighten-clear`.
+When you've had enough, `cider-enlighten-stop` turns everything off at once:
+it disables `cider-enlighten-mode`, removes the overlays, and ignores any
+further values still streaming from definitions you instrumented earlier - all
+without re-evaluating anything.  (Disabling the mode on its own only stops
+_new_ instrumentation; already-instrumented definitions keep lighting up until
+you re-evaluate them clean.)  To just clear the overlays from a buffer (they
+will come back the next time the code runs), use `cider-enlighten-clear`.
 
 If you only want to enlighten a single definition, you don't have to toggle the
 global mode at all.  Put point in the form and run

--- a/lisp/cider-enlighten.el
+++ b/lisp/cider-enlighten.el
@@ -42,6 +42,12 @@
 (declare-function cider--debug-find-source-position "cider-debug")
 (declare-function cider-eval-defun-at-point "cider-eval")
 
+(defvar cider-enlighten--suppress nil
+  "When non-nil, drop incoming enlighten values instead of rendering them.
+Previously-instrumented code keeps streaming values even after you stop
+caring; this lets `cider-enlighten-stop' quiet the overlays at once, without
+re-evaluating everything.  Resuming enlightenment clears it.")
+
 (defface cider-enlightened-face
   '((((class color) (background light)) :inherit cider-result-overlay-face
      :box (:color "darkorange" :line-width -1))
@@ -63,8 +69,9 @@
   "Handle an enlighten notification.
 RESPONSE is a message received from the nrepl describing the value and
 coordinates of a sexp.  Create an overlay after the specified sexp
-displaying its value."
-  (when-let* ((marker (cider--debug-find-source-position response)))
+displaying its value.  Does nothing while `cider-enlighten--suppress' is set."
+  (unless cider-enlighten--suppress
+    (when-let* ((marker (cider--debug-find-source-position response)))
     (with-current-buffer (marker-buffer marker)
       (save-excursion
         (goto-char marker)
@@ -87,13 +94,16 @@ displaying its value."
                 :format "%s"
                 :where (cons (point) marker)
                 :type 'enlighten
-                'face 'cider-enlightened-local-face))))))))
+                'face 'cider-enlightened-local-face)))))))))
 
 (define-minor-mode cider-enlighten-mode
   "Minor mode for displaying locals in debugger-instrumented evaluations."
   :lighter (cider-mode " light")
   :global t
-  :group 'cider)
+  :group 'cider
+  (when cider-enlighten-mode
+    ;; resuming enlightenment un-mutes the renderer
+    (setq cider-enlighten--suppress nil)))
 
 ;;;###autoload
 (defun cider-enlighten-defun-at-point ()
@@ -102,6 +112,7 @@ This is like enabling `cider-enlighten-mode' and evaluating the form, but
 scoped to this single evaluation, so you needn't toggle the global mode on
 and off (and re-evaluate everything) just to light up one definition."
   (interactive)
+  (setq cider-enlighten--suppress nil)
   (let ((cider-enlighten-mode t))
     (cider-eval-defun-at-point)))
 
@@ -109,6 +120,22 @@ and off (and re-evaluate everything) just to light up one definition."
   "Remove all enlighten value overlays from the current buffer."
   (interactive)
   (remove-overlays nil nil 'category 'enlighten))
+
+;;;###autoload
+(defun cider-enlighten-stop ()
+  "Stop displaying enlighten overlays, without re-evaluating anything.
+Turn off `cider-enlighten-mode', remove the existing overlays, and ignore
+any further enlighten values still streaming from previously-instrumented
+code.  This quiets things down at once - unlike disabling the mode alone,
+which leaves already-instrumented definitions lighting up every time they
+run.  Re-enabling the mode (or `cider-enlighten-defun-at-point') resumes
+display."
+  (interactive)
+  (setq cider-enlighten--suppress t)
+  (cider-enlighten-mode -1)
+  (dolist (buffer (buffer-list))
+    (with-current-buffer buffer
+      (remove-overlays nil nil 'category 'enlighten))))
 
 (provide 'cider-enlighten)
 

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -453,6 +453,7 @@ If invoked with a prefix ARG eval the expression after inserting it."
      ["Toggle Enlighten mode" cider-enlighten-mode
       :style toggle :selected cider-enlighten-mode]
      ["Clear enlighten overlays" cider-enlighten-clear]
+     ["Stop enlightening" cider-enlighten-stop]
      "--"
      ["Configure the Debugger" (customize-group 'cider-debug)])
     ,cider-profile-menu

--- a/test/cider-enlighten-tests.el
+++ b/test/cider-enlighten-tests.el
@@ -54,7 +54,16 @@
       (cider--handle-enlighten (nrepl-dict "debug-value" "42"))
       (let ((ov (car (cider-enlighten-tests--overlays))))
         (expect ov :not :to-be nil)
-        (expect (overlay-get ov 'face) :to-equal 'cider-enlightened-local-face)))))
+        (expect (overlay-get ov 'face) :to-equal 'cider-enlightened-local-face))))
+
+  (it "renders nothing while suppressed"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(+ 1 2)")
+      (spy-on 'cider--debug-find-source-position :and-return-value (point-marker))
+      (let ((cider-enlighten--suppress t))
+        (cider--handle-enlighten (nrepl-dict "debug-value" "3")))
+      (expect (cider-enlighten-tests--overlays) :to-be nil))))
 
 (describe "cider-enlighten-defun-at-point"
   (it "evaluates the form with the enlighten mode bound on, then restores it"
@@ -77,6 +86,25 @@
       (expect (length (cider-enlighten-tests--overlays)) :to-equal 1)
       (cider-enlighten-clear)
       (expect (cider-enlighten-tests--overlays) :to-be nil))))
+
+(describe "cider-enlighten-stop"
+  (it "mutes rendering, disables the mode, and clears overlays"
+    (with-temp-buffer
+      (insert "(foo)")
+      (overlay-put (make-overlay (point-min) (point-max)) 'category 'enlighten)
+      (let ((cider-enlighten--suppress nil))
+        (cider-enlighten-mode 1)
+        (cider-enlighten-stop)
+        (expect cider-enlighten--suppress :to-be t)
+        (expect cider-enlighten-mode :to-be nil)
+        (expect (cider-enlighten-tests--overlays) :to-be nil)))))
+
+(describe "cider-enlighten-mode"
+  (it "clears the suppression flag when re-enabled"
+    (let ((cider-enlighten--suppress t))
+      (cider-enlighten-mode 1)
+      (expect cider-enlighten--suppress :to-be nil)
+      (cider-enlighten-mode -1))))
 
 (provide 'cider-enlighten-tests)
 


### PR DESCRIPTION
First and highest-leverage piece of the enlighten activation overhaul (item #4 of the enlighten/tracing audit).

Enlighten instruments code at eval time, so disabling `cider-enlighten-mode` only stops *new* instrumentation - functions you already instrumented keep streaming values and re-lighting on every call. The documented way to truly stop was to disable the mode *and re-evaluate everything*.

`cider-enlighten-stop` fixes that with a client-side mute: it suppresses incoming enlighten values, clears the overlays, and turns the mode off - quieting everything at once, no re-eval. Resuming enlightenment (re-enabling the mode, or `cider-enlighten-defun-at-point`) clears the suppression. In the Debug menu; M-x for now.
