### PR TITLE
Render the namespace browser on cider-tree-view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Changes
 
+- [#4005](https://github.com/clojure-emacs/cider/pull/4005): Render the namespace browser (`cider-browse-ns`) on the `cider-tree-view` widget: groups (by type or visibility) are now foldable with `TAB`, and `n`/`p` move between entries.
 - [#4003](https://github.com/clojure-emacs/cider/pull/4003): Turn `C-c M-m` into a prefix map (`cider-macroexpand-map`) grouping all the macro-expanding commands - `macroexpand-1`/`macroexpand-all` into a buffer (`1`/`a`) and the inline `cider-macrostep` commands (`e`/`E`/`b`). `cider-macroexpand-all` thus moves from `C-c M-m` to `C-c M-m a`; `C-c C-m` still runs `macroexpand-1` directly.
 - [#4002](https://github.com/clojure-emacs/cider/pull/4002): Bump the injected `cider-nrepl` to 0.60.0, which provides the `cider/who-implements`, `cider/type-protocols` and `cider/protocols-with-method` ops backing the protocol-exploration commands.
 - [#4001](https://github.com/clojure-emacs/cider/pull/4001): `cider-type-protocols` and `cider-protocols-with-method` now use cider-nrepl's `cider/type-protocols` and `cider/protocols-with-method` ops when available, falling back to the previous client-side query otherwise.

--- a/doc/modules/ROOT/pages/usage/misc_features.adoc
+++ b/doc/modules/ROOT/pages/usage/misc_features.adoc
@@ -281,10 +281,11 @@ image::ns_browser.png[Namespace Browser]
 You can also browse all available namespaces with kbd:[M-x]
 `cider-browse-ns-all`.
 
-The UI contains buttons in the header which allow you to control how
-the buffer is displayed (see below for keybindings).  You may also
-configure the `cider-browse-ns-default-filters` variable to a list of
-the element types you want to be hidden by default.
+The contents are shown as a navigable tree: when you group them (see below)
+each group is a foldable node you can collapse with kbd:[TAB].  The header
+contains buttons which let you control how the buffer is displayed (see below
+for keybindings).  You may also configure the `cider-browse-ns-default-filters`
+variable to a list of the element types you want to be hidden by default.
 
 There are a bunch of useful keybindings that are defined in browser buffers.
 
@@ -307,7 +308,10 @@ There are a bunch of useful keybindings that are defined in browser buffers.
 | Toggle showing all items (ignore active filters).
 
 | kbd:[n]
-| Go to next line.
+| Go to the next node.
+
+| kbd:[TAB]
+| Fold or unfold the group at point.
 
 | kbd:[h p]
 | Toggle visibility of private items.
@@ -331,7 +335,7 @@ There are a bunch of useful keybindings that are defined in browser buffers.
 | Group items by visibility (public vs. private).
 
 | kbd:[p]
-| Go to previous line.
+| Go to the previous node.
 |===
 
 == Browsing the Clojure Spec Registry

--- a/lisp/cider-browse-ns.el
+++ b/lisp/cider-browse-ns.el
@@ -37,6 +37,7 @@
 
 (require 'cider-client)
 (require 'cider-popup)
+(require 'cider-tree-view)
 (require 'cider-util)
 (require 'nrepl-dict)
 
@@ -81,13 +82,12 @@ Available options include `private', `test', `macro', `function', and
 
 (defvar cider-browse-ns-mode-map
   (let ((map (make-sparse-keymap)))
-    (set-keymap-parent map cider-popup-buffer-mode-map)
+    ;; `cider-tree-view-mode' (the parent) already provides n/p navigation,
+    ;; TAB to fold a group, and RET/. to act on the var at point; we only add
+    ;; the browser-specific commands on top.
     (define-key map "d" #'cider-browse-ns-doc-at-point)
     (define-key map "s" #'cider-browse-ns-find-at-point)
-    (define-key map (kbd "RET") #'cider-browse-ns-operate-at-point)
     (define-key map "^" #'cider-browse-ns-all)
-    (define-key map "n" #'next-line)
-    (define-key map "p" #'previous-line)
 
     (define-key map "a" #'cider-browse-ns-toggle-all)
 
@@ -121,19 +121,12 @@ Available options include `private', `test', `macro', `function', and
          ["Visibility" cider-browse-ns-group-by-visibility])))
     map))
 
-(defvar cider-browse-ns-mouse-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map [mouse-1] #'cider-browse-ns-handle-mouse)
-    map))
-
-(define-derived-mode cider-browse-ns-mode special-mode "browse-ns"
+(define-derived-mode cider-browse-ns-mode cider-tree-view-mode "browse-ns"
   "Major mode for browsing Clojure namespaces.
 
 \\{cider-browse-ns-mode-map}"
   (setq-local electric-indent-chars nil)
   (setq-local sesman-system 'CIDER)
-  (when cider-special-mode-truncate-lines
-    (setq-local truncate-lines t))
   (setq-local cider-browse-ns-current-ns nil))
 
 (defun cider-browse-ns--text-face (var-meta)
@@ -150,20 +143,10 @@ When VAR-META is nil, default to `font-lock-function-name-face'."
    ((nrepl-dict-contains var-meta "arglists") 'font-lock-function-name-face)
    (t 'font-lock-variable-name-face)))
 
-(defun cider-browse-ns--properties (var var-meta)
-  "Decorate VAR with a clickable keymap and a face.
-VAR-META is used to decide a font-lock face."
-  (let ((face (cider-browse-ns--text-face var-meta)))
-    (propertize var
-                'font-lock-face face
-                'mouse-face 'highlight
-                'keymap cider-browse-ns-mouse-map)))
-
 (defun cider-browse-ns--ns-list (buffer title nss)
   "List the namespaces NSS in BUFFER.
 
-Buffer is rendered with TITLE at the top and lists ITEMS filtered according
-to user settings."
+Buffer is rendered with TITLE at the top and lists the namespaces as a tree."
   (let ((dict (nrepl-dict)))
     (dolist (ns nss)
       (nrepl-dict-put dict ns (nrepl-dict "ns" "true")))
@@ -226,88 +209,82 @@ displayed."
                    (and var-p var-filter-p)
                    (and private-p private-filter-p)))))))
 
-(defun cider-browse-ns--propertized-item (key items)
-  "Return propertized line of item KEY in nrepl-dict ITEMS."
+(defun cider-browse-ns--node-label (key items)
+  "Build the fontified tree label for item KEY in nrepl-dict ITEMS.
+When a namespace is being browsed, the var's first doc line is appended."
   (let* ((var-meta (nrepl-dict-get items key))
          (face (cider-browse-ns--text-face var-meta))
-         (private-p (string= (nrepl-dict-get var-meta "private") "true"))
-         (test-p (nrepl-dict-contains var-meta "test"))
-         (ns-p (nrepl-dict-contains var-meta "ns")))
+         (private-p (cider-browse-ns--meta-private-p var-meta))
+         (test-p (cider-browse-ns--meta-test-p var-meta)))
     (concat
-     (propertize key
-                 'font-lock-face face
-                 'ns ns-p)
-     " "
+     (propertize key 'font-lock-face face)
      (cond
-      (test-p (propertize "(test) " 'face 'cider-browse-ns-extra-info-face))
-      (private-p (propertize "(-) " 'face 'cider-browse-ns-extra-info-face))
-      (t "")))))
+      (test-p (propertize " (test)" 'face 'cider-browse-ns-extra-info-face))
+      (private-p (propertize " (-)" 'face 'cider-browse-ns-extra-info-face))
+      (t ""))
+     (when cider-browse-ns-current-ns
+       (let* ((doc (nrepl-dict-get-in items (list key "doc")))
+              (doc (when doc (ignore-errors (read doc)))))
+         (concat "  " (propertize (cider-browse-ns--first-doc-line doc)
+                                  'font-lock-face 'font-lock-doc-face)))))))
 
-(defun cider-browse-ns--display-list (keys items max-length &optional label)
-  "Render the items of KEYS as contained in the nrepl-dict ITEMS.
+(defun cider-browse-ns--var-node (key items)
+  "Build a `cider-tree-view' node for item KEY in nrepl-dict ITEMS.
+The node carries a (TYPE VALUE) payload read back by
+`cider-browse-ns--thing-at-point' so RET/`d'/`s' can act on it.  When a
+namespace is being browsed KEY is one of its vars; otherwise (the all-namespaces
+listing) KEY is itself a namespace."
+  (let ((value (if cider-browse-ns-current-ns
+                   (list 'var (format "%s/%s" cider-browse-ns-current-ns key))
+                 (list 'ns key))))
+    (cider-tree-view-node-create
+     :label (cider-browse-ns--node-label key items)
+     :value value
+     :on-visit #'cider-browse-ns-operate-at-point)))
 
-Pad the row to be MAX-LENGTH+1.  If LABEL is non-nil, add a header to the
-list of items."
+(defun cider-browse-ns--group-node (label keys items)
+  "Build an expandable group node titled LABEL over var KEYS in ITEMS.
+Return nil when KEYS is empty, so empty groups are dropped."
   (when keys
-    (when label
-      (insert "  " label ":\n"))
-    (dolist (key keys)
-      (let* ((doc (nrepl-dict-get-in items (list key "doc")))
-             (doc (when doc (read doc)))
-             (first-doc-line (cider-browse-ns--first-doc-line doc))
-             (item-line (cider-browse-ns--propertized-item key items)))
-        (insert "  ")
-        (insert-text-button item-line
-                            'action (lambda (_) (cider-browse-ns-operate-at-point))
-                            'face (cider-browse-ns--text-face (nrepl-dict-get items key)))
-        (when cider-browse-ns-current-ns
-          (insert (make-string (+ (- max-length (string-width item-line)) 1) ?·))
-          (insert " " (propertize first-doc-line 'font-lock-face 'font-lock-doc-face)))
-        (insert "\n")))
-    (insert "\n")))
+    (let ((node (cider-tree-view-node-create
+                 :label (propertize (format "%s (%d)" label (length keys)) 'face 'bold)
+                 :children-fn (lambda ()
+                                (mapcar (lambda (key)
+                                          (cider-browse-ns--var-node key items))
+                                        keys)))))
+      (setf (cider-tree-view-node-expanded node) t)
+      node)))
 
-(defun cider-browse-ns--column-width (items)
-  "Determine the display width of displayed ITEMS."
-  (let* ((propertized-lines
-          (seq-map (lambda (key)
-                     (cider-browse-ns--propertized-item key items))
-                   (nrepl-dict-keys items))))
-    (if propertized-lines
-        (apply #'max (seq-map (lambda (entry) (string-width entry))
-                              propertized-lines))
-      0)))
-
-(defun cider-browse-ns--render-items (items)
-  "Render the nrepl-dict ITEMS to the browse-ns buffer."
-  (let* ((max-length (cider-browse-ns--column-width items)))
-    (cl-flet
-        ((keys-from-pred
-          (pred items)
-          (nrepl-dict-keys (nrepl-dict-filter (lambda (_ var-meta)
-                                                (funcall pred var-meta))
-                                              items))))
-      (cond
-       ((eql cider-browse-ns-group-by 'type)
-        (let* ((func-keys (keys-from-pred #'cider-browse-ns--meta-function-p items))
-               (macro-keys (keys-from-pred #'cider-browse-ns--meta-macro-p items))
-               (var-keys (keys-from-pred #'cider-browse-ns--meta-var-p items))
-               (test-keys (keys-from-pred #'cider-browse-ns--meta-test-p items)))
-          (cider-browse-ns--display-list func-keys items max-length "Functions")
-          (cider-browse-ns--display-list macro-keys items max-length "Macros")
-          (cider-browse-ns--display-list var-keys items max-length "Vars")
-          (cider-browse-ns--display-list test-keys items max-length "Tests")))
-       ((eql cider-browse-ns-group-by 'visibility)
-        (let* ((public-keys
-                (keys-from-pred
-                 (lambda (var-meta)
-                   (not (cider-browse-ns--meta-private-p var-meta)))
-                 items))
-               (private-keys (keys-from-pred #'cider-browse-ns--meta-private-p items)))
-          (cider-browse-ns--display-list public-keys items max-length "Public")
-          (cider-browse-ns--display-list private-keys items max-length "Private")))
-       (t
-        (cider-browse-ns--display-list
-         (nrepl-dict-keys items) items max-length))))))
+(defun cider-browse-ns--roots (items)
+  "Build the `cider-tree-view' roots for nrepl-dict ITEMS per the grouping."
+  (cl-flet
+      ((keys-from-pred
+        (pred)
+        (nrepl-dict-keys (nrepl-dict-filter (lambda (_ var-meta)
+                                              (funcall pred var-meta))
+                                            items))))
+    (cond
+     ((eql cider-browse-ns-group-by 'type)
+      (delq nil
+            (list (cider-browse-ns--group-node
+                   "Functions" (keys-from-pred #'cider-browse-ns--meta-function-p) items)
+                  (cider-browse-ns--group-node
+                   "Macros" (keys-from-pred #'cider-browse-ns--meta-macro-p) items)
+                  (cider-browse-ns--group-node
+                   "Vars" (keys-from-pred #'cider-browse-ns--meta-var-p) items)
+                  (cider-browse-ns--group-node
+                   "Tests" (keys-from-pred #'cider-browse-ns--meta-test-p) items))))
+     ((eql cider-browse-ns-group-by 'visibility)
+      (delq nil
+            (list (cider-browse-ns--group-node
+                   "Public"
+                   (keys-from-pred (lambda (m) (not (cider-browse-ns--meta-private-p m))))
+                   items)
+                  (cider-browse-ns--group-node
+                   "Private" (keys-from-pred #'cider-browse-ns--meta-private-p) items))))
+     (t
+      (mapcar (lambda (key) (cider-browse-ns--var-node key items))
+              (nrepl-dict-keys items))))))
 
 (defun cider-browse-ns--filter (flag)
   "Toggle the filter indicated by FLAG and re-render the buffer."
@@ -394,23 +371,22 @@ are being filtered."
   (insert "\n\n"))
 
 (defun cider-browse-ns--render-buffer (&optional buffer)
-  "Render the sections of the browse-ns buffer.
+  "Render the browse-ns BUFFER as a `cider-tree-view'.
 
-Render occurs in BUFFER if non-nil.  This function is the main entrypoint
-for redisplaying the buffer when filters change."
+Render occurs in BUFFER if non-nil.  This is the main entrypoint for
+redisplaying the buffer when filters or grouping change."
   (with-current-buffer (or buffer (current-buffer))
-    (let* ((inhibit-read-only t)
-           (point (point))
-           (filtered-items (nrepl-dict-filter #'cider-browse-ns--item-filter
+    (let* ((filtered-items (nrepl-dict-filter #'cider-browse-ns--item-filter
                                               cider-browse-ns-items))
            (filtered-item-ct (- (length (nrepl-dict-keys cider-browse-ns-items))
                                 (length (nrepl-dict-keys filtered-items)))))
-      (erase-buffer)
-      (insert (propertize (cider-propertize cider-browse-ns-title 'ns) 'ns t) "\n")
-      (when cider-browse-ns-current-ns
-        (cider-browse-ns--render-header filtered-item-ct))
-      (cider-browse-ns--render-items filtered-items)
-      (goto-char point))))
+      (cider-tree-view-render
+       (cider-browse-ns--roots filtered-items)
+       cider-browse-ns-title
+       ;; The filter/group controls only make sense for a single namespace's
+       ;; vars, not the flat "all namespaces" listing.
+       (when cider-browse-ns-current-ns
+         (lambda () (cider-browse-ns--render-header filtered-item-ct)))))))
 
 (defun cider-browse-ns--first-doc-line (doc)
   "Return the first line of the given DOC string.
@@ -464,25 +440,14 @@ var-meta map."
       (cider-browse-ns--ns-list
        (current-buffer)
        "All loaded namespaces"
-       (mapcar (lambda (name)
-                 (cider-browse-ns--properties name nil))
-               names)))))
+       names))))
 
 (defun cider-browse-ns--thing-at-point ()
   "Get the thing at point.
-Return a list of the type (`ns' or `var') and the value."
-  (let ((ns-p (get-text-property (point) 'ns))
-        (line (car (split-string (string-trim (thing-at-point 'line)) " "))))
-    ;; In the "all namespaces" listing `cider-browse-ns-current-ns' is nil and
-    ;; every line is a namespace.  Relying on the `ns' text property alone fails
-    ;; when point sits on the leading whitespace, and the `.' heuristic misses
-    ;; single-segment namespaces like `user' (#3221).
-    (if (or ns-p (null cider-browse-ns-current-ns) (string-match "\\." line))
-        `(ns ,line)
-      `(var ,(format "%s/%s"
-                     (or (get-text-property (point) 'cider-browse-ns-current-ns)
-                         cider-browse-ns-current-ns)
-                     line)))))
+Return a list of the type (`ns' or `var') and the value, or nil if point is
+not on a var or namespace node (e.g. on a group header or the controls)."
+  (when-let* ((node (cider-tree-view-node-at-point)))
+    (cider-tree-view-node-value node)))
 
 (defun cider-browse-ns-toggle-all ()
   "Toggle showing all of the items in the browse-ns buffer."
@@ -530,10 +495,9 @@ Return a list of the type (`ns' or `var') and the value."
 (defun cider-browse-ns-doc-at-point ()
   "Show the documentation for the thing at current point."
   (interactive)
-  (let* ((thing (cider-browse-ns--thing-at-point))
-         (value (cadr thing)))
+  (when-let* ((thing (cider-browse-ns--thing-at-point)))
     ;; value is either some ns or a var
-    (cider-doc-lookup value)))
+    (cider-doc-lookup (cadr thing))))
 
 (defun cider-browse-ns-operate-at-point ()
   "Expand browser according to thing at current point.
@@ -541,12 +505,10 @@ If the thing at point is a ns it will be browsed,
 and if the thing at point is some var - its documentation will
 be displayed."
   (interactive)
-  (let* ((thing (cider-browse-ns--thing-at-point))
-         (type (car thing))
-         (value (cadr thing)))
-    (if (eq type 'ns)
-        (cider-browse-ns value)
-      (cider-doc-lookup value))))
+  (when-let* ((thing (cider-browse-ns--thing-at-point)))
+    (if (eq (car thing) 'ns)
+        (cider-browse-ns (cadr thing))
+      (cider-doc-lookup (cadr thing)))))
 
 (declare-function cider-find-ns "cider-find")
 (declare-function cider-find-var "cider-find")
@@ -554,17 +516,10 @@ be displayed."
 (defun cider-browse-ns-find-at-point ()
   "Find the definition of the thing at point."
   (interactive)
-  (let* ((thing (cider-browse-ns--thing-at-point))
-         (type (car thing))
-         (value (cadr thing)))
-    (if (eq type 'ns)
-        (cider-find-ns nil value)
-      (cider-find-var current-prefix-arg value))))
-
-(defun cider-browse-ns-handle-mouse (_event)
-  "Handle mouse click EVENT."
-  (interactive "e")
-  (cider-browse-ns-operate-at-point))
+  (when-let* ((thing (cider-browse-ns--thing-at-point)))
+    (if (eq (car thing) 'ns)
+        (cider-find-ns nil (cadr thing))
+      (cider-find-var current-prefix-arg (cadr thing)))))
 
 (provide 'cider-browse-ns)
 

--- a/lisp/cider-tree-view.el
+++ b/lisp/cider-tree-view.el
@@ -40,6 +40,7 @@
 
 (require 'cl-lib)
 (require 'subr-x)
+(require 'text-property-search)
 
 (cl-defstruct (cider-tree-view-node (:constructor cider-tree-view-node-create)
                                     (:copier nil))
@@ -48,15 +49,23 @@ LABEL is the (already fontified) string shown for the node.  ON-VISIT, when
 non-nil, is a function of no arguments run as the node's primary action.
 CHILDREN-FN, when non-nil, is a function of no arguments returning a list of
 child `cider-tree-view-node's; its presence is what makes a node expandable.
+VALUE is an arbitrary payload a consumer can attach and read back via
+`cider-tree-view-node-at-point' (e.g. to act on the thing the node names).
 The remaining slots are display state managed by this module."
   label
   on-visit
   children-fn
+  value
   (expanded nil)
   (children 'unloaded))
 
 (defvar-local cider-tree-view--roots nil
   "The list of root `cider-tree-view-node's rendered in this buffer.")
+
+(defvar-local cider-tree-view--header-fn nil
+  "When non-nil, a function of no arguments that inserts content above the tree.
+It runs on every (re-)render, so a consumer can show controls - filter toggles,
+say - that survive expand/collapse.")
 
 (defun cider-tree-view-node-expandable-p (node)
   "Return non-nil when NODE can have children.
@@ -75,7 +84,7 @@ returned nothing, at which point it is known to be a leaf."
             (funcall fn))))
   (cider-tree-view-node-children node))
 
-(defun cider-tree-view--node-at-point ()
+(defun cider-tree-view-node-at-point ()
   "Return the `cider-tree-view-node' on the current line, or nil."
   (get-text-property (point) 'cider-tree-view-node))
 
@@ -109,6 +118,8 @@ returned nothing, at which point it is known to be a leaf."
   "Redraw the whole tree from `cider-tree-view--roots'."
   (let ((inhibit-read-only t))
     (erase-buffer)
+    (when cider-tree-view--header-fn
+      (funcall cider-tree-view--header-fn))
     (dolist (root cider-tree-view--roots)
       (cider-tree-view--insert-node root 0))))
 
@@ -123,7 +134,7 @@ returned nothing, at which point it is known to be a leaf."
 Expanding realizes the node's children on first use; a node that turns out to
 have none is demoted to a leaf rather than expanding into nothing."
   (interactive)
-  (let ((node (cider-tree-view--node-at-point)))
+  (let ((node (cider-tree-view-node-at-point)))
     (cond
      ((null node) (user-error "No node here"))
      ((not (cider-tree-view-node-expandable-p node)) (user-error "Node is a leaf"))
@@ -142,7 +153,7 @@ EVENT is the mouse event, when invoked with the mouse."
   (interactive (list last-nonmenu-event))
   (when (mouse-event-p event)
     (mouse-set-point event))
-  (let ((node (cider-tree-view--node-at-point)))
+  (let ((node (cider-tree-view-node-at-point)))
     (cond
      ((null node) (user-error "No node here"))
      ((cider-tree-view-node-on-visit node) (funcall (cider-tree-view-node-on-visit node)))
@@ -179,19 +190,23 @@ EVENT is the mouse event, when invoked with the mouse."
 \\{cider-tree-view-mode-map}"
   (setq-local truncate-lines t))
 
-(defun cider-tree-view-render (roots title)
+(defun cider-tree-view-render (roots title &optional header-fn)
   "Render ROOTS in the current buffer, which must be in `cider-tree-view-mode'.
-TITLE is shown in the header line; point is left on the first node.  Callers are
-expected to have created and displayed the buffer (e.g. via `cider-popup-buffer')
-before handing it here."
+TITLE is shown in the header line; point is left on the first node.  HEADER-FN,
+when non-nil, is a function of no arguments inserting content above the tree on
+every render (e.g. filter controls).  Callers are expected to have created and
+displayed the buffer (e.g. via `cider-popup-buffer') before handing it here."
   (setq cider-tree-view--roots roots)
+  (setq-local cider-tree-view--header-fn header-fn)
   (setq-local header-line-format
               (concat (propertize (format " %s" title) 'face 'bold)
                       (propertize
                        "   n/p: move   TAB: expand   RET/.: visit   q: quit"
                        'face 'shadow)))
   (cider-tree-view--render)
-  (goto-char (point-min)))
+  (goto-char (point-min))
+  (unless (cider-tree-view-node-at-point)
+    (ignore-errors (cider-tree-view-next-node))))
 
 (provide 'cider-tree-view)
 ;;; cider-tree-view.el ends here

--- a/test/cider-browse-ns-tests.el
+++ b/test/cider-browse-ns-tests.el
@@ -57,8 +57,7 @@
     (with-temp-buffer
       (setq cider-browse-ns-buffer (buffer-name (current-buffer)))
       (cider-browse-ns "clojure.string")
-      (search-forward "clojure")
-      (expect (get-text-property (point) 'face) :to-equal 'font-lock-type-face)
+      ;; the namespace name is shown in the header line, not the buffer body
       (search-forward "blank")
       (expect (get-text-property (point) 'font-lock-face) :to-equal 'font-lock-function-name-face)
       (search-forward "True")
@@ -73,6 +72,28 @@
     (spy-on 'cider-sync-request:private-ns-vars-with-meta :and-return-value '(dict))
     (spy-on 'cider-ns-loaded-p :and-return-value nil)
     (expect (cider-browse-ns "foo.bar") :to-throw 'user-error)))
+
+(describe "cider-browse-ns grouping"
+  :var (cider-browse-ns-buffer)
+  (it "groups vars under expandable type headers and tags var nodes"
+    (spy-on 'cider-sync-request:ns-vars-with-meta :and-return-value
+            '(dict "afn" (dict "arglists" "([x])")
+                   "amacro" (dict "arglists" "([x])" "macro" "true")))
+    (spy-on 'cider-sync-request:private-ns-vars-with-meta :and-return-value '(dict))
+    (with-temp-buffer
+      (setq cider-browse-ns-buffer (buffer-name (current-buffer)))
+      (cider-browse-ns "my.ns")
+      ;; each var node carries a fully-qualified payload
+      (goto-char (point-min))
+      (search-forward "afn")
+      (expect (cider-browse-ns--thing-at-point) :to-equal '(var "my.ns/afn"))
+      ;; grouping by type yields counted headers with the vars nested under them
+      (cider-browse-ns-group-by-type)
+      (goto-char (point-min))
+      (expect (re-search-forward "Functions (1)" nil t) :to-be-truthy)
+      (expect (re-search-forward "afn" nil t) :to-be-truthy)
+      (goto-char (point-min))
+      (expect (re-search-forward "Macros (1)" nil t) :to-be-truthy))))
 
 (describe "cider-browse-ns--thing-at-point"
   :var (cider-browse-ns-buffer)

--- a/test/cider-tree-view-tests.el
+++ b/test/cider-tree-view-tests.el
@@ -99,15 +99,40 @@
         ;; from the root, n moves to the child line
         (goto-char (point-min))
         (cider-tree-view-next-node)
-        (expect (cider-tree-view-node-label (cider-tree-view--node-at-point))
+        (expect (cider-tree-view-node-label (cider-tree-view-node-at-point))
                 :to-equal "child")
         ;; visiting the child fires its action
         (cider-tree-view-visit)
         (expect visited :to-equal "child")
         ;; p moves back to the root
         (cider-tree-view-previous-node)
-        (expect (cider-tree-view-node-label (cider-tree-view--node-at-point))
+        (expect (cider-tree-view-node-label (cider-tree-view-node-at-point))
                 :to-equal "root")))))
+
+(describe "cider-tree-view payload and header"
+  (it "round-trips a node's value via cider-tree-view-node-at-point"
+    (with-temp-buffer
+      (cider-tree-view-tests--render
+       (list (cider-tree-view-node-create :label "x" :value '(var "a/b"))))
+      (goto-char (point-min))
+      (expect (cider-tree-view-node-value (cider-tree-view-node-at-point))
+              :to-equal '(var "a/b"))))
+
+  (it "renders a header above the tree and keeps it across re-renders"
+    (with-temp-buffer
+      (cider-tree-view-mode)
+      (let ((root (cider-tree-view-node-create
+                   :label "root" :expanded t
+                   :children-fn (lambda ()
+                                  (list (cider-tree-view-node-create :label "kid"))))))
+        (cider-tree-view-render (list root) "test" (lambda () (insert "CONTROLS\n")))
+        (expect (buffer-string) :to-match "\\`CONTROLS")
+        ;; point lands on the first node, not on the header line
+        (expect (cider-tree-view-node-at-point) :not :to-be nil)
+        ;; collapsing re-renders, and the header is drawn again
+        (cider-tree-view--goto-node root)
+        (cider-tree-view-toggle)
+        (expect (buffer-string) :to-match "\\`CONTROLS")))))
 
 (provide 'cider-tree-view-tests)
 


### PR DESCRIPTION
Continuing the wider adoption of the `cider-tree-view` widget: this rebuilds `cider-browse-ns` on it instead of the hand-rolled flat list. Groups (by type or visibility) are now foldable nodes you can collapse with `TAB`, `n`/`p` move between entries, and the var/namespace at point is acted on through a payload stored on each node rather than by parsing the line text (which incidentally makes the single-segment-namespace handling robust by construction).

This is the use-case that drove a few small, reusable widget additions, in their own commit:

- a `value` payload slot on `cider-tree-view-node` (read back via the now-public `cider-tree-view-node-at-point`)
- a buffer-local header hook so a consumer can render controls above the tree that survive expand/collapse - here, the existing filter/group-by buttons
- an explicit `(require 'text-property-search)` that was missing (the functions were already used, just happening to be loaded)

All the existing commands (`d`/`s`/`^`/`a`, the `h`/`g` filter and group-by prefixes) keep working. One deliberate visual change: doc snippets now follow the var name after a fixed gap rather than dotted column alignment, which doesn't carry over to an indented tree.

- [x] The commits are consistent with our contribution guidelines
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`)
- [x] You've updated the changelog
- [x] You've updated the user manual