### PR TITLE
Add cider-browse-spec-tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- [#4004](https://github.com/clojure-emacs/cider/pull/4004): Add `cider-browse-spec-tree`, which browses a spec and the specs it references as an expandable tree - expand a node to reveal its sub-specs (a level at a time), `RET` to open a spec's full definition.
 - [#3999](https://github.com/clojure-emacs/cider/pull/3999): Add `cider-type-protocols` (`C-c C-w t`), listing the protocols a type implements (the reverse of `cider-who-implements`), and `cider-protocols-with-method` (`C-c C-w p`), listing the protocols that declare a given method.
 - [#3997](https://github.com/clojure-emacs/cider/pull/3997): Add `cider-who-implements` (`C-c C-w i`), which browses a protocol's implementing types or a multimethod's dispatch values on an expandable tree. (Currently a client-side approximation; inline `defrecord`/`deftype` impls and per-`defmethod` jumps await a follow-up middleware op.)
 - [#3996](https://github.com/clojure-emacs/cider/pull/3996): Add `cider-who-macroexpands` (`C-c C-w m`), which finds a macro's use sites by searching the project's source - the runtime ops can't see them, since macros are expanded away at compile time.

--- a/doc/modules/ROOT/pages/usage/misc_features.adoc
+++ b/doc/modules/ROOT/pages/usage/misc_features.adoc
@@ -348,6 +348,12 @@ a regex and will filter out all the spec names that don't match.
 
 image::spec_browser_all.png[Spec Browser]
 
+To explore how a spec is composed, kbd:[M-x] `cider-browse-spec-tree` shows the
+spec and the specs it references as an expandable tree: kbd:[TAB] on a node
+reveals the namespaced specs that spec depends on (fetched a level at a time),
+and kbd:[RET] opens that spec's full definition in the regular browser. A spec
+that recurs onto its own path is shown as a leaf, so the tree never loops.
+
 Once in the browser you can use your mouse or the keybindings below to
 navigate deeper.
 

--- a/lisp/cider-browse-spec.el
+++ b/lisp/cider-browse-spec.el
@@ -36,6 +36,7 @@
 
 (require 'cider-client)
 (require 'cider-popup)
+(require 'cider-tree-view)
 (require 'cider-util)
 (require 'nrepl-dict)
 (require 'seq)
@@ -471,6 +472,55 @@ With a prefix argument ARG, prompts for a regexp to filter specs.
 No filter applied if the regexp is the empty string."
   (interactive "P")
   (cider-browse-spec-regex (if arg (read-string "Filter regex: ") "")))
+
+
+;;; Spec tree - explore a spec's referenced sub-specs as an expandable tree.
+
+(defun cider-browse-spec--collect-keywords (form acc)
+  "Collect the namespaced-keyword strings in spec FORM into ACC, returning it."
+  (cond ((and (stringp form) (cider--qualified-keyword-p form))
+         (cons form acc))
+        ((listp form)
+         (dolist (x form acc)
+           (setq acc (cider-browse-spec--collect-keywords x acc))))
+        (t acc)))
+
+(defun cider-browse-spec--subspecs (form)
+  "Return the distinct namespaced specs referenced in spec FORM, in order."
+  (seq-uniq (nreverse (cider-browse-spec--collect-keywords form nil))))
+
+(defun cider-browse-spec--tree-node (spec ancestors)
+  "Return a `cider-tree-view' node for SPEC.
+ANCESTORS is the list of specs on the path from the root; a SPEC that recurs
+onto its own path is rendered as a leaf, so expansion can't loop on a recursive
+spec.  Visiting a node shows that spec's full definition."
+  (let ((recursive (member spec ancestors)))
+    (cider-tree-view-node-create
+     :label (concat (cider-font-lock-as-clojure spec)
+                    (when recursive (propertize "  (recursive)" 'face 'shadow)))
+     :on-visit (lambda () (cider-browse-spec--browse spec))
+     :children-fn (unless recursive
+                    (lambda ()
+                      (mapcar (lambda (s)
+                                (cider-browse-spec--tree-node s (cons spec ancestors)))
+                              (cider-browse-spec--subspecs
+                               (cider-sync-request:spec-form spec))))))))
+
+;;;###autoload
+(defun cider-browse-spec-tree (spec)
+  "Browse SPEC and the specs it references as an interactive tree.
+Each node expands to the namespaced specs that spec depends on - fetched a level
+at a time - so you can walk a spec's structure in place; \\<cider-tree-view-mode-map>\\[cider-tree-view-visit] on a node
+shows that spec's full definition."
+  (interactive (list (completing-read "Browse spec tree: "
+                                      (cider-sync-request:spec-list))))
+  (cider-ensure-connected)
+  (cider-ensure-op-supported "cider/spec-form")
+  (let ((root (cider-browse-spec--tree-node spec nil)))
+    (setf (cider-tree-view-node-expanded root) t)
+    (with-current-buffer (cider-popup-buffer "*cider-spec-tree*" 'select
+                                             'cider-tree-view-mode 'ancillary)
+      (cider-tree-view-render (list root) (format "Spec tree: %s" spec)))))
 
 (provide 'cider-browse-spec)
 

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -433,6 +433,7 @@ If invoked with a prefix ARG eval the expression after inserting it."
      ["Browse namespace" cider-browse-ns]
      ["Browse all namespaces" cider-browse-ns-all]
      ["Browse spec" cider-browse-spec]
+     ["Browse spec tree" cider-browse-spec-tree]
      ["Browse all specs" cider-browse-spec-all]
      ["Browse REPL input history" cider-repl-history]
      ["Browse classpath" cider-classpath]

--- a/test/cider-browse-spec-tests.el
+++ b/test/cider-browse-spec-tests.el
@@ -99,3 +99,24 @@
       (expect (bufferp buf) :to-be-truthy)
       (expect (with-current-buffer buf (buffer-string)) :to-match "s/union")
       (kill-buffer buf))))
+
+(describe "cider-browse-spec--subspecs"
+  (it "collects the distinct namespaced specs referenced in a form"
+    (expect (cider-browse-spec--subspecs
+             cider-browse-spec-tests--company-addr-response)
+            :to-equal '(":test/addr" ":test/company" ":test/suite")))
+
+  (it "returns nil when the form references no specs"
+    (expect (cider-browse-spec--subspecs '("clojure.core/string?")) :to-be nil)))
+
+(describe "cider-browse-spec--tree-node"
+  (it "expands lazily into one node per referenced sub-spec"
+    (cider-browse-spec-tests--setup-spec-form
+     cider-browse-spec-tests--company-addr-response)
+    (let* ((node (cider-browse-spec--tree-node ":user/company-addr" nil))
+           (children (funcall (cider-tree-view-node-children-fn node))))
+      (expect (length children) :to-equal 3)))
+
+  (it "makes a recursive spec a leaf so expansion can't loop"
+    (let ((node (cider-browse-spec--tree-node ":my/tree" '(":my/tree"))))
+      (expect (cider-tree-view-node-children-fn node) :to-be nil))))


### PR DESCRIPTION
First step in applying the `cider-tree-view` widget (from the who-* work) more widely: `cider-browse-spec-tree` browses a spec and the specs it references as an expandable tree.

Each node expands to the namespaced specs that spec depends on - extracted from its `spec-form` and fetched lazily, a level at a time - so you can walk a spec's structure in place rather than the existing back-and-forth button navigation. `RET` on a node opens that spec's full definition in the regular browser, and a spec that recurs onto its own path is drawn as a leaf so the tree never loops.

No widget changes were needed for this one - it's a clean fit for the lazy-children model. (Wider adoption to `browse-ns` etc. will drive the widget improvements, e.g. section headers.)

- [x] The commits are consistent with our contribution guidelines
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`)
- [x] You've updated the changelog
- [x] You've updated the user manual