### PR TITLE
Use ops for type-protocols and protocols-with-method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Changes
 
+- [#4001](https://github.com/clojure-emacs/cider/pull/4001): `cider-type-protocols` and `cider-protocols-with-method` now use cider-nrepl's `cider/type-protocols` and `cider/protocols-with-method` ops when available, falling back to the previous client-side query otherwise.
 - [#4000](https://github.com/clojure-emacs/cider/pull/4000): `cider-who-implements` now makes a multimethod's methods jump to their `defmethod` definitions, located by searching the project's source (the method functions carry no source metadata at runtime, so there's nothing for the runtime to point at).
 - [#3998](https://github.com/clojure-emacs/cider/pull/3998): `cider-who-implements` now uses cider-nrepl's `cider/who-implements` op when available, so it also lists inline `defrecord`/`deftype` implementers and jumps to each implementation's source; it falls back to the previous client-side approximation otherwise.
 - [#3993](https://github.com/clojure-emacs/cider/pull/3993): Round out the `*cider-trace*` buffer: navigate between calls with `n`/`p`, jump to a function's definition (`.` or click its name), fold or unfold every call at once (`F`/`U`), click a call line to fold it, and a `CIDER Trace` menu.

--- a/doc/modules/ROOT/pages/usage/misc_features.adoc
+++ b/doc/modules/ROOT/pages/usage/misc_features.adoc
@@ -181,7 +181,9 @@ inline `defrecord`/`deftype` implementations. `cider-protocols-with-method`
 (kbd:[C-c C-w p]) takes a method name (by default the one at point) and lists the
 protocols that declare it - handy when you spot a bare method call and want to
 know which protocol it belongs to. Both jump to the matching protocol's
-definition, and both see loaded Clojure-on-the-JVM code only.
+definition, and both see loaded Clojure-on-the-JVM code only. With a recent
+enough `cider-nrepl` they use a dedicated middleware op; otherwise they fall back
+to a client-side query that works against any nREPL.
 
 The call-graph bindings are also available under the kbd:[C-c C-?] xref prefix,
 as kbd:[C-c C-? R] and kbd:[C-c C-? D].

--- a/lisp/cider-client.el
+++ b/lisp/cider-client.el
@@ -1075,6 +1075,25 @@ The result is a dict with a \"kind\" of \"protocol\", \"multimethod\" or
                 (cider-nrepl-send-sync-request)
                 (nrepl-dict-get "who-implements")))
 
+(defun cider-sync-request:type-protocols (ns sym)
+  "Return the protocols implemented by the type NS and SYM.
+Each is a dict with a \"name\" and source location."
+  (cider-ensure-op-supported "cider/type-protocols")
+  (thread-first `("op" "cider/type-protocols"
+                  "ns" ,ns
+                  "sym" ,sym)
+                (cider-nrepl-send-sync-request)
+                (nrepl-dict-get "type-protocols")))
+
+(defun cider-sync-request:protocols-with-method (method)
+  "Return the protocols declaring a method named METHOD.
+Each is a dict with a \"name\" and source location."
+  (cider-ensure-op-supported "cider/protocols-with-method")
+  (thread-first `("op" "cider/protocols-with-method"
+                  "method" ,method)
+                (cider-nrepl-send-sync-request)
+                (nrepl-dict-get "protocols-with-method")))
+
 (defun cider-sync-request:format-code (code &optional format-options)
   "Perform nREPL \"format-code\" op with CODE.
 FORMAT-OPTIONS is an optional configuration map for cljfmt."

--- a/lisp/cider-xref-tree.el
+++ b/lisp/cider-xref-tree.el
@@ -319,18 +319,40 @@ CODE must yield a vector of qualified-name strings; returns nil on failure."
     (when (vectorp vec)
       (append vec nil))))
 
-(defun cider-xref-tree--show-protocols (root-label title names empty-msg)
-  "Render protocol NAMES as a tree under ROOT-LABEL in a popup titled TITLE.
-Each name jumps to its definition.  Signal EMPTY-MSG when NAMES is empty."
-  (unless names
+(defun cider-xref-tree--show-protocols (root-label title nodes empty-msg)
+  "Render protocol NODES as a tree under ROOT-LABEL in a popup titled TITLE.
+Signal EMPTY-MSG when NODES is empty."
+  (unless nodes
     (user-error "%s" empty-msg))
   (let ((root (cider-tree-view-node-create
                :label root-label
                :expanded t
-               :children-fn (lambda () (mapcar #'cider-xref-tree--name-node names)))))
+               :children-fn (lambda () nodes))))
     (with-current-buffer (cider-popup-buffer "*cider-protocols*" 'select
                                              'cider-tree-view-mode 'ancillary)
       (cider-tree-view-render (list root) title))))
+
+(defun cider-xref-tree--type-protocol-nodes (symbol)
+  "Return tree nodes for the protocols implemented by the type SYMBOL.
+Uses the `cider/type-protocols' op when available (so each jumps straight to its
+source), else the client-side tooling eval."
+  (if (cider-nrepl-op-supported-p "cider/type-protocols")
+      (mapcar #'cider-xref-tree--impl-node
+              (cider-sync-request:type-protocols (cider-current-ns) symbol))
+    (mapcar #'cider-xref-tree--name-node
+            (cider-xref-tree--protocol-names
+             cider-xref-tree--type-protocols-code symbol))))
+
+(defun cider-xref-tree--method-protocol-nodes (method)
+  "Return tree nodes for the protocols declaring a method named METHOD.
+Uses the `cider/protocols-with-method' op when available, else the client-side
+tooling eval."
+  (if (cider-nrepl-op-supported-p "cider/protocols-with-method")
+      (mapcar #'cider-xref-tree--impl-node
+              (cider-sync-request:protocols-with-method method))
+    (mapcar #'cider-xref-tree--name-node
+            (cider-xref-tree--protocol-names
+             cider-xref-tree--protocols-with-method-code method))))
 
 ;;;###autoload
 (defun cider-type-protocols (&optional symbol)
@@ -340,14 +362,12 @@ Point should be on a type's name (a record/class) or a dotted class name; only
 loaded Clojure-on-the-JVM code is visible."
   (interactive)
   (cider-ensure-connected)
-  (let* ((symbol (or symbol (cider-symbol-at-point)
-                     (read-string "Protocols of type: ")))
-         (names (cider-xref-tree--protocol-names
-                 cider-xref-tree--type-protocols-code symbol)))
+  (let ((symbol (or symbol (cider-symbol-at-point)
+                    (read-string "Protocols of type: "))))
     (cider-xref-tree--show-protocols
      (cider-font-lock-as-clojure symbol)
      (format "Protocols implemented by %s" symbol)
-     names
+     (cider-xref-tree--type-protocol-nodes symbol)
      (format "No protocols found for %s; is it a loaded type?" symbol))))
 
 ;;;###autoload
@@ -361,13 +381,11 @@ Clojure-on-the-JVM code is visible."
                      (read-string "Protocols with method: ")))
          ;; drop a namespace qualifier (m/area -> area) but keep a bare `/'
          (method (let ((parts (split-string method "/" t)))
-                   (if (cdr parts) (car (last parts)) method)))
-         (names (cider-xref-tree--protocol-names
-                 cider-xref-tree--protocols-with-method-code method)))
+                   (if (cdr parts) (car (last parts)) method))))
     (cider-xref-tree--show-protocols
      (cider-font-lock-as-clojure method)
      (format "Protocols with a method named %s" method)
-     names
+     (cider-xref-tree--method-protocol-nodes method)
      (format "No protocol declares a method named %s" method))))
 
 ;;;###autoload (autoload 'cider-who-map "cider-xref-tree" "CIDER call-graph keymap." nil 'keymap)

--- a/test/cider-xref-tree-tests.el
+++ b/test/cider-xref-tree-tests.el
@@ -175,9 +175,27 @@
     (spy-on 'cider-sync-tooling-eval :and-return-value (nrepl-dict))
     (expect (cider-xref-tree--protocol-names "%s" "x") :to-be nil)))
 
+(describe "cider-xref-tree--type-protocol-nodes"
+  (before-each
+    (spy-on 'cider-current-ns :and-return-value "user"))
+
+  (it "builds jumpable nodes from the op when it is supported"
+    (spy-on 'cider-nrepl-op-supported-p :and-return-value t)
+    (spy-on 'cider-sync-request:type-protocols :and-return-value
+            (list (nrepl-dict "name" "my.ns/P" "file-url" "file:///x.clj" "line" 3)))
+    (let ((nodes (cider-xref-tree--type-protocol-nodes "Square")))
+      (expect (length nodes) :to-equal 1)
+      (expect (cider-tree-view-node-on-visit (car nodes)) :to-be-truthy)))
+
+  (it "falls back to the client eval when the op is unsupported"
+    (spy-on 'cider-nrepl-op-supported-p :and-return-value nil)
+    (spy-on 'cider-xref-tree--protocol-names :and-return-value '("my.ns/P"))
+    (expect (length (cider-xref-tree--type-protocol-nodes "Square")) :to-equal 1)))
+
 (describe "cider-type-protocols"
   (before-each
     (spy-on 'cider-ensure-connected)
+    (spy-on 'cider-nrepl-op-supported-p :and-return-value nil)
     (spy-on 'cider-current-ns :and-return-value "user"))
 
   (it "errors when the type implements no protocols"
@@ -195,6 +213,7 @@
 (describe "cider-protocols-with-method"
   (before-each
     (spy-on 'cider-ensure-connected)
+    (spy-on 'cider-nrepl-op-supported-p :and-return-value nil)
     (spy-on 'cider-current-ns :and-return-value "user"))
 
   (it "strips a namespace qualifier before searching by method name"


### PR DESCRIPTION
The polish item from after #3999: `cider-type-protocols` and `cider-protocols-with-method` now prefer cider-nrepl's `cider/type-protocols` / `cider/protocols-with-method` ops (cider-nrepl#986, on orchard#402) when available, falling back to the existing client-side tooling-eval query otherwise.

No capability change - the client-eval was already complete - so this is consistency with `who-implements` plus a server-side scan. It degrades gracefully: without the op (or against bare nREPL) the eval path keeps working, which the op path alone wouldn't. Both paths build the same tree, so feature detection is the only branch.

- [x] The commits are consistent with our contribution guidelines
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`)
- [x] You've updated the changelog
- [x] You've updated the user manual