### PR TITLE
Add who-calls / who-is-called call-graph browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- [#3995](https://github.com/clojure-emacs/cider/pull/3995): Add `cider-who-calls` (`C-c C-w c`) and `cider-who-is-called` (`C-c C-w d`), SLIME-style call-graph browsers that present a function's callers/callees as an interactive tree you can expand a level at a time.
 - [#3994](https://github.com/clojure-emacs/cider/pull/3994): Find references by searching the project's source files, covering code that hasn't been loaded into the REPL yet: `xref-find-references` (`M-?`) now uses this source search by default (configurable via `cider-xref-references-mode`, which can also fold in the runtime references), and `cider-xref-fn-refs-in-source` (`C-c C-? s`) runs it explicitly.
 - [#3991](https://github.com/clojure-emacs/cider/pull/3991): Add `cider-enlighten-stop` to turn off enlightenment at once - it disables `cider-enlighten-mode`, clears the overlays, and ignores any further values still streaming from previously-instrumented code, so you no longer have to re-evaluate everything just to make it stop.
 - [#3990](https://github.com/clojure-emacs/cider/pull/3990): Add `cider-trace`, opening a dedicated `*cider-trace*` buffer that streams the calls and return values of traced functions live, instead of interleaving them into the REPL (requires a recent enough `cider-nrepl`).

--- a/doc/modules/ROOT/pages/usage/cider_mode.adoc
+++ b/doc/modules/ROOT/pages/usage/cider_mode.adoc
@@ -345,6 +345,14 @@ kbd:[C-c C-t C-b]
 | kbd:[C-c C-? C-d]
 | Display function deps (other functions used by it) in a minibuffer selector.
 
+| `cider-who-calls`
+| kbd:[C-c C-w c] (also kbd:[C-c C-? R])
+| Browse a function's callers as an expandable call-graph tree.
+
+| `cider-who-is-called`
+| kbd:[C-c C-w d] (also kbd:[C-c C-? D])
+| Browse a function's callees as an expandable call-graph tree.
+
 | `cider-pop-back`
 | kbd:[M-,]
 | Return to your pre-jump location.

--- a/doc/modules/ROOT/pages/usage/misc_features.adoc
+++ b/doc/modules/ROOT/pages/usage/misc_features.adoc
@@ -126,6 +126,33 @@ Don't forget you also have a couple of third-party alternatives:
 - The much more sophisticated AST-powered "find usages" provided by `clj-refactor.el`
 - https://github.com/bbatsov/projectile[Projectile's] "grep in project" (`projectile-grep`, typically bound to kbd:[C-c p g])
 
+=== Browsing the call graph
+
+The flat commands above answer "who uses this, right here". To explore further -
+"who calls the callers, and who calls them" - CIDER offers two SLIME-style
+browsers that present the same runtime data as an interactive tree:
+
+- `cider-who-calls` (kbd:[C-c C-w c]) shows the callers of the function at point
+- `cider-who-is-called` (kbd:[C-c C-w d]) shows what the function at point calls
+
+Each node can be expanded with kbd:[TAB] to reveal the next level of the graph,
+so you walk it one step at a time rather than computing the whole thing up
+front; every level is a single round trip, taken only when you ask for it.
+kbd:[n] and kbd:[p] move between nodes, kbd:[RET] (or kbd:[.]) jumps to a node's
+definition, and a function that calls back onto its own path is shown as a leaf
+so expansion can't loop forever.
+
+[NOTE]
+====
+Like the flat `cider-xref-fn-refs`, these browsers are powered by the runtime
+`fn-refs`/`fn-deps` ops, so they cover loaded Clojure-on-the-JVM code only.  Use
+`cider-xref-fn-refs-in-source` when you need to reach code that hasn't been
+evaluated, or ClojureScript.
+====
+
+The bindings are also available under the kbd:[C-c C-?] xref prefix, as
+kbd:[C-c C-? R] and kbd:[C-c C-? D].
+
 == CIDER Selector
 
 The `cider-selector` (kbd:[C-c M-s]) command allows you to quickly navigate to

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -421,7 +421,10 @@ If invoked with a prefix ARG eval the expression after inserting it."
      ["Find fn references and select" cider-xref-fn-refs-select]
      ["Find fn references in source" cider-xref-fn-refs-in-source]
      ["Find fn dependencies" cider-xref-fn-deps]
-     ["Find fn dependencies and select" cider-xref-fn-deps-select])
+     ["Find fn dependencies and select" cider-xref-fn-deps-select]
+     "--"
+     ["Who calls (tree)" cider-who-calls]
+     ["Who is called (tree)" cider-who-is-called])
     ("Browse"
      ["Browse namespace" cider-browse-ns]
      ["Browse all namespaces" cider-browse-ns-all]
@@ -505,6 +508,8 @@ If invoked with a prefix ARG eval the expression after inserting it."
 (declare-function cider-xref-fn-refs-select "cider-xref")
 (declare-function cider-xref-fn-deps "cider-xref")
 (declare-function cider-xref-fn-deps-select "cider-xref")
+(declare-function cider-who-calls "cider-xref-tree")
+(declare-function cider-who-is-called "cider-xref-tree")
 
 (defconst cider--has-many-mouse-buttons (not (memq window-system '(mac ns)))
   "Non-nil if system binds forward and back buttons to <mouse-8> and <mouse-9>.
@@ -578,6 +583,9 @@ higher precedence."
     (define-key map (kbd "C-c C-? s") #'cider-xref-fn-refs-in-source)
     (define-key map (kbd "C-c C-? d") #'cider-xref-fn-deps)
     (define-key map (kbd "C-c C-? C-d") #'cider-xref-fn-deps-select)
+    (define-key map (kbd "C-c C-? R") #'cider-who-calls)
+    (define-key map (kbd "C-c C-? D") #'cider-who-is-called)
+    (define-key map (kbd "C-c C-w") 'cider-who-map)
     (define-key map (kbd "C-c C-q") #'cider-quit)
     (define-key map (kbd "C-c M-r") #'cider-restart)
     ;; NOTE: all cider-log* vars are autoloaded. Please do not add a require.

--- a/lisp/cider-tree-view.el
+++ b/lisp/cider-tree-view.el
@@ -1,0 +1,197 @@
+;;; cider-tree-view.el --- A navigable, foldable tree view for result buffers -*- lexical-binding: t -*-
+
+;; Copyright © 2026 Bozhidar Batsov and CIDER contributors
+;;
+;; Author: Bozhidar Batsov <bozhidar@batsov.dev>
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+
+;; A small tree view for result buffers that present a hierarchy of items the
+;; user can navigate, expand, and act on - think \"who calls this function\", a
+;; call graph, or any flat list of jump-able results (a flat list is just a tree
+;; of depth one).
+;;
+;; A node (see `cider-tree-view-node') carries a display label, an optional
+;; primary action (`on-visit', bound to RET), and an optional `children-fn' that
+;; yields its child nodes.  Children are realized lazily: a node's `children-fn'
+;; runs the first time it is expanded, so a deep graph can be explored a level at
+;; a time without computing the whole thing up front.
+;;
+;; The buffer keeps the node model and re-renders from it on every expand or
+;; collapse, rather than juggling overlays in place.  That is a touch more work
+;; per toggle, but the trees here are small and the bookkeeping stays trivial.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'subr-x)
+
+(cl-defstruct (cider-tree-view-node (:constructor cider-tree-view-node-create)
+                                    (:copier nil))
+  "A single node in a `cider-tree-view' buffer.
+LABEL is the (already fontified) string shown for the node.  ON-VISIT, when
+non-nil, is a function of no arguments run as the node's primary action.
+CHILDREN-FN, when non-nil, is a function of no arguments returning a list of
+child `cider-tree-view-node's; its presence is what makes a node expandable.
+The remaining slots are display state managed by this module."
+  label
+  on-visit
+  children-fn
+  (expanded nil)
+  (children 'unloaded))
+
+(defvar-local cider-tree-view--roots nil
+  "The list of root `cider-tree-view-node's rendered in this buffer.")
+
+(defun cider-tree-view-node-expandable-p (node)
+  "Return non-nil when NODE can have children.
+A node with a `children-fn' is expandable until that function has run and
+returned nothing, at which point it is known to be a leaf."
+  (and (cider-tree-view-node-children-fn node)
+       (let ((children (cider-tree-view-node-children node)))
+         (or (eq children 'unloaded) children))
+       t))
+
+(defun cider-tree-view--children (node)
+  "Return NODE's children, realizing them via its `children-fn' on first use."
+  (when (eq (cider-tree-view-node-children node) 'unloaded)
+    (setf (cider-tree-view-node-children node)
+          (when-let* ((fn (cider-tree-view-node-children-fn node)))
+            (funcall fn))))
+  (cider-tree-view-node-children node))
+
+(defun cider-tree-view--node-at-point ()
+  "Return the `cider-tree-view-node' on the current line, or nil."
+  (get-text-property (point) 'cider-tree-view-node))
+
+(defvar cider-tree-view--node-keymap
+  (let ((map (make-sparse-keymap)))
+    (define-key map [mouse-1] #'cider-tree-view-visit)
+    map)
+  "Keymap put on a node's label so a click visits it.")
+
+(defun cider-tree-view--insert-node (node depth)
+  "Insert NODE at indentation DEPTH, recursing into expanded children."
+  (let* ((expandable (cider-tree-view-node-expandable-p node))
+         (indicator (cond ((not expandable) "  ")
+                          ((cider-tree-view-node-expanded node) "▾ ")
+                          (t "▸ ")))
+         (start (point)))
+    (insert (make-string (* 2 depth) ?\s)
+            (propertize indicator 'face 'shadow))
+    (let ((label-start (point)))
+      (insert (cider-tree-view-node-label node))
+      (when (cider-tree-view-node-on-visit node)
+        (put-text-property label-start (point) 'mouse-face 'highlight)
+        (put-text-property label-start (point) 'keymap cider-tree-view--node-keymap)))
+    (insert "\n")
+    (put-text-property start (point) 'cider-tree-view-node node)
+    (when (and expandable (cider-tree-view-node-expanded node))
+      (dolist (child (cider-tree-view--children node))
+        (cider-tree-view--insert-node child (1+ depth))))))
+
+(defun cider-tree-view--render ()
+  "Redraw the whole tree from `cider-tree-view--roots'."
+  (let ((inhibit-read-only t))
+    (erase-buffer)
+    (dolist (root cider-tree-view--roots)
+      (cider-tree-view--insert-node root 0))))
+
+(defun cider-tree-view--goto-node (node)
+  "Move point to the line rendering NODE, if it is on screen."
+  (goto-char (point-min))
+  (when-let* ((match (text-property-search-forward 'cider-tree-view-node node #'eq)))
+    (goto-char (prop-match-beginning match))))
+
+(defun cider-tree-view-toggle ()
+  "Expand or collapse the node on the current line.
+Expanding realizes the node's children on first use; a node that turns out to
+have none is demoted to a leaf rather than expanding into nothing."
+  (interactive)
+  (let ((node (cider-tree-view--node-at-point)))
+    (cond
+     ((null node) (user-error "No node here"))
+     ((not (cider-tree-view-node-expandable-p node)) (user-error "Node is a leaf"))
+     ((cider-tree-view-node-expanded node)
+      (setf (cider-tree-view-node-expanded node) nil))
+     (t
+      ;; realize the children; an empty result leaves the node a leaf
+      (setf (cider-tree-view-node-expanded node)
+            (and (cider-tree-view--children node) t))))
+    (cider-tree-view--render)
+    (cider-tree-view--goto-node node)))
+
+(defun cider-tree-view-visit (&optional event)
+  "Run the primary action of the node on the current line.
+EVENT is the mouse event, when invoked with the mouse."
+  (interactive (list last-nonmenu-event))
+  (when (mouse-event-p event)
+    (mouse-set-point event))
+  (let ((node (cider-tree-view--node-at-point)))
+    (cond
+     ((null node) (user-error "No node here"))
+     ((cider-tree-view-node-on-visit node) (funcall (cider-tree-view-node-on-visit node)))
+     (t (user-error "Nothing to visit here")))))
+
+(defun cider-tree-view-next-node ()
+  "Move point to the next node."
+  (interactive)
+  (if-let* ((match (text-property-search-forward 'cider-tree-view-node nil nil t)))
+      (goto-char (prop-match-beginning match))
+    (user-error "No next node")))
+
+(defun cider-tree-view-previous-node ()
+  "Move point to the previous node."
+  (interactive)
+  (if-let* ((match (text-property-search-backward 'cider-tree-view-node nil nil t)))
+      (goto-char (prop-match-beginning match))
+    (user-error "No previous node")))
+
+(defvar cider-tree-view-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "TAB") #'cider-tree-view-toggle)
+    (define-key map (kbd "RET") #'cider-tree-view-visit)
+    (define-key map (kbd ".") #'cider-tree-view-visit)
+    (define-key map (kbd "n") #'cider-tree-view-next-node)
+    (define-key map (kbd "p") #'cider-tree-view-previous-node)
+    (define-key map (kbd "q") #'quit-window)
+    map)
+  "Keymap for `cider-tree-view-mode'.")
+
+(define-derived-mode cider-tree-view-mode special-mode "cider-tree-view"
+  "Major mode for navigable, foldable CIDER result trees.
+
+\\{cider-tree-view-mode-map}"
+  (setq-local truncate-lines t))
+
+(defun cider-tree-view-render (roots title)
+  "Render ROOTS in the current buffer, which must be in `cider-tree-view-mode'.
+TITLE is shown in the header line; point is left on the first node.  Callers are
+expected to have created and displayed the buffer (e.g. via `cider-popup-buffer')
+before handing it here."
+  (setq cider-tree-view--roots roots)
+  (setq-local header-line-format
+              (concat (propertize (format " %s" title) 'face 'bold)
+                      (propertize
+                       "   n/p: move   TAB: expand   RET/.: visit   q: quit"
+                       'face 'shadow)))
+  (cider-tree-view--render)
+  (goto-char (point-min)))
+
+(provide 'cider-tree-view)
+;;; cider-tree-view.el ends here

--- a/lisp/cider-xref-tree.el
+++ b/lisp/cider-xref-tree.el
@@ -1,0 +1,120 @@
+;;; cider-xref-tree.el --- Call-graph browsers built on cider-tree -*- lexical-binding: t -*-
+
+;; Copyright © 2026 Bozhidar Batsov and CIDER contributors
+;;
+;; Author: Bozhidar Batsov <bozhidar@batsov.dev>
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+
+;; SLIME-style call-graph browsers, presented as interactive trees (see
+;; `cider-tree-view').  `cider-who-calls' shows who calls a var;
+;; `cider-who-is-called' shows what a var calls.  Either node can be expanded to
+;; reveal the next level, so the call graph is walked a level at a time rather
+;; than computed whole.
+;;
+;; Both are powered by the runtime `fn-refs'/`fn-deps' ops, so - like the flat
+;; `cider-xref-fn-refs' - they see loaded Clojure-on-the-JVM code only.  The
+;; lazy, on-demand expansion is what keeps that bearable: each level is one round
+;; trip, taken only when the user asks for it.
+
+;;; Code:
+
+(require 'cider-client)
+(require 'cider-find)
+(require 'cider-popup)
+(require 'cider-tree-view)
+(require 'cider-util)
+(require 'nrepl-dict)
+
+(defun cider-xref-tree--children (var op ns ancestors)
+  "Build child nodes of VAR by calling OP in namespace NS.
+OP is `cider-sync-request:fn-refs' (callers) or `cider-sync-request:fn-deps'
+\(callees).  Every name OP returns is already namespace-qualified, so NS only
+disambiguates the (qualified) root and is threaded through unchanged; ANCESTORS
+is the path so far, used by `cider-xref-tree--node' for cycle detection."
+  (mapcar (lambda (dict)
+            (cider-xref-tree--node (nrepl-dict-get dict "name") op ns ancestors))
+          (funcall op ns var)))
+
+(defun cider-xref-tree--node (var op ns ancestors)
+  "Return a `cider-tree-view-node' for VAR expanding via OP in namespace NS.
+ANCESTORS is the list of qualified names on the path from the root; a VAR that
+recurs onto its own path is rendered as a non-expandable leaf so expansion can't
+loop forever."
+  (let ((recursive (member var ancestors)))
+    (cider-tree-view-node-create
+     :label (concat (cider-font-lock-as-clojure var)
+                    (when recursive (propertize "  (recursive)" 'face 'shadow)))
+     :on-visit (lambda () (cider-find-var nil var))
+     :children-fn (unless recursive
+                    (lambda ()
+                      (cider-xref-tree--children var op ns (cons var ancestors)))))))
+
+(defun cider-xref-tree--browse (symbol op op-name buffer-name title-fmt noun)
+  "Open a call-graph tree rooted at SYMBOL, expanding via OP.
+OP-NAME is the nREPL op SYMBOL's children come from; BUFFER-NAME and TITLE-FMT
+name and describe the buffer; NOUN names the search for the prompt.  Resolves
+SYMBOL up front, signalling a typo/unloaded-namespace hint when it can't be."
+  (cider-ensure-connected)
+  (cider-ensure-op-supported op-name)
+  (let* ((symbol (or symbol (cider-symbol-at-point)
+                     (read-string (format "%s: " noun))))
+         (info (or (cider-var-info symbol)
+                   (user-error "%s" (cider-resolution-failure-message symbol))))
+         (var (concat (nrepl-dict-get info "ns") "/" (nrepl-dict-get info "name")))
+         ;; capture the source buffer's namespace now - by the time a node is
+         ;; expanded the current buffer is the popup, not the source.
+         (ns (cider-current-ns))
+         (root (cider-xref-tree--node var op ns nil)))
+    (with-current-buffer (cider-popup-buffer buffer-name 'select
+                                             'cider-tree-view-mode 'ancillary)
+      (cider-tree-view-render (list root) (format title-fmt var)))))
+
+;;;###autoload
+(defun cider-who-calls (&optional symbol)
+  "Browse the callers of SYMBOL as an interactive tree.
+Expand a node to reveal its own callers and walk the call graph upward.  Uses
+the runtime `fn-refs' op, so it covers loaded Clojure-on-the-JVM code."
+  (interactive)
+  (cider-xref-tree--browse symbol #'cider-sync-request:fn-refs "cider/fn-refs"
+                           "*cider-who-calls*" "Callers of %s" "Who calls"))
+
+;;;###autoload
+(defun cider-who-is-called (&optional symbol)
+  "Browse the callees of SYMBOL as an interactive tree.
+Expand a node to reveal what it calls in turn and walk the call graph downward.
+Uses the runtime `fn-deps' op, so it covers loaded Clojure-on-the-JVM code."
+  (interactive)
+  (cider-xref-tree--browse symbol #'cider-sync-request:fn-deps "cider/fn-deps"
+                           "*cider-who-is-called*" "Called by %s" "What is called by"))
+
+;;;###autoload (autoload 'cider-who-map "cider-xref-tree" "CIDER call-graph keymap." nil 'keymap)
+(defvar cider-who-map
+  (let ((map (define-prefix-command 'cider-who-map)))
+    (define-key map (kbd "c") #'cider-who-calls)
+    (define-key map (kbd "C-c") #'cider-who-calls)
+    (define-key map (kbd "d") #'cider-who-is-called)
+    (define-key map (kbd "C-d") #'cider-who-is-called)
+    map)
+  "CIDER call-graph (\"who calls\") keymap.
+The letters mirror SLIME's who-map: `c' for callers and `d' for callees.  The
+letters `m' (macro use sites) and `i' (protocol/multimethod implementations)
+are left free for future views.")
+
+(provide 'cider-xref-tree)
+;;; cider-xref-tree.el ends here

--- a/test/cider-tree-view-tests.el
+++ b/test/cider-tree-view-tests.el
@@ -1,0 +1,114 @@
+;;; cider-tree-view-tests.el  -*- lexical-binding: t; -*-
+
+;; Copyright © 2026 Bozhidar Batsov
+
+;; Author: Bozhidar Batsov <bozhidar@batsov.dev>
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; This file is part of CIDER
+
+;;; Code:
+
+(require 'buttercup)
+(require 'cider-tree-view)
+
+;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
+
+(defun cider-tree-view-tests--render (roots)
+  "Render ROOTS into the current buffer in `cider-tree-view-mode'."
+  (cider-tree-view-mode)
+  (cider-tree-view-render roots "test"))
+
+(describe "cider-tree-view expansion"
+  (it "realizes children lazily and only once"
+    (with-temp-buffer
+      (let* ((calls 0)
+             (root (cider-tree-view-node-create
+                    :label "root"
+                    :children-fn (lambda ()
+                                   (setq calls (1+ calls))
+                                   (list (cider-tree-view-node-create :label "a")
+                                         (cider-tree-view-node-create :label "b"))))))
+        (cider-tree-view-tests--render (list root))
+        ;; collapsed: children-fn untouched, only the root line is shown
+        (expect calls :to-equal 0)
+        (expect (count-lines (point-min) (point-max)) :to-equal 1)
+        ;; expand: children-fn runs once and both children appear
+        (goto-char (point-min))
+        (cider-tree-view-toggle)
+        (expect calls :to-equal 1)
+        (expect (count-lines (point-min) (point-max)) :to-equal 3)
+        ;; collapse then re-expand: children are cached, no second fetch
+        (cider-tree-view--goto-node root)
+        (cider-tree-view-toggle)
+        (expect (count-lines (point-min) (point-max)) :to-equal 1)
+        (cider-tree-view--goto-node root)
+        (cider-tree-view-toggle)
+        (expect calls :to-equal 1)
+        (expect (count-lines (point-min) (point-max)) :to-equal 3))))
+
+  (it "refuses to expand a leaf"
+    (with-temp-buffer
+      (cider-tree-view-tests--render
+       (list (cider-tree-view-node-create :label "leaf")))
+      (goto-char (point-min))
+      (expect (cider-tree-view-toggle) :to-throw 'user-error)))
+
+  (it "demotes an expandable node to a leaf when it has no children"
+    (with-temp-buffer
+      (let ((root (cider-tree-view-node-create
+                   :label "root"
+                   :children-fn (lambda () nil))))
+        (cider-tree-view-tests--render (list root))
+        ;; looks expandable until probed
+        (expect (cider-tree-view-node-expandable-p root) :to-be-truthy)
+        (goto-char (point-min))
+        ;; probing finds nothing: no error, and the node becomes a leaf
+        (cider-tree-view-toggle)
+        (expect (cider-tree-view-node-expandable-p root) :not :to-be-truthy)
+        (expect (count-lines (point-min) (point-max)) :to-equal 1)))))
+
+(describe "cider-tree-view navigation and visiting"
+  (it "moves between nodes and runs the node's action"
+    (with-temp-buffer
+      (let* ((visited nil)
+             (child (cider-tree-view-node-create
+                     :label "child"
+                     :on-visit (lambda () (setq visited "child"))))
+             (root (cider-tree-view-node-create
+                    :label "root"
+                    :expanded t
+                    :children-fn (lambda () (list child)))))
+        (cider-tree-view-tests--render (list root))
+        ;; from the root, n moves to the child line
+        (goto-char (point-min))
+        (cider-tree-view-next-node)
+        (expect (cider-tree-view-node-label (cider-tree-view--node-at-point))
+                :to-equal "child")
+        ;; visiting the child fires its action
+        (cider-tree-view-visit)
+        (expect visited :to-equal "child")
+        ;; p moves back to the root
+        (cider-tree-view-previous-node)
+        (expect (cider-tree-view-node-label (cider-tree-view--node-at-point))
+                :to-equal "root")))))
+
+(provide 'cider-tree-view-tests)
+
+;;; cider-tree-view-tests.el ends here

--- a/test/cider-xref-tree-tests.el
+++ b/test/cider-xref-tree-tests.el
@@ -1,0 +1,71 @@
+;;; cider-xref-tree-tests.el  -*- lexical-binding: t; -*-
+
+;; Copyright © 2026 Bozhidar Batsov
+
+;; Author: Bozhidar Batsov <bozhidar@batsov.dev>
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; This file is part of CIDER
+
+;;; Code:
+
+(require 'buttercup)
+(require 'nrepl-dict)
+(require 'cider-tree-view)
+(require 'cider-xref-tree)
+
+;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
+
+(describe "cider-xref-tree--node"
+  (before-each
+    ;; A tiny caller graph: foo is called by bar; bar is called by foo (a cycle)
+    ;; and by baz.
+    (spy-on 'cider-sync-request:fn-refs :and-call-fake
+            (lambda (_ns var)
+              (pcase var
+                ("my.ns/foo" (list (nrepl-dict "name" "my.ns/bar")))
+                ("my.ns/bar" (list (nrepl-dict "name" "my.ns/foo")
+                                   (nrepl-dict "name" "my.ns/baz")))
+                (_ nil)))))
+
+  (it "expands lazily, one round trip per level"
+    (let ((root (cider-xref-tree--node "my.ns/foo" #'cider-sync-request:fn-refs
+                                       "my.ns" nil)))
+      (expect (cider-tree-view-node-expandable-p root) :to-be-truthy)
+      ;; building the node alone must not hit the op
+      (expect 'cider-sync-request:fn-refs :not :to-have-been-called)
+      (let ((children (funcall (cider-tree-view-node-children-fn root))))
+        (expect 'cider-sync-request:fn-refs :to-have-been-called-times 1)
+        (expect (length children) :to-equal 1))))
+
+  (it "stops a cycle by making the recurring node a leaf"
+    (let* ((root (cider-xref-tree--node "my.ns/foo" #'cider-sync-request:fn-refs
+                                        "my.ns" nil))
+           (bar (car (funcall (cider-tree-view-node-children-fn root))))
+           (grandkids (funcall (cider-tree-view-node-children-fn bar))))
+      ;; bar is called by foo (already on the path -> leaf) and baz (expandable)
+      (expect (length grandkids) :to-equal 2)
+      (expect (length (seq-remove #'cider-tree-view-node-expandable-p grandkids))
+              :to-equal 1)
+      (expect (length (seq-filter #'cider-tree-view-node-expandable-p grandkids))
+              :to-equal 1))))
+
+(provide 'cider-xref-tree-tests)
+
+;;; cider-xref-tree-tests.el ends here


### PR DESCRIPTION
The flat `cider-xref-fn-refs` answers "who uses this, right here". This adds two SLIME-style browsers - `cider-who-calls` (`C-c C-w c`) and `cider-who-is-called` (`C-c C-w d`) - that present the same runtime `fn-refs`/`fn-deps` data as an interactive tree you can expand a level at a time. Each level is a single round trip, taken only when you ask for it, and a function that recurs onto its own path is drawn as a leaf so expansion can't loop.

They sit on a new generic `cider-tree-view` widget (lazy children, `n`/`p`/`TAB`/`RET`), which is deliberately decoupled from the rest of CIDER so other result buffers can adopt it down the line. Bindings are also mirrored under the xref prefix (`C-c C-? R` / `C-c C-? D`); the who-map reserves `m` and `i` for the macro-use-site and protocol/multimethod-implementation views that are the other genuinely Clojure-applicable members of SLIME's who-family.

Like the flat command, these are powered by the runtime ops, so they cover loaded Clojure-on-the-JVM code only - the docs point at `cider-xref-fn-refs-in-source` for unloaded code and ClojureScript.

- [x] The commits are consistent with our contribution guidelines
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`)
- [x] You've updated the changelog
- [x] You've updated the user manual