### PR TITLE
[Fix #3721] Add pass/fail fringe indicators for tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 - [#4023](https://github.com/clojure-emacs/cider/pull/4023): `cider-auto-inspect-after-eval` now accepts `interactive`, `repl` or `all` (in addition to `t`/`nil`), so a visible inspector can also be refreshed after REPL evaluations ([#3636](https://github.com/clojure-emacs/cider/issues/3636)).
+- [#4025](https://github.com/clojure-emacs/cider/pull/4025): Mark each `deftest` with a green (passed) or red (failed) left-fringe indicator after a test run. `cider-use-fringe-indicators` now accepts a list of kinds (`eval`, `test`) for finer control, in addition to `t`/`nil` ([#3721](https://github.com/clojure-emacs/cider/issues/3721)).
 - [#4004](https://github.com/clojure-emacs/cider/pull/4004): Add `cider-browse-spec-tree`, which browses a spec and the specs it references as an expandable tree - expand a node to reveal its sub-specs (a level at a time), `RET` to open a spec's full definition.
 - [#3999](https://github.com/clojure-emacs/cider/pull/3999): Add `cider-type-protocols` (`C-c C-w t`), listing the protocols a type implements (the reverse of `cider-who-implements`), and `cider-protocols-with-method` (`C-c C-w p`), listing the protocols that declare a given method.
 - [#3997](https://github.com/clojure-emacs/cider/pull/3997): Add `cider-who-implements` (`C-c C-w i`), which browses a protocol's implementing types or a multimethod's dispatch values on an expandable tree. (Currently a client-side approximation; inline `defrecord`/`deftype` impls and per-`defmethod` jumps await a follow-up middleware op.)

--- a/doc/modules/ROOT/pages/testing/running_tests.adoc
+++ b/doc/modules/ROOT/pages/testing/running_tests.adoc
@@ -153,6 +153,24 @@ passed or failed:
 (setq cider-test-show-report-on-success t)
 ----
 
+[#test-fringe-indicators]
+=== Test fringe indicators
+
+After a test run, CIDER marks each `deftest` in the source buffer with a marker
+in the left fringe: green (`cider-fringe-good-face`) when all of the var's
+assertions passed, red (`cider-fringe-bad-face`) when any failed or errored.
+The markers are cleared when you re-run the tests.
+
+These are governed by `cider-use-fringe-indicators` (the same option used for
+the xref:usage/code_evaluation.adoc#per-form-fringe-indicators[evaluation
+markers]), which is `t` by default. To keep the evaluation markers but turn the
+test ones off, set it to a list of the kinds you want:
+
+[source,lisp]
+----
+(setq cider-use-fringe-indicators '(eval))
+----
+
 === Running a callback on errors
 
 Sometimes, for fine-grained integrations or debugging, you might want

--- a/doc/modules/ROOT/pages/usage/code_evaluation.adoc
+++ b/doc/modules/ROOT/pages/usage/code_evaluation.adoc
@@ -277,6 +277,7 @@ Beyond the result overlays, CIDER can show, at a glance, which code is in sync
 with the REPL.  These indicators are kept up to date as you evaluate and reload
 code, including via kbd:[C-c C-k], `cider-ns-reload` and `cider-ns-refresh`.
 
+[#per-form-fringe-indicators]
 ==== Per-form fringe indicators
 
 When you evaluate a top-level form, CIDER places a small green marker in the
@@ -290,6 +291,17 @@ This is on by default.  To turn the indicators off entirely:
 [source,lisp]
 ----
 (setq cider-use-fringe-indicators nil)
+----
+
+`cider-use-fringe-indicators` also accepts a list of the indicator kinds to
+show, so you can enable some but not others.  The recognized kinds are `eval`
+(the per-form evaluation markers described here) and `test` (the
+xref:testing/running_tests.adoc#test-fringe-indicators[test pass/fail markers]).
+For example, to keep only the evaluation markers:
+
+[source,lisp]
+----
+(setq cider-use-fringe-indicators '(eval))
 ----
 
 To keep the indicators but restore the older behavior, where editing an

--- a/lisp/cider-overlays.el
+++ b/lisp/cider-overlays.el
@@ -169,12 +169,44 @@ This function also removes itself from `post-command-hook'."
   (propertize " " 'display '(left-fringe empty-line cider-fringe-stale-face))
   "The before-string property that adds a stale indicator on the fringe.")
 
-(defcustom cider-use-fringe-indicators t
-  "Whether to display evaluation indicators on the left fringe."
-  :safe #'booleanp
+(defface cider-fringe-bad-face
+  '((((class color) (background light)) :foreground "red3")
+    (((class color) (background dark)) :foreground "red1"))
+  "Face used on the fringe indicator for a failing test."
   :group 'cider
-  :type 'boolean
+  :package-version '(cider . "1.23.0"))
+
+(defconst cider--fringe-overlay-bad
+  (propertize " " 'display '(left-fringe empty-line cider-fringe-bad-face))
+  "The before-string property that adds a red indicator on the fringe.")
+
+(defcustom cider-use-fringe-indicators t
+  "Whether to display indicators on the left fringe.
+The value selects which kinds of indicators are shown:
+  t      - all kinds (the default);
+  nil    - none;
+  a list - only the listed kinds, e.g. (eval) or (eval test).
+
+Recognized kinds:
+  `eval' - a marker on each evaluated top-level form;
+  `test' - a green/red marker on each `deftest' after a test run."
+  :safe (lambda (x) (or (booleanp x)
+                        (and (listp x) (seq-every-p #'symbolp x))))
+  :group 'cider
+  :type '(choice (const :tag "All kinds" t)
+                 (const :tag "None" nil)
+                 (set :tag "Selected kinds"
+                      (const :tag "Evaluated forms" eval)
+                      (const :tag "Test results" test)))
   :package-version '(cider . "0.13.0"))
+
+(defun cider--use-fringe-indicators-p (kind)
+  "Return non-nil when fringe indicators are enabled for KIND.
+KIND is `eval' or `test'.  See `cider-use-fringe-indicators'."
+  (cond ((null cider-use-fringe-indicators) nil)
+        ((listp cider-use-fringe-indicators)
+         (memq kind cider-use-fringe-indicators))
+        (t t)))
 
 (defcustom cider-mark-stale-after-edit t
   "Whether editing an evaluated form marks its fringe indicator stale.
@@ -199,7 +231,7 @@ is re-evaluated."
 (defun cider--make-fringe-overlay (&optional end)
   "Place an eval indicator at the fringe before a sexp.
 END is the position where the sexp ends, and defaults to point."
-  (when cider-use-fringe-indicators
+  (when (cider--use-fringe-indicators-p 'eval)
     (with-current-buffer (if (markerp end)
                              (marker-buffer end)
                            (current-buffer))

--- a/lisp/cider-test.el
+++ b/lisp/cider-test.el
@@ -650,17 +650,49 @@ Or nil if not found."
               (file (nrepl-dict-get info "file")))
     (cider-find-file file)))
 
+(defun cider-test--var-passed-p (tests)
+  "Return non-nil when every assertion in TESTS has passed."
+  (seq-every-p (lambda (test)
+                 (equal "pass" (nrepl-dict-get test "type")))
+               tests))
+
+(defun cider-test--add-fringe-indicator (buffer line passed)
+  "Put a pass/fail test fringe indicator on the form at LINE in BUFFER.
+PASSED selects the green (success) or red (failure) marker.  Does nothing
+when LINE is nil."
+  (when line
+    (with-current-buffer buffer
+      (save-excursion
+        (goto-char (point-min))
+        (forward-line (1- line))
+        (cider--make-overlay (line-beginning-position) (line-end-position)
+                             'cider-test-fringe-indicator
+                             'before-string (if passed
+                                                cider--fringe-overlay-good
+                                              cider--fringe-overlay-bad))))))
+
 (defun cider-test-highlight-problems (results)
-  "Highlight all non-passing tests in the test RESULTS."
+  "Highlight all non-passing tests in the test RESULTS.
+When `cider-use-fringe-indicators' enables them for tests, also mark every
+tested var with a green (all passed) or red (any failure) fringe indicator."
   (nrepl-dict-map
    (lambda (ns vars)
      (nrepl-dict-map
       (lambda (var tests)
-        (when-let* ((buffer (cider-find-var-file ns var)))
+        ;; Resolve the var once: `cider-find-var-file' would re-query, but we
+        ;; also need the definition line for the fringe indicator.
+        (when-let* ((info (cider-var-info (concat ns "/" var)))
+                    (file (nrepl-dict-get info "file"))
+                    (buffer (cider-find-file file)))
           (dolist (test tests)
             (nrepl-dbind-response test (type)
               (unless (equal "pass" type)
-                (cider-test-highlight-problem buffer test))))))
+                (cider-test-highlight-problem buffer test))))
+          (when (cider--use-fringe-indicators-p 'test)
+            (cider-test--add-fringe-indicator
+             buffer
+             (nrepl-dict-get info "line")
+             (cider-test--var-passed-p tests)))))
       vars))
    results))
 
@@ -673,7 +705,8 @@ Or nil if not found."
        (dolist (var (nrepl-dict-keys vars))
          (when-let* ((buffer (cider-find-var-file ns var)))
            (with-current-buffer buffer
-             (remove-overlays nil nil 'category 'cider-test)))))
+             (remove-overlays nil nil 'category 'cider-test)
+             (remove-overlays nil nil 'category 'cider-test-fringe-indicator)))))
      cider-test-last-results)))
 
 

--- a/test/cider-overlay-tests.el
+++ b/test/cider-overlay-tests.el
@@ -221,7 +221,32 @@ being set that way"
         (insert "Hello")
         (expect (overlay-count) :to-be 0)))))
 
+(describe "cider--use-fringe-indicators-p"
+  (it "treats t as all kinds enabled"
+    (let ((cider-use-fringe-indicators t))
+      (expect (cider--use-fringe-indicators-p 'eval) :to-be-truthy)
+      (expect (cider--use-fringe-indicators-p 'test) :to-be-truthy)))
+  (it "treats nil as nothing enabled"
+    (let ((cider-use-fringe-indicators nil))
+      (expect (cider--use-fringe-indicators-p 'eval) :not :to-be-truthy)
+      (expect (cider--use-fringe-indicators-p 'test) :not :to-be-truthy)))
+  (it "treats a list as only the listed kinds"
+    (let ((cider-use-fringe-indicators '(eval)))
+      (expect (cider--use-fringe-indicators-p 'eval) :to-be-truthy)
+      (expect (cider--use-fringe-indicators-p 'test) :not :to-be-truthy))
+    (let ((cider-use-fringe-indicators '(eval test)))
+      (expect (cider--use-fringe-indicators-p 'eval) :to-be-truthy)
+      (expect (cider--use-fringe-indicators-p 'test) :to-be-truthy))))
+
 (describe "cider--make-fringe-overlay"
+  (it "doesn't place an eval indicator when eval indicators are disabled"
+    (let ((cider-use-fringe-indicators '(test)))
+      (with-temp-buffer
+        (clojure-mode)
+        (insert "(def x 1)")
+        (cider--make-fringe-overlay (point))
+        (expect (overlays-in (point-min) (point-max)) :to-be nil))))
+
   (it "flips the indicator to stale when the evaluated form is edited"
     (let ((cider-use-fringe-indicators t)
           (cider-mark-stale-after-edit t))

--- a/test/cider-test-tests.el
+++ b/test/cider-test-tests.el
@@ -132,3 +132,33 @@
             :to-equal "{:a 1}")
     (expect (cider-test--extract-from-actual "(not (= {:a 1} {:a 2}))" 2)
             :to-equal "{:a 2}")))
+
+(describe "cider-test--var-passed-p"
+  (it "is true only when every assertion passed"
+    (expect (cider-test--var-passed-p (list (nrepl-dict "type" "pass")
+                                            (nrepl-dict "type" "pass")))
+            :to-be-truthy)
+    (expect (cider-test--var-passed-p (list (nrepl-dict "type" "pass")
+                                            (nrepl-dict "type" "fail")))
+            :not :to-be-truthy)
+    (expect (cider-test--var-passed-p (list (nrepl-dict "type" "error")))
+            :not :to-be-truthy)))
+
+(describe "cider-test--add-fringe-indicator (#3721)"
+  (it "uses the success fringe for a passing var and the failure fringe for a failing one"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(deftest foo (is true))\n(deftest bar (is false))\n")
+      (cider-test--add-fringe-indicator (current-buffer) 1 t)
+      (cider-test--add-fringe-indicator (current-buffer) 2 nil)
+      (goto-char (point-min))
+      (expect (overlay-get (car (overlays-at (line-beginning-position))) 'before-string)
+              :to-equal cider--fringe-overlay-good)
+      (forward-line 1)
+      (expect (overlay-get (car (overlays-at (line-beginning-position))) 'before-string)
+              :to-equal cider--fringe-overlay-bad)))
+  (it "does nothing when the line is nil"
+    (with-temp-buffer
+      (insert "x")
+      (cider-test--add-fringe-indicator (current-buffer) nil t)
+      (expect (overlays-in (point-min) (point-max)) :to-be nil))))


### PR DESCRIPTION
After a test run, each tested `deftest` now gets a green (all assertions passed) or red (any failure/error) marker on the left fringe, so you can see test state at a glance from the source buffer.

To control it, `cider-use-fringe-indicators` is now granular (per the suggestion in #3721): it accepts `t` (all kinds, the default), `nil` (none), or a list of kinds, e.g. `(eval)` or `(eval test)`. A new `cider--use-fringe-indicators-p` predicate gates both the eval and the test indicators, so existing `t`/`nil` configs keep working and you can scope indicators to just evaluation or just tests.

The markers are placed during `cider-test-highlight-problems` (reusing the var lookup it already does, so no extra requests) and cleared by `cider-test-clear-highlights`. Note: since the default is `t`, test fringes are on by default; set `cider-use-fringe-indicators` to `(eval)` to keep only the evaluation markers. Added tests.

Fixes #3721.