### PR TITLE
[Fix #3679] Inspect the tagged class when point is on a type tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 ### Changes
 
+- [#4022](https://github.com/clojure-emacs/cider/pull/4022): `cider-inspect-last-sexp` now inspects the tagged class when point is on a type tag (e.g. `^String`), instead of the form the tag applies to ([#3679](https://github.com/clojure-emacs/cider/issues/3679)).
 - [#4005](https://github.com/clojure-emacs/cider/pull/4005): Render the namespace browser (`cider-browse-ns`) on the `cider-tree-view` widget: groups (by type or visibility) are now foldable with `TAB`, and `n`/`p` move between entries.
 - [#4003](https://github.com/clojure-emacs/cider/pull/4003): Turn `C-c M-m` into a prefix map (`cider-macroexpand-map`) grouping all the macro-expanding commands - `macroexpand-1`/`macroexpand-all` into a buffer (`1`/`a`) and the inline `cider-macrostep` commands (`e`/`E`/`b`). `cider-macroexpand-all` thus moves from `C-c M-m` to `C-c M-m a`; `C-c C-m` still runs `macroexpand-1` directly.
 - [#4002](https://github.com/clojure-emacs/cider/pull/4002): Bump the injected `cider-nrepl` to 0.60.0, which provides the `cider/who-implements`, `cider/type-protocols` and `cider/protocols-with-method` ops backing the protocol-exploration commands.

--- a/lisp/cider-inspector.el
+++ b/lisp/cider-inspector.el
@@ -236,10 +236,25 @@ the text is already colored by clojure mode font-locking."
                          'face 'font-lock-warning-face))))
 
 ;;;###autoload
+(defun cider--type-tag-at-point ()
+  "Return the class name of the type tag at point, or nil.
+A type tag is a symbol preceded by `^', e.g. the `String' in `^String x'.
+This lets the inspector act on the tagged class directly, the way
+`cider-doc' does, instead of reading the form the tag applies to (#3679)."
+  (when-let* ((sym (cider-symbol-at-point)))
+    (save-excursion
+      (skip-syntax-backward "w_")
+      (when (eq (char-before) ?^)
+        sym))))
+
 (defun cider-inspect-last-sexp ()
-  "Inspect the result of the expression preceding point."
+  "Inspect the result of the expression preceding point.
+When point is on a type tag (e.g. `^String'), inspect the tagged class
+itself rather than the form it applies to."
   (interactive)
-  (cider-inspect-expr (cider-last-sexp) (cider-current-ns)))
+  (cider-inspect-expr (or (cider--type-tag-at-point)
+                          (cider-last-sexp))
+                      (cider-current-ns)))
 
 ;;;###autoload
 (defun cider-inspect-defun-at-point ()

--- a/test/cider-inspector-tests.el
+++ b/test/cider-inspector-tests.el
@@ -279,6 +279,44 @@
     (:newline)
     "  " "class"))
 
+(describe "cider--type-tag-at-point"
+  (it "returns the class name when point is on a type tag"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(defn f [^String x] x)")
+      (goto-char (point-min))
+      (search-forward "String")
+      (backward-char 1)
+      (expect (cider--type-tag-at-point) :to-equal "String")))
+  (it "returns nil for an ordinary symbol that isn't a type tag"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(defn f [^String x] x)")
+      (goto-char (point-max))
+      (search-backward "x")
+      (expect (cider--type-tag-at-point) :to-be nil))))
+
+(describe "cider-inspect-last-sexp"
+  (it "inspects the tagged class when point is on a type tag (#3679)"
+    (spy-on 'cider-inspect-expr)
+    (spy-on 'cider-current-ns :and-return-value "user")
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(defn f [^String x] x)")
+      (goto-char (point-min))
+      (search-forward "String")
+      (backward-char 1)
+      (cider-inspect-last-sexp)
+      (expect 'cider-inspect-expr :to-have-been-called-with "String" "user")))
+  (it "falls back to the preceding sexp otherwise"
+    (spy-on 'cider-inspect-expr)
+    (spy-on 'cider-current-ns :and-return-value "user")
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(+ 1 2)")
+      (cider-inspect-last-sexp)
+      (expect 'cider-inspect-expr :to-have-been-called-with "(+ 1 2)" "user"))))
+
 (describe "cider-inspector-render*"
   (it "Produces a well-known string without errors"
     (expect


### PR DESCRIPTION
`cider-inspect-last-sexp` reads the form a type tag applies to, so inspecting a class written as `^String` in source meant deleting the `^` first. `cider-doc` already handles type tags (via `cider-symbol-at-point`, which strips the `^`).

This adds `cider--type-tag-at-point` (a symbol immediately preceded by `^`) and has `cider-inspect-last-sexp` prefer it, falling back to `cider-last-sexp`. Per the discussion in #3679, this is scoped narrowly: behavior only changes when point is actually on a type tag, so the usual inspect-the-preceding-sexp flow is untouched. Added tests.

Fixes #3679.