### PR TITLE
Jump multimethod methods to their defmethod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Changes
 
+- [#4000](https://github.com/clojure-emacs/cider/pull/4000): `cider-who-implements` now makes a multimethod's methods jump to their `defmethod` definitions, located by searching the project's source (the method functions carry no source metadata at runtime, so there's nothing for the runtime to point at).
 - [#3998](https://github.com/clojure-emacs/cider/pull/3998): `cider-who-implements` now uses cider-nrepl's `cider/who-implements` op when available, so it also lists inline `defrecord`/`deftype` implementers and jumps to each implementation's source; it falls back to the previous client-side approximation otherwise.
 - [#3993](https://github.com/clojure-emacs/cider/pull/3993): Round out the `*cider-trace*` buffer: navigate between calls with `n`/`p`, jump to a function's definition (`.` or click its name), fold or unfold every call at once (`F`/`U`), click a call line to fold it, and a `CIDER Trace` menu.
 - [#3992](https://github.com/clojure-emacs/cider/pull/3992): Make `*cider-trace*` calls foldable - `TAB` on a call line collapses or expands the nested calls between it and its return.

--- a/doc/modules/ROOT/pages/usage/misc_features.adoc
+++ b/doc/modules/ROOT/pages/usage/misc_features.adoc
@@ -158,9 +158,11 @@ the project's source instead (the same mechanism as
 
 `cider-who-implements` (kbd:[C-c C-w i]) goes the other way around: point it at a
 protocol and it lists the types that implement it; point it at a multimethod and
-it lists its dispatch values, all on the same expandable tree. With a recent
-enough `cider-nrepl` it covers inline `defrecord`/`deftype` implementers too and
-jumps straight to each implementation's source.
+it lists its methods, all on the same expandable tree. With a recent enough
+`cider-nrepl` it covers inline `defrecord`/`deftype` implementers too and jumps
+straight to each implementation's source. For a multimethod, each method jumps to
+its `defmethod` - found by searching the project's source, since the method
+functions themselves carry no source metadata at runtime.
 
 [NOTE]
 ====
@@ -168,8 +170,8 @@ When the `cider/who-implements` middleware op isn't available, the command falls
 back to a client-side approximation: it sees only the types registered via
 `extend`/`extend-type`/`extend-protocol` (not inline `defrecord`/`deftype`
 implementers, which implement the protocol's generated interface rather than
-extending it) and offers no per-implementation jumps.  Either way, only loaded
-Clojure-on-the-JVM code is visible.
+extending it). The multimethod side works either way, as it's source-driven.
+Only loaded Clojure-on-the-JVM code is visible.
 ====
 
 Two more protocol-oriented commands round out the family. `cider-type-protocols`

--- a/lisp/cider-xref-source.el
+++ b/lisp/cider-xref-source.el
@@ -167,10 +167,10 @@ TARGET-NS is nil only bare matching applies, so `:referred' is forced on."
       (list :this-ns this-ns :alias alias :referred referred
             :ns-beg ns-beg :ns-end ns-end))))
 
-(defun cider-xref--reference-regexp (target-ns name context)
-  "Build a regexp matching references to TARGET-NS/NAME licensed by CONTEXT.
-Group 1 captures the symbol token itself (so its bounds are the match bounds).
-CONTEXT is a plist as returned by `cider-xref--ns-context'."
+(defun cider-xref--name-alts (target-ns name context)
+  "Return the regexp alternatives matching TARGET-NS/NAME as licensed by CONTEXT.
+Each alt is a `regexp-quote'd qualified, aliased, or bare form of NAME, per the
+file's `(ns ...)' form; CONTEXT is a plist as returned by `cider-xref--ns-context'."
   (let* ((qname (regexp-quote name))
          ;; The bare name is an alt only when this file licenses unqualified use.
          (alts (when (plist-get context :referred) (list qname))))
@@ -178,11 +178,17 @@ CONTEXT is a plist as returned by `cider-xref--ns-context'."
       (push (concat (regexp-quote target-ns) "/" qname) alts))
     (when-let* ((alias (plist-get context :alias)))
       (push (concat (regexp-quote alias) "/" qname) alts))
-    (when alts
-      (concat "\\(?:^\\|[^" cider-xref--symbol-chars "]\\)"  ; left boundary
-              "\\(?:#'\\|[#'@`]\\)?"                          ; optional reader prefix
-              "\\(" (mapconcat #'identity alts "\\|") "\\)"   ; the symbol token
-              "\\(?:$\\|[^" cider-xref--symbol-chars "]\\)")))) ; right boundary
+    alts))
+
+(defun cider-xref--reference-regexp (target-ns name context)
+  "Build a regexp matching references to TARGET-NS/NAME licensed by CONTEXT.
+Group 1 captures the symbol token itself (so its bounds are the match bounds).
+CONTEXT is a plist as returned by `cider-xref--ns-context'."
+  (when-let* ((alts (cider-xref--name-alts target-ns name context)))
+    (concat "\\(?:^\\|[^" cider-xref--symbol-chars "]\\)"  ; left boundary
+            "\\(?:#'\\|[#'@`]\\)?"                          ; optional reader prefix
+            "\\(" (mapconcat #'identity alts "\\|") "\\)"   ; the symbol token
+            "\\(?:$\\|[^" cider-xref--symbol-chars "]\\)"))) ; right boundary
 
 (defun cider-xref--scan-buffer (regexp file &optional exclude)
   "Collect references matching REGEXP in the current buffer as xref match items.
@@ -276,6 +282,84 @@ matching VAR's bare name."
   (if-let* ((resolved (and (cider-connected-p) (cider-xref--resolve-var var))))
       (cider-xref--source-references (car resolved) (cdr resolved))
     (cider-xref--source-references nil (cider-xref--short-name var))))
+
+(defun cider-xref--defmethod-regexp (target-ns name context)
+  "Build a regexp matching `(defmethod NAME ...)' forms for TARGET-NS/NAME.
+NAME is matched per CONTEXT (qualified, aliased, or bare).  Group 1 captures the
+method-name token; the dispatch value follows it."
+  (when-let* ((alts (cider-xref--name-alts target-ns name context)))
+    (concat "(" cider-xref--ws "*defmethod" cider-xref--ws "+"
+            "\\(" (mapconcat #'identity alts "\\|") "\\)"
+            "\\(?:$\\|[^" cider-xref--symbol-chars "]\\)")))
+
+(defun cider-xref--scan-defmethods (regexp file)
+  "Collect `(defmethod ...)' sites matching REGEXP in the current buffer.
+FILE is the path the locations point at.  Each result is a plist with the
+method's `:dispatch' value (as written), `:file', `:line' and `:column'.
+Matches inside strings and comments are skipped."
+  (let ((line 1)
+        (counted (point-min))
+        results)
+    (save-excursion
+      (goto-char (point-min))
+      (while (re-search-forward regexp nil t)
+        (let ((name-beg (match-beginning 1))
+              (name-end (match-end 1)))
+          (goto-char name-end)
+          (unless (nth 8 (syntax-ppss name-beg))   ; skip strings and comments
+            (setq line (+ line (save-excursion
+                                 (goto-char counted)
+                                 (let ((n 0))
+                                   (while (search-forward "\n" name-beg t)
+                                     (setq n (1+ n)))
+                                   n)))
+                  counted name-beg)
+            (let ((dispatch (save-excursion
+                              (goto-char name-end)
+                              (skip-chars-forward " \t\r\n\f")
+                              (ignore-errors
+                                (let ((beg (point)))
+                                  (forward-sexp)
+                                  (string-trim
+                                   (buffer-substring-no-properties beg (point)))))))
+                  (col (save-excursion
+                         (goto-char name-beg)
+                         (- name-beg (line-beginning-position)))))
+              (push (list :dispatch (or dispatch "?")
+                          :file file :line line :column col)
+                    results))))))
+    (nreverse results)))
+
+(defun cider-xref--defmethods-in-file (file target-ns name)
+  "Return the `(defmethod TARGET-NS/NAME ...)' sites in FILE as plists.
+A buffer opened solely to perform the scan is killed afterwards."
+  (let* ((existing (find-buffer-visiting file))
+         (buffer (or existing
+                     (let ((find-file-hook nil)
+                           (inhibit-message t))
+                       (find-file-noselect file t)))))
+    (unwind-protect
+        (with-current-buffer buffer
+          (when-let* ((context (cider-xref--ns-context target-ns name))
+                      (regexp (cider-xref--defmethod-regexp target-ns name context)))
+            (cider-xref--scan-defmethods regexp file)))
+      (unless existing
+        (kill-buffer buffer)))))
+
+(defun cider-xref--defmethod-sites (var)
+  "Return the `(defmethod VAR ...)' sites across the project source.
+VAR is the multimethod, resolved via the REPL when possible (else matched by
+bare name).  Each element is a plist with `:dispatch', `:file', `:line' and
+`:column' - locating the `defmethod's the runtime can't, since their method
+functions carry no source metadata."
+  (let* ((resolved (and (cider-connected-p) (cider-xref--resolve-var var)))
+         (target-ns (car resolved))
+         (name (or (cdr resolved) (cider-xref--short-name var))))
+    (when-let* ((files (cider-xref--project-source-files))
+                (candidates (cider-xref--candidate-files name files)))
+      (seq-mapcat (lambda (file)
+                    (cider-xref--defmethods-in-file file target-ns name))
+                  candidates))))
 
 (defun cider-xref--dedupe (items)
   "Remove xref ITEMS that point at the same file, line and column."

--- a/lisp/cider-xref-tree.el
+++ b/lisp/cider-xref-tree.el
@@ -40,6 +40,7 @@
 (require 'cider-popup)
 (require 'cider-tree-view)
 (require 'cider-util)
+(require 'cider-xref-source)
 (require 'nrepl-dict)
 (require 'parseedn)
 
@@ -176,6 +177,24 @@ falls back to looking the name up via `cider-find-var'."
          :on-visit (lambda () (cider-xref-tree--jump-to-file file line)))
       (cider-xref-tree--name-node name))))
 
+(defun cider-xref-tree--defmethod-node (site)
+  "Return a tree node for a `defmethod' SITE plist, jumping to its source."
+  (let ((dispatch (plist-get site :dispatch))
+        (file (plist-get site :file))
+        (line (plist-get site :line)))
+    (cider-tree-view-node-create
+     :label (cider-font-lock-as-clojure dispatch)
+     :on-visit (lambda () (cider-xref-tree--jump-to-file file line)))))
+
+(defun cider-xref-tree--multimethod-nodes (var dispatch-values)
+  "Build the child nodes for multimethod VAR.
+Prefer source `(defmethod ...)' sites, so each method jumps to its own
+definition; fall back to the runtime DISPATCH-VALUES as display-only leaves when
+no sites are found (no project source, or methods added dynamically)."
+  (if-let* ((sites (cider-xref--defmethod-sites var)))
+      (mapcar #'cider-xref-tree--defmethod-node sites)
+    (mapcar #'cider-xref-tree--leaf-node dispatch-values)))
+
 (defun cider-xref-tree--implements-op-plan (var)
   "Build an implementations plan for VAR via the `cider/who-implements' op."
   (let* ((result (cider-sync-request:who-implements (cider-current-ns) var))
@@ -192,8 +211,8 @@ falls back to looking the name up via `cider-find-var'."
        (list :kind "multimethod"
              :title (format "Methods of %s" var)
              :empty-noun "dispatch values"
-             :nodes (mapcar #'cider-xref-tree--leaf-node
-                            (nrepl-dict-get result "dispatch-values"))))
+             :nodes (cider-xref-tree--multimethod-nodes
+                     var (nrepl-dict-get result "dispatch-values"))))
       (_ (list :kind "other")))))
 
 (defun cider-xref-tree--implements-eval-plan (var)
@@ -212,7 +231,7 @@ falls back to looking the name up via `cider-find-var'."
        (list :kind "multimethod"
              :title (format "Methods of %s" var)
              :empty-noun "dispatch values"
-             :nodes (mapcar #'cider-xref-tree--leaf-node (cdr result))))
+             :nodes (cider-xref-tree--multimethod-nodes var (cdr result))))
       (_ (list :kind "other")))))
 
 (defun cider-xref-tree--show-implements (var plan)

--- a/test/cider-xref-source-tests.el
+++ b/test/cider-xref-source-tests.el
@@ -158,6 +158,43 @@ context, and scanned - exercising the whole non-REPL half of the engine."
                         (xref-make-match "y" loc-b 3))))
       (expect (length (cider-xref--dedupe items)) :to-equal 2))))
 
+(defun cider-xref-source-tests--defmethods (content target-ns name)
+  "Return the dispatch values of (defmethod NAME ...) sites in CONTENT."
+  (with-temp-buffer
+    (insert content)
+    (delay-mode-hooks (clojure-mode))
+    (let* ((context (cider-xref--ns-context target-ns name))
+           (regexp (cider-xref--defmethod-regexp target-ns name context)))
+      (when regexp
+        (mapcar (lambda (site) (plist-get site :dispatch))
+                (cider-xref--scan-defmethods regexp "test.clj"))))))
+
+(describe "cider-xref--defmethod scanning"
+  (it "finds defmethod sites and reads their dispatch values, ignoring plain calls"
+    (expect (cider-xref-source-tests--defmethods
+             (concat "(ns my.app (:require [my.ns :as m]))\n"
+                     "(defmethod m/area :circle [_] 1)\n"
+                     "(defmethod m/area :square [_] 2)\n"
+                     "(m/area x)\n")
+             "my.ns" "area")
+            :to-equal '(":circle" ":square")))
+
+  (it "reads a vector dispatch value as written"
+    (expect (cider-xref-source-tests--defmethods
+             (concat "(ns my.ns)\n"
+                     "(defmethod area [:a :b] [_] 1)\n")
+             "my.ns" "area")
+            :to-equal '("[:a :b]")))
+
+  (it "skips defmethods inside strings and comments"
+    (expect (cider-xref-source-tests--defmethods
+             (concat "(ns my.ns)\n"
+                     "(defmethod area :real [_] 1)\n"
+                     "\"(defmethod area :in-string [_] 1)\"\n"
+                     ";; (defmethod area :in-comment [_] 1)\n")
+             "my.ns" "area")
+            :to-equal '(":real"))))
+
 (provide 'cider-xref-source-tests)
 
 ;;; cider-xref-source-tests.el ends here

--- a/test/cider-xref-tree-tests.el
+++ b/test/cider-xref-tree-tests.el
@@ -145,6 +145,22 @@
     (let ((node (cider-xref-tree--impl-node (nrepl-dict "name" "java.lang.String"))))
       (expect (cider-tree-view-node-on-visit node) :to-be-truthy))))
 
+(describe "cider-xref-tree--multimethod-nodes"
+  (it "builds jumpable nodes from defmethod sites when found"
+    (spy-on 'cider-xref--defmethod-sites :and-return-value
+            (list (list :dispatch ":circle" :file "/x.clj" :line 5)
+                  (list :dispatch ":square" :file "/x.clj" :line 6)))
+    (let ((nodes (cider-xref-tree--multimethod-nodes "my.ns/area" '(":other"))))
+      (expect (length nodes) :to-equal 2)
+      (expect (cider-tree-view-node-on-visit (car nodes)) :to-be-truthy)))
+
+  (it "falls back to display-only dispatch values when no sites are found"
+    (spy-on 'cider-xref--defmethod-sites :and-return-value nil)
+    (let ((nodes (cider-xref-tree--multimethod-nodes
+                  "my.ns/area" '(":circle" ":square"))))
+      (expect (length nodes) :to-equal 2)
+      (expect (cider-tree-view-node-on-visit (car nodes)) :not :to-be-truthy))))
+
 (describe "cider-xref-tree--protocol-names"
   (before-each
     (spy-on 'cider-current-ns :and-return-value "user"))


### PR DESCRIPTION
The last open piece of #1969. `cider-who-implements` on a multimethod used to show its dispatch values as dead text, because the method functions carry no source metadata at runtime - so there's nothing for the runtime (or a middleware op) to point at. I probed the bytecode route (orchard #180) and it's a dead end: normal Clojure fns are compiled in-memory, so their `LineNumberTable` isn't reachable in a dev session.

So this takes the text-search route instead, the same one behind `cider-xref-fn-refs-in-source`: the #3994 engine now finds `(defmethod <multi> ...)` forms across the project source, reads each dispatch value as written, and makes each method jump to its `defmethod`. When no sites are found (no project source, or methods added dynamically) it falls back to the runtime dispatch values as before. Client-side, so it works in both the op and client-eval paths.

This finally closes the multimethod half of orchard#180.

- [x] The commits are consistent with our contribution guidelines
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`)
- [x] You've updated the changelog
- [x] You've updated the user manual