### PR TITLE
Add cider-who-implements for protocols and multimethods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- [#3997](https://github.com/clojure-emacs/cider/pull/3997): Add `cider-who-implements` (`C-c C-w i`), which browses a protocol's implementing types or a multimethod's dispatch values on an expandable tree. (Currently a client-side approximation; inline `defrecord`/`deftype` impls and per-`defmethod` jumps await a follow-up middleware op.)
 - [#3996](https://github.com/clojure-emacs/cider/pull/3996): Add `cider-who-macroexpands` (`C-c C-w m`), which finds a macro's use sites by searching the project's source - the runtime ops can't see them, since macros are expanded away at compile time.
 - [#3995](https://github.com/clojure-emacs/cider/pull/3995): Add `cider-who-calls` (`C-c C-w c`) and `cider-who-is-called` (`C-c C-w d`), SLIME-style call-graph browsers that present a function's callers/callees as an interactive tree you can expand a level at a time.
 - [#3994](https://github.com/clojure-emacs/cider/pull/3994): Find references by searching the project's source files, covering code that hasn't been loaded into the REPL yet: `xref-find-references` (`M-?`) now uses this source search by default (configurable via `cider-xref-references-mode`, which can also fold in the runtime references), and `cider-xref-fn-refs-in-source` (`C-c C-? s`) runs it explicitly.

--- a/doc/modules/ROOT/pages/usage/cider_mode.adoc
+++ b/doc/modules/ROOT/pages/usage/cider_mode.adoc
@@ -357,6 +357,10 @@ kbd:[C-c C-t C-b]
 | kbd:[C-c C-w m]
 | Find a macro's use sites by searching the project's source.
 
+| `cider-who-implements`
+| kbd:[C-c C-w i]
+| Browse a protocol's implementing types or a multimethod's dispatch values.
+
 | `cider-pop-back`
 | kbd:[M-,]
 | Return to your pre-jump location.

--- a/doc/modules/ROOT/pages/usage/misc_features.adoc
+++ b/doc/modules/ROOT/pages/usage/misc_features.adoc
@@ -156,8 +156,22 @@ ops never see their call sites and `cider-who-calls` comes up empty for them.
 the project's source instead (the same mechanism as
 `cider-xref-fn-refs-in-source`).
 
-The bindings are also available under the kbd:[C-c C-?] xref prefix, as
-kbd:[C-c C-? R] and kbd:[C-c C-? D].
+`cider-who-implements` (kbd:[C-c C-w i]) goes the other way around: point it at a
+protocol and it lists the types that extend it; point it at a multimethod and it
+lists its dispatch values, all on the same expandable tree.
+
+[NOTE]
+====
+`cider-who-implements` is currently a client-side approximation.  It sees the
+types registered via `extend`/`extend-type`/`extend-protocol`, but not inline
+`defrecord`/`deftype`/`reify` implementers (those implement the protocol's
+generated interface rather than extending it), and it can't yet jump to an
+individual `defmethod`, since those methods carry no source metadata at runtime.
+Rounding this out is slated for a follow-up that adds the necessary middleware.
+====
+
+The call-graph bindings are also available under the kbd:[C-c C-?] xref prefix,
+as kbd:[C-c C-? R] and kbd:[C-c C-? D].
 
 == CIDER Selector
 

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -425,7 +425,8 @@ If invoked with a prefix ARG eval the expression after inserting it."
      "--"
      ["Who calls (tree)" cider-who-calls]
      ["Who is called (tree)" cider-who-is-called]
-     ["Who macroexpands (source)" cider-who-macroexpands])
+     ["Who macroexpands (source)" cider-who-macroexpands]
+     ["Who implements (protocol/multimethod)" cider-who-implements])
     ("Browse"
      ["Browse namespace" cider-browse-ns]
      ["Browse all namespaces" cider-browse-ns-all]
@@ -512,6 +513,7 @@ If invoked with a prefix ARG eval the expression after inserting it."
 (declare-function cider-who-macroexpands "cider-xref")
 (declare-function cider-who-calls "cider-xref-tree")
 (declare-function cider-who-is-called "cider-xref-tree")
+(declare-function cider-who-implements "cider-xref-tree")
 
 (defconst cider--has-many-mouse-buttons (not (memq window-system '(mac ns)))
   "Non-nil if system binds forward and back buttons to <mouse-8> and <mouse-9>.

--- a/lisp/cider-xref-tree.el
+++ b/lisp/cider-xref-tree.el
@@ -40,6 +40,7 @@
 (require 'cider-tree-view)
 (require 'cider-util)
 (require 'nrepl-dict)
+(require 'parseedn)
 
 ;; bound in `cider-who-map' below, but defined in cider-xref.el
 (declare-function cider-who-macroexpands "cider-xref")
@@ -106,6 +107,96 @@ Uses the runtime `fn-deps' op, so it covers loaded Clojure-on-the-JVM code."
   (cider-xref-tree--browse symbol #'cider-sync-request:fn-deps "cider/fn-deps"
                            "*cider-who-is-called*" "Called by %s" "What is called by"))
 
+
+;;; who-implements - protocol/multimethod implementations.
+;;
+;; This is a client-side approximation: it evaluates a little introspection form
+;; to read a protocol's `extenders' or a multimethod's dispatch values.  It can't
+;; see inline `defrecord'/`deftype'/`reify' implementers (they implement the
+;; protocol's generated interface, not via `extend'), nor per-`defmethod' source
+;; locations (the methods are anonymous fns with no metadata) - those need richer
+;; introspection than the runtime exposes, slated for a follow-up middleware op.
+
+(defconst cider-xref-tree--implements-code
+  "(let [v (resolve '%s) x (when v (deref v))]
+     (into [(cond (instance? clojure.lang.MultiFn x) \"multimethod\"
+                  (and (map? x) (:on-interface x)) \"protocol\"
+                  :else \"other\")]
+           (cond (instance? clojure.lang.MultiFn x)
+                 (mapv pr-str (sort-by str (keys (methods x))))
+                 (and (map? x) (:on-interface x))
+                 (sort (mapv #(.getName ^Class %%) (extenders x)))
+                 :else [])))"
+  "Clojure form (with a `%s' for the var) classifying it and listing its impls.
+Returns a vector whose head is \"protocol\", \"multimethod\" or \"other\" and
+whose tail is the implementation names (extender classes or dispatch values).")
+
+(defun cider-xref-tree--implements (var)
+  "Classify VAR and list its implementations via a tooling eval.
+Return a cons of the kind (\"protocol\"/\"multimethod\"/\"other\") and the list
+of implementation strings, or nil when the eval yields nothing."
+  (when-let* ((result (cider-sync-tooling-eval
+                       (format cider-xref-tree--implements-code var)
+                       (cider-current-ns)))
+              (value (nrepl-dict-get result "value"))
+              (vec (ignore-errors (parseedn-read-str value))))
+    (when (and (vectorp vec) (> (length vec) 0))
+      (let ((items (append vec nil)))
+        (cons (car items) (cdr items))))))
+
+(defun cider-xref-tree--show-implements (var impls title-fmt noun jumpable)
+  "Render IMPLS of VAR in a popup titled by TITLE-FMT.
+NOUN names the implementations for the empty-result message; when JUMPABLE,
+each implementation node jumps to its own definition (protocol extenders are
+types; multimethod dispatch values are plain data with nowhere to jump)."
+  (unless impls
+    (user-error "No %s found for %s%s" noun var
+                (if jumpable
+                    " (inline defrecord/deftype/reify impls aren't visible yet)"
+                  "")))
+  (let ((root (cider-tree-view-node-create
+               :label (cider-font-lock-as-clojure var)
+               :on-visit (lambda () (cider-find-var nil var))
+               :expanded t
+               :children-fn
+               (lambda ()
+                 (mapcar (lambda (impl)
+                           (cider-tree-view-node-create
+                            :label (cider-font-lock-as-clojure impl)
+                            :on-visit (when jumpable
+                                        (lambda () (cider-find-var nil impl)))))
+                         impls)))))
+    (with-current-buffer (cider-popup-buffer "*cider-who-implements*" 'select
+                                             'cider-tree-view-mode 'ancillary)
+      (cider-tree-view-render (list root) (format title-fmt var)))))
+
+;;;###autoload
+(defun cider-who-implements (&optional symbol)
+  "Browse the implementations of the protocol or multimethod SYMBOL.
+For a protocol, lists the types that extend it via `extend'/`extend-type'/
+`extend-protocol'; for a multimethod, lists its dispatch values.
+
+This is a client-side approximation - inline `defrecord'/`deftype'/`reify'
+implementers and per-`defmethod' source locations aren't shown yet, as they need
+introspection the runtime doesn't expose.  Clojure-on-the-JVM only."
+  (interactive)
+  (cider-ensure-connected)
+  (let* ((symbol (or symbol (cider-symbol-at-point)
+                     (read-string "Implementations of: ")))
+         (info (or (cider-var-info symbol)
+                   (user-error "%s" (cider-resolution-failure-message symbol))))
+         (var (concat (nrepl-dict-get info "ns") "/" (nrepl-dict-get info "name")))
+         (result (cider-xref-tree--implements var)))
+    (pcase (car result)
+      ('nil (user-error "Couldn't introspect %s; is its namespace loaded?" var))
+      ("protocol"
+       (cider-xref-tree--show-implements var (cdr result) "Implementations of %s"
+                                         "extenders" t))
+      ("multimethod"
+       (cider-xref-tree--show-implements var (cdr result) "Methods of %s"
+                                         "dispatch values" nil))
+      (_ (user-error "%s is not a protocol or multimethod" var)))))
+
 ;;;###autoload (autoload 'cider-who-map "cider-xref-tree" "CIDER call-graph keymap." nil 'keymap)
 (defvar cider-who-map
   (let ((map (define-prefix-command 'cider-who-map)))
@@ -115,11 +206,12 @@ Uses the runtime `fn-deps' op, so it covers loaded Clojure-on-the-JVM code."
     (define-key map (kbd "C-d") #'cider-who-is-called)
     (define-key map (kbd "m") #'cider-who-macroexpands)
     (define-key map (kbd "C-m") #'cider-who-macroexpands)
+    (define-key map (kbd "i") #'cider-who-implements)
+    (define-key map (kbd "C-i") #'cider-who-implements)
     map)
   "CIDER call-graph (\"who calls\") keymap.
-The letters mirror SLIME's who-map: `c' for callers, `d' for callees, and `m'
-for a macro's use sites.  The letter `i' (protocol/multimethod implementations)
-is left free for a future view.")
+The letters mirror SLIME's who-map: `c' for callers, `d' for callees, `m' for a
+macro's use sites, and `i' for a protocol's or multimethod's implementations.")
 
 (provide 'cider-xref-tree)
 ;;; cider-xref-tree.el ends here

--- a/test/cider-xref-tree-tests.el
+++ b/test/cider-xref-tree-tests.el
@@ -66,6 +66,44 @@
       (expect (length (seq-filter #'cider-tree-view-node-expandable-p grandkids))
               :to-equal 1))))
 
+(describe "cider-xref-tree--implements"
+  (before-each
+    (spy-on 'cider-current-ns :and-return-value "my.ns"))
+
+  (it "parses a protocol's extenders"
+    (spy-on 'cider-sync-tooling-eval :and-return-value
+            (nrepl-dict "value" "[\"protocol\" \"my.ns.Foo\" \"my.ns.Bar\"]"))
+    (expect (cider-xref-tree--implements "my.ns/Greet")
+            :to-equal '("protocol" "my.ns.Foo" "my.ns.Bar")))
+
+  (it "parses a multimethod's dispatch values"
+    (spy-on 'cider-sync-tooling-eval :and-return-value
+            (nrepl-dict "value" "[\"multimethod\" \":circle\" \":square\"]"))
+    (expect (cider-xref-tree--implements "my.ns/area")
+            :to-equal '("multimethod" ":circle" ":square")))
+
+  (it "returns nil when the eval yields no value"
+    (spy-on 'cider-sync-tooling-eval :and-return-value (nrepl-dict))
+    (expect (cider-xref-tree--implements "my.ns/whatever") :to-be nil)))
+
+(describe "cider-who-implements"
+  (before-each
+    (spy-on 'cider-ensure-connected)
+    (spy-on 'cider-var-info :and-return-value
+            (nrepl-dict "ns" "my.ns" "name" "Greet")))
+
+  (it "rejects a symbol that is neither protocol nor multimethod"
+    (spy-on 'cider-xref-tree--implements :and-return-value '("other"))
+    (expect (cider-who-implements "my.ns/Greet") :to-throw 'user-error))
+
+  (it "reports when a protocol has no visible extenders"
+    (spy-on 'cider-xref-tree--implements :and-return-value '("protocol"))
+    (expect (cider-who-implements "my.ns/Greet") :to-throw 'user-error))
+
+  (it "reports a distinct error when introspection yields nothing"
+    (spy-on 'cider-xref-tree--implements :and-return-value nil)
+    (expect (cider-who-implements "my.ns/Greet") :to-throw 'user-error)))
+
 (provide 'cider-xref-tree-tests)
 
 ;;; cider-xref-tree-tests.el ends here


### PR DESCRIPTION
Picks up the long-standing request in #1969. `cider-who-implements` (`C-c C-w i`, the last slot in the who-map) browses a protocol's implementing types or a multimethod's dispatch values on the same expandable tree as the call-graph browsers.

It's deliberately a client-side approximation for now: a small introspection form is evaluated via a tooling eval, so it sees the types registered via `extend`/`extend-type`/`extend-protocol` and a multimethod's dispatch values. It does **not** yet see inline `defrecord`/`deftype`/`reify` implementers (those implement the protocol's generated interface rather than extending it) or per-`defmethod` source locations (the methods carry no metadata at runtime). Both gaps need richer introspection than the runtime exposes - the plan is to follow up with a dedicated middleware op (orchard + cider-nrepl) that returns each implementation with `file`/`line`, at which point this folds into the same shape as the other views.

Shipping the client-side version first to validate the tree UX. Clojure-on-the-JVM only.

- [x] The commits are consistent with our contribution guidelines
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`)
- [x] You've updated the changelog
- [x] You've updated the user manual