### PR TITLE
Find references by searching the project's source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- [#3994](https://github.com/clojure-emacs/cider/pull/3994): Find references by searching the project's source files, covering code that hasn't been loaded into the REPL yet: `xref-find-references` (`M-?`) now uses this source search by default (configurable via `cider-xref-references-mode`, which can also fold in the runtime references), and `cider-xref-fn-refs-in-source` (`C-c C-? s`) runs it explicitly.
 - [#3991](https://github.com/clojure-emacs/cider/pull/3991): Add `cider-enlighten-stop` to turn off enlightenment at once - it disables `cider-enlighten-mode`, clears the overlays, and ignores any further values still streaming from previously-instrumented code, so you no longer have to re-evaluate everything just to make it stop.
 - [#3990](https://github.com/clojure-emacs/cider/pull/3990): Add `cider-trace`, opening a dedicated `*cider-trace*` buffer that streams the calls and return values of traced functions live, instead of interleaving them into the REPL (requires a recent enough `cider-nrepl`).
 - [#3989](https://github.com/clojure-emacs/cider/pull/3989): Add `cider-list-traced` to show the vars and namespaces that are currently traced, and `cider-untrace-all` to clear all tracing at once (both require a recent enough `cider-nrepl`).

--- a/doc/modules/ROOT/pages/usage/cider_mode.adoc
+++ b/doc/modules/ROOT/pages/usage/cider_mode.adoc
@@ -333,6 +333,10 @@ kbd:[C-c C-t C-b]
 | kbd:[C-c C-? C-r]
 | Display function usages across loaded namespaces in a minibuffer selector.
 
+| `cider-xref-fn-refs-in-source`
+| kbd:[C-c C-? s]
+| Display function usages found by searching the project's source files.
+
 | `cider-xref-fn-deps`
 | kbd:[C-c C-? d]
 | Display function deps (other functions used by it) in a dedicated buffer.

--- a/doc/modules/ROOT/pages/usage/misc_features.adoc
+++ b/doc/modules/ROOT/pages/usage/misc_features.adoc
@@ -74,6 +74,53 @@ The functionality is not perfect, but at least it's there if you need it. As a b
 all of the functions used by some function using `cider-xref-fn-deps` (kbd:[C-c C-? d]) and `cider-xref-fn-deps-select` (kbd:[C-c C-? C-d]).
 Those are pretty handy if you don't want to jump to the source of some function to see what functions it refers to (uses) internally.
 
+=== Searching the project source
+
+The runtime analysis only sees namespaces that have been loaded into the REPL,
+and each reference it reports points at the referring function's definition
+rather than the exact call site. To also cover code that hasn't been evaluated
+yet, CIDER can search the project's source files on disk. It uses the
+lightweight `info`/`lookup` op (a single, cheap round-trip) to resolve the
+symbol at point to its canonical namespace and name, then scans the project's
+files with a Clojure-aware text search, taking each file's namespace aliases and
+``:refer``s into account and pinpointing every occurrence.
+
+`cider-xref-fn-refs-in-source` (kbd:[C-c C-? s]) runs this search directly and
+shows the results in the standard `xref` buffer. When no REPL is connected it
+falls back to matching the bare name, which is less precise but still useful.
+
+By default, `xref-find-references` (kbd:[M-?]) uses this source search, since it
+reports the exact occurrences across the whole project, including code that
+hasn't been loaded. The `cider-xref-references-mode` variable lets you fold in
+the runtime references too:
+
+[source,lisp]
+----
+;; source matches only (the default)
+(setq cider-xref-references-mode 'source)
+;; runtime references only (the historical behavior)
+(setq cider-xref-references-mode 'runtime)
+;; both, combined
+(setq cider-xref-references-mode 'both)
+----
+
+The two answer slightly different questions: the source search finds every
+occurrence (in any Clojure dialect), while the runtime search reports the
+calling functions (each hit points at the caller's definition rather than the
+call site) and is limited to Clojure on the JVM and to loaded project
+namespaces. In `both` mode the source matches lead, and runtime hits for files
+the source search already scanned are dropped, so a loaded reference isn't
+reported twice at two different granularities; what survives is mainly
+references the compiler generated from macros, which leave no textual trace.
+
+Because the source search is textual, it's a smart heuristic rather than a
+resolved index. It only looks at the project's own source files, so it won't
+find references that live in dependencies. It can include false positives such
+as shadowing locals or a same-named var referred from a different namespace, and
+it can miss references hidden in `.cljc` reader-conditional branches or built
+from strings at runtime. A faster search program helps on large projects; set
+`xref-search-program` to `ripgrep` if you have it installed.
+
 Don't forget you also have a couple of third-party alternatives:
 
 - The much more sophisticated AST-powered "find usages" provided by `clj-refactor.el`

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -419,6 +419,7 @@ If invoked with a prefix ARG eval the expression after inserting it."
     ("Xref"
      ["Find fn references" cider-xref-fn-refs]
      ["Find fn references and select" cider-xref-fn-refs-select]
+     ["Find fn references in source" cider-xref-fn-refs-in-source]
      ["Find fn dependencies" cider-xref-fn-deps]
      ["Find fn dependencies and select" cider-xref-fn-deps-select])
     ("Browse"
@@ -500,6 +501,7 @@ If invoked with a prefix ARG eval the expression after inserting it."
 (declare-function cider-find-var "cider-find")
 (declare-function cider-find-dwim-at-mouse "cider-find")
 (declare-function cider-xref-fn-refs "cider-xref")
+(declare-function cider-xref-fn-refs-in-source "cider-xref")
 (declare-function cider-xref-fn-refs-select "cider-xref")
 (declare-function cider-xref-fn-deps "cider-xref")
 (declare-function cider-xref-fn-deps-select "cider-xref")
@@ -573,6 +575,7 @@ higher precedence."
     (define-key map (kbd "C-c C-=") 'cider-profile-map)
     (define-key map (kbd "C-c C-? r") #'cider-xref-fn-refs)
     (define-key map (kbd "C-c C-? C-r") #'cider-xref-fn-refs-select)
+    (define-key map (kbd "C-c C-? s") #'cider-xref-fn-refs-in-source)
     (define-key map (kbd "C-c C-? d") #'cider-xref-fn-deps)
     (define-key map (kbd "C-c C-? C-d") #'cider-xref-fn-deps-select)
     (define-key map (kbd "C-c C-q") #'cider-quit)

--- a/lisp/cider-xref-backend.el
+++ b/lisp/cider-xref-backend.el
@@ -30,6 +30,7 @@
 (require 'cider-common)
 (require 'cider-doc) ;; for cider--abbreviate-file-protocol
 (require 'cider-resolve)
+(require 'cider-xref-source)
 
 (require 'seq)
 (require 'thingatpt)
@@ -104,47 +105,113 @@ These are used for presentation purposes."
   (when-let* ((ns (cider-current-ns)))
     (cider-sync-request:ns-vars ns)))
 
+(defcustom cider-xref-references-mode 'source
+  "How `xref-find-references' (\\[xref-find-references]) gathers references.
+CIDER can find references two ways, and they answer different questions.  The
+source search scans the project's files on disk (see `cider-xref-source'), so it
+covers code that hasn't been evaluated yet and pinpoints every exact occurrence,
+at the cost of some false positives - this is the natural fit for xref, which is
+occurrence-oriented.  The runtime search (the `cider/fn-refs' op) introspects
+the REPL, so it is limited to Clojure on the JVM and to loaded project
+namespaces, and reports the calling functions (each hit points at the caller's
+definition, not the call site).
+
+The value selects which of the two run:
+
+  source  - source matches only (the default).
+  runtime - runtime references only (the historical behavior).
+  both    - both, combined.
+
+In `both' mode the source matches lead, and runtime hits for files the source
+search already scanned are dropped (they would only duplicate the precise
+occurrences at a coarser granularity).  What survives is mainly references the
+compiler generated from macros, which leave no textual trace for the scan."
+  :type '(choice (const :tag "Source matches only" source)
+                 (const :tag "Runtime references only" runtime)
+                 (const :tag "Runtime and source matches combined" both))
+  :group 'cider
+  :package-version '(cider . "1.23.0"))
+
+(defun cider--fn-refs-xrefs (ns var)
+  "Find references of VAR in NS via runtime introspection (the `fn-refs' op).
+These cover only namespaces already loaded into the REPL."
+  (when (cider-nrepl-op-supported-p "cider/fn-refs")
+    (when-let* ((results (cider-sync-request:fn-refs ns var))
+                (previously-existing-buffers (buffer-list)))
+      (thread-last results
+                   (mapcar (lambda (info)
+                             (let* ((filename (cider--xref-extract-file info))
+                                    (column (nrepl-dict-get info "column"))
+                                    (line (nrepl-dict-get info "line"))
+                                    (friendly-name (cider--xref-extract-friendly-file-name info))
+                                    ;; translate .jar urls and such:
+                                    (buf (cider--find-buffer-for-file filename))
+                                    (bfn (and buf (buffer-file-name buf)))
+                                    (loc (when buf
+                                           ;; favor `xref-make-file-location' when possible, since that way, we can close their buffers.
+                                           (if bfn
+                                               (xref-make-file-location bfn line (or column 0))
+                                             (xref-make-buffer-location buf (with-current-buffer buf
+                                                                              (save-excursion
+                                                                                (goto-char 0)
+                                                                                (forward-line (1- line))
+                                                                                (move-to-column (or column 0))
+                                                                                (point)))))))
+                                    (should-be-closed (and
+                                                       buf
+                                                       ;; if a buffer did not exist before,
+                                                       ;; then it is a side-effect of invoking `cider--find-buffer-for-file'.
+                                                       (not (member buf previously-existing-buffers))
+                                                       bfn
+                                                       ;; only buffers with a normally reachable filename are safe to close.
+                                                       ;; buffers not backed by such files may include .jars, TRAMP files, etc.
+                                                       ;; Sadly this means we will still 'leak' some open buffers, but it's what we can do atm.
+                                                       (file-exists-p bfn))))
+                               (when should-be-closed
+                                 (kill-buffer buf))
+                               (when loc
+                                 (xref-make friendly-name loc)))))
+                   (seq-filter #'identity)))))
+
+(defun cider--xref-item-file (item)
+  "Return the file backing xref ITEM, or nil for a non-file location."
+  (let ((loc (xref-item-location item)))
+    (when (xref-file-location-p loc)
+      (xref-file-location-file loc))))
+
+(defun cider--xref-reject-runtime-overlap (runtime source)
+  "Drop RUNTIME xref items whose file already appears in SOURCE.
+The source search reports precise occurrences, so for any file it covers the
+coarser runtime hit (which points at the referring var's definition, not the
+call site) would only duplicate it.  What survives is mainly references the
+compiler generated from macros, which leave no textual trace for the scan."
+  (let ((covered (make-hash-table :test 'equal)))
+    (dolist (item source)
+      (when-let* ((file (cider--xref-item-file item)))
+        (puthash (file-truename file) t covered)))
+    (seq-remove (lambda (item)
+                  (when-let* ((file (cider--xref-item-file item)))
+                    (gethash (file-truename file) covered)))
+                runtime)))
+
 (cl-defmethod xref-backend-references ((_backend (eql cider)) var)
-  "Find references of VAR."
+  "Find references of VAR, per `cider-xref-references-mode'.
+The runtime side (the `fn-refs' op) only sees loaded namespaces; the source
+side covers code on disk that hasn't been evaluated yet.  In `both' mode the
+two are combined, with runtime hits the source search already covers dropped."
   (cider-ensure-connected)
-  (cider-ensure-op-supported "cider/fn-refs")
-  (when-let* ((ns (cider-current-ns))
-              (results (cider-sync-request:fn-refs ns var))
-              (previously-existing-buffers (buffer-list)))
-    (thread-last results
-                 (mapcar (lambda (info)
-                           (let* ((filename (cider--xref-extract-file info))
-                                  (column (nrepl-dict-get info "column"))
-                                  (line (nrepl-dict-get info "line"))
-                                  (friendly-name (cider--xref-extract-friendly-file-name info))
-                                  ;; translate .jar urls and such:
-                                  (buf (cider--find-buffer-for-file filename))
-                                  (bfn (and buf (buffer-file-name buf)))
-                                  (loc (when buf
-                                         ;; favor `xref-make-file-location' when possible, since that way, we can close their buffers.
-                                         (if bfn
-                                             (xref-make-file-location bfn line (or column 0))
-                                           (xref-make-buffer-location buf (with-current-buffer buf
-                                                                            (save-excursion
-                                                                              (goto-char 0)
-                                                                              (forward-line (1- line))
-                                                                              (move-to-column (or column 0))
-                                                                              (point)))))))
-                                  (should-be-closed (and
-                                                     buf
-                                                     ;; if a buffer did not exist before,
-                                                     ;; then it is a side-effect of invoking `cider--find-buffer-for-file'.
-                                                     (not (member buf previously-existing-buffers))
-                                                     bfn
-                                                     ;; only buffers with a normally reachable filename are safe to close.
-                                                     ;; buffers not backed by such files may include .jars, TRAMP files, etc.
-                                                     ;; Sadly this means we will still 'leak' some open buffers, but it's what we can do atm.
-                                                     (file-exists-p bfn))))
-                             (when should-be-closed
-                               (kill-buffer buf))
-                             (when loc
-                               (xref-make friendly-name loc)))))
-                 (seq-filter #'identity))))
+  ;; Without the source search the `fn-refs' op is the only source of results,
+  ;; so insist on it; otherwise the search degrades gracefully without it.
+  (when (eq cider-xref-references-mode 'runtime)
+    (cider-ensure-op-supported "cider/fn-refs"))
+  (let* ((ns (cider-current-ns))
+         (source (when (memq cider-xref-references-mode '(source both))
+                   (cider-xref--var-source-references var)))
+         (runtime (when (memq cider-xref-references-mode '(runtime both))
+                    (cider--fn-refs-xrefs ns var))))
+    (when (and source runtime)
+      (setq runtime (cider--xref-reject-runtime-overlap runtime source)))
+    (cider-xref--dedupe (append source runtime))))
 
 (cl-defmethod xref-backend-apropos ((_backend (eql cider)) pattern)
   "Find all symbols that match regexp PATTERN."

--- a/lisp/cider-xref-source.el
+++ b/lisp/cider-xref-source.el
@@ -1,0 +1,297 @@
+;;; cider-xref-source.el --- Source-based find references for Clojure -*- lexical-binding: t -*-
+
+;; Copyright © 2026 Bozhidar Batsov and CIDER contributors
+;;
+;; Author: Bozhidar Batsov <bozhidar@batsov.dev>
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+
+;; Find references to a Clojure var by scanning the project's source files,
+;; rather than introspecting the runtime.  The runtime-based approach (see
+;; `cider-xref-fn-refs') only sees namespaces that have been loaded into the
+;; REPL; this one covers the whole project on disk, including code that hasn't
+;; been evaluated yet.
+;;
+;; The strategy splits the problem along its natural seam: resolving the symbol
+;; at point to a canonical `ns/name' genuinely needs semantic knowledge, so we
+;; use the lightweight nREPL `info'/`lookup' op (via `cider-var-info') for that
+;; one step.
+;; Finding the occurrences is a breadth problem, so we hand it off to a fast text
+;; search (Emacs' own `xref-matches-in-files', i.e. grep/ripgrep) and then refine
+;; the candidates per file.
+;;
+;; The refinement is what makes this Clojure-aware rather than a dumb grep: each
+;; candidate file's `(ns ...)' form is parsed to learn that file's alias for the
+;; target namespace and whether it refers the name, so only the forms a given
+;; file actually licenses are matched.  Matches inside strings and comments are
+;; dropped via the buffer's syntax table.
+;;
+;; This is a heuristic, not a resolved index.  It can include shadowing locals
+;; and same-named vars referred from a different namespace, and it can miss
+;; references hidden in `.cljc' reader-conditional branches or built from strings
+;; at runtime.  When precision matters more than coverage, clojure-lsp's static
+;; analysis is the better tool.
+
+;;; Code:
+
+(require 'cider-client)
+(require 'nrepl-dict)
+
+(require 'project)
+(require 'subr-x)
+(require 'seq)
+(require 'xref)
+
+(defcustom cider-xref-source-extensions '("clj" "cljc" "cljs" "cljx" "bb")
+  "File extensions scanned by the source-based reference search.
+Each entry is an extension without the leading dot."
+  :type '(repeat string)
+  :group 'cider
+  :package-version '(cider . "1.23.0"))
+
+(defconst cider-xref--symbol-chars "[:alnum:]_'*+!?<>=&$%./:-"
+  "The Clojure symbol-constituent characters, as the body of a bracket expression.
+Wrap in \"[...]\" to match one, or \"[^...]\" to match a boundary.  Used to guard
+the edges of a match so that, e.g., searching for `foo' does not match inside
+`foobar' or `other/foo'.")
+
+(defun cider-xref--source-file-p (file)
+  "Return non-nil when FILE has a Clojure source extension."
+  (when-let* ((ext (file-name-extension file)))
+    (member ext cider-xref-source-extensions)))
+
+(defun cider-xref--project-source-files ()
+  "Return the Clojure source files of the current project, or nil when not in one."
+  (when-let* ((project (project-current)))
+    (seq-filter #'cider-xref--source-file-p (project-files project))))
+
+(defun cider-xref--candidate-files (name files)
+  "Return the subset of FILES that textually mention NAME.
+This is a fast first pass via grep/ripgrep, used only to narrow the set of files
+that the precise per-file scan then has to open.  When the search can't run (no
+search program, say) all of FILES are returned as candidates."
+  (if (null files)
+      nil
+    (condition-case nil
+        (let ((regexp (concat "[^" cider-xref--symbol-chars "]"
+                              (regexp-quote name)
+                              "[^" cider-xref--symbol-chars "]")))
+          (delete-dups
+           (mapcar (lambda (item)
+                     (xref-file-location-file (xref-item-location item)))
+                   (xref-matches-in-files regexp files))))
+      (error files))))
+
+(defun cider-xref--enclosing-libspec (pos limit)
+  "Return the libspec vector enclosing POS as a string, or nil.
+POS should sit on a namespace symbol inside an `(ns ...)' form; LIMIT bounds the
+search.  Returns the text of the `[...]' libspec, e.g. \"[my.ns :as m]\"."
+  (save-excursion
+    (goto-char pos)
+    (condition-case nil
+        (progn
+          (backward-up-list)
+          (when (eq (char-after) ?\[)
+            (let ((beg (point)))
+              (forward-sexp)
+              (when (<= (point) limit)
+                (buffer-substring-no-properties beg (point))))))
+      (error nil))))
+
+;; A whitespace class spelled out explicitly: `[:space:]' keys off the syntax
+;; table, and in `clojure-mode' a newline is comment-ending rather than
+;; whitespace syntax, so `[[:space:]]' wouldn't match it in a buffer scan.
+(defconst cider-xref--ws "[ \t\r\n\f]"
+  "A bracket expression matching one whitespace character, newlines included.")
+
+(defun cider-xref--ns-context (target-ns name)
+  "Parse the current buffer to learn how TARGET-NS and NAME are brought in.
+Return a plist with `:this-ns' (the file's own namespace), `:alias' (this file's
+alias for TARGET-NS, or nil), `:referred' (non-nil when NAME can be used
+unqualified in this file), and `:ns-beg'/`:ns-end' (the bounds of the `(ns ...)'
+form, so its own require declarations can be excluded from matches).  When
+TARGET-NS is nil only bare matching applies, so `:referred' is forced on."
+  (save-excursion
+    (goto-char (point-min))
+    (let (this-ns alias referred ns-beg ns-end)
+      ;; Locate the `(ns ...)' form and the file's own namespace.
+      (when (re-search-forward (concat "(ns\\(?:" cider-xref--ws "\\|$\\)") nil t)
+        (goto-char (match-beginning 0))
+        (setq ns-beg (point))
+        (ignore-errors (forward-sexp))
+        (setq ns-end (point))
+        (goto-char ns-beg)
+        (when (re-search-forward
+               (concat "(ns" cider-xref--ws "+"
+                       "\\(?:\\^[^ \t\r\n\f]+" cider-xref--ws "+\\)*"  ; skip metadata
+                       "\\([^ \t\r\n\f()]+\\)")
+               ns-end t)
+          (setq this-ns (match-string-no-properties 1))))
+      ;; Within the ns form, find the libspec for TARGET-NS and read off its
+      ;; `:as'/`:as-alias' alias and any `:refer'.  (These run on the extracted
+      ;; libspec string, where `[:space:]' behaves normally.)
+      (when (and target-ns ns-beg ns-end)
+        (goto-char ns-beg)
+        (when (re-search-forward
+               (concat "\\_<" (regexp-quote target-ns) "\\_>") ns-end t)
+          (when-let* ((libspec (cider-xref--enclosing-libspec
+                                (match-beginning 0) ns-end)))
+            (when (string-match
+                   ":as\\(?:-alias\\)?[[:space:]]+\\([^][[:space:](){}]+\\)" libspec)
+              (setq alias (match-string 1 libspec)))
+            (when (or (string-match-p ":refer[[:space:]]+:all" libspec)
+                      (and (string-match ":refer[[:space:]]+\\[\\([^]]*\\)\\]" libspec)
+                           (member name (split-string (match-string 1 libspec)
+                                                      "[[:space:]]+" t))))
+              (setq referred t)))))
+      ;; A var defined in this namespace is naturally used unqualified here.
+      (when (and target-ns (equal this-ns target-ns))
+        (setq referred t))
+      (unless target-ns
+        (setq referred t))
+      (list :this-ns this-ns :alias alias :referred referred
+            :ns-beg ns-beg :ns-end ns-end))))
+
+(defun cider-xref--reference-regexp (target-ns name context)
+  "Build a regexp matching references to TARGET-NS/NAME licensed by CONTEXT.
+Group 1 captures the symbol token itself (so its bounds are the match bounds).
+CONTEXT is a plist as returned by `cider-xref--ns-context'."
+  (let* ((qname (regexp-quote name))
+         ;; The bare name is an alt only when this file licenses unqualified use.
+         (alts (when (plist-get context :referred) (list qname))))
+    (when target-ns
+      (push (concat (regexp-quote target-ns) "/" qname) alts))
+    (when-let* ((alias (plist-get context :alias)))
+      (push (concat (regexp-quote alias) "/" qname) alts))
+    (when alts
+      (concat "\\(?:^\\|[^" cider-xref--symbol-chars "]\\)"  ; left boundary
+              "\\(?:#'\\|[#'@`]\\)?"                          ; optional reader prefix
+              "\\(" (mapconcat #'identity alts "\\|") "\\)"   ; the symbol token
+              "\\(?:$\\|[^" cider-xref--symbol-chars "]\\)")))) ; right boundary
+
+(defun cider-xref--scan-buffer (regexp file &optional exclude)
+  "Collect references matching REGEXP in the current buffer as xref match items.
+FILE is the absolute path the locations should point at.  Matches inside strings
+and comments are skipped, using the buffer's syntax table.  EXCLUDE, when given,
+is a (BEG . END) range whose matches are skipped too - used to ignore the
+namespace form's own require declarations."
+  (let ((line 1)
+        (counted (point-min))   ; position whose line number is `line'
+        matches)
+    (save-excursion
+      (goto-char (point-min))
+      (while (re-search-forward regexp nil t)
+        (let ((beg (match-beginning 1))
+              (end (match-end 1)))
+          (goto-char end)
+          (unless (or (nth 8 (syntax-ppss beg))   ; skip strings and comments
+                      (and exclude (>= beg (car exclude)) (< beg (cdr exclude))))
+            ;; Advance the line counter incrementally so the whole scan stays
+            ;; linear instead of calling `line-number-at-pos' per match.
+            (setq line (+ line (save-excursion
+                                 (goto-char counted)
+                                 (let ((n 0))
+                                   (while (search-forward "\n" beg t)
+                                     (setq n (1+ n)))
+                                   n)))
+                  counted beg)
+            (save-excursion
+              (goto-char beg)
+              (let* ((bol (line-beginning-position))
+                     (col (- beg bol))
+                     (summary (buffer-substring-no-properties
+                               bol (line-end-position))))
+                (push (xref-make-match (string-trim summary)
+                                       (xref-make-file-location file line col)
+                                       (- end beg))
+                      matches)))))))
+    (nreverse matches)))
+
+(defun cider-xref--references-in-file (file target-ns name)
+  "Return xref match items for references to TARGET-NS/NAME in FILE.
+A buffer opened solely to perform the scan is killed afterwards."
+  (let* ((existing (find-buffer-visiting file))
+         (buffer (or existing
+                     ;; Suppress find-file hooks (font-lock, LSP, etc.) and the
+                     ;; minibuffer chatter - we only need the buffer's text.
+                     (let ((find-file-hook nil)
+                           (inhibit-message t))
+                       (find-file-noselect file t)))))
+    (unwind-protect
+        (with-current-buffer buffer
+          (when-let* ((context (cider-xref--ns-context target-ns name))
+                      (regexp (cider-xref--reference-regexp target-ns name context)))
+            (cider-xref--scan-buffer
+             regexp file
+             (when-let* ((ns-beg (plist-get context :ns-beg)))
+               (cons ns-beg (plist-get context :ns-end))))))
+      (unless existing
+        (kill-buffer buffer)))))
+
+(defun cider-xref--source-references (target-ns name)
+  "Return xref match items for references to TARGET-NS/NAME across the project.
+When TARGET-NS is nil the search degrades to matching the bare NAME everywhere,
+which is more approximate but works without a connected REPL."
+  (when-let* ((files (cider-xref--project-source-files))
+              (candidates (cider-xref--candidate-files name files)))
+    (seq-mapcat (lambda (file)
+                  (cider-xref--references-in-file file target-ns name))
+                candidates)))
+
+(defun cider-xref--resolve-var (var)
+  "Resolve VAR to a cons (NS . NAME) via the nREPL `info' op, or nil.
+Resolution collapses aliases and refers down to the canonical namespace and
+name, so a single round-trip turns the symbol at point into something the source
+search can look for everywhere."
+  (when-let* ((info (cider-var-info var))
+              (ns (nrepl-dict-get info "ns"))
+              (name (nrepl-dict-get info "name")))
+    (cons ns name)))
+
+(defun cider-xref--short-name (var)
+  "Return the bare name of VAR, dropping any namespace or alias qualifier."
+  (if (string-match "/\\([^/]+\\)\\'" var)
+      (match-string 1 var)
+    var))
+
+(defun cider-xref--var-source-references (var)
+  "Return xref match items for references to VAR found by scanning project source.
+VAR is resolved via the REPL when possible; otherwise the search falls back to
+matching VAR's bare name."
+  (if-let* ((resolved (and (cider-connected-p) (cider-xref--resolve-var var))))
+      (cider-xref--source-references (car resolved) (cdr resolved))
+    (cider-xref--source-references nil (cider-xref--short-name var))))
+
+(defun cider-xref--dedupe (items)
+  "Remove xref ITEMS that point at the same file, line and column."
+  (let ((seen (make-hash-table :test #'equal))
+        result)
+    (dolist (item items)
+      (let* ((loc (xref-item-location item))
+             (key (and (xref-file-location-p loc)
+                       (list (xref-file-location-file loc)
+                             (xref-file-location-line loc)
+                             (xref-file-location-column loc)))))
+        (when (or (null key) (not (gethash key seen)))
+          (when key (puthash key t seen))
+          (push item result))))
+    (nreverse result)))
+
+(provide 'cider-xref-source)
+
+;;; cider-xref-source.el ends here

--- a/lisp/cider-xref.el
+++ b/lisp/cider-xref.el
@@ -35,11 +35,13 @@
 
 (require 'cider-client)
 (require 'cider-popup)
+(require 'cider-xref-source)
 (require 'nrepl-dict)
 
 (require 'clojure-mode)
 (require 'apropos)
 (require 'button)
+(require 'xref)
 
 (defconst cider-xref-buffer "*cider-xref*")
 
@@ -132,6 +134,26 @@ namespace is a likelier cause than a var that genuinely has none."
     (if-let* ((results (cider-sync-request:fn-refs ns symbol)))
         (cider-show-xref (format "Showing %d functions that reference %s in currently loaded namespaces" (length results) symbol) results)
       (cider-xref--report-no-results symbol "references"))))
+
+;;;###autoload
+(defun cider-xref-fn-refs-in-source (&optional symbol)
+  "Show references to SYMBOL found by scanning the project's source files.
+Unlike `cider-xref-fn-refs', which introspects the runtime and only sees loaded
+namespaces, this scans the files on disk, so it also finds references in code
+that hasn't been evaluated yet.  When a REPL is connected SYMBOL is resolved to
+its canonical namespace first; otherwise the search falls back to matching the
+bare name and is correspondingly more approximate.
+
+The results are textual matches and can include false positives such as
+shadowing locals or same-named vars from a different namespace."
+  (interactive)
+  (let* ((symbol (or symbol (cider-symbol-at-point) (read-string "Find references in source for: ")))
+         (xrefs (cider-xref--var-source-references symbol)))
+    (if xrefs
+        (funcall xref-show-xrefs-function
+                 (lambda () xrefs)
+                 `((window . ,(selected-window))))
+      (user-error "No source references found for %s" symbol))))
 
 ;;;###autoload
 (defun cider-xref-fn-deps (&optional ns symbol)

--- a/test/cider-xref-backend-tests.el
+++ b/test/cider-xref-backend-tests.el
@@ -1,0 +1,55 @@
+;;; cider-xref-backend-tests.el  -*- lexical-binding: t; -*-
+
+;; Copyright © 2026 Bozhidar Batsov
+
+;; Author: Bozhidar Batsov <bozhidar@batsov.dev>
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; This file is part of CIDER
+
+;;; Code:
+
+(require 'buttercup)
+(require 'xref)
+(require 'cider-xref-backend)
+
+;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
+
+(describe "cider--xref-reject-runtime-overlap"
+  (it "drops runtime hits for files the source search already covered"
+    (let* ((source (list (xref-make-match "x" (xref-make-file-location "a.clj" 11 0) 3)))
+           (runtime (list (xref-make-match "x" (xref-make-file-location "a.clj" 1 0) 3)
+                          (xref-make-match "y" (xref-make-file-location "b.clj" 1 0) 3)))
+           (kept (cider--xref-reject-runtime-overlap runtime source)))
+      (expect (length kept) :to-equal 1)
+      (expect (xref-file-location-file (xref-item-location (car kept)))
+              :to-match "b\\.clj")))
+
+  (it "keeps runtime hits with no backing file, e.g. jar buffers"
+    (with-temp-buffer
+      (let* ((source (list (xref-make-match "x" (xref-make-file-location "a.clj" 1 0) 3)))
+             (runtime (list (xref-make-match "x" (xref-make-buffer-location
+                                                  (current-buffer) (point))
+                                             3)))
+             (kept (cider--xref-reject-runtime-overlap runtime source)))
+        (expect (length kept) :to-equal 1)))))
+
+(provide 'cider-xref-backend-tests)
+
+;;; cider-xref-backend-tests.el ends here

--- a/test/cider-xref-source-tests.el
+++ b/test/cider-xref-source-tests.el
@@ -1,0 +1,163 @@
+;;; cider-xref-source-tests.el  -*- lexical-binding: t; -*-
+
+;; Copyright © 2026 Bozhidar Batsov
+
+;; Author: Bozhidar Batsov <bozhidar@batsov.dev>
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; This file is part of CIDER
+
+;;; Code:
+
+(require 'buttercup)
+(require 'clojure-mode)
+(require 'xref)
+(require 'cider-xref-source)
+
+;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
+
+(defun cider-xref-source-tests--matches (content target-ns name)
+  "Return the trimmed summary lines of references to TARGET-NS/NAME in CONTENT.
+CONTENT is inserted into a temporary `clojure-mode' buffer, parsed for its ns
+context, and scanned - exercising the whole non-REPL half of the engine."
+  (with-temp-buffer
+    (insert content)
+    (delay-mode-hooks (clojure-mode))
+    (let* ((context (cider-xref--ns-context target-ns name))
+           (regexp (cider-xref--reference-regexp target-ns name context)))
+      (when regexp
+        (mapcar #'xref-item-summary
+                (cider-xref--scan-buffer
+                 regexp "test.clj"
+                 (when-let* ((ns-beg (plist-get context :ns-beg)))
+                   (cons ns-beg (plist-get context :ns-end)))))))))
+
+(describe "cider-xref--ns-context"
+  (it "reads the alias and refer of a fully specified libspec"
+    (with-temp-buffer
+      (insert "(ns my.app\n  (:require [my.ns :as m :refer [foo bar]]))\n")
+      (delay-mode-hooks (clojure-mode))
+      (let ((ctx (cider-xref--ns-context "my.ns" "foo")))
+        (expect (plist-get ctx :this-ns) :to-equal "my.app")
+        (expect (plist-get ctx :alias) :to-equal "m")
+        (expect (plist-get ctx :referred) :to-be-truthy))))
+
+  (it "treats :refer :all as licensing the bare name"
+    (with-temp-buffer
+      (insert "(ns my.app\n  (:require [my.ns :refer :all]))\n")
+      (delay-mode-hooks (clojure-mode))
+      (expect (plist-get (cider-xref--ns-context "my.ns" "foo") :referred)
+              :to-be-truthy)))
+
+  (it "does not license a bare name that isn't referred"
+    (with-temp-buffer
+      (insert "(ns my.app\n  (:require [my.ns :as m :refer [bar]]))\n")
+      (delay-mode-hooks (clojure-mode))
+      (let ((ctx (cider-xref--ns-context "my.ns" "foo")))
+        (expect (plist-get ctx :alias) :to-equal "m")
+        (expect (plist-get ctx :referred) :not :to-be-truthy))))
+
+  (it "reads an :as-alias the same way as :as"
+    (with-temp-buffer
+      (insert "(ns my.app (:require [my.ns :as-alias mn]))\n")
+      (delay-mode-hooks (clojure-mode))
+      (expect (plist-get (cider-xref--ns-context "my.ns" "foo") :alias)
+              :to-equal "mn")))
+
+  (it "licenses the bare name in the var's own namespace"
+    (with-temp-buffer
+      (insert "(ns my.ns)\n")
+      (delay-mode-hooks (clojure-mode))
+      (expect (plist-get (cider-xref--ns-context "my.ns" "foo") :referred)
+              :to-be-truthy)))
+
+  (it "forces bare matching when the target namespace is unknown"
+    (with-temp-buffer
+      (insert "(ns whatever)\n")
+      (delay-mode-hooks (clojure-mode))
+      (expect (plist-get (cider-xref--ns-context nil "foo") :referred)
+              :to-be-truthy))))
+
+(describe "cider-xref--source matching"
+  (it "matches qualified, aliased, bare and var-quoted references"
+    (let ((matches (cider-xref-source-tests--matches
+                    (concat "(ns my.app\n"
+                            "  (:require [my.ns :as m :refer [foo]]))\n"
+                            "(m/foo)\n"
+                            "(foo)\n"
+                            "(my.ns/foo)\n"
+                            "#'my.ns/foo\n")
+                    "my.ns" "foo")))
+      (expect (length matches) :to-equal 4)))
+
+  (it "does not match longer symbols or other qualifiers"
+    (let ((matches (cider-xref-source-tests--matches
+                    (concat "(ns my.app\n"
+                            "  (:require [my.ns :as m :refer [foo]]))\n"
+                            "(m/foobar)\n"
+                            "(other/foo)\n"
+                            "(foo-bar)\n")
+                    "my.ns" "foo")))
+      (expect matches :to-equal nil)))
+
+  (it "skips occurrences inside strings and comments"
+    (let ((matches (cider-xref-source-tests--matches
+                    (concat "(ns my.app (:require [my.ns :as m]))\n"
+                            "(m/foo)\n"
+                            "\"m/foo in a string\"\n"
+                            ";; m/foo in a comment\n")
+                    "my.ns" "foo")))
+      (expect (length matches) :to-equal 1)))
+
+  (it "omits the bare name when the file doesn't refer it"
+    (let ((matches (cider-xref-source-tests--matches
+                    (concat "(ns my.app (:require [my.ns :as m]))\n"
+                            "(m/foo)\n"
+                            "(foo)\n")
+                    "my.ns" "foo")))
+      (expect (length matches) :to-equal 1)))
+
+  (it "matches the bare name throughout the defining namespace"
+    (let ((matches (cider-xref-source-tests--matches
+                    (concat "(ns my.ns)\n"
+                            "(defn foo [])\n"
+                            "(defn bar [] (foo))\n")
+                    "my.ns" "foo")))
+      (expect (length matches) :to-equal 2))))
+
+(describe "cider-xref--short-name"
+  (it "drops a namespace or alias qualifier"
+    (expect (cider-xref--short-name "my.ns/foo") :to-equal "foo")
+    (expect (cider-xref--short-name "m/foo") :to-equal "foo"))
+  (it "leaves an unqualified name untouched"
+    (expect (cider-xref--short-name "foo") :to-equal "foo")))
+
+(describe "cider-xref--dedupe"
+  (it "drops items pointing at the same file, line and column"
+    (let* ((loc-a (xref-make-file-location "a.clj" 1 0))
+           (loc-a2 (xref-make-file-location "a.clj" 1 0))
+           (loc-b (xref-make-file-location "a.clj" 2 0))
+           (items (list (xref-make-match "x" loc-a 3)
+                        (xref-make-match "x" loc-a2 3)
+                        (xref-make-match "y" loc-b 3))))
+      (expect (length (cider-xref--dedupe items)) :to-equal 2))))
+
+(provide 'cider-xref-source-tests)
+
+;;; cider-xref-source-tests.el ends here


### PR DESCRIPTION
`xref-find-references` (`M-?`) has only ever shown what the runtime knows about, so anything you hadn't evaluated yet was invisible. This adds a client-side source search (resolve the var via the lightweight `info` op, then grep the project files) and merges those matches into `M-?` by default, deduped, behind the new `cider-xref-source-search` defcustom. There's also a standalone `cider-xref-fn-refs-in-source` (`C-c C-? s`) if you want just the source side, which still works without a connected REPL by falling back to bare-name matching.

The engine parses each file's `ns` form so it can match qualified, aliased, and (only when the form licenses it) bare names, while skipping strings, comments, and the `ns` form itself. No new `cider-nrepl` middleware is involved.

- [x] The commits are consistent with our contribution guidelines
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`)
- [x] You've updated the changelog
- [x] You've updated the user manual