### PR TITLE
Wire up ClojureScript support improvements from cider-nrepl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### Bugs fixed
 
+- [#4026](https://github.com/clojure-emacs/cider/pull/4026): `cider-macroexpand-1` and friends now work in ClojureScript for user-defined macros (fixed in `cider-nrepl`, delivered via the 0.61.0-alpha1 bump) ([#2099](https://github.com/clojure-emacs/cider/issues/2099)).
 - [#4016](https://github.com/clojure-emacs/cider/pull/4016): Show the REPL prompt right away when a server (e.g. jank) sends `value` and `("done")` in the same response, instead of only after the next keypress ([#3869](https://github.com/clojure-emacs/cider/issues/3869)).
 - [#4019](https://github.com/clojure-emacs/cider/pull/4019): Stop the dynamic local-variable font-locking from mistaking a `def`'s value for an arglist, which tagged literals, function names and other non-locals as locals (`cider-locals` false positives) ([#3657](https://github.com/clojure-emacs/cider/issues/3657)).
 - [#4021](https://github.com/clojure-emacs/cider/pull/4021): Stop unbalanced parentheses in REPL output (e.g. printed strings or shadow-cljs warnings) from breaking sexp navigation and paredit in the REPL buffer ([#3102](https://github.com/clojure-emacs/cider/issues/3102)).
@@ -41,6 +42,7 @@
 
 ### Changes
 
+- [#4026](https://github.com/clojure-emacs/cider/pull/4026): Bump the injected `cider-nrepl` to 0.61.0-alpha1, which provides ClojureScript test support, the `clojure-only` op signal and the ClojureScript macroexpansion fix.
 - [#4026](https://github.com/clojure-emacs/cider/pull/4026): Show a clear message when a Clojure-only operation (apropos, xref, trace, profile, refresh, reload, undef, spec) is invoked under a ClojureScript REPL, instead of failing confusingly or returning JVM-only results (requires a recent enough `cider-nrepl`) ([#2198](https://github.com/clojure-emacs/cider/issues/2198)).
 - [#4022](https://github.com/clojure-emacs/cider/pull/4022): `cider-inspect-last-sexp` now inspects the tagged class when point is on a type tag (e.g. `^String`), instead of the form the tag applies to ([#3679](https://github.com/clojure-emacs/cider/issues/3679)).
 - [#4024](https://github.com/clojure-emacs/cider/pull/4024): The `*cider-ns-refresh-log*` buffer now supports `r`/`g`/`C-c M-n r` to re-run the refresh from within it ([#2798](https://github.com/clojure-emacs/cider/issues/2798)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 
 ### Changes
 
+- [#4026](https://github.com/clojure-emacs/cider/pull/4026): Show a clear message when a Clojure-only operation (apropos, xref, trace, profile, refresh, reload, undef, spec) is invoked under a ClojureScript REPL, instead of failing confusingly or returning JVM-only results (requires a recent enough `cider-nrepl`) ([#2198](https://github.com/clojure-emacs/cider/issues/2198)).
 - [#4022](https://github.com/clojure-emacs/cider/pull/4022): `cider-inspect-last-sexp` now inspects the tagged class when point is on a type tag (e.g. `^String`), instead of the form the tag applies to ([#3679](https://github.com/clojure-emacs/cider/issues/3679)).
 - [#4024](https://github.com/clojure-emacs/cider/pull/4024): The `*cider-ns-refresh-log*` buffer now supports `r`/`g`/`C-c M-n r` to re-run the refresh from within it ([#2798](https://github.com/clojure-emacs/cider/issues/2798)).
 - [#4005](https://github.com/clojure-emacs/cider/pull/4005): Render the namespace browser (`cider-browse-ns`) on the `cider-tree-view` widget: groups (by type or visibility) are now foldable with `TAB`, and `n`/`p` move between entries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- [#4026](https://github.com/clojure-emacs/cider/pull/4026): Run ClojureScript tests with the regular test commands (e.g. `cider-test-run-ns-tests`) when a ClojureScript REPL is active, instead of refusing them; requires a recent enough `cider-nrepl` (synchronous tests only for now).
 - [#4023](https://github.com/clojure-emacs/cider/pull/4023): `cider-auto-inspect-after-eval` now accepts `interactive`, `repl` or `all` (in addition to `t`/`nil`), so a visible inspector can also be refreshed after REPL evaluations ([#3636](https://github.com/clojure-emacs/cider/issues/3636)).
 - [#4025](https://github.com/clojure-emacs/cider/pull/4025): Mark each `deftest` with a green (passed) or red (failed) left-fringe indicator after a test run. `cider-use-fringe-indicators` now accepts a list of kinds (`eval`, `test`) for finer control, in addition to `t`/`nil` ([#3721](https://github.com/clojure-emacs/cider/issues/3721)).
 - [#4004](https://github.com/clojure-emacs/cider/pull/4004): Add `cider-browse-spec-tree`, which browses a spec and the specs it references as an expandable tree - expand a node to reveal its sub-specs (a level at a time), `RET` to open a spec's full definition.

--- a/lisp/cider-jack-in.el
+++ b/lisp/cider-jack-in.el
@@ -322,7 +322,7 @@ the artifact.")
 
 Used when `cider-jack-in-auto-inject-clojure' is set to `latest'.")
 
-(defconst cider-required-middleware-version "0.60.0"
+(defconst cider-required-middleware-version "0.61.0-alpha1"
   "The CIDER nREPL version that's known to work properly with CIDER.")
 
 (defcustom cider-injected-middleware-version cider-required-middleware-version

--- a/lisp/cider-test.el
+++ b/lisp/cider-test.el
@@ -779,7 +779,9 @@ running them."
              (cider-test--prompt-for-selectors
               "Test selectors to exclude (space separated): ")
            cider-test-default-exclude-selectors)))
-    (cider-map-repls :clj-strict
+    ;; ClojureScript tests run too, via cider-nrepl's cljs.test support
+    ;; (clojure-emacs/cider#555); cljc files dispatch to both REPLs.
+    (cider-map-repls :auto
       (lambda (conn)
         (unless silent
           (if (and tests (= (length tests) 1))

--- a/lisp/nrepl-client.el
+++ b/lisp/nrepl-client.el
@@ -324,6 +324,16 @@ later responses on the floor."
               (with-demoted-errors "Error in nREPL response dispatch: %s"
                 (nrepl--dispatch-response response)))))))))
 
+(defun nrepl--clojure-only-error (response)
+  "Return RESPONSE's Clojure-only message, or nil.
+Non-nil when RESPONSE's status reports the op as `clojure-only' - i.e. the
+server (cider-nrepl) declined to run it because a ClojureScript REPL is
+active (see clojure-emacs/cider#2198).  Falls back to a generic message when
+the server didn't supply one."
+  (when (member "clojure-only" (nrepl-dict-get response "status"))
+    (string-trim (or (nrepl-dict-get response "err")
+                     "This operation isn't available in a ClojureScript REPL."))))
+
 (defun nrepl--dispatch-response (response)
   "Dispatch the RESPONSE to associated callback.
 First we check the callbacks of pending requests.  If no callback was found,
@@ -336,6 +346,11 @@ dispatcher to do, and signaling here used to abort processing of any
 later responses sitting in the queue."
   (nrepl-dbind-response response (id)
     (nrepl-log-message response 'response)
+    ;; Surface a Clojure-only rejection for asynchronous ops.  Synchronous
+    ;; requests get a `user-error' from `nrepl-sync-request' so the calling
+    ;; command aborts cleanly instead of reporting empty results.
+    (when-let* ((msg (nrepl--clojure-only-error response)))
+      (message "%s" msg))
     (let ((callback (or (gethash id nrepl-pending-requests)
                         (gethash id nrepl-completed-requests))))
       (if callback
@@ -928,6 +943,10 @@ positional shim retained for backward compatibility."
         (when id
           (with-current-buffer connection
             (nrepl--mark-id-completed id)))
+        ;; The op was declined because a ClojureScript REPL is active; abort
+        ;; the calling command with a clear message (clojure-emacs/cider#2198).
+        (when-let* ((msg (nrepl--clojure-only-error response)))
+          (user-error "%s" msg))
         response))))
 
 (defun nrepl-send-sync-request (request connection &optional abort-on-input

--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -352,7 +352,28 @@
     ;; spec just locks the contract: the dispatcher itself doesn't add
     ;; its own protection -- protection is at the filter layer.
     (expect (nrepl--dispatch-response '(dict "id" "1" "value" "v"))
-            :to-throw 'error)))
+            :to-throw 'error))
+
+  (it "surfaces a clojure-only rejection via a message (#2198)"
+    (spy-on 'message)
+    (puthash "1" #'ignore nrepl-pending-requests)
+    (nrepl--dispatch-response '(dict "id" "1"
+                                     "status" ("done" "clojure-only")
+                                     "err" "nope\n"))
+    (expect 'message :to-have-been-called-with "%s" "nope")))
+
+(describe "nrepl--clojure-only-error"
+  (it "returns the trimmed server message for a clojure-only response"
+    (expect (nrepl--clojure-only-error
+             '(dict "status" ("done" "clojure-only")
+                    "err" "The \"cider/apropos\" op is Clojure-only.\n"))
+            :to-equal "The \"cider/apropos\" op is Clojure-only."))
+  (it "falls back to a generic message when no err is supplied"
+    (expect (nrepl--clojure-only-error '(dict "status" ("done" "clojure-only")))
+            :to-equal "This operation isn't available in a ClojureScript REPL."))
+  (it "returns nil for an ordinary response"
+    (expect (nrepl--clojure-only-error '(dict "status" ("done") "value" "42"))
+            :to-be nil)))
 
 (describe "nrepl--mark-id-completed cap"
   :var (nrepl-pending-requests nrepl-completed-requests


### PR DESCRIPTION
Wires up today's ClojureScript-focused cider-nrepl changes, part of gradually improving cljs support and making it clear what doesn't work under ClojureScript. Now bundled with the **cider-nrepl 0.61.0-alpha1** bump, so it works out of the box.

Commits:

- **[#2198] Surface Clojure-only ops under a cljs REPL.** cider-nrepl now replies with a `clojure-only` status + a clear message when a Clojure-only op (apropos, xref, trace, profile, refresh, reload, undef, spec) runs while a cljs REPL is active. CIDER reacts centrally: `nrepl--dispatch-response` messages the explanation for async ops, and `nrepl-sync-request` raises a `user-error` so sync commands abort cleanly instead of reporting empty results. `nrepl--clojure-only-error` centralizes the check, so the server owns the op list.
- **[cider-nrepl#555] Run ClojureScript tests.** The test ops now run cljs tests via `cljs.test`; relaxed the test runner from `:clj-strict` to `:auto` so the commands dispatch to the cljs REPL (sync tests only for now).
- **Bump injected cider-nrepl to 0.61.0-alpha1**, which also delivers the cljs `macroexpand-1` fix (#2099) - no CIDER code change needed for that one.

Tests added for the `clojure-only` handling; `cider-test` specs still green.

Fixes #2198. Fixes #2099.