### PR TITLE
[Fix #3657] Don't treat a def's value as an arglist for locals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 ### Bugs fixed
 
 - [#4016](https://github.com/clojure-emacs/cider/pull/4016): Show the REPL prompt right away when a server (e.g. jank) sends `value` and `("done")` in the same response, instead of only after the next keypress ([#3869](https://github.com/clojure-emacs/cider/issues/3869)).
+- [#4019](https://github.com/clojure-emacs/cider/pull/4019): Stop the dynamic local-variable font-locking from mistaking a `def`'s value for an arglist, which tagged literals, function names and other non-locals as locals (`cider-locals` false positives) ([#3657](https://github.com/clojure-emacs/cider/issues/3657)).
 - [#4006](https://github.com/clojure-emacs/cider/pull/4006): Fix a doubled colon when both `cider-clojure-cli-global-aliases` and `cider-clojure-cli-aliases` are set in the documented `:foo:bar` form, which produced a malformed `-M:global::local:cider/nrepl` jack-in invocation.
 - [#3971](https://github.com/clojure-emacs/cider/pull/3971): Fix `cider-macroexpand-again` (`g` in the macroexpansion buffer) to actually re-expand the form instead of redisplaying the original input.
 - [#3986](https://github.com/clojure-emacs/cider/pull/3986): Signal a `user-error` (instead of a generic `error`) when a var to trace isn't found or isn't traceable, so the failure no longer triggers a backtrace under `debug-on-error`.

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -1023,6 +1023,14 @@ before point."
                                 end 'noerror)
     (goto-char (match-beginning 0))
     (let ((sym (match-string 1))
+          ;; The regexp only captures the `def' prefix, so read the full
+          ;; head symbol to tell value-binding forms apart from
+          ;; function-defining ones (see the `def' branch below).
+          (head (save-excursion
+                  (ignore-errors
+                    (forward-char 1)
+                    (buffer-substring-no-properties
+                     (point) (progn (forward-sexp 1) (point))))))
           (sexp-end (save-excursion
                       (or (ignore-errors (forward-sexp 1)
                                          (point))
@@ -1036,7 +1044,15 @@ before point."
         (forward-sexp 1)
         (let ((locals (append outer-locals
                               (pcase sym
-                                ((or "fn" "def" "") (cider--read-locals-from-arglist))
+                                ;; #3657: plain value-binding `def' forms
+                                ;; (`def', `defonce') have no arglist -
+                                ;; reading their value as one slurps the
+                                ;; whole value in as bogus locals.  Only
+                                ;; function-defining forms (`defn',
+                                ;; `defmacro', ...) carry an arglist.
+                                ("def" (unless (member head '("def" "defonce"))
+                                         (cider--read-locals-from-arglist)))
+                                ((or "fn" "") (cider--read-locals-from-arglist))
                                 (_ (cider--read-locals-from-bindings-vector))))))
           (add-text-properties (point) sexp-end (list 'cider-locals locals))
           (clojure-forward-logical-sexp 1)

--- a/test/cider-locals-tests.el
+++ b/test/cider-locals-tests.el
@@ -142,4 +142,44 @@
         ("a" "b" "the-ns")
       (cider--read-locals-from-arglist))))
 
+
+(describe "cider--parse-and-apply-locals"
+  (it "does not slurp a `def' value vector as an arglist (#3657)"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(def foo-routes
+  [[\"/foos\"
+    {:get {:handler (fn [{{{:keys [archived]} :query} :parameters
+                          :keys [sub]
+                          :as req}]
+                      (let [foo (reduce + (range 4))]
+                        {:status 200}))}}]])")
+      (goto-char (point-min))
+      (cider--parse-and-apply-locals (point-max))
+      ;; The def's value - literals, function names, route strings - must
+      ;; not be mistaken for locals.
+      (goto-char (point-min))
+      (search-forward "range")
+      (let ((locals (get-text-property (1- (point)) 'cider-locals)))
+        (dolist (false-positive '("range" "reduce" "+" "200" "4" "foos" "let" "fn"))
+          (expect locals :not :to-contain false-positive)))
+      ;; The genuine fn params are still detected in the body.
+      (goto-char (point-min))
+      (search-forward ":status")
+      (let ((locals (get-text-property (1- (point)) 'cider-locals)))
+        (expect locals :to-contain "sub")
+        (expect locals :to-contain "req"))))
+
+  (it "still reads the arglist of function-defining def forms"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(defn foo [a b] (+ a b))")
+      (goto-char (point-min))
+      (cider--parse-and-apply-locals (point-max))
+      (goto-char (point-min))
+      (search-forward "(+ a b)")
+      (let ((locals (get-text-property (1- (point)) 'cider-locals)))
+        (expect locals :to-contain "a")
+        (expect locals :to-contain "b")))))
+
 ;;; cider-locals-tests.el ends here


### PR DESCRIPTION
The dynamic local-variable font-locking (`cider--parse-and-apply-locals`) matches the `def` prefix for the whole `def*` family, so a plain `(def x [...])` went down the same code path as `defn` and had its *value* vector read as a function arglist. Every symbol and literal in the value got tagged with the `cider-locals` text property - in the reported case `range`, `reduce`, `+`, numeric/string literals, etc. - which causes the false positives in #3657 and subtly breaks font-locking.

Fix reads the full head symbol and skips arglist parsing for value-binding forms (`def`, `defonce`); `defn`/`defmacro`/etc. still read their arglist as before. Added regression tests.

Fixes #3657.