### PR TITLE
Teach the mock nREPL server to echo eval values

### DIFF
--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -437,6 +437,43 @@
                (message ":nrepl-lifecycle/error %s" (buffer-string))))
            (error error-details))))))
 
+(describe "nrepl eval round-trip against the mock server"
+  (it "establishes a session and returns the value the mock echoes back"
+    (let* ((server-buffer (get-buffer-create ":nrepl-eval/server"))
+           (server-endpoint nil)
+           (server-process (nrepl-start-server-process
+                            default-directory
+                            (nrepl-server-mock-invocation-string)
+                            (lambda (_endpoint)
+                              (setq server-endpoint nrepl-endpoint)
+                              server-buffer))))
+      (unwind-protect
+          (progn
+            (nrepl-tests-poll-until (eq (process-status server-process) 'run) 2)
+            (nrepl-tests-poll-until server-endpoint 2)
+            (let* ((client-buffer (get-buffer-create ":nrepl-eval/client"))
+                   (client-proc (nrepl-start-client-process
+                                 (plist-get server-endpoint :host)
+                                 (plist-get server-endpoint :port)
+                                 server-process
+                                 (lambda (_endpoint) client-buffer)
+                                 (plist-get server-endpoint :socket-file))))
+              (unwind-protect
+                  (with-current-buffer (process-buffer client-proc)
+                    ;; the connect handshake cloned a session against the mock
+                    (expect nrepl-session :not :to-be nil)
+                    ;; a full eval request round-trips: encode -> socket -> mock
+                    ;; -> value response -> decode -> joined sync response
+                    (let ((response (nrepl-send-sync-request
+                                     '("op" "eval" "code" "(+ 1 2)")
+                                     (current-buffer))))
+                      (expect (nrepl-dict-get response "value") :to-equal "(+ 1 2)")
+                      (expect (nrepl-dict-get response "ns") :to-equal "user")
+                      (expect (nrepl-dict-get response "status") :to-contain "done")))
+                (when (process-live-p client-proc) (delete-process client-proc)))))
+        (when (process-live-p server-process) (delete-process server-process))
+        (when (buffer-live-p server-buffer) (kill-buffer server-buffer))))))
+
 (describe "nrepl-make-response-handler legacy shim"
   ;; Makes sure the obsolete shim still consults the global handler hooks
   ;; and emits the legacy status messages, so extension code that targeted

--- a/test/nrepl-server-mock.el
+++ b/test/nrepl-server-mock.el
@@ -31,25 +31,36 @@
 (require 'nrepl-client)
 (require 'nrepl-tests-utils "test/utils/nrepl-tests-utils")
 (require 'queue)
-(require 'cl)
 
-(defun nrepl-server-mock--get-keys (dict keys)
-  "Get the values for KEYS from nrepl-dict DICT.
-Get them as a list, so they can be easily consumed by
-`cl-destructuring-bind`."
-  (mapcar (lambda (k) (nrepl-dict-get dict k)) keys))
+(defun nrepl-server-mock--response (op msg msg-id msg-session)
+  "Return the canned response dict for nREPL operation OP, or nil if unsupported.
+MSG is the decoded request; MSG-ID and MSG-SESSION are its `id' and `session'.
+Responses are deliberately minimal - just enough for clients to exercise the
+request/response plumbing.  The `eval' op echoes the request's `code' back as
+the `value', so the full eval round-trip (request -> value response) can be
+tested against the mock."
+  (pcase op
+    ("clone"
+     `(dict "id" ,msg-id "session" "a-session"
+            "status" ("done") "new-session" "a-new-session"))
+    ("describe"
+     `(dict "id" ,msg-id "session" ,msg-session "status" ("done")))
+    ("eval"
+     `(dict "id" ,msg-id "session" ,msg-session
+            "value" ,(or (nrepl-dict-get msg "code") "")
+            "ns" "user"
+            "status" ("done")))
+    ("interrupt"
+     `(dict "id" ,msg-id "session" ,msg-session "status" ("done" "interrupted")))
+    ("close"
+     `(dict "id" ,msg-id "session" ,msg-session "status" ("done")))))
 
 (defun nrepl-server-mock-filter (proc output)
   "Handle the nREPL message found in OUTPUT sent by the client PROC.
 Minimal implementation, just enough for fulfilling clients' testing
-requirements.
-
-Additional complexity is added by the fact that bencoded dictionaries
-must have their keys in sorted order.  But we don't want to have to
-remember to write them down as such in the test values here (because
-there is ample room for mistakes that are harder to debug)."
+requirements.  Dispatches on the request's `op' via
+`nrepl-server-mock--response'."
   ;; (mock/log! ":mock.filter/output %s :msg %s" proc output)
-
   (condition-case error-details
       (let* ((msg (queue-dequeue (cdr (nrepl-bdecode output))))
              (_ (mock/log! ":mock.filter/msg :in %S" msg))
@@ -57,43 +68,8 @@ there is ample room for mistakes that are harder to debug)."
              ;; messages and responses. Get them once here.
              (msg-id (nrepl-dict-get msg "id"))
              (msg-session (nrepl-dict-get msg "session"))
-             (response (pcase msg
-                         ((pred (lambda (msg)
-                                  (equal "clone" (nrepl-dict-get msg "op"))))
-                          `(dict "id" ,msg-id
-                                 "session" "a-session"
-                                 "status" ("done")
-                                 "new-session" "a-new-session"))
-
-                         ((pred (bencodable-obj-equal? `(dict "op" "describe"
-                                                              "id" ,msg-id
-                                                              "session" ,msg-session)))
-                          `(dict "id" ,msg-id
-                                 "session" ,msg-session
-                                 "status" ("done")))
-
-                         ;; Eval op can include other fields in addition to the
-                         ;; code, we only need the signature and the session and
-                         ;; id fields.
-                         ((pred (lambda (msg)
-                                  (let ((keys '("op")))
-                                    (cl-destructuring-bind (op) (nrepl-server-mock--get-keys msg keys)
-                                      (bencodable-obj-equal? `(dict "op" ,op
-                                                                    "id" ,msg-id
-                                                                    "session" ,msg-session)
-                                                             `(dict "op" "eval"
-                                                                    "id" ,msg-id
-                                                                    "session" ,msg-session))))))
-                          `(dict "id" ,msg-id
-                                 "session" ,msg-session
-                                 "status" ("done")))
-
-                         ((pred (bencodable-obj-equal? `(dict "op" "close"
-                                                              "id" ,msg-id
-                                                              "session" ,msg-session)))
-                          `(dict "id" ,msg-id
-                                 "session" ,msg-session
-                                 "status" ("done"))))))
+             (op (nrepl-dict-get msg "op"))
+             (response (nrepl-server-mock--response op msg msg-id msg-session)))
 
         (mock/log! ":mock.filter/msg :out %S" response)
         (if (not response)
@@ -108,10 +84,7 @@ there is ample room for mistakes that are harder to debug)."
 
     (error
      (mock/log! ":mock.filter/fatal-error %s" error-details)
-     (error error-details))
-
-
-    ))
+     (error error-details))))
 
 (defun nrepl-server-mock-start ()
   "Start a mock nREPL server process.


### PR DESCRIPTION
Our mock nREPL server (`test/nrepl-server-mock.el`) only handled connection lifecycle - clone/describe/eval/close - and its `eval` reply carried no `value`. So the mock could cover connecting and session management, but not an actual eval round-trip, which is most of what a client does.

This reworks the mock's request handling into an op-keyed `nrepl-server-mock--response` (clearer than the previous nested shape-matching pcase), has `eval` echo the request's `code` back as the `value`, and adds an `interrupt` op. On top of that it adds an integration test that connects a client, lets the connect handshake clone a session, sends a sync eval and asserts the `value`/`ns`/`done` come back - exercising the encode -> socket -> mock -> decode -> joined-sync-response path end to end.

This is meant as groundwork: the mock can now back tests for code paths that need a real value response, not just a live socket.

- [x] The commits are consistent with our contribution guidelines
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`)
- [ ] You've updated the changelog (n/a - test infrastructure only)
- [ ] You've updated the user manual (n/a)