### PR TITLE
Make cider-trace calls foldable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### Changes
 
+- [#3992](https://github.com/clojure-emacs/cider/pull/3992): Make `*cider-trace*` calls foldable - `TAB` on a call line collapses or expands the nested calls between it and its return.
 - [#3984](https://github.com/clojure-emacs/cider/pull/3984): Stop dumping the full jack-in command and the ClojureScript REPL init form into the REPL transcript on startup (a ClojureScript REPL now just notes its type). The launch details are available on demand via `cider-repl-describe-startup` (the `,startup` REPL shortcut).
 - [#3983](https://github.com/clojure-emacs/cider/pull/3983): Slim down the REPL welcome banner - the long help banner is gone, replaced by a one-line hint, and the getting-started content now lives in a summonable `cider-repl-help` reference card (`C-c C-h`, or the `,refcard` REPL shortcut). `cider-repl-display-help-banner` now toggles the hint.
 - [#3982](https://github.com/clojure-emacs/cider/pull/3982): Warn (once per session) when a deprecated CIDER keybinding is used, starting with the REPL-only jack-in/connect keys `C-c M-j`/`M-J`/`M-c`/`M-C` (superseded by the `C-c C-x` start map back in 0.18.0). They still work; toggle with `cider-warn-on-deprecated-keybindings`, list pending removals with `M-x cider-list-deprecated-keybindings`.

--- a/doc/modules/ROOT/pages/debugging/tracing.adoc
+++ b/doc/modules/ROOT/pages/debugging/tracing.adoc
@@ -21,6 +21,8 @@ displays all the currently traced vars and namespaces in a buffer, and
 By default the trace output lands in the REPL, mixed in with everything else.
 `cider-trace` opens a dedicated `+*cider-trace*+` buffer instead: trace some
 functions, call them, and their calls and return values stream into that buffer
-live, indented to show the call nesting.  Kill the buffer to stop streaming.
+live, indented to show the call nesting.  Press kbd:[TAB] on a call line to fold
+or unfold the nested calls between it and its return, so you can collapse the
+noise and keep just the call and its result.  Kill the buffer to stop streaming.
 
 All of these require a recent enough `cider-nrepl`.

--- a/lisp/cider-tracing.el
+++ b/lisp/cider-tracing.el
@@ -142,13 +142,25 @@ Defaults to the current ns.  With prefix arg QUERY, prompts for a ns."
 (defvar-local cider-trace--connection nil
   "The REPL connection this trace buffer is subscribed through.")
 
+(defvar-local cider-trace--open-calls nil
+  "Hash table of call id -> marker at the start of that call's children.
+Holds calls whose return event hasn't arrived yet.")
+
+(defvar-local cider-trace--folds nil
+  "Hash table of call id -> the overlay covering that call's children.")
+
 (defun cider-trace--indent (depth)
   "Return the nesting indentation string for DEPTH."
   (apply #'concat (make-list (or depth 0) "│ ")))
 
 (defun cider-trace--render-event (event)
-  "Append the trace EVENT to the current buffer, following the tail."
-  (nrepl-dbind-response event (phase name depth args value)
+  "Append the trace EVENT to the current buffer, following the tail.
+A call and its return are paired by their shared `id', so the lines
+nested between them become a foldable region (see `cider-trace-toggle-fold')."
+  (unless cider-trace--open-calls
+    (setq cider-trace--open-calls (make-hash-table :test 'equal)
+          cider-trace--folds (make-hash-table :test 'equal)))
+  (nrepl-dbind-response event (id phase name depth args value)
     (let ((inhibit-read-only t)
           (indent (cider-trace--indent depth))
           (at-end (= (point) (point-max))))
@@ -156,16 +168,41 @@ Defaults to the current ns.  With prefix arg QUERY, prompts for a ns."
         (goto-char (point-max))
         (pcase phase
           ("call"
-           (insert indent
-                   (cider-font-lock-as-clojure
-                    (format "(%s%s)" name
-                            (if args (concat " " (mapconcat #'identity args " ")) "")))
-                   "\n"))
+           (let ((line-start (point)))
+             (insert indent
+                     (cider-font-lock-as-clojure
+                      (format "(%s%s)" name
+                              (if args (concat " " (mapconcat #'identity args " ")) "")))
+                     "\n")
+             (when id
+               ;; tag the whole call line so a fold toggle on it can find its id,
+               ;; and remember where this call's children will begin
+               (put-text-property line-start (point) 'cider-trace-call-id id)
+               (puthash id (copy-marker (point)) cider-trace--open-calls))))
           ("return"
-           (insert indent "└─→ "
-                   (cider-font-lock-as-clojure (or value "nil"))
-                   "\n"))))
+           (let ((children-start (and id (gethash id cider-trace--open-calls)))
+                 (children-end (point-marker)))
+             (when id (remhash id cider-trace--open-calls))
+             (insert indent "└─→ "
+                     (cider-font-lock-as-clojure (or value "nil"))
+                     "\n")
+             ;; if the call had nested children, make that block foldable
+             (when (and children-start (< children-start children-end))
+               (let ((ov (make-overlay children-start children-end)))
+                 (overlay-put ov 'evaporate t)
+                 (puthash id ov cider-trace--folds)))))))
       (when at-end (goto-char (point-max))))))
+
+(defun cider-trace-toggle-fold ()
+  "Fold or unfold the children of the trace call on the current line."
+  (interactive)
+  (let* ((id (get-text-property (point) 'cider-trace-call-id))
+         (ov (and id cider-trace--folds (gethash id cider-trace--folds))))
+    (if (not ov)
+        (user-error "No foldable call on this line")
+      (overlay-put ov 'display
+                   (unless (overlay-get ov 'display)
+                     (propertize " ⋯\n" 'face 'shadow))))))
 
 (defun cider-trace--handle (buffer msg)
   "Handle a trace subscription response MSG, rendering into BUFFER."
@@ -194,10 +231,13 @@ Fires a best-effort async request, since this runs from `kill-buffer-hook'."
   "Clear the trace buffer."
   (interactive)
   (let ((inhibit-read-only t))
-    (erase-buffer)))
+    (erase-buffer))
+  (when cider-trace--open-calls (clrhash cider-trace--open-calls))
+  (when cider-trace--folds (clrhash cider-trace--folds)))
 
 (defvar cider-trace-mode-map
   (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "TAB") #'cider-trace-toggle-fold)
     (define-key map (kbd "c") #'cider-trace-clear)
     (define-key map (kbd "q") #'quit-window)
     map)
@@ -208,6 +248,8 @@ Fires a best-effort async request, since this runs from `kill-buffer-hook'."
 
 \\{cider-trace-mode-map}"
   (setq-local truncate-lines nil)
+  (setq-local header-line-format
+              (propertize " TAB: fold call   c: clear   q: quit" 'face 'shadow))
   (add-hook 'kill-buffer-hook #'cider-trace--unsubscribe nil 'local))
 
 ;;;###autoload

--- a/test/cider-tracing-tests.el
+++ b/test/cider-tracing-tests.el
@@ -111,6 +111,33 @@
                    (nrepl-dict "phase" "call" "name" "user/foo" "depth" 0 "args" nil)))
       (expect (string-search "foo" (buffer-string)) :not :to-be nil))))
 
+(describe "cider-trace folding"
+  (it "makes a call with children foldable and toggles it"
+    (with-temp-buffer
+      (cider-trace-mode)
+      ;; outer call (1) wrapping a nested call+return (2), then outer return (1)
+      (cider-trace--render-event (nrepl-dict "id" 1 "phase" "call" "name" "outer" "depth" 0 "args" nil))
+      (cider-trace--render-event (nrepl-dict "id" 2 "phase" "call" "name" "inner" "depth" 1 "args" nil))
+      (cider-trace--render-event (nrepl-dict "id" 2 "phase" "return" "name" "inner" "depth" 1 "value" "9"))
+      (cider-trace--render-event (nrepl-dict "id" 1 "phase" "return" "name" "outer" "depth" 0 "value" "10"))
+      ;; the outer call got a fold overlay; the leaf inner call did not
+      (let ((ov (gethash 1 cider-trace--folds)))
+        (expect ov :not :to-be nil)
+        (expect (gethash 2 cider-trace--folds) :to-be nil)
+        ;; folding from the outer call line sets the overlay's display, unfolding clears it
+        (goto-char (point-min))
+        (cider-trace-toggle-fold)
+        (expect (overlay-get ov 'display) :not :to-be nil)
+        (cider-trace-toggle-fold)
+        (expect (overlay-get ov 'display) :to-be nil))))
+
+  (it "errors on a line with nothing to fold"
+    (with-temp-buffer
+      (cider-trace-mode)
+      (cider-trace--render-event (nrepl-dict "id" 1 "phase" "call" "name" "leaf" "depth" 0 "args" nil))
+      (goto-char (point-min))
+      (expect (cider-trace-toggle-fold) :to-throw 'user-error))))
+
 (provide 'cider-tracing-tests)
 
 ;;; cider-tracing-tests.el ends here


### PR DESCRIPTION
Polish for the `*cider-trace*` buffer (follow-up to #3990): foldable call nodes.

Deep or recursive traces produce a wall of lines. Now each call is paired with its return by their shared event id, so the block nested between them is a foldable region - `TAB` on a call line collapses the children (replacing them with an ellipsis) leaving just the call and its result, or expands them again.

Click-to-inspect on args/values is the other half I floated, but it can't be done correctly client-side: trace events carry *printed* values, and a Clojure printed seq like `(1 2 3)` isn't self-evaluating (re-reading it tries to call `1`). Doing it right needs orchard to attach an inspectable handle to each value - so I've left it for the orchard-side schema work rather than ship something broken.
