### PR TITLE
Bump injected cider-nrepl to 0.60.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Changes
 
+- [#4002](https://github.com/clojure-emacs/cider/pull/4002): Bump the injected `cider-nrepl` to 0.60.0, which provides the `cider/who-implements`, `cider/type-protocols` and `cider/protocols-with-method` ops backing the protocol-exploration commands.
 - [#4001](https://github.com/clojure-emacs/cider/pull/4001): `cider-type-protocols` and `cider-protocols-with-method` now use cider-nrepl's `cider/type-protocols` and `cider/protocols-with-method` ops when available, falling back to the previous client-side query otherwise.
 - [#4000](https://github.com/clojure-emacs/cider/pull/4000): `cider-who-implements` now makes a multimethod's methods jump to their `defmethod` definitions, located by searching the project's source (the method functions carry no source metadata at runtime, so there's nothing for the runtime to point at).
 - [#3998](https://github.com/clojure-emacs/cider/pull/3998): `cider-who-implements` now uses cider-nrepl's `cider/who-implements` op when available, so it also lists inline `defrecord`/`deftype` implementers and jumps to each implementation's source; it falls back to the previous client-side approximation otherwise.

--- a/lisp/cider-jack-in.el
+++ b/lisp/cider-jack-in.el
@@ -322,7 +322,7 @@ the artifact.")
 
 Used when `cider-jack-in-auto-inject-clojure' is set to `latest'.")
 
-(defconst cider-required-middleware-version "0.60.0-alpha1"
+(defconst cider-required-middleware-version "0.60.0"
   "The CIDER nREPL version that's known to work properly with CIDER.")
 
 (defcustom cider-injected-middleware-version cider-required-middleware-version


### PR DESCRIPTION
cider-nrepl 0.60.0 is out, carrying the `cider/who-implements`, `cider/type-protocols` and `cider/protocols-with-method` ops. Bumping `cider-required-middleware-version` from the pre-ops `0.60.0-alpha1` so jack-in injects the middleware that actually backs the protocol-exploration commands - otherwise they keep falling back to the client-side path.

- [x] The commits are consistent with our contribution guidelines
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`)
- [x] You've updated the changelog
- [ ] You've updated the user manual (n/a - internal version constant)