### PR TITLE
[Fix #2798] Add a keymap to the ns-refresh log buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 ### Changes
 
 - [#4022](https://github.com/clojure-emacs/cider/pull/4022): `cider-inspect-last-sexp` now inspects the tagged class when point is on a type tag (e.g. `^String`), instead of the form the tag applies to ([#3679](https://github.com/clojure-emacs/cider/issues/3679)).
+- [#4024](https://github.com/clojure-emacs/cider/pull/4024): The `*cider-ns-refresh-log*` buffer now supports `r`/`g`/`C-c M-n r` to re-run the refresh from within it ([#2798](https://github.com/clojure-emacs/cider/issues/2798)).
 - [#4005](https://github.com/clojure-emacs/cider/pull/4005): Render the namespace browser (`cider-browse-ns`) on the `cider-tree-view` widget: groups (by type or visibility) are now foldable with `TAB`, and `n`/`p` move between entries.
 - [#4003](https://github.com/clojure-emacs/cider/pull/4003): Turn `C-c M-m` into a prefix map (`cider-macroexpand-map`) grouping all the macro-expanding commands - `macroexpand-1`/`macroexpand-all` into a buffer (`1`/`a`) and the inline `cider-macrostep` commands (`e`/`E`/`b`). `cider-macroexpand-all` thus moves from `C-c M-m` to `C-c M-m a`; `C-c C-m` still runs `macroexpand-1` directly.
 - [#4002](https://github.com/clojure-emacs/cider/pull/4002): Bump the injected `cider-nrepl` to 0.60.0, which provides the `cider/who-implements`, `cider/type-protocols` and `cider/protocols-with-method` ops backing the protocol-exploration commands.

--- a/doc/modules/ROOT/pages/usage/code_reloading.adoc
+++ b/doc/modules/ROOT/pages/usage/code_reloading.adoc
@@ -76,6 +76,11 @@ the echo area.
 (setq cider-ns-refresh-show-log-buffer t)
 ----
 
+From within the `+*cider-ns-refresh-log*+` buffer you can re-run the
+refresh without leaving it: kbd:[r], kbd:[g] or kbd:[C-c M-n r] all
+invoke `cider-ns-refresh` again (there's also a `Refresh Log` menu with
+the same actions).
+
 By default, CIDER will prompt for whether to save all modified `clojure-mode`
 buffers visiting files on the classpath. You can customize this behavior with
 `cider-ns-save-files-on-refresh` and `cider-ns-save-files-on-refresh-modes`.

--- a/lisp/cider-ns.el
+++ b/lisp/cider-ns.el
@@ -57,6 +57,7 @@
 
 ;;; Code:
 
+(require 'easymenu)
 (require 'map)
 (require 'seq)
 (require 'subr-x)
@@ -89,6 +90,29 @@ If t, all buffers visiting files on the classpath might be saved."
   :package-version '(cider . "0.21.0"))
 
 (defconst cider-ns-refresh-log-buffer "*cider-ns-refresh-log*")
+
+(defvar cider-ns-refresh-log-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "g") #'cider-ns-refresh)
+    (define-key map (kbd "r") #'cider-ns-refresh)
+    (define-key map (kbd "C-c M-n r") #'cider-ns-refresh)
+    (easy-menu-define cider-ns-refresh-log-mode-menu map
+      "Menu for CIDER's namespace refresh log."
+      '("Refresh Log"
+        ["Refresh modified namespaces" cider-ns-refresh]
+        ["Refresh all namespaces" (cider-ns-refresh 'refresh-all)]
+        ["Clear tracker and refresh" (cider-ns-refresh 'clear)]
+        "--"
+        ["Quit" cider-popup-buffer-quit-function]))
+    map)
+  "Keymap for `cider-ns-refresh-log-mode'.")
+
+(define-derived-mode cider-ns-refresh-log-mode special-mode "Refresh Log"
+  "Major mode for the `*cider-ns-refresh-log*' buffer.
+
+\\{cider-ns-refresh-log-mode-map}"
+  ;; the buffer is populated asynchronously; don't ask to confirm a revert
+  (setq-local revert-buffer-function (lambda (&rest _) (cider-ns-refresh))))
 
 (defcustom cider-ns-refresh-show-log-buffer nil
   "Controls when to display the refresh log buffer.
@@ -346,7 +370,8 @@ refresh functions (defined in `cider-ns-refresh-before-fn' and
         (cider-ns-refresh--save-modified-buffers conn)
         ;; Inside the lambda, so the buffer is not created if we error out.
         (let ((log-buffer (or (get-buffer cider-ns-refresh-log-buffer)
-                              (cider-make-popup-buffer cider-ns-refresh-log-buffer))))
+                              (cider-make-popup-buffer cider-ns-refresh-log-buffer
+                                                       #'cider-ns-refresh-log-mode))))
           (when cider-ns-refresh-show-log-buffer
             (cider-popup-buffer-display log-buffer))
           (when inhibit-refresh-fns

--- a/test/cider-ns-tests.el
+++ b/test/cider-ns-tests.el
@@ -239,3 +239,14 @@
       (funcall cb (nrepl-dict "status" '("eval-error")))
       (funcall cb (nrepl-dict "status" '("done")))
       (expect 'cider-ns--mark-reloaded :not :to-have-been-called))))
+
+(describe "cider-ns-refresh-log-mode"
+  (it "binds the refresh keys to cider-ns-refresh (#2798)"
+    (expect (lookup-key cider-ns-refresh-log-mode-map (kbd "r"))
+            :to-equal 'cider-ns-refresh)
+    (expect (lookup-key cider-ns-refresh-log-mode-map (kbd "g"))
+            :to-equal 'cider-ns-refresh)
+    (expect (lookup-key cider-ns-refresh-log-mode-map (kbd "C-c M-n r"))
+            :to-equal 'cider-ns-refresh))
+  (it "provides a menu (#2798)"
+    (expect (lookup-key cider-ns-refresh-log-mode-map [menu-bar]) :to-be-truthy)))


### PR DESCRIPTION
The `*cider-ns-refresh-log*` buffer had no keybindings, so re-running a refresh while focused on it meant switching away first. This gives it a `cider-ns-refresh-log-mode` that binds `r`, `g` and `C-c M-n r` to `cider-ns-refresh` (and points `revert-buffer` at it too). Added a test.

Fixes #2798.