### PR TITLE
Group the macroexpansion commands under a C-c M-m prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Changes
 
+- [#4003](https://github.com/clojure-emacs/cider/pull/4003): Turn `C-c M-m` into a prefix map (`cider-macroexpand-map`) grouping all the macro-expanding commands - `macroexpand-1`/`macroexpand-all` into a buffer (`1`/`a`) and the inline `cider-macrostep` commands (`e`/`E`/`b`). `cider-macroexpand-all` thus moves from `C-c M-m` to `C-c M-m a`; `C-c C-m` still runs `macroexpand-1` directly.
 - [#4002](https://github.com/clojure-emacs/cider/pull/4002): Bump the injected `cider-nrepl` to 0.60.0, which provides the `cider/who-implements`, `cider/type-protocols` and `cider/protocols-with-method` ops backing the protocol-exploration commands.
 - [#4001](https://github.com/clojure-emacs/cider/pull/4001): `cider-type-protocols` and `cider-protocols-with-method` now use cider-nrepl's `cider/type-protocols` and `cider/protocols-with-method` ops when available, falling back to the previous client-side query otherwise.
 - [#4000](https://github.com/clojure-emacs/cider/pull/4000): `cider-who-implements` now makes a multimethod's methods jump to their `defmethod` definitions, located by searching the project's source (the method functions carry no source metadata at runtime, so there's nothing for the runtime to point at).

--- a/doc/modules/ROOT/pages/debugging/macroexpansion.adoc
+++ b/doc/modules/ROOT/pages/debugging/macroexpansion.adoc
@@ -2,10 +2,45 @@
 :experimental:
 
 Typing kbd:[C-c C-m] after some form in a source buffer or the REPL will show
-you the `macroexpand-1` expansion of the form in a new buffer; kbd:[C-c M-m]
-does the same with `macroexpand-all`. You'll have access to additional
-keybindings in the macro expansion buffer (which is internally using
-`cider-macroexpansion-mode`):
+you the `macroexpand-1` expansion of the form in a new buffer.
+
+kbd:[C-c M-m] is a prefix map (`cider-macroexpand-map`) gathering all of CIDER's
+form-expanding commands:
+
+[cols="1,3"]
+|===
+| Keyboard shortcut | Description
+
+| kbd:[C-c M-m 1]
+| `macroexpand-1` into a macroexpansion buffer (the same as kbd:[C-c C-m]).
+
+| kbd:[C-c M-m a]
+| `macroexpand-all` into a macroexpansion buffer.
+
+| kbd:[C-c M-m e]
+| Expand the macro at point one step, inline in the source buffer (see xref:#inline[inline macro stepping] below).
+
+| kbd:[C-c M-m E]
+| Fully expand the macro at point, inline in the source buffer.
+
+| kbd:[C-c M-m b]
+| Run an inline-style stepping session in a dedicated popup buffer.
+|===
+
+[TIP]
+====
+Prefer kbd:[C-c C-m] as the prefix instead? Point it at the same map:
+
+[source,lisp]
+----
+(define-key cider-mode-map (kbd "C-c C-m") 'cider-macroexpand-map)
+----
+
+You'll then reach plain `macroexpand-1` at kbd:[C-c C-m 1].
+====
+
+When you expand into a buffer you'll have access to additional keybindings there
+(the buffer uses `cider-macroexpansion-mode`):
 
 |===
 | Keyboard shortcut | Description
@@ -116,6 +151,7 @@ namespaces in the macroexpansion buffer. It can be set to one of the following:
 The option `cider-macroexpansion-print-metadata` controls whether to print the var metadata
 in the macroexpansion buffer. It's set to `nil` by default.
 
+[#inline]
 == Inline macroexpansion
 
 As an alternative to the separate buffer, `cider-macrostep-expand` expands

--- a/doc/modules/ROOT/pages/usage/cider_mode.adoc
+++ b/doc/modules/ROOT/pages/usage/cider_mode.adoc
@@ -160,12 +160,24 @@ kbd:[C-u C-c C-c]
 | Interrupt any pending evaluations.
 
 | `cider-macroexpand-1`
-| kbd:[C-c C-m]
+| kbd:[C-c C-m] (also kbd:[C-c M-m 1])
 | Invoke `macroexpand-1` on the form at point and display the result in a macroexpansion buffer.  If invoked with a prefix argument, `macroexpand` is used instead of `macroexpand-1`.
 
 | `cider-macroexpand-all`
-| kbd:[C-c M-m]
+| kbd:[C-c M-m a]
 | Invoke `clojure.walk/macroexpand-all` on the form at point and display the result in a macroexpansion buffer.
+
+| `cider-macrostep-expand`
+| kbd:[C-c M-m e]
+| Expand the macro at point one step, inline in the source buffer.
+
+| `cider-macrostep-expand-all`
+| kbd:[C-c M-m E]
+| Fully expand the macro at point, inline in the source buffer.
+
+| `cider-macrostep-expand-in-buffer`
+| kbd:[C-c M-m b]
+| Run an inline-style macro-stepping session in a dedicated popup buffer.
 
 | `cider-eval-ns-form`
 | kbd:[C-c C-v n]

--- a/lisp/cider-macroexpansion.el
+++ b/lisp/cider-macroexpansion.el
@@ -292,6 +292,24 @@ buffer's key bindings."
   (when cider-macroexpansion-mode
     (setq-local header-line-format '(:eval (cider-macroexpansion--header-line)))))
 
+(declare-function cider-macrostep-expand "cider-macrostep")
+(declare-function cider-macrostep-expand-all "cider-macrostep")
+(declare-function cider-macrostep-expand-in-buffer "cider-macrostep")
+
+;;;###autoload (autoload 'cider-macroexpand-map "cider-macroexpansion" "CIDER macroexpansion keymap." nil 'keymap)
+(defvar cider-macroexpand-map
+  (let ((map (define-prefix-command 'cider-macroexpand-map)))
+    (define-key map (kbd "1") #'cider-macroexpand-1)
+    (define-key map (kbd "a") #'cider-macroexpand-all)
+    (define-key map (kbd "e") #'cider-macrostep-expand)
+    (define-key map (kbd "E") #'cider-macrostep-expand-all)
+    (define-key map (kbd "b") #'cider-macrostep-expand-in-buffer)
+    map)
+  "CIDER macroexpansion keymap, grouping the form-expanding commands.
+Keys 1 and a open the macroexpansion buffer on one level or the full expansion;
+e and E expand inline (a single step, or all the way) via `cider-macrostep'; b
+runs an inline-style stepping session in a dedicated popup buffer.")
+
 (provide 'cider-macroexpansion)
 
 ;;; cider-macroexpansion.el ends here

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -443,7 +443,11 @@ If invoked with a prefix ARG eval the expression after inserting it."
      ["Format EDN buffer" cider-format-edn-buffer])
     ("Macroexpand"
      ["Macroexpand-1" cider-macroexpand-1]
-     ["Macroexpand-all" cider-macroexpand-all])
+     ["Macroexpand-all" cider-macroexpand-all]
+     "--"
+     ["Macrostep expand (inline)" cider-macrostep-expand]
+     ["Macrostep expand all (inline)" cider-macrostep-expand-all]
+     ["Macrostep in a buffer" cider-macrostep-expand-in-buffer])
     ,cider-test-menu
     ("Debug"
      ["Inspect" cider-inspect]
@@ -500,6 +504,9 @@ If invoked with a prefix ARG eval the expression after inserting it."
 ;; used. That optimizes CIDER's initial load time.
 (declare-function cider-macroexpand-1 "cider-macroexpansion")
 (declare-function cider-macroexpand-all "cider-macroexpansion")
+(declare-function cider-macrostep-expand "cider-macrostep")
+(declare-function cider-macrostep-expand-all "cider-macrostep")
+(declare-function cider-macrostep-expand-in-buffer "cider-macrostep")
 (declare-function cider-selector "cider-selector")
 (declare-function cider-toggle-trace-ns "cider-tracing")
 (declare-function cider-toggle-trace-var "cider-tracing")
@@ -568,7 +575,7 @@ higher precedence."
     (define-key map (kbd "C-c C-u") #'cider-undef)
     (define-key map (kbd "C-c C-M-u") #'cider-undef-all)
     (define-key map (kbd "C-c C-m") #'cider-macroexpand-1)
-    (define-key map (kbd "C-c M-m") #'cider-macroexpand-all)
+    (define-key map (kbd "C-c M-m") 'cider-macroexpand-map)
     (define-key map (kbd "C-c M-n") 'cider-ns-map)
     (define-key map (kbd "C-c M-i") #'cider-inspect)
     (define-key map (kbd "C-c M-t v") #'cider-toggle-trace-var)


### PR DESCRIPTION
`C-c M-m` becomes a prefix map (`cider-macroexpand-map`) that gathers all of CIDER's form-expanding commands in one place:

- `1` -> `cider-macroexpand-1`, `a` -> `cider-macroexpand-all` (into the macroexpansion buffer)
- `e` -> `cider-macrostep-expand`, `E` -> `cider-macrostep-expand-all` (inline), `b` -> `cider-macrostep-expand-in-buffer`

`C-c C-m` still runs `macroexpand-1` directly. The one migration is that `cider-macroexpand-all` moves from `C-c M-m` to `C-c M-m a` - documented in the CHANGELOG (the deprecation engine can't warn on a key that's now a prefix). The docs also show how to point `C-c C-m` at the same map if you prefer that prefix.

- [x] The commits are consistent with our contribution guidelines
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`)
- [x] You've updated the changelog
- [x] You've updated the user manual