### PR TITLE
Improvements to cider-eval-to-comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - [#3978](https://github.com/clojure-emacs/cider/pull/3978): Add `cider-macrostep-expand-all` (`a` in `cider-macrostep-mode`) to fully expand the form at point inline in one step, instead of stepping level by level.
 - [#3985](https://github.com/clojure-emacs/cider/pull/3985): Add `cider-macrostep-expand-in-buffer` to run a macro-stepping session in a dedicated `*cider-macrostep*` popup, leaving the source buffer untouched.
 - [#3973](https://github.com/clojure-emacs/cider/pull/3973): Indicate namespace load-state: a `cider-mode` lighter (and optional fringe) marker showing when the current buffer's namespace isn't loaded into the REPL or is stale (`cider-ns-load-state-display`), and a per-form fringe marker that turns from green to amber when you edit an evaluated form (`cider-mark-stale-after-edit`).
+- [#4018](https://github.com/clojure-emacs/cider/pull/4018): Detect and replace eval comments in `cider-pprint-form-to-comment`. Successive calls to eval-to-comment commands now update in-place instead of stacking stale results.
 
 ### Bugs fixed
 
@@ -55,6 +56,7 @@
 - [#4006](https://github.com/clojure-emacs/cider/pull/4006): Fix a doubled colon when both `cider-clojure-cli-global-aliases` and `cider-clojure-cli-aliases` are set in the documented `:foo:bar` form, which produced a malformed `-M:global::local:cider/nrepl` jack-in invocation.
 - [#3971](https://github.com/clojure-emacs/cider/pull/3971): Fix `cider-macroexpand-again` (`g` in the macroexpansion buffer) to actually re-expand the form instead of redisplaying the original input.
 - [#3986](https://github.com/clojure-emacs/cider/pull/3986): Signal a `user-error` (instead of a generic `error`) when a var to trace isn't found or isn't traceable, so the failure no longer triggers a backtrace under `debug-on-error`.
+- [#4018](https://github.com/clojure-emacs/cider/pull/4018): Fix interleaving of value and stderr output in `cider-eval-pprint-with-multiline-comment-handler`.
 
 ### Changes
 

--- a/doc/modules/ROOT/pages/usage/code_evaluation.adoc
+++ b/doc/modules/ROOT/pages/usage/code_evaluation.adoc
@@ -393,6 +393,9 @@ comment text.
 NOTE: The `ignore` and `comment` styles ignore the `cider-comment-*` prefix
 options and use their own fixed formatting.
 
+Re-evaluating a form replaces any existing eval comment in-place, rather than inserting a second one.
+You can preserve the old eval comment by detaching it from the form (e.g. with a newline).
+
 === Change the Output Destination
 
 By default CIDER will display the output produced by some evaluation in the REPL buffer, but you can also funnel the output to a dedicated buffer. You can configure this behavior via `cider-eval-output-destination`.

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -511,28 +511,63 @@ result."
                     (insert (concat comment-prefix res (or comment-postfix "") "\n"))))
                 (cider--maybe-set-eval-register res)))))
 
+(defun cider-maybe-delete-multiline-comment (comment-prefix continued-prefix comment-postfix)
+  "Delete the region after the point in the form of a multiline comment.
+The region must begin with COMMENT-PREFIX, followed by multiple lines
+beginning with CONTINUED-PREFIX at the same indentation,
+and optionally end with COMMENT-POSTFIX."
+  (let ((pre-rgx (rx (group-n 1 (* (any " \t"))) ;; may be indented
+                     (literal comment-prefix))))
+    (when (looking-at pre-rgx)
+      (let* ((cont-rgx (rx (literal (match-string 1)) ;; match indentation rigidly
+                           (literal continued-prefix)))
+             (post-rgx (rx (literal (match-string 1))
+                           ;; trim the leading newline, NOTE string-trim messes with match data
+                           (literal (if (string-prefix-p "\n" comment-postfix)
+                                        (substring comment-postfix 1)
+                                      comment-postfix))))
+             (start (point))
+             (end (save-excursion
+                    (goto-char (match-end 0))
+                    (if (string-prefix-p ";" comment-prefix)
+                        ;; line comment - skip past any similarly indented comments
+                        (progn
+                          (forward-line 1)
+                          (while (and (not (eobp))
+                                      (looking-at-p cont-rgx))
+                            (forward-line 1)))
+                      ;; otherwise it's probably some sort of discarded form like #_
+                      (clojure-forward-logical-sexp 1))
+                    (if (looking-at post-rgx) ;; skip past postfix
+                        (match-end 0)
+                      (point)))))
+        (delete-region start end)))))
+
 (defun cider-maybe-insert-multiline-comment (result comment-prefix continued-prefix comment-postfix)
   "Insert eval RESULT at current location if RESULT is not empty.
+Returns bounds of the inserted text, or nil if nothing was inserted.
 RESULT will be preceded by COMMENT-PREFIX.
 CONTINUED-PREFIX is inserted for each additional line of output.
 COMMENT-POSTFIX is inserted after final text output."
   (unless (string= result "")
+    ;; Make sure inserted comments are indented properly
     (indent-according-to-mode)
-    (let ((lines (split-string result "[\n]+" t))
+    (let ((lines (split-string result "[\n]" nil))
           (beg (point))
           (col (current-indentation)))
       ;; only the first line gets the normal comment-prefix
       (insert (concat comment-prefix (pop lines)))
       (dolist (elem lines)
         (insert (concat "\n" continued-prefix elem)))
-      (indent-rigidly beg (point) col)
-      (unless (string= comment-postfix "")
-        (insert comment-postfix)))))
+      (insert comment-postfix)
+      (indent-rigidly beg (line-end-position) col)
+      (list beg (point)))))
 
 (defun cider-eval-pprint-with-multiline-comment-handler (buffer location comment-prefix continued-prefix comment-postfix)
   "Make a handler for evaluating and inserting results in BUFFER.
 The inserted text is pretty-printed and region will be commented.
 LOCATION is the location marker at which to insert.
+Any existing eval comment on the following line is replaced.
 COMMENT-PREFIX is the comment prefix for the first line of output.
 CONTINUED-PREFIX is the comment prefix to use for the remaining lines.
 COMMENT-POSTFIX is the text to output after the last line."
@@ -550,6 +585,8 @@ COMMENT-POSTFIX is the text to output after the last line."
                 (with-current-buffer buffer
                   (save-excursion
                     (goto-char (marker-position location))
+                    ;; Replace an existing eval comment on the following line
+                    (cider-maybe-delete-multiline-comment comment-prefix continued-prefix comment-postfix)
                     ;; edge case: defun at eob
                     (unless (bolp) (insert "\n"))
                     (cider-maybe-insert-multiline-comment
@@ -841,7 +878,8 @@ The comment style is controlled by `cider-comment-style'.  For the default
 `line' style the formatting is further controlled via the `cider-comment-prefix',
 `cider-comment-continued-prefix' and `cider-comment-postfix' options.
 
-If INSERT-BEFORE is non-nil, insert before the form, otherwise afterwards."
+If INSERT-BEFORE is non-nil, insert before the form, otherwise afterwards.
+Any existing eval comment is replaced."
   (pcase-let* ((bounds (funcall form-fn 'bounds))
                (insertion-point (nth (if insert-before 0 1) bounds))
                (`(,prefix ,continued ,postfix) (cider--comment-format))

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -883,10 +883,9 @@ Any existing eval comment is replaced."
   (pcase-let* ((bounds (funcall form-fn 'bounds))
                (insertion-point (nth (if insert-before 0 1) bounds))
                (`(,prefix ,continued ,postfix) (cider--comment-format))
-               ;; when insert-before, we need a newline after the output to
+               ;; we need a newline after the output to
                ;; avoid commenting the first line of the form
-               (comment-postfix (concat postfix
-                                        (if insert-before "\n" ""))))
+               (comment-postfix (concat postfix "\n")))
     (cider-interactive-eval nil
                             (cider-eval-pprint-with-multiline-comment-handler
                              (current-buffer)

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -497,7 +497,8 @@ Optional argument DONE-HANDLER lambda will be run once load is complete."
 LOCATION is the location marker at which to insert.  COMMENT-PREFIX is the
 comment prefix to use and COMMENT-POSTFIX (if any) is appended after the
 result."
-  (let ((res ""))
+  (let ((res "")
+        (location (copy-marker location)))
     (cider-make-eval-handler
      :buffer buffer
      :on-value (lambda (value) (setq res (concat res value)))
@@ -536,7 +537,8 @@ COMMENT-PREFIX is the comment prefix for the first line of output.
 CONTINUED-PREFIX is the comment prefix to use for the remaining lines.
 COMMENT-POSTFIX is the text to output after the last line."
   (let ((res "")
-        (stderr ""))
+        (stderr "")
+        (location (copy-marker location)))
     (cider-make-eval-handler
      :buffer buffer
      :on-value (lambda (value) (setq res (concat res value)))
@@ -825,7 +827,7 @@ With the prefix arg INSERT-BEFORE, insert before the form, otherwise afterwards.
     (cider-interactive-eval nil
                             (cider-eval-print-with-comment-handler
                              (current-buffer)
-                             (set-marker (make-marker) insertion-point)
+                             insertion-point
                              prefix
                              postfix)
                             bounds
@@ -850,7 +852,7 @@ If INSERT-BEFORE is non-nil, insert before the form, otherwise afterwards."
     (cider-interactive-eval nil
                             (cider-eval-pprint-with-multiline-comment-handler
                              (current-buffer)
-                             (set-marker (make-marker) insertion-point)
+                             insertion-point
                              prefix
                              continued
                              comment-postfix)

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -535,14 +535,15 @@ LOCATION is the location marker at which to insert.
 COMMENT-PREFIX is the comment prefix for the first line of output.
 CONTINUED-PREFIX is the comment prefix to use for the remaining lines.
 COMMENT-POSTFIX is the text to output after the last line."
-  (let ((res ""))
+  (let ((res "")
+        (stderr ""))
     (cider-make-eval-handler
      :buffer buffer
      :on-value (lambda (value) (setq res (concat res value)))
      ;; Forward stdout to the usual interactive sink so output like the
      ;; `time' macro's "Elapsed time" line isn't silently dropped (#3732).
      :on-stdout #'cider-emit-interactive-eval-output
-     :on-stderr (lambda (err) (setq res (concat res err)))
+     :on-stderr (lambda (err) (setq stderr (concat stderr err)))
      :on-done (lambda ()
                 (with-current-buffer buffer
                   (save-excursion
@@ -550,7 +551,11 @@ COMMENT-POSTFIX is the text to output after the last line."
                     ;; edge case: defun at eob
                     (unless (bolp) (insert "\n"))
                     (cider-maybe-insert-multiline-comment
-                     res comment-prefix continued-prefix comment-postfix)))
+                     (if (or (string-blank-p res)
+                             (string-blank-p stderr))
+                         (string-trim (concat res stderr))
+                       (concat res "\n" (string-trim stderr)))
+                     comment-prefix continued-prefix comment-postfix)))
                 (cider--maybe-set-eval-register res)))))
 
 (defun cider-popup-eval-handler (&optional buffer _bounds source-buffer)

--- a/test/cider-eval-tests.el
+++ b/test/cider-eval-tests.el
@@ -41,6 +41,24 @@
         (expect 'cider-emit-interactive-eval-output
                 :to-have-been-called-with "Elapsed time: 0.042 msecs\n"))))
 
+  (it "tracks async buffer edits using markers (#2607)"
+    (with-temp-buffer
+      (setq-local nrepl-pending-requests (make-hash-table :test 'equal))
+      (insert "(+ 1 2)")
+      (let* ((indent-line-function #'ignore)
+             (insertion-point (point-max))
+             (handler (cider-eval-pprint-with-multiline-comment-handler
+                       (current-buffer) insertion-point ";; => " ";;    " "")))
+        ;; simulate user editing BEFORE the eval result arrives:
+        (goto-char 1)
+        (insert "(ns repro)\n\n")
+        (funcall handler (nrepl-dict "value" "3"))
+        (funcall handler (nrepl-dict "status" '("done")))
+        (expect (string-trim (buffer-string)) :to-equal
+                (concat "(ns repro)\n\n"
+                        "(+ 1 2)\n"
+                        ";; => 3")))))
+
   ;; When eval produces both a value and stderr output (e.g. a reflection warning),
   ;; the two must not be interleaved in the inserted comment.
   (it "keeps value and stderr separate when both are present"

--- a/test/cider-eval-tests.el
+++ b/test/cider-eval-tests.el
@@ -98,7 +98,49 @@
         (funcall handler (nrepl-dict "status" '("done")))
         (expect (string-trim (buffer-string)) :to-equal
                 (concat ";; => Syntax error compiling at (user.clj:5:1)\n"
-                        ";;    Unable to resolve symbol: oops in this context"))))))
+                        ";;    Unable to resolve symbol: oops in this context")))))
+
+  (it "replaces an existing multiline comment on re-eval"
+    (with-temp-buffer
+      (setq-local nrepl-pending-requests (make-hash-table :test 'equal))
+      (let ((indent-line-function #'ignore))
+        (insert "(inc 0)\n")
+        (let ((h (cider-eval-pprint-with-multiline-comment-handler
+                  (current-buffer) (point) ";; => " ";;    " "")))
+          (funcall h (nrepl-dict "value" "1"))
+          (funcall h (nrepl-dict "status" '("done")))
+          (expect (buffer-string) :to-equal "(inc 0)\n;; => 1"))
+        ;; Simulate an edit and re-eval
+        (goto-char (point-min))
+        (kill-line 1)
+        (insert "(dec 3)\n")
+        (let ((h (cider-eval-pprint-with-multiline-comment-handler
+                  (current-buffer) (point) ";; => " ";;    " "")))
+          (funcall h (nrepl-dict "value" "2"))
+          (funcall h (nrepl-dict "status" '("done")))
+          (expect (buffer-string) :to-equal "(dec 3)\n;; => 2")))))
+
+  (it "replaces a single-line comment with a multiline result"
+    (with-temp-buffer
+      (setq-local nrepl-pending-requests (make-hash-table :test 'equal))
+      (let ((indent-line-function #'ignore)
+            loc)
+        (insert "(range 3)\n")
+        (setq loc (point))
+        (let ((h1 (cider-eval-pprint-with-multiline-comment-handler
+                   (current-buffer) loc ";; => " ";;    " "")))
+          (funcall h1 (nrepl-dict "value" "(0 1 2)"))
+          (funcall h1 (nrepl-dict "status" '("done")))
+          (expect (buffer-string) :to-equal "(range 3)\n;; => (0 1 2)"))
+        (let ((h2 (cider-eval-pprint-with-multiline-comment-handler
+                   (current-buffer) loc ";; => " ";;    " "")))
+          (funcall h2 (nrepl-dict "value" "(0\n 1\n 2)"))
+          (funcall h2 (nrepl-dict "status" '("done")))
+          (expect (buffer-string) :to-equal
+                  (concat "(range 3)\n"
+                          ";; => (0\n"
+                          ";;     1\n"
+                          ";;     2)")))))))
 
 (describe "cider--auto-inspect-after-eval-p"
   (it "treats t and `interactive' as interactive-only (back-compat)"

--- a/test/cider-eval-tests.el
+++ b/test/cider-eval-tests.el
@@ -39,7 +39,48 @@
                       (current-buffer) (point-marker) ";; => " ";;    " "")))
         (funcall handler (nrepl-dict "out" "Elapsed time: 0.042 msecs\n"))
         (expect 'cider-emit-interactive-eval-output
-                :to-have-been-called-with "Elapsed time: 0.042 msecs\n")))))
+                :to-have-been-called-with "Elapsed time: 0.042 msecs\n"))))
+
+  ;; When eval produces both a value and stderr output (e.g. a reflection warning),
+  ;; the two must not be interleaved in the inserted comment.
+  (it "keeps value and stderr separate when both are present"
+    (with-temp-buffer
+      (setq-local nrepl-pending-requests (make-hash-table :test 'equal))
+      (let* ((indent-line-function #'ignore)
+             (handler (cider-eval-pprint-with-multiline-comment-handler
+                       (current-buffer) (point-marker) ";; => " ";;    " "")))
+        ;; Simulate nREPL responses: stderr chunk interleaved with value chunks
+        (funcall handler (nrepl-dict "value" "{:a 1, "))
+        (funcall handler (nrepl-dict "err" "Reflection warning, user.clj:5:1 - reference to field foo can't be resolved.\n"))
+        (funcall handler (nrepl-dict "value" ":b 2}"))
+        (funcall handler (nrepl-dict "status" '("done")))
+        ;; Value and stderr should be separated by a newline, not mashed together
+        (expect (string-trim (buffer-string))
+                :to-equal
+                (concat ";; => {:a 1, :b 2}\n"
+                        ";;    Reflection warning, user.clj:5:1 - reference to field foo can't be resolved.")))))
+
+  (it "inserts only the value when no stderr is produced"
+    (with-temp-buffer
+      (setq-local nrepl-pending-requests (make-hash-table :test 'equal))
+      (let* ((indent-line-function #'ignore)
+             (handler (cider-eval-pprint-with-multiline-comment-handler
+                       (current-buffer) (point-marker) ";; => " ";;    " "")))
+        (funcall handler (nrepl-dict "value" "42"))
+        (funcall handler (nrepl-dict "status" '("done")))
+        (expect (string-trim (buffer-string)) :to-equal ";; => 42"))))
+
+  (it "inserts only stderr when no value is produced"
+    (with-temp-buffer
+      (setq-local nrepl-pending-requests (make-hash-table :test 'equal))
+      (let* ((indent-line-function #'ignore)
+             (handler (cider-eval-pprint-with-multiline-comment-handler
+                       (current-buffer) (point-marker) ";; => " ";;    " "")))
+        (funcall handler (nrepl-dict "err" "Syntax error compiling at (user.clj:5:1)\nUnable to resolve symbol: oops in this context\n"))
+        (funcall handler (nrepl-dict "status" '("done")))
+        (expect (string-trim (buffer-string)) :to-equal
+                (concat ";; => Syntax error compiling at (user.clj:5:1)\n"
+                        ";;    Unable to resolve symbol: oops in this context"))))))
 
 (describe "cider--auto-inspect-after-eval-p"
   (it "treats t and `interactive' as interactive-only (back-compat)"


### PR DESCRIPTION
Some improvements to `cider-eval-defun-to-comment ` commands:

**Prevent value and stderr comments from being interleaved**

#3148 introduced printing of stderr output (e.g. reflection warnings, compile errors) into the comments, however these were naively concatenated with the value strings as they streamed in, producing out-of-order or interleaved text in some cases.
Stderr is now accumulated separately and appended after the value with a newline.

**Replace stale eval comments on subsequent re-evals**
Easier to explain with the following gif:

https://github.com/user-attachments/assets/90908331-cdf7-474d-9e39-7c7178bbf59e

Importantly, it only matches against the exact `cider-comment-prefix`, and deletion only extends as far as the continued prefix.

### Open question
Do we want to introduce a separate toggle defcustom for this behavior? I personally don't see a good reason a user would prefer the current behaviour of accumulating stale results. It's also easy enough to 'bypass' by adding even a single newline between the form and the eval comment, which breaks the match detection. 

That was my original plan - 2771d8b3999e6c3aa0eb7e599eadb4a007b562f7 adds this defcustom (defaulting to t) and the following commit 7df655e43bfa061d3fa45feda60d6964c9922d0b removes it entirely making the detect-and-replace behavior always active. 

Will either drop the latter commit or squash away the back-and-forth changes depending on the decision.

**Also fixes**
Minor refactor bringing the point marker coercion (from #2607) into the handler instead of requiring callsites to pass a marker type. No user-facing change.

(disclosure: minor LLM assistance used in writing the test boilerplate, which I reviewed in full. All other changes certified organic and tested in person)

No changelog and user manual edits yet, pending the above question


-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)
