### PR TITLE
[Fix #3636] Allow auto-inspecting after REPL eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- [#4023](https://github.com/clojure-emacs/cider/pull/4023): `cider-auto-inspect-after-eval` now accepts `interactive`, `repl` or `all` (in addition to `t`/`nil`), so a visible inspector can also be refreshed after REPL evaluations ([#3636](https://github.com/clojure-emacs/cider/issues/3636)).
 - [#4004](https://github.com/clojure-emacs/cider/pull/4004): Add `cider-browse-spec-tree`, which browses a spec and the specs it references as an expandable tree - expand a node to reveal its sub-specs (a level at a time), `RET` to open a spec's full definition.
 - [#3999](https://github.com/clojure-emacs/cider/pull/3999): Add `cider-type-protocols` (`C-c C-w t`), listing the protocols a type implements (the reverse of `cider-who-implements`), and `cider-protocols-with-method` (`C-c C-w p`), listing the protocols that declare a given method.
 - [#3997](https://github.com/clojure-emacs/cider/pull/3997): Add `cider-who-implements` (`C-c C-w i`), which browses a protocol's implementing types or a multimethod's dispatch values on an expandable tree. (Currently a client-side approximation; inline `defrecord`/`deftype` impls and per-`defmethod` jumps await a follow-up middleware op.)

--- a/doc/modules/ROOT/pages/debugging/inspector.adoc
+++ b/doc/modules/ROOT/pages/debugging/inspector.adoc
@@ -17,7 +17,9 @@ Alternatively, after a regular eval command, you can inspect the last
 evaluated value using `cider-inspect-last-result`. When an inspector
 buffer is visible in the background, it is automatically updated with
 the last result. This behavior can be controlled with the variable
-`cider-auto-inspect-after-eval`.
+`cider-auto-inspect-after-eval`, which selects which evaluations trigger
+the refresh: `t` or `interactive` (interactive evaluations only, the
+default), `repl` (REPL evaluations only), `all` (both), or `nil` (never).
 
 TIP: The inspector can also be invoked in the middle of a debugging
 session, see xref:debugging/debugger.adoc[here] for more details.

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -87,10 +87,29 @@ ns forms manually themselves."
 
 (defcustom cider-auto-inspect-after-eval t
   "Controls whether to auto-update the inspector buffer after eval.
-Only applies when the *cider-inspect* buffer is currently visible."
-  :type 'boolean
+Only applies when the *cider-inspect* buffer is currently visible.
+
+The value selects which evaluations trigger the refresh:
+  t or `interactive' - only interactive evaluations (the default);
+  `repl'             - only REPL evaluations;
+  `all'              - both interactive and REPL evaluations;
+  nil                - never."
+  :type '(choice (const :tag "Interactive evaluations (default)" t)
+                 (const :tag "Interactive evaluations" interactive)
+                 (const :tag "REPL evaluations" repl)
+                 (const :tag "All evaluations" all)
+                 (const :tag "Never" nil))
   :group 'cider
   :package-version '(cider . "0.25.0"))
+
+(defun cider--auto-inspect-after-eval-p (context)
+  "Return non-nil when the inspector should refresh after a CONTEXT eval.
+CONTEXT is `interactive' or `repl'.  See `cider-auto-inspect-after-eval'."
+  (pcase cider-auto-inspect-after-eval
+    ('all t)
+    ('repl (eq context 'repl))
+    ((or 't 'interactive) (eq context 'interactive))
+    (_ nil)))
 
 (defcustom cider-save-file-on-load 'prompt
   "Controls whether to prompt to save the file when loading a buffer.
@@ -348,7 +367,7 @@ when `cider-auto-inspect-after-eval' is non-nil."
                       (setq fringed t))
                   (cider--make-fringe-overlay end))
                 (let ((target (or buffer eval-buffer)))
-                  (when (and cider-auto-inspect-after-eval
+                  (when (and (cider--auto-inspect-after-eval-p 'interactive)
                              (boundp 'cider-inspector-buffer)
                              (windowp (get-buffer-window cider-inspector-buffer 'visible)))
                     (cider-inspect-last-result)

--- a/lisp/cider-repl.el
+++ b/lisp/cider-repl.el
@@ -53,7 +53,9 @@
 (require 'cider-resolve)
 
 (declare-function cider-inspect "cider-inspector")
+(declare-function cider-inspect-last-result "cider-inspector")
 (declare-function cider-make-eval-handler "cider-eval")
+(declare-function cider--auto-inspect-after-eval-p "cider-eval")
 (declare-function cider-quit "cider-connection")
 (declare-function cider-restart "cider-connection")
 (declare-function cider-describe-connection "cider-connection")
@@ -1166,6 +1168,20 @@ and responding to them.")
 (defvar cider--repl-done-functions (list #'cider--shadow-cljs-handle-done)
   "Functions to be invoked each time a given REPL interaction is complete.")
 
+(defvar cider-inspector-buffer)
+
+(defun cider-repl--auto-inspect-last-result (buffer)
+  "Refresh the inspector with the last REPL value when configured.
+Acts only when `cider-auto-inspect-after-eval' enables it for REPL evals
+and the inspector buffer is currently visible, and keeps focus on the
+REPL BUFFER rather than popping to the inspector (#3636)."
+  (when (and (cider--auto-inspect-after-eval-p 'repl)
+             (boundp 'cider-inspector-buffer)
+             (windowp (get-buffer-window cider-inspector-buffer 'visible)))
+    (cider-inspect-last-result)
+    (when-let* ((win (get-buffer-window buffer)))
+      (select-window win))))
+
 (defun cider-repl-handler (buffer)
   "Make an nREPL evaluation handler for the REPL BUFFER."
   (let ((show-prompt t))
@@ -1186,6 +1202,7 @@ and responding to them.")
                   (cider-repl-emit-prompt buffer))
                 (when cider-repl-buffer-size-limit
                   (cider-repl-maybe-trim-buffer buffer))
+                (cider-repl--auto-inspect-last-result buffer)
                 (dolist (f cider--repl-done-functions)
                   (funcall f buffer)))
      :on-content-type (lambda (value content-type)

--- a/test/cider-eval-tests.el
+++ b/test/cider-eval-tests.el
@@ -41,6 +41,25 @@
         (expect 'cider-emit-interactive-eval-output
                 :to-have-been-called-with "Elapsed time: 0.042 msecs\n")))))
 
+(describe "cider--auto-inspect-after-eval-p"
+  (it "treats t and `interactive' as interactive-only (back-compat)"
+    (dolist (val '(t interactive))
+      (let ((cider-auto-inspect-after-eval val))
+        (expect (cider--auto-inspect-after-eval-p 'interactive) :to-be-truthy)
+        (expect (cider--auto-inspect-after-eval-p 'repl) :not :to-be-truthy))))
+  (it "treats `repl' as repl-only"
+    (let ((cider-auto-inspect-after-eval 'repl))
+      (expect (cider--auto-inspect-after-eval-p 'repl) :to-be-truthy)
+      (expect (cider--auto-inspect-after-eval-p 'interactive) :not :to-be-truthy)))
+  (it "treats `all' as both contexts"
+    (let ((cider-auto-inspect-after-eval 'all))
+      (expect (cider--auto-inspect-after-eval-p 'interactive) :to-be-truthy)
+      (expect (cider--auto-inspect-after-eval-p 'repl) :to-be-truthy)))
+  (it "treats nil as never"
+    (let ((cider-auto-inspect-after-eval nil))
+      (expect (cider--auto-inspect-after-eval-p 'interactive) :not :to-be-truthy)
+      (expect (cider--auto-inspect-after-eval-p 'repl) :not :to-be-truthy))))
+
 (describe "cider--comment-format"
   (it "returns the configured prefixes for the `line' style"
     (let ((cider-comment-style 'line)

--- a/test/cider-repl-tests.el
+++ b/test/cider-repl-tests.el
@@ -198,6 +198,23 @@
                 :to-equal (text-property-make "green3" italic))
         ))))
 
+(describe "cider-repl--auto-inspect-last-result (#3636)"
+  (it "refreshes the inspector after a repl eval when enabled and visible"
+    (spy-on 'cider-inspect-last-result)
+    (spy-on 'get-buffer-window :and-return-value (selected-window))
+    (spy-on 'select-window)
+    (let ((cider-auto-inspect-after-eval 'repl)
+          (cider-inspector-buffer (current-buffer)))
+      (cider-repl--auto-inspect-last-result (current-buffer))
+      (expect 'cider-inspect-last-result :to-have-been-called)))
+  (it "does nothing when repl auto-inspect isn't enabled"
+    (spy-on 'cider-inspect-last-result)
+    (spy-on 'get-buffer-window :and-return-value (selected-window))
+    (let ((cider-auto-inspect-after-eval t) ; interactive only
+          (cider-inspector-buffer (current-buffer)))
+      (cider-repl--auto-inspect-last-result (current-buffer))
+      (expect 'cider-inspect-last-result :not :to-have-been-called))))
+
 (defun simulate-cider-output (s property)
   "Return S's properties from `cider-repl--emit-output'.
 PROPERTY should be a symbol of either 'text, 'ansi-context or


### PR DESCRIPTION
`cider-auto-inspect-after-eval` only refreshed the inspector after interactive evaluation. Per the discussion in #3636, rather than add a separate option this extends the existing one to accept symbols:

- `t` or `interactive` - interactive evals only (the default, unchanged)
- `repl` - REPL evals only
- `all` - both
- `nil` - never

A new `cider--auto-inspect-after-eval-p` predicate centralizes the check. The REPL's done handler refreshes the inspector with the last value, and only when it's already visible, keeping focus on the REPL (so it isn't disruptive). The old boolean values keep working, so it's backward compatible. Added tests.

Fixes #3636.