### PR TITLE
Add cider-type-protocols and cider-protocols-with-method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- [#3999](https://github.com/clojure-emacs/cider/pull/3999): Add `cider-type-protocols` (`C-c C-w t`), listing the protocols a type implements (the reverse of `cider-who-implements`), and `cider-protocols-with-method` (`C-c C-w p`), listing the protocols that declare a given method.
 - [#3997](https://github.com/clojure-emacs/cider/pull/3997): Add `cider-who-implements` (`C-c C-w i`), which browses a protocol's implementing types or a multimethod's dispatch values on an expandable tree. (Currently a client-side approximation; inline `defrecord`/`deftype` impls and per-`defmethod` jumps await a follow-up middleware op.)
 - [#3996](https://github.com/clojure-emacs/cider/pull/3996): Add `cider-who-macroexpands` (`C-c C-w m`), which finds a macro's use sites by searching the project's source - the runtime ops can't see them, since macros are expanded away at compile time.
 - [#3995](https://github.com/clojure-emacs/cider/pull/3995): Add `cider-who-calls` (`C-c C-w c`) and `cider-who-is-called` (`C-c C-w d`), SLIME-style call-graph browsers that present a function's callers/callees as an interactive tree you can expand a level at a time.

--- a/doc/modules/ROOT/pages/usage/cider_mode.adoc
+++ b/doc/modules/ROOT/pages/usage/cider_mode.adoc
@@ -361,6 +361,14 @@ kbd:[C-c C-t C-b]
 | kbd:[C-c C-w i]
 | Browse a protocol's implementing types or a multimethod's dispatch values.
 
+| `cider-type-protocols`
+| kbd:[C-c C-w t]
+| Browse the protocols a type implements.
+
+| `cider-protocols-with-method`
+| kbd:[C-c C-w p]
+| Browse the protocols that declare a given method.
+
 | `cider-pop-back`
 | kbd:[M-,]
 | Return to your pre-jump location.

--- a/doc/modules/ROOT/pages/usage/misc_features.adoc
+++ b/doc/modules/ROOT/pages/usage/misc_features.adoc
@@ -172,6 +172,15 @@ extending it) and offers no per-implementation jumps.  Either way, only loaded
 Clojure-on-the-JVM code is visible.
 ====
 
+Two more protocol-oriented commands round out the family. `cider-type-protocols`
+(kbd:[C-c C-w t]) is the reverse of `cider-who-implements`: point it at a type
+(a record or class) and it lists the protocols that type implements, including
+inline `defrecord`/`deftype` implementations. `cider-protocols-with-method`
+(kbd:[C-c C-w p]) takes a method name (by default the one at point) and lists the
+protocols that declare it - handy when you spot a bare method call and want to
+know which protocol it belongs to. Both jump to the matching protocol's
+definition, and both see loaded Clojure-on-the-JVM code only.
+
 The call-graph bindings are also available under the kbd:[C-c C-?] xref prefix,
 as kbd:[C-c C-? R] and kbd:[C-c C-? D].
 

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -426,7 +426,9 @@ If invoked with a prefix ARG eval the expression after inserting it."
      ["Who calls (tree)" cider-who-calls]
      ["Who is called (tree)" cider-who-is-called]
      ["Who macroexpands (source)" cider-who-macroexpands]
-     ["Who implements (protocol/multimethod)" cider-who-implements])
+     ["Who implements (protocol/multimethod)" cider-who-implements]
+     ["Protocols implemented by type" cider-type-protocols]
+     ["Protocols declaring a method" cider-protocols-with-method])
     ("Browse"
      ["Browse namespace" cider-browse-ns]
      ["Browse all namespaces" cider-browse-ns-all]
@@ -514,6 +516,8 @@ If invoked with a prefix ARG eval the expression after inserting it."
 (declare-function cider-who-calls "cider-xref-tree")
 (declare-function cider-who-is-called "cider-xref-tree")
 (declare-function cider-who-implements "cider-xref-tree")
+(declare-function cider-type-protocols "cider-xref-tree")
+(declare-function cider-protocols-with-method "cider-xref-tree")
 
 (defconst cider--has-many-mouse-buttons (not (memq window-system '(mac ns)))
   "Non-nil if system binds forward and back buttons to <mouse-8> and <mouse-9>.

--- a/lisp/cider-xref-tree.el
+++ b/lisp/cider-xref-tree.el
@@ -255,6 +255,102 @@ values only.  Clojure-on-the-JVM only."
       ("other" (user-error "%s is not a protocol or multimethod" var))
       (_ (cider-xref-tree--show-implements var plan)))))
 
+
+;;; Protocol exploration - reverse lookup and method search.
+;;
+;; Both scan the loaded protocols (a protocol var derefs to a map with an
+;; `:on-interface') and report the matches as qualified names, jumping to each
+;; protocol's definition.  Client-side eval is enough here: the answers are
+;; protocols, which are ordinary locatable vars.  Loaded JVM Clojure only.
+
+(defconst cider-xref-tree--type-protocols-code
+  "(let [sym '%s
+         r (try (resolve sym) (catch Throwable _ nil))
+         c (cond (class? r) r
+                 (and (var? r) (class? (deref r))) (deref r)
+                 (var? r) (class (deref r))
+                 :else (try (Class/forName (str sym)) (catch Throwable _ nil)))]
+     (when c
+       (vec (sort (for [ns (all-ns)
+                        [s v] (ns-publics ns)
+                        :let [val (try (deref v) (catch Throwable _ nil))]
+                        :when (and (map? val) (:on-interface val)
+                                   (or (extends? val c)
+                                       (.isAssignableFrom ^Class (:on-interface val) c)))]
+                    (str (symbol (str ns) (str s))))))))"
+  "Clojure form (with a `%s' for the type) listing the protocols it implements.
+Covers both `extend'-style and inline `defrecord'/`deftype' implementations.")
+
+(defconst cider-xref-tree--protocols-with-method-code
+  "(vec (sort (for [ns (all-ns)
+                    [s v] (ns-publics ns)
+                    :let [val (try (deref v) (catch Throwable _ nil))]
+                    :when (and (map? val) (:on-interface val)
+                               (some #(= \"%s\" (name %%)) (keys (:sigs val))))]
+                (str (symbol (str ns) (str s))))))"
+  "Clojure form (with a `%s' for a method name) listing protocols declaring it.")
+
+(defun cider-xref-tree--protocol-names (code arg)
+  "Evaluate CODE with ARG spliced in and return its list of protocol names.
+CODE must yield a vector of qualified-name strings; returns nil on failure."
+  (when-let* ((result (cider-sync-tooling-eval
+                       (format code arg) (cider-current-ns)))
+              (value (nrepl-dict-get result "value"))
+              (vec (ignore-errors (parseedn-read-str value))))
+    (when (vectorp vec)
+      (append vec nil))))
+
+(defun cider-xref-tree--show-protocols (root-label title names empty-msg)
+  "Render protocol NAMES as a tree under ROOT-LABEL in a popup titled TITLE.
+Each name jumps to its definition.  Signal EMPTY-MSG when NAMES is empty."
+  (unless names
+    (user-error "%s" empty-msg))
+  (let ((root (cider-tree-view-node-create
+               :label root-label
+               :expanded t
+               :children-fn (lambda () (mapcar #'cider-xref-tree--name-node names)))))
+    (with-current-buffer (cider-popup-buffer "*cider-protocols*" 'select
+                                             'cider-tree-view-mode 'ancillary)
+      (cider-tree-view-render (list root) title))))
+
+;;;###autoload
+(defun cider-type-protocols (&optional symbol)
+  "Browse the protocols implemented by the type SYMBOL.
+Covers both `extend'-style and inline `defrecord'/`deftype' implementations.
+Point should be on a type's name (a record/class) or a dotted class name; only
+loaded Clojure-on-the-JVM code is visible."
+  (interactive)
+  (cider-ensure-connected)
+  (let* ((symbol (or symbol (cider-symbol-at-point)
+                     (read-string "Protocols of type: ")))
+         (names (cider-xref-tree--protocol-names
+                 cider-xref-tree--type-protocols-code symbol)))
+    (cider-xref-tree--show-protocols
+     (cider-font-lock-as-clojure symbol)
+     (format "Protocols implemented by %s" symbol)
+     names
+     (format "No protocols found for %s; is it a loaded type?" symbol))))
+
+;;;###autoload
+(defun cider-protocols-with-method (&optional method)
+  "Browse the protocols that declare a method named METHOD.
+With no argument, uses the (unqualified) name at point.  Only loaded
+Clojure-on-the-JVM code is visible."
+  (interactive)
+  (cider-ensure-connected)
+  (let* ((method (or method (cider-symbol-at-point)
+                     (read-string "Protocols with method: ")))
+         ;; drop a namespace qualifier (m/area -> area) but keep a bare `/'
+         (method (let ((parts (split-string method "/" t)))
+                   (if (cdr parts) (car (last parts)) method)))
+         (names (cider-xref-tree--protocol-names
+                 cider-xref-tree--protocols-with-method-code method)))
+    (cider-xref-tree--show-protocols
+     (cider-font-lock-as-clojure method)
+     (format "Protocols with a method named %s" method)
+     names
+     (format "No protocol declares a method named %s" method))))
+
 ;;;###autoload (autoload 'cider-who-map "cider-xref-tree" "CIDER call-graph keymap." nil 'keymap)
 (defvar cider-who-map
   (let ((map (define-prefix-command 'cider-who-map)))
@@ -266,10 +362,16 @@ values only.  Clojure-on-the-JVM only."
     (define-key map (kbd "C-m") #'cider-who-macroexpands)
     (define-key map (kbd "i") #'cider-who-implements)
     (define-key map (kbd "C-i") #'cider-who-implements)
+    (define-key map (kbd "t") #'cider-type-protocols)
+    (define-key map (kbd "C-t") #'cider-type-protocols)
+    (define-key map (kbd "p") #'cider-protocols-with-method)
+    (define-key map (kbd "C-p") #'cider-protocols-with-method)
     map)
-  "CIDER call-graph (\"who calls\") keymap.
+  "CIDER relationship-query (\"who calls\") keymap.
 The letters mirror SLIME's who-map: `c' for callers, `d' for callees, `m' for a
-macro's use sites, and `i' for a protocol's or multimethod's implementations.")
+macro's use sites, and `i' for a protocol's or multimethod's implementations.
+The protocol-exploration commands extend it, on keys t and p: the protocols a
+type implements, and the protocols declaring a given method.")
 
 (provide 'cider-xref-tree)
 ;;; cider-xref-tree.el ends here

--- a/test/cider-xref-tree-tests.el
+++ b/test/cider-xref-tree-tests.el
@@ -145,6 +145,60 @@
     (let ((node (cider-xref-tree--impl-node (nrepl-dict "name" "java.lang.String"))))
       (expect (cider-tree-view-node-on-visit node) :to-be-truthy))))
 
+(describe "cider-xref-tree--protocol-names"
+  (before-each
+    (spy-on 'cider-current-ns :and-return-value "user"))
+
+  (it "parses the eval result into a list of names"
+    (spy-on 'cider-sync-tooling-eval :and-return-value
+            (nrepl-dict "value" "[\"user/Shape\" \"user/Drawable\"]"))
+    (expect (cider-xref-tree--protocol-names "%s" "Square")
+            :to-equal '("user/Shape" "user/Drawable")))
+
+  (it "returns nil when the eval yields no value"
+    (spy-on 'cider-sync-tooling-eval :and-return-value (nrepl-dict))
+    (expect (cider-xref-tree--protocol-names "%s" "x") :to-be nil)))
+
+(describe "cider-type-protocols"
+  (before-each
+    (spy-on 'cider-ensure-connected)
+    (spy-on 'cider-current-ns :and-return-value "user"))
+
+  (it "errors when the type implements no protocols"
+    (spy-on 'cider-xref-tree--protocol-names :and-return-value nil)
+    (expect (cider-type-protocols "Plain") :to-throw 'user-error))
+
+  (it "renders the protocols the type implements"
+    (spy-on 'cider-xref-tree--protocol-names :and-return-value '("user/Shape"))
+    (spy-on 'cider-popup-buffer :and-call-fake
+            (lambda (name &rest _) (get-buffer-create name)))
+    (cider-type-protocols "Square")
+    (with-current-buffer "*cider-protocols*"
+      (expect (buffer-string) :to-match "Shape"))))
+
+(describe "cider-protocols-with-method"
+  (before-each
+    (spy-on 'cider-ensure-connected)
+    (spy-on 'cider-current-ns :and-return-value "user"))
+
+  (it "strips a namespace qualifier before searching by method name"
+    (let (captured)
+      (spy-on 'cider-xref-tree--protocol-names :and-call-fake
+              (lambda (_code arg) (setq captured arg) '("user/Shape")))
+      (spy-on 'cider-popup-buffer :and-call-fake
+              (lambda (name &rest _) (get-buffer-create name)))
+      (cider-protocols-with-method "m/area")
+      (expect captured :to-equal "area")))
+
+  (it "keeps a bare slash method name intact"
+    (let (captured)
+      (spy-on 'cider-xref-tree--protocol-names :and-call-fake
+              (lambda (_code arg) (setq captured arg) '("user/Arith")))
+      (spy-on 'cider-popup-buffer :and-call-fake
+              (lambda (name &rest _) (get-buffer-create name)))
+      (cider-protocols-with-method "/")
+      (expect captured :to-equal "/"))))
+
 (provide 'cider-xref-tree-tests)
 
 ;;; cider-xref-tree-tests.el ends here


### PR DESCRIPTION
Two protocol-exploration commands rounding out the `C-c C-w` family, picking up the remaining ideas from #1969.

- `cider-type-protocols` (`C-c C-w t`) is the reverse of `cider-who-implements`: point at a type (a record/class) and it lists the protocols it implements - both `extend`-style and inline `defrecord`/`deftype`.
- `cider-protocols-with-method` (`C-c C-w p`) takes a method name (the one at point by default) and lists the protocols that declare it.

Both scan the loaded protocols via a client-side tooling eval and render the matches on the same tree-view, jumping to each protocol's definition. Unlike `who-implements`, no middleware is needed here: the *results* are protocols, which are ordinary locatable vars, so the client-side version is the complete feature rather than an approximation. Loaded Clojure-on-the-JVM only; the one entry-point caveat is that a slash-qualified record symbol (`my.ns/Rec`) doesn't resolve (records are classes, not vars) - point at the bare or dotted name instead.

- [x] The commits are consistent with our contribution guidelines
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`)
- [x] You've updated the changelog
- [x] You've updated the user manual