### PR TITLE
Use the who-implements op for cider-who-implements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### Changes
 
+- [#3998](https://github.com/clojure-emacs/cider/pull/3998): `cider-who-implements` now uses cider-nrepl's `cider/who-implements` op when available, so it also lists inline `defrecord`/`deftype` implementers and jumps to each implementation's source; it falls back to the previous client-side approximation otherwise.
 - [#3993](https://github.com/clojure-emacs/cider/pull/3993): Round out the `*cider-trace*` buffer: navigate between calls with `n`/`p`, jump to a function's definition (`.` or click its name), fold or unfold every call at once (`F`/`U`), click a call line to fold it, and a `CIDER Trace` menu.
 - [#3992](https://github.com/clojure-emacs/cider/pull/3992): Make `*cider-trace*` calls foldable - `TAB` on a call line collapses or expands the nested calls between it and its return.
 - [#3984](https://github.com/clojure-emacs/cider/pull/3984): Stop dumping the full jack-in command and the ClojureScript REPL init form into the REPL transcript on startup (a ClojureScript REPL now just notes its type). The launch details are available on demand via `cider-repl-describe-startup` (the `,startup` REPL shortcut).

--- a/doc/modules/ROOT/pages/usage/misc_features.adoc
+++ b/doc/modules/ROOT/pages/usage/misc_features.adoc
@@ -157,17 +157,19 @@ the project's source instead (the same mechanism as
 `cider-xref-fn-refs-in-source`).
 
 `cider-who-implements` (kbd:[C-c C-w i]) goes the other way around: point it at a
-protocol and it lists the types that extend it; point it at a multimethod and it
-lists its dispatch values, all on the same expandable tree.
+protocol and it lists the types that implement it; point it at a multimethod and
+it lists its dispatch values, all on the same expandable tree. With a recent
+enough `cider-nrepl` it covers inline `defrecord`/`deftype` implementers too and
+jumps straight to each implementation's source.
 
 [NOTE]
 ====
-`cider-who-implements` is currently a client-side approximation.  It sees the
-types registered via `extend`/`extend-type`/`extend-protocol`, but not inline
-`defrecord`/`deftype`/`reify` implementers (those implement the protocol's
-generated interface rather than extending it), and it can't yet jump to an
-individual `defmethod`, since those methods carry no source metadata at runtime.
-Rounding this out is slated for a follow-up that adds the necessary middleware.
+When the `cider/who-implements` middleware op isn't available, the command falls
+back to a client-side approximation: it sees only the types registered via
+`extend`/`extend-type`/`extend-protocol` (not inline `defrecord`/`deftype`
+implementers, which implement the protocol's generated interface rather than
+extending it) and offers no per-implementation jumps.  Either way, only loaded
+Clojure-on-the-JVM code is visible.
 ====
 
 The call-graph bindings are also available under the kbd:[C-c C-?] xref prefix,

--- a/lisp/cider-client.el
+++ b/lisp/cider-client.el
@@ -1063,6 +1063,18 @@ The result entries are relative to the classpath."
                 (cider-nrepl-send-sync-request)
                 (nrepl-dict-get "fn-deps")))
 
+(defun cider-sync-request:who-implements (ns sym)
+  "Return the implementations of the protocol or multimethod NS and SYM.
+The result is a dict with a \"kind\" of \"protocol\", \"multimethod\" or
+\"other\"; for a protocol an \"impls\" list, for a multimethod a
+\"dispatch-values\" list."
+  (cider-ensure-op-supported "cider/who-implements")
+  (thread-first `("op" "cider/who-implements"
+                  "ns" ,ns
+                  "sym" ,sym)
+                (cider-nrepl-send-sync-request)
+                (nrepl-dict-get "who-implements")))
+
 (defun cider-sync-request:format-code (code &optional format-options)
   "Perform nREPL \"format-code\" op with CODE.
 FORMAT-OPTIONS is an optional configuration map for cljfmt."

--- a/lisp/cider-xref-tree.el
+++ b/lisp/cider-xref-tree.el
@@ -35,6 +35,7 @@
 ;;; Code:
 
 (require 'cider-client)
+(require 'cider-common)
 (require 'cider-find)
 (require 'cider-popup)
 (require 'cider-tree-view)
@@ -110,12 +111,14 @@ Uses the runtime `fn-deps' op, so it covers loaded Clojure-on-the-JVM code."
 
 ;;; who-implements - protocol/multimethod implementations.
 ;;
-;; This is a client-side approximation: it evaluates a little introspection form
-;; to read a protocol's `extenders' or a multimethod's dispatch values.  It can't
-;; see inline `defrecord'/`deftype'/`reify' implementers (they implement the
-;; protocol's generated interface, not via `extend'), nor per-`defmethod' source
-;; locations (the methods are anonymous fns with no metadata) - those need richer
-;; introspection than the runtime exposes, slated for a follow-up middleware op.
+;; When cider-nrepl provides the `cider/who-implements' op we use it: it sees
+;; inline `defrecord'/`deftype' implementers (not just `extend' targets) and
+;; carries a source location for each, so every implementation is a jump target.
+;;
+;; Without the op we fall back to a client-side approximation - evaluating a
+;; little introspection form to read a protocol's `extenders' or a multimethod's
+;; dispatch values.  That can't see inline implementers and has no per-impl
+;; locations, but it keeps the command useful against older middleware.
 
 (defconst cider-xref-tree--implements-code
   "(let [v (resolve '%s) x (when v (deref v))]
@@ -144,41 +147,99 @@ of implementation strings, or nil when the eval yields nothing."
       (let ((items (append vec nil)))
         (cons (car items) (cdr items))))))
 
-(defun cider-xref-tree--show-implements (var impls title-fmt noun jumpable)
-  "Render IMPLS of VAR in a popup titled by TITLE-FMT.
-NOUN names the implementations for the empty-result message; when JUMPABLE,
-each implementation node jumps to its own definition (protocol extenders are
-types; multimethod dispatch values are plain data with nowhere to jump)."
-  (unless impls
-    (user-error "No %s found for %s%s" noun var
-                (if jumpable
-                    " (inline defrecord/deftype/reify impls aren't visible yet)"
-                  "")))
-  (let ((root (cider-tree-view-node-create
-               :label (cider-font-lock-as-clojure var)
-               :on-visit (lambda () (cider-find-var nil var))
-               :expanded t
-               :children-fn
-               (lambda ()
-                 (mapcar (lambda (impl)
-                           (cider-tree-view-node-create
-                            :label (cider-font-lock-as-clojure impl)
-                            :on-visit (when jumpable
-                                        (lambda () (cider-find-var nil impl)))))
-                         impls)))))
-    (with-current-buffer (cider-popup-buffer "*cider-who-implements*" 'select
-                                             'cider-tree-view-mode 'ancillary)
-      (cider-tree-view-render (list root) (format title-fmt var)))))
+(defun cider-xref-tree--leaf-node (label)
+  "Return a display-only tree node showing LABEL (no jump)."
+  (cider-tree-view-node-create :label (cider-font-lock-as-clojure label)))
+
+(defun cider-xref-tree--name-node (name)
+  "Return a tree node labelled NAME that jumps to NAME's definition."
+  (cider-tree-view-node-create
+   :label (cider-font-lock-as-clojure name)
+   :on-visit (lambda () (cider-find-var nil name))))
+
+(defun cider-xref-tree--jump-to-file (file line)
+  "Visit FILE and move to LINE."
+  (if-let* ((buffer (cider-find-file file)))
+      (cider-jump-to buffer (when line (cons line nil)))
+    (user-error "Can't find source file %s" file)))
+
+(defun cider-xref-tree--impl-node (dict)
+  "Return a tree node for one protocol-impl DICT from the op.
+Jumps to the impl's own source location when the op resolved a real one, else
+falls back to looking the name up via `cider-find-var'."
+  (let ((name (nrepl-dict-get dict "name"))
+        (file (nrepl-dict-get dict "file-url"))
+        (line (nrepl-dict-get dict "line")))
+    (if (and file (not (cider--tooling-file-p file)))
+        (cider-tree-view-node-create
+         :label (cider-font-lock-as-clojure name)
+         :on-visit (lambda () (cider-xref-tree--jump-to-file file line)))
+      (cider-xref-tree--name-node name))))
+
+(defun cider-xref-tree--implements-op-plan (var)
+  "Build an implementations plan for VAR via the `cider/who-implements' op."
+  (let* ((result (cider-sync-request:who-implements (cider-current-ns) var))
+         (kind (and result (nrepl-dict-get result "kind"))))
+    (pcase kind
+      ('nil (list :kind nil))
+      ("protocol"
+       (list :kind "protocol"
+             :title (format "Implementations of %s" var)
+             :empty-noun "implementations"
+             :nodes (mapcar #'cider-xref-tree--impl-node
+                            (nrepl-dict-get result "impls"))))
+      ("multimethod"
+       (list :kind "multimethod"
+             :title (format "Methods of %s" var)
+             :empty-noun "dispatch values"
+             :nodes (mapcar #'cider-xref-tree--leaf-node
+                            (nrepl-dict-get result "dispatch-values"))))
+      (_ (list :kind "other")))))
+
+(defun cider-xref-tree--implements-eval-plan (var)
+  "Build an implementations plan for VAR via the client-side tooling eval."
+  (let ((result (cider-xref-tree--implements var)))
+    (pcase (car result)
+      ('nil (list :kind nil))
+      ("protocol"
+       (list :kind "protocol"
+             :title (format "Implementations of %s" var)
+             :empty-noun "extenders"
+             :empty-hint (concat " (inline defrecord/deftype impls need"
+                                 " cider-nrepl's who-implements op)")
+             :nodes (mapcar #'cider-xref-tree--name-node (cdr result))))
+      ("multimethod"
+       (list :kind "multimethod"
+             :title (format "Methods of %s" var)
+             :empty-noun "dispatch values"
+             :nodes (mapcar #'cider-xref-tree--leaf-node (cdr result))))
+      (_ (list :kind "other")))))
+
+(defun cider-xref-tree--show-implements (var plan)
+  "Render the implementations PLAN for VAR in a popup tree."
+  (let ((nodes (plist-get plan :nodes)))
+    (unless nodes
+      (user-error "No %s found for %s%s" (plist-get plan :empty-noun) var
+                  (or (plist-get plan :empty-hint) "")))
+    (let ((root (cider-tree-view-node-create
+                 :label (cider-font-lock-as-clojure var)
+                 :on-visit (lambda () (cider-find-var nil var))
+                 :expanded t
+                 :children-fn (lambda () nodes))))
+      (with-current-buffer (cider-popup-buffer "*cider-who-implements*" 'select
+                                               'cider-tree-view-mode 'ancillary)
+        (cider-tree-view-render (list root) (plist-get plan :title))))))
 
 ;;;###autoload
 (defun cider-who-implements (&optional symbol)
   "Browse the implementations of the protocol or multimethod SYMBOL.
-For a protocol, lists the types that extend it via `extend'/`extend-type'/
-`extend-protocol'; for a multimethod, lists its dispatch values.
+For a protocol, lists the types that implement it; for a multimethod, lists its
+dispatch values - on an expandable tree.
 
-This is a client-side approximation - inline `defrecord'/`deftype'/`reify'
-implementers and per-`defmethod' source locations aren't shown yet, as they need
-introspection the runtime doesn't expose.  Clojure-on-the-JVM only."
+With cider-nrepl's `cider/who-implements' op this includes inline
+`defrecord'/`deftype' implementers and jumps to each implementation's source.
+Without it, a client-side fallback lists `extend'-style targets and dispatch
+values only.  Clojure-on-the-JVM only."
   (interactive)
   (cider-ensure-connected)
   (let* ((symbol (or symbol (cider-symbol-at-point)
@@ -186,16 +247,13 @@ introspection the runtime doesn't expose.  Clojure-on-the-JVM only."
          (info (or (cider-var-info symbol)
                    (user-error "%s" (cider-resolution-failure-message symbol))))
          (var (concat (nrepl-dict-get info "ns") "/" (nrepl-dict-get info "name")))
-         (result (cider-xref-tree--implements var)))
-    (pcase (car result)
+         (plan (if (cider-nrepl-op-supported-p "cider/who-implements")
+                   (cider-xref-tree--implements-op-plan var)
+                 (cider-xref-tree--implements-eval-plan var))))
+    (pcase (plist-get plan :kind)
       ('nil (user-error "Couldn't introspect %s; is its namespace loaded?" var))
-      ("protocol"
-       (cider-xref-tree--show-implements var (cdr result) "Implementations of %s"
-                                         "extenders" t))
-      ("multimethod"
-       (cider-xref-tree--show-implements var (cdr result) "Methods of %s"
-                                         "dispatch values" nil))
-      (_ (user-error "%s is not a protocol or multimethod" var)))))
+      ("other" (user-error "%s is not a protocol or multimethod" var))
+      (_ (cider-xref-tree--show-implements var plan)))))
 
 ;;;###autoload (autoload 'cider-who-map "cider-xref-tree" "CIDER call-graph keymap." nil 'keymap)
 (defvar cider-who-map

--- a/test/cider-xref-tree-tests.el
+++ b/test/cider-xref-tree-tests.el
@@ -86,9 +86,11 @@
     (spy-on 'cider-sync-tooling-eval :and-return-value (nrepl-dict))
     (expect (cider-xref-tree--implements "my.ns/whatever") :to-be nil)))
 
-(describe "cider-who-implements"
+(describe "cider-who-implements (eval fallback)"
   (before-each
     (spy-on 'cider-ensure-connected)
+    (spy-on 'cider-nrepl-op-supported-p :and-return-value nil)
+    (spy-on 'cider-current-ns :and-return-value "my.ns")
     (spy-on 'cider-var-info :and-return-value
             (nrepl-dict "ns" "my.ns" "name" "Greet")))
 
@@ -103,6 +105,45 @@
   (it "reports a distinct error when introspection yields nothing"
     (spy-on 'cider-xref-tree--implements :and-return-value nil)
     (expect (cider-who-implements "my.ns/Greet") :to-throw 'user-error)))
+
+(describe "cider-xref-tree--implements-op-plan"
+  (before-each
+    (spy-on 'cider-current-ns :and-return-value "my.ns"))
+
+  (it "builds an impl node per protocol implementation"
+    (spy-on 'cider-sync-request:who-implements :and-return-value
+            (nrepl-dict "kind" "protocol"
+                        "impls" (list (nrepl-dict "name" "my.ns.Foo"
+                                                  "file-url" "file:///x.clj"
+                                                  "line" 5)
+                                      (nrepl-dict "name" "java.lang.String"))))
+    (let ((plan (cider-xref-tree--implements-op-plan "my.ns/Greet")))
+      (expect (plist-get plan :kind) :to-equal "protocol")
+      (expect (length (plist-get plan :nodes)) :to-equal 2)))
+
+  (it "builds a node per multimethod dispatch value"
+    (spy-on 'cider-sync-request:who-implements :and-return-value
+            (nrepl-dict "kind" "multimethod"
+                        "dispatch-values" (list ":circle" ":square")))
+    (let ((plan (cider-xref-tree--implements-op-plan "my.ns/area")))
+      (expect (plist-get plan :kind) :to-equal "multimethod")
+      (expect (length (plist-get plan :nodes)) :to-equal 2)))
+
+  (it "classifies a plain function as other"
+    (spy-on 'cider-sync-request:who-implements :and-return-value
+            (nrepl-dict "kind" "other"))
+    (expect (plist-get (cider-xref-tree--implements-op-plan "my.ns/x") :kind)
+            :to-equal "other")))
+
+(describe "cider-xref-tree--impl-node"
+  (it "produces a jumpable node when the op resolved a real location"
+    (let ((node (cider-xref-tree--impl-node
+                 (nrepl-dict "name" "my.ns.Foo" "file-url" "file:///x.clj" "line" 5))))
+      (expect (cider-tree-view-node-on-visit node) :to-be-truthy)))
+
+  (it "falls back to a name lookup when the impl has no file"
+    (let ((node (cider-xref-tree--impl-node (nrepl-dict "name" "java.lang.String"))))
+      (expect (cider-tree-view-node-on-visit node) :to-be-truthy))))
 
 (provide 'cider-xref-tree-tests)
 


### PR DESCRIPTION
Completes the who-implements chain (orchard#401 -> cider-nrepl#985 -> here). `cider-who-implements` now prefers cider-nrepl's `cider/who-implements` op when it's available, so it lists inline `defrecord`/`deftype` implementers (not just `extend` targets) and jumps to each implementation's own source. Without the op it falls back to the client-side approximation shipped in #3997, so it keeps working against older middleware.

The op and eval paths produce a uniform "plan" (a kind plus a list of tree nodes) that a single renderer draws, so the feature detection is the only real branch. Needs `orchard` 0.43.0-alpha2 + the cider-nrepl op to light up the richer path; degrades gracefully otherwise.

- [x] The commits are consistent with our contribution guidelines
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`)
- [x] You've updated the changelog
- [x] You've updated the user manual