### PR TITLE
Add cider-who-macroexpands to find macro use sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- [#3996](https://github.com/clojure-emacs/cider/pull/3996): Add `cider-who-macroexpands` (`C-c C-w m`), which finds a macro's use sites by searching the project's source - the runtime ops can't see them, since macros are expanded away at compile time.
 - [#3995](https://github.com/clojure-emacs/cider/pull/3995): Add `cider-who-calls` (`C-c C-w c`) and `cider-who-is-called` (`C-c C-w d`), SLIME-style call-graph browsers that present a function's callers/callees as an interactive tree you can expand a level at a time.
 - [#3994](https://github.com/clojure-emacs/cider/pull/3994): Find references by searching the project's source files, covering code that hasn't been loaded into the REPL yet: `xref-find-references` (`M-?`) now uses this source search by default (configurable via `cider-xref-references-mode`, which can also fold in the runtime references), and `cider-xref-fn-refs-in-source` (`C-c C-? s`) runs it explicitly.
 - [#3991](https://github.com/clojure-emacs/cider/pull/3991): Add `cider-enlighten-stop` to turn off enlightenment at once - it disables `cider-enlighten-mode`, clears the overlays, and ignores any further values still streaming from previously-instrumented code, so you no longer have to re-evaluate everything just to make it stop.

--- a/doc/modules/ROOT/pages/usage/cider_mode.adoc
+++ b/doc/modules/ROOT/pages/usage/cider_mode.adoc
@@ -353,6 +353,10 @@ kbd:[C-c C-t C-b]
 | kbd:[C-c C-w d] (also kbd:[C-c C-? D])
 | Browse a function's callees as an expandable call-graph tree.
 
+| `cider-who-macroexpands`
+| kbd:[C-c C-w m]
+| Find a macro's use sites by searching the project's source.
+
 | `cider-pop-back`
 | kbd:[M-,]
 | Return to your pre-jump location.

--- a/doc/modules/ROOT/pages/usage/misc_features.adoc
+++ b/doc/modules/ROOT/pages/usage/misc_features.adoc
@@ -150,6 +150,12 @@ Like the flat `cider-xref-fn-refs`, these browsers are powered by the runtime
 evaluated, or ClojureScript.
 ====
 
+Macros are a special case: they're expanded away at compile time, so the runtime
+ops never see their call sites and `cider-who-calls` comes up empty for them.
+`cider-who-macroexpands` (kbd:[C-c C-w m]) finds a macro's use sites by searching
+the project's source instead (the same mechanism as
+`cider-xref-fn-refs-in-source`).
+
 The bindings are also available under the kbd:[C-c C-?] xref prefix, as
 kbd:[C-c C-? R] and kbd:[C-c C-? D].
 

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -424,7 +424,8 @@ If invoked with a prefix ARG eval the expression after inserting it."
      ["Find fn dependencies and select" cider-xref-fn-deps-select]
      "--"
      ["Who calls (tree)" cider-who-calls]
-     ["Who is called (tree)" cider-who-is-called])
+     ["Who is called (tree)" cider-who-is-called]
+     ["Who macroexpands (source)" cider-who-macroexpands])
     ("Browse"
      ["Browse namespace" cider-browse-ns]
      ["Browse all namespaces" cider-browse-ns-all]
@@ -508,6 +509,7 @@ If invoked with a prefix ARG eval the expression after inserting it."
 (declare-function cider-xref-fn-refs-select "cider-xref")
 (declare-function cider-xref-fn-deps "cider-xref")
 (declare-function cider-xref-fn-deps-select "cider-xref")
+(declare-function cider-who-macroexpands "cider-xref")
 (declare-function cider-who-calls "cider-xref-tree")
 (declare-function cider-who-is-called "cider-xref-tree")
 

--- a/lisp/cider-xref-tree.el
+++ b/lisp/cider-xref-tree.el
@@ -41,6 +41,9 @@
 (require 'cider-util)
 (require 'nrepl-dict)
 
+;; bound in `cider-who-map' below, but defined in cider-xref.el
+(declare-function cider-who-macroexpands "cider-xref")
+
 (defun cider-xref-tree--children (var op ns ancestors)
   "Build child nodes of VAR by calling OP in namespace NS.
 OP is `cider-sync-request:fn-refs' (callers) or `cider-sync-request:fn-deps'
@@ -110,11 +113,13 @@ Uses the runtime `fn-deps' op, so it covers loaded Clojure-on-the-JVM code."
     (define-key map (kbd "C-c") #'cider-who-calls)
     (define-key map (kbd "d") #'cider-who-is-called)
     (define-key map (kbd "C-d") #'cider-who-is-called)
+    (define-key map (kbd "m") #'cider-who-macroexpands)
+    (define-key map (kbd "C-m") #'cider-who-macroexpands)
     map)
   "CIDER call-graph (\"who calls\") keymap.
-The letters mirror SLIME's who-map: `c' for callers and `d' for callees.  The
-letters `m' (macro use sites) and `i' (protocol/multimethod implementations)
-are left free for future views.")
+The letters mirror SLIME's who-map: `c' for callers, `d' for callees, and `m'
+for a macro's use sites.  The letter `i' (protocol/multimethod implementations)
+is left free for a future view.")
 
 (provide 'cider-xref-tree)
 ;;; cider-xref-tree.el ends here

--- a/lisp/cider-xref.el
+++ b/lisp/cider-xref.el
@@ -147,13 +147,33 @@ bare name and is correspondingly more approximate.
 The results are textual matches and can include false positives such as
 shadowing locals or same-named vars from a different namespace."
   (interactive)
-  (let* ((symbol (or symbol (cider-symbol-at-point) (read-string "Find references in source for: ")))
-         (xrefs (cider-xref--var-source-references symbol)))
-    (if xrefs
-        (funcall xref-show-xrefs-function
-                 (lambda () xrefs)
-                 `((window . ,(selected-window))))
-      (user-error "No source references found for %s" symbol))))
+  (let ((symbol (or symbol (cider-symbol-at-point)
+                    (read-string "Find references in source for: "))))
+    (cider-xref--show-source-references symbol)))
+
+(defun cider-xref--show-source-references (symbol)
+  "Show SYMBOL's project-source references via xref, or report none found."
+  (if-let* ((xrefs (cider-xref--var-source-references symbol)))
+      (funcall xref-show-xrefs-function
+               (lambda () xrefs)
+               `((window . ,(selected-window))))
+    (user-error "No source references found for %s" symbol)))
+
+;;;###autoload
+(defun cider-who-macroexpands (&optional symbol)
+  "Show the use sites of the macro SYMBOL by scanning the project's source.
+Macro calls are expanded away at compile time, so the runtime `fn-refs' op (and
+hence `cider-who-calls') can't see them; this finds them textually instead, the
+same way `cider-xref-fn-refs-in-source' does.  It works for any var, but for a
+function `cider-who-calls' is usually the better tool."
+  (interactive)
+  (let ((symbol (or symbol (cider-symbol-at-point)
+                    (read-string "Macro use sites of: "))))
+    (when-let* ((info (cider-var-info symbol)))
+      (unless (string= (nrepl-dict-get info "macro") "true")
+        (message "%s doesn't look like a macro; showing its source references anyway"
+                 symbol)))
+    (cider-xref--show-source-references symbol)))
 
 ;;;###autoload
 (defun cider-xref-fn-deps (&optional ns symbol)

--- a/test/cider-xref-tests.el
+++ b/test/cider-xref-tests.el
@@ -42,6 +42,40 @@
     (spy-on 'cider-resolution-failure-message :and-return-value "nope")
     (expect (cider-xref--report-no-results "foo" "references") :to-throw 'user-error)))
 
+(describe "cider-who-macroexpands"
+  (it "shows the macro's source references"
+    (spy-on 'cider-var-info :and-return-value (nrepl-dict "macro" "true"))
+    (spy-on 'cider-xref--var-source-references :and-return-value '(ref))
+    (let* ((shown nil)
+           (xref-show-xrefs-function (lambda (fetcher _alist)
+                                       (setq shown (funcall fetcher)))))
+      (cider-who-macroexpands "my.ns/when-let")
+      (expect 'cider-xref--var-source-references :to-have-been-called-with "my.ns/when-let")
+      (expect shown :to-equal '(ref))))
+
+  (it "notes when the symbol isn't a macro but still searches"
+    (spy-on 'cider-var-info :and-return-value (nrepl-dict "macro" "false"))
+    (spy-on 'cider-xref--var-source-references :and-return-value '(ref))
+    (spy-on 'message)
+    (let ((xref-show-xrefs-function (lambda (&rest _) nil)))
+      (cider-who-macroexpands "my.ns/inc")
+      (expect 'message :to-have-been-called)
+      (expect 'cider-xref--var-source-references :to-have-been-called)))
+
+  (it "still searches when the symbol doesn't resolve"
+    (spy-on 'cider-var-info :and-return-value nil)
+    (spy-on 'cider-xref--var-source-references :and-return-value '(ref))
+    (spy-on 'message)
+    (let ((xref-show-xrefs-function (lambda (&rest _) nil)))
+      (cider-who-macroexpands "my.ns/unloaded")
+      (expect 'message :not :to-have-been-called)
+      (expect 'cider-xref--var-source-references :to-have-been-called)))
+
+  (it "errors when there are no source references"
+    (spy-on 'cider-var-info :and-return-value (nrepl-dict "macro" "true"))
+    (spy-on 'cider-xref--var-source-references :and-return-value nil)
+    (expect (cider-who-macroexpands "my.ns/nope") :to-throw 'user-error)))
+
 (provide 'cider-xref-tests)
 
 ;;; cider-xref-tests.el ends here


### PR DESCRIPTION
Completes the SLIME-style who-map from #3995. Macros are expanded away at compile time, so the runtime `fn-refs` op never sees their call sites and `cider-who-calls` comes up empty for a macro. `cider-who-macroexpands` (`C-c C-w m`) finds them by searching the project's source instead, reusing the same engine as `cider-xref-fn-refs-in-source`. The shared "show source references via xref" bit is factored into a small helper.

It works for any var, but gently notes when the symbol isn't actually a macro (for functions `cider-who-calls` is the better tool).

- [x] The commits are consistent with our contribution guidelines
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`)
- [x] You've updated the changelog
- [x] You've updated the user manual