### PR TITLE
[Fix #3869] Refresh REPL prompt on combined value+done responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### Bugs fixed
 
+- [#4016](https://github.com/clojure-emacs/cider/pull/4016): Show the REPL prompt right away when a server (e.g. jank) sends `value` and `("done")` in the same response, instead of only after the next keypress ([#3869](https://github.com/clojure-emacs/cider/issues/3869)).
 - [#4006](https://github.com/clojure-emacs/cider/pull/4006): Fix a doubled colon when both `cider-clojure-cli-global-aliases` and `cider-clojure-cli-aliases` are set in the documented `:foo:bar` form, which produced a malformed `-M:global::local:cider/nrepl` jack-in invocation.
 - [#3971](https://github.com/clojure-emacs/cider/pull/3971): Fix `cider-macroexpand-again` (`g` in the macroexpansion buffer) to actually re-expand the form instead of redisplaying the original input.
 - [#3986](https://github.com/clojure-emacs/cider/pull/3986): Signal a `user-error` (instead of a generic `error`) when a var to trace isn't found or isn't traceable, so the failure no longer triggers a backtrace under `debug-on-error`.

--- a/lisp/nrepl-client.el
+++ b/lisp/nrepl-client.el
@@ -746,6 +746,8 @@ Sub-handlers, all optional:
                                                  value ns out err status id)
       (when (and ns on-ns)
         (funcall on-ns ns))
+      ;; The value/output slots are mutually exclusive within a single
+      ;; message, so they stay in a `cond'.
       (cond ((and content-type on-content-type)
              (funcall on-content-type
                       (if (string= content-transfer-encoding "base64")
@@ -757,17 +759,21 @@ Sub-handlers, all optional:
             (out
              (when on-stdout (funcall on-stdout out)))
             (err
-             (when on-stderr (funcall on-stderr err)))
-            (status
-             (when on-status (funcall on-status status response))
-             (when (and on-truncated
-                        (member "nrepl.middleware.print/truncated" status))
-               (funcall on-truncated))
-             (when (and on-eval-error (member "eval-error" status))
-               (funcall on-eval-error))
-             (when (member "done" status)
-               (nrepl--mark-id-completed id)
-               (when on-done (funcall on-done))))))))
+             (when on-stderr (funcall on-stderr err))))
+      ;; A `status' can accompany any of the slots above in the same
+      ;; message -- e.g. jank sends `value' and `("done")' together -- so
+      ;; it has to be handled independently rather than as a `cond' branch,
+      ;; otherwise the prompt is never refreshed on such responses (#3869).
+      (when status
+        (when on-status (funcall on-status status response))
+        (when (and on-truncated
+                   (member "nrepl.middleware.print/truncated" status))
+          (funcall on-truncated))
+        (when (and on-eval-error (member "eval-error" status))
+          (funcall on-eval-error))
+        (when (member "done" status)
+          (nrepl--mark-id-completed id)
+          (when on-done (funcall on-done)))))))
 
 (defun nrepl-make-response-handler (buffer value-handler stdout-handler
                                            stderr-handler done-handler

--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -240,6 +240,17 @@
       (funcall handler '(dict "id" "1" "status" ("done")))
       (expect called :to-be t)))
 
+  (it "handles a status alongside a value in the same message (#3869)"
+    ;; Some servers (e.g. jank) send `value' and `("done")' in a single
+    ;; response.  Both sub-handlers must fire, not just the value one.
+    (let* (value-received done-called
+           (handler (nrepl-make-eval-handler
+                     :on-value (lambda (v) (setq value-received v))
+                     :on-done  (lambda () (setq done-called t)))))
+      (funcall handler '(dict "id" "1" "value" "nil" "status" ("done")))
+      (expect value-received :to-equal "nil")
+      (expect done-called :to-be t)))
+
   (it "calls :on-eval-error with no args on eval-error status"
     (let* (called
            (handler (nrepl-make-eval-handler


### PR DESCRIPTION
Some nREPL servers send the eval `value` and the `("done")` status in a single message rather than in two separate ones (jank does this). Our response dispatcher treated value/out/err/status as mutually exclusive `cond` branches, so when both showed up together the value branch won and the done handler never ran. The visible symptom is the REPL prompt not appearing until you press a key.

Fix is to handle `status` independently of the value/output slots, so both fire for a combined response. Added a unit test for `nrepl-make-eval-handler` covering the value+done case.

Fixes #3869.