### PR TITLE
[Fix #3981] Single-source track-state ns-cache access

### DIFF
--- a/lisp/cider-client.el
+++ b/lisp/cider-client.el
@@ -663,6 +663,16 @@ unless ALL is truthy."
 
 (defvar cider-repl-ns-cache) ; defined in cider-repl.el, populated by track-state
 
+(defun cider-ns-load-cache (&optional repl)
+  "Return the track-state namespace cache dict for REPL, or nil.
+REPL defaults to the current connection (function `cider-current-repl').
+This is the low-level accessor for `cider-repl-ns-cache' - a buffer-local
+in the REPL buffer kept up to date by the track-state middleware.  Readers
+layer their own policy (membership, full-dict lookup, the unknown-versus-not-
+loaded distinction) on top of this single access point."
+  (when-let* ((repl (or repl (cider-current-repl))))
+    (buffer-local-value 'cider-repl-ns-cache repl)))
+
 (defun cider-ns-loaded-p (&optional ns)
   "Return non-nil when NS is loaded in the connected runtime.
 NS defaults to the current namespace.  Consults the track-state namespace
@@ -673,7 +683,7 @@ nREPL server too.  Returns nil when the namespace can't be determined."
               (repl (cider-current-repl)))
     (or
      ;; Fast path: track-state already knows about this namespace.
-     (and (nrepl-dict-get (buffer-local-value 'cider-repl-ns-cache repl) ns) t)
+     (and (nrepl-dict-get (cider-ns-load-cache repl) ns) t)
      ;; Fallback: ask the runtime directly (works without cider-nrepl).
      (equal "true"
             (nrepl-dict-get

--- a/lisp/cider-ns-state.el
+++ b/lisp/cider-ns-state.el
@@ -41,8 +41,6 @@
 (require 'cider-eval)
 (require 'nrepl-dict)
 
-(defvar cider-repl-ns-cache) ; defined in cider-repl.el, populated by track-state
-
 (defcustom cider-ns-load-state-display '(mode-line)
   "Where to surface the current buffer's namespace load-state.
 A list of presentations to enable (an empty list disables the indicator):
@@ -151,14 +149,15 @@ staleness is surfaced separately, by the evaluation fringe indicators."
 
 (defun cider-ns-state--refresh (&optional buffer)
   "Refresh the cached namespace load-state for BUFFER from track-state.
-BUFFER defaults to the current buffer.  Reads `cider-repl-ns-cache', which the
-track-state middleware keeps up to date, so it issues no request of its own.
-An empty cache means \"not yet reported\" (left unknown), not \"nothing
-loaded\".  Does nothing without a connection or a namespace."
+BUFFER defaults to the current buffer.  Reads the track-state namespace cache
+via `cider-ns-load-cache', which the middleware keeps up to date, so it issues
+no request of its own.  An empty cache means \"not yet reported\" (left
+unknown), not \"nothing loaded\".  Does nothing without a connection or a
+namespace."
   (with-current-buffer (or buffer (current-buffer))
     (when-let* ((repl (and (cider-connected-p) (cider-current-repl)))
                 (ns (cider-current-ns 'no-default))
-                (cache (buffer-local-value 'cider-repl-ns-cache repl)))
+                (cache (cider-ns-load-cache repl)))
       (unless (nrepl-dict-empty-p cache)
         (setq-local cider-ns-state--loaded
                     (if (nrepl-dict-get cache ns) t 'not-loaded))

--- a/lisp/cider-resolve.el
+++ b/lisp/cider-resolve.el
@@ -68,22 +68,19 @@
 (require 'nrepl-dict)
 (require 'cider-util)
 
-(defvar cider-repl-ns-cache)
-
 (defun cider-resolve--get-in (&rest keys)
-  "Return (nrepl-dict-get-in cider-repl-ns-cache KEYS)."
-  (when-let* ((conn (cider-current-repl)))
-    (with-current-buffer conn
-      (nrepl-dict-get-in cider-repl-ns-cache keys))))
+  "Return the track-state cache value at KEYS for the current connection."
+  (when-let* ((cache (cider-ns-load-cache)))
+    (nrepl-dict-get-in cache keys)))
 
 (defun cider-resolve--ns-cache ()
-  "Return the current connection's `cider-repl-ns-cache' dict, or nil.
-Resolving the connection is comparatively expensive when called from a
-source buffer (the indentation path does this), so callers performing
-several lookups should bind this once and reuse it rather than going
-through `cider-resolve--get-in' repeatedly."
-  (when-let* ((conn (cider-current-repl)))
-    (buffer-local-value 'cider-repl-ns-cache conn)))
+  "Return the current connection's track-state namespace cache dict, or nil.
+Thin wrapper over `cider-ns-load-cache'.  Resolving the connection is
+comparatively expensive when called from a source buffer (the indentation
+path does this), so callers performing several lookups should bind this
+once and reuse it rather than going through `cider-resolve--get-in'
+repeatedly."
+  (cider-ns-load-cache))
 
 (defun cider-resolve-alias (ns alias)
   "Return the namespace that ALIAS refers to in namespace NS.
@@ -125,7 +122,7 @@ This will be clojure.core or cljs.core depending on the return value of the
 function `cider-repl-type'."
   (when-let* ((repl (cider-current-repl)))
     (with-current-buffer repl
-      (nrepl-dict-get-in cider-repl-ns-cache
+      (nrepl-dict-get-in (cider-ns-load-cache repl)
                          (list (if (eq cider-repl-type 'cljs)
                                    "cljs.core"
                                  "clojure.core"))))))

--- a/test/cider-client-tests.el
+++ b/test/cider-client-tests.el
@@ -112,6 +112,23 @@
     (expect (cider--symbol-operator-p "") :to-be nil)
     (expect (cider--symbol-operator-p nil) :to-be nil)))
 
+(describe "cider-ns-load-cache"
+  (it "returns the REPL buffer's track-state cache"
+    (with-temp-buffer
+      (setq-local cider-repl-ns-cache (nrepl-dict "foo.bar" (nrepl-dict)))
+      (let ((repl (current-buffer)))
+        (expect (cider-ns-load-cache repl) :to-equal
+                (nrepl-dict "foo.bar" (nrepl-dict))))))
+  (it "defaults to the current connection when no REPL is given"
+    (with-temp-buffer
+      (setq-local cider-repl-ns-cache (nrepl-dict "foo.bar" (nrepl-dict)))
+      (spy-on 'cider-current-repl :and-return-value (current-buffer))
+      (expect (cider-ns-load-cache) :to-equal
+              (nrepl-dict "foo.bar" (nrepl-dict)))))
+  (it "returns nil when there's no connection"
+    (spy-on 'cider-current-repl :and-return-value nil)
+    (expect (cider-ns-load-cache) :to-be nil)))
+
 (describe "cider-ns-loaded-p"
   (it "uses the track-state cache as a free fast path"
     (with-temp-buffer


### PR DESCRIPTION
The track-state `cider-repl-ns-cache` (a `defvar-local` in `cider-repl.el`, populated by the middleware) is read independently by three modules, each forward-declaring the variable and pulling it out with `buffer-local-value`:

- `cider-resolve--ns-cache` (cider-resolve.el)
- `cider-ns-loaded-p` (cider-client.el)
- `cider-ns-state--refresh` (cider-ns-state.el)

This extracts the low-level access into a single `cider-ns-load-cache` accessor in `cider-client.el` (the lowest layer all three already require) and has the readers build their own policies on top. The three readers still differ on purpose (full dict vs membership, eval fallback vs cache-only, unknown-vs-not-loaded), so they're not merged - only the access point is shared. Drops the forward declarations from `cider-resolve.el` and `cider-ns-state.el`.

No behavior change. Added tests for the new accessor.

Fixes #3981.