### PR TITLE
Centralize the connection and op-support checks

### DIFF
--- a/lisp/cider-apropos.el
+++ b/lisp/cider-apropos.el
@@ -146,7 +146,6 @@ optionally search doc strings (based on DOCS-P), include private vars
 \(based on PRIVATES-P), and be case-sensitive (based on CASE-SENSITIVE-P)."
   (interactive (cider-apropos--read-args))
   (cider-ensure-connected)
-  (cider-ensure-op-supported "cider/apropos")
   (if-let* ((summary (cider-apropos-summary
                       query ns docs-p privates-p case-sensitive-p))
             (results (cider-apropos-request query
@@ -162,7 +161,6 @@ optionally search doc strings (based on DOCS-P), include private vars
   "Shortcut for (cider-apropos <query> nil t)."
   (interactive)
   (cider-ensure-connected)
-  (cider-ensure-op-supported "cider/apropos")
   (cider-apropos (read-string "Search for Clojure documentation (a regular expression): ") nil t))
 
 (defun cider-apropos-act-on-symbol (symbol)
@@ -189,7 +187,6 @@ optionally search doc strings (based on DOCS-P), include private vars
 \(based on PRIVATES-P), and be case-sensitive (based on CASE-SENSITIVE-P)."
   (interactive (cider-apropos--read-args))
   (cider-ensure-connected)
-  (cider-ensure-op-supported "cider/apropos")
   (if-let* ((summary (cider-apropos-summary
                       query ns docs-p privates-p case-sensitive-p))
             (results (mapcar (lambda (r) (nrepl-dict-get r "name"))
@@ -206,7 +203,6 @@ optionally search doc strings (based on DOCS-P), include private vars
   "Shortcut for (cider-apropos-select <query> nil t)."
   (interactive)
   (cider-ensure-connected)
-  (cider-ensure-op-supported "cider/apropos")
   (cider-apropos-select (read-string "Search for Clojure documentation (a regular expression): ") nil t))
 
 (provide 'cider-apropos)

--- a/lisp/cider-apropos.el
+++ b/lisp/cider-apropos.el
@@ -145,7 +145,6 @@ behind the scenes.  The search may be limited to the namespace NS, and may
 optionally search doc strings (based on DOCS-P), include private vars
 \(based on PRIVATES-P), and be case-sensitive (based on CASE-SENSITIVE-P)."
   (interactive (cider-apropos--read-args))
-  (cider-ensure-connected)
   (if-let* ((summary (cider-apropos-summary
                       query ns docs-p privates-p case-sensitive-p))
             (results (cider-apropos-request query
@@ -186,7 +185,6 @@ behind the scenes.  The search may be limited to the namespace NS, and may
 optionally search doc strings (based on DOCS-P), include private vars
 \(based on PRIVATES-P), and be case-sensitive (based on CASE-SENSITIVE-P)."
   (interactive (cider-apropos--read-args))
-  (cider-ensure-connected)
   (if-let* ((summary (cider-apropos-summary
                       query ns docs-p privates-p case-sensitive-p))
             (results (mapcar (lambda (r) (nrepl-dict-get r "name"))

--- a/lisp/cider-browse-spec.el
+++ b/lisp/cider-browse-spec.el
@@ -391,7 +391,6 @@ a more user friendly representation of SPEC-FORM."
 
 (defun cider-browse-spec--browse (spec)
   "Browse SPEC."
-  (cider-ensure-connected)
   ;; Expand auto-resolved keywords
   (when-let* ((val (and (string-match-p "^::.+" spec)
                         (nrepl-dict-get (cider-sync-tooling-eval spec (cider-current-ns)) "value"))))

--- a/lisp/cider-browse-spec.el
+++ b/lisp/cider-browse-spec.el
@@ -392,7 +392,6 @@ a more user friendly representation of SPEC-FORM."
 (defun cider-browse-spec--browse (spec)
   "Browse SPEC."
   (cider-ensure-connected)
-  (cider-ensure-op-supported "cider/spec-form")
   ;; Expand auto-resolved keywords
   (when-let* ((val (and (string-match-p "^::.+" spec)
                         (nrepl-dict-get (cider-sync-tooling-eval spec (cider-current-ns)) "value"))))

--- a/lisp/cider-browse-spec.el
+++ b/lisp/cider-browse-spec.el
@@ -419,8 +419,6 @@ property."
 (defun cider-browse-spec--print-curr-spec-example ()
   "Generate and print an example of the current spec."
   (interactive)
-  (cider-ensure-connected)
-  (cider-ensure-op-supported "cider/spec-example")
   (if-let* ((spec cider-browse-spec--current-spec))
       (if-let* ((example (cider-sync-request:spec-example spec)))
           (with-current-buffer (cider-popup-buffer cider-browse-spec-example-buffer 'select #'cider-browse-spec-example-mode 'ancillary)
@@ -452,7 +450,6 @@ Generates a new example for the current spec."
   "Open the list of specs that matches REGEX in a popup buffer.
 Displays all specs when REGEX is nil."
   (cider-ensure-connected)
-  (cider-ensure-op-supported "cider/spec-list")
   (let ((filter-regex (or regex "")))
     (with-current-buffer (cider-popup-buffer cider-browse-spec-buffer 'select nil 'ancillary)
       (let ((specs (cider-sync-request:spec-list filter-regex)))
@@ -512,8 +509,6 @@ at a time - so you can walk a spec's structure in place; \\<cider-tree-view-mode
 shows that spec's full definition."
   (interactive (list (completing-read "Browse spec tree: "
                                       (cider-sync-request:spec-list))))
-  (cider-ensure-connected)
-  (cider-ensure-op-supported "cider/spec-form")
   (let ((root (cider-browse-spec--tree-node spec nil)))
     (setf (cider-tree-view-node-expanded root) t)
     (with-current-buffer (cider-popup-buffer "*cider-spec-tree*" 'select

--- a/lisp/cider-client.el
+++ b/lisp/cider-client.el
@@ -839,7 +839,6 @@ prefer the keyword-argument `cider-apropos-request'."
 
 (defun cider-sync-request:classpath (&optional connection)
   "Return a list of classpath entries for CONNECTION."
-  (cider-ensure-op-supported "cider/classpath" connection)
   (thread-first
     '("op" "cider/classpath")
     (cider-nrepl-send-sync-request connection)
@@ -1084,7 +1083,6 @@ The result entries are relative to the classpath."
 
 (defun cider-sync-request:fn-refs (ns sym)
   "Return a list of functions that reference the function identified by NS and SYM."
-  (cider-ensure-op-supported "cider/fn-refs")
   (thread-first `("op" "cider/fn-refs"
                   "ns" ,ns
                   "sym" ,sym)
@@ -1093,7 +1091,6 @@ The result entries are relative to the classpath."
 
 (defun cider-sync-request:fn-deps (ns sym)
   "Return a list of function deps for the function identified by NS and SYM."
-  (cider-ensure-op-supported "cider/fn-deps")
   (thread-first `("op" "cider/fn-deps"
                   "ns" ,ns
                   "sym" ,sym)
@@ -1105,7 +1102,6 @@ The result entries are relative to the classpath."
 The result is a dict with a \"kind\" of \"protocol\", \"multimethod\" or
 \"other\"; for a protocol an \"impls\" list, for a multimethod a
 \"dispatch-values\" list."
-  (cider-ensure-op-supported "cider/who-implements")
   (thread-first `("op" "cider/who-implements"
                   "ns" ,ns
                   "sym" ,sym)
@@ -1115,7 +1111,6 @@ The result is a dict with a \"kind\" of \"protocol\", \"multimethod\" or
 (defun cider-sync-request:type-protocols (ns sym)
   "Return the protocols implemented by the type NS and SYM.
 Each is a dict with a \"name\" and source location."
-  (cider-ensure-op-supported "cider/type-protocols")
   (thread-first `("op" "cider/type-protocols"
                   "ns" ,ns
                   "sym" ,sym)
@@ -1125,7 +1120,6 @@ Each is a dict with a \"name\" and source location."
 (defun cider-sync-request:protocols-with-method (method)
   "Return the protocols declaring a method named METHOD.
 Each is a dict with a \"name\" and source location."
-  (cider-ensure-op-supported "cider/protocols-with-method")
   (thread-first `("op" "cider/protocols-with-method"
                   "method" ,method)
                 (cider-nrepl-send-sync-request)

--- a/lisp/cider-client.el
+++ b/lisp/cider-client.el
@@ -239,10 +239,37 @@ Signal an error if it is not supported."
   (unless (cider-nrepl-op-supported-p op connection)
     (user-error "`%s' requires the nREPL op \"%s\" (provided by cider-nrepl)" this-command op)))
 
+(defvar cider--skip-op-ensure nil
+  "When non-nil, skip the automatic op-support check in CIDER's nREPL senders.
+Background or best-effort callers that should degrade silently when an op
+isn't available (instead of signaling) can bind this around their sends.
+Note that callers which already probe `cider-nrepl-op-supported-p' before
+sending never reach the check, so they don't need this.")
+
+(defun cider--ensure-request-op-supported (request connection)
+  "Signal a `user-error' when REQUEST's op isn't supported by CONNECTION.
+Only namespaced middleware ops (those containing a \"/\", e.g.
+\"cider/apropos\") are checked; core nREPL ops pass through.  Does nothing
+when `cider--skip-op-ensure' is non-nil.
+
+This is the central enforcement that lets interactive commands omit explicit
+`cider-ensure-op-supported' calls: every CIDER-level send routes through
+`cider--resolve-op-in-request', so an unsupported op fails uniformly with a
+clear message no matter which command sent it."
+  (let ((op (cider-plist-get request "op")))
+    (when (and op
+               (not cider--skip-op-ensure)
+               (string-search "/" op)
+               (not (cider-nrepl-op-supported-p op connection 'skip-ensure)))
+      (user-error "`%s' requires the nREPL op \"%s\" (provided by cider-nrepl)"
+                  (or this-command "This request") op))))
+
 (defun cider--resolve-op-in-request (request connection)
   "Resolve the op in REQUEST to a name supported by CONNECTION.
 Falls back to the unprefixed legacy op name when the server
-doesn't support namespaced ops."
+doesn't support namespaced ops.  Signals a `user-error' when the op isn't
+available at all (see `cider--ensure-request-op-supported')."
+  (cider--ensure-request-op-supported request connection)
   (let* ((op (cider-plist-get request "op"))
          (effective (cider--fallback-op op connection)))
     (if (equal op effective)

--- a/lisp/cider-doc.el
+++ b/lisp/cider-doc.el
@@ -249,7 +249,6 @@ the value of `cider-prompt-for-symbol'.  With prefix arg ARG, does the
 opposite of what that option dictates."
   (interactive "P")
   (cider-ensure-connected)
-  (cider-ensure-op-supported "cider/info")
   (funcall (cider-prompt-for-symbol-function arg)
            "Javadoc for"
            #'cider-javadoc-handler))

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -1127,7 +1127,6 @@ passing arguments."
 (defun cider-undef ()
   "Undefine a symbol from the current ns."
   (interactive)
-  (cider-ensure-op-supported "cider/undef")
   (cider-read-symbol-name
    "Undefine symbol: "
    (lambda (sym)
@@ -1140,7 +1139,6 @@ passing arguments."
 (defun cider-undef-all (&optional ns)
   "Undefine all symbols and aliases from the namespace NS."
   (interactive)
-  (cider-ensure-op-supported "cider/undef-all")
   (cider-nrepl-send-sync-request
    `("op" "cider/undef-all"
      "ns" ,(or ns (cider-current-ns)))))
@@ -1309,7 +1307,6 @@ all ns aliases and var mappings from the namespaces being reloaded"
   "Load all namespaces in the current project."
   (interactive)
   (cider-ensure-connected)
-  (cider-ensure-op-supported "cider/ns-load-all")
   (when (y-or-n-p "Are you sure you want to load all namespaces in the project? ")
     (message "Loading all project namespaces...")
     (let ((loaded-ns-count (length (cider-sync-request:ns-load-all))))

--- a/lisp/cider-find.el
+++ b/lisp/cider-find.el
@@ -84,7 +84,6 @@ Show results in a different window if OTHER-WINDOW is true."
   (if-let* ((info (cider-var-info symbol-file)))
       (cider--jump-to-loc-from-info info other-window)
     (progn
-      (cider-ensure-op-supported "cider/resource")
       (if-let* ((resource (cider-sync-request:resource symbol-file))
                 (buffer (cider-find-file resource)))
           (cider-jump-to buffer 0 other-window)
@@ -144,7 +143,6 @@ value is thing at point."
                          nil nil
                          (thing-at-point 'filename))
       (or (thing-at-point 'filename) ""))))
-  (cider-ensure-op-supported "cider/resource")
   (when (string-empty-p path)
     (error "Cannot find resource for empty path"))
   (if-let* ((resource (cider-sync-request:resource path))
@@ -194,7 +192,6 @@ A prefix ARG of `-` or a double prefix argument causes
 the results to be displayed in a different window."
   (interactive "P")
   (cider-ensure-connected)
-  (cider-ensure-op-supported "cider/ns-path")
   (if ns
       (cider--find-ns ns)
     (let* ((namespaces (cider-sync-request:ns-list))

--- a/lisp/cider-format.el
+++ b/lisp/cider-format.el
@@ -83,7 +83,6 @@ Uses the following heuristic to try to maintain point position:
   "Format the Clojure code in the current region.
 START and END represent the region's boundaries."
   (interactive "r")
-  (cider-ensure-connected)
   (cider--format-region start end
                         (lambda (buf)
                           (cider-sync-request:format-code buf cider-format-code-options))))
@@ -95,7 +94,6 @@ START and END represent the region's boundaries."
 (defun cider-format-defun ()
   "Format the code in the current defun."
   (interactive)
-  (cider-ensure-connected)
   (let ((defun-bounds (cider-defun-at-point 't)))
     (cider-format-region (car defun-bounds) (cadr defun-bounds))))
 
@@ -114,7 +112,6 @@ of the buffer into a formatted string."
   "Format the Clojure code in the current buffer."
   (interactive)
   (check-parens)
-  (cider-ensure-connected)
   (cider--format-buffer (lambda (buf)
                           (cider-sync-request:format-code buf cider-format-code-options))))
 
@@ -126,7 +123,6 @@ of the buffer into a formatted string."
   "Format the EDN data in the current buffer."
   (interactive)
   (check-parens)
-  (cider-ensure-connected)
   (cider--format-buffer (lambda (edn)
                           (cider-sync-request:format-edn edn fill-column))))
 
@@ -135,7 +131,6 @@ of the buffer into a formatted string."
   "Format the EDN data in the current region.
 START and END represent the region's boundaries."
   (interactive "r")
-  (cider-ensure-connected)
   (let* ((start-column (save-excursion (goto-char start) (current-column)))
          (right-margin (- fill-column start-column)))
     (cider--format-region start end

--- a/lisp/cider-inspector.el
+++ b/lisp/cider-inspector.el
@@ -485,7 +485,6 @@ current-namespace."
   "Print the current value of the inspector."
   (interactive)
   (cider-ensure-connected)
-  (cider-ensure-op-supported "cider/inspect-print-current-value")
   (let ((buffer (cider-popup-buffer cider-result-buffer nil 'clojure-mode 'ancillary)))
     (cider-nrepl-send-request
      `("op" "cider/inspect-print-current-value"

--- a/lisp/cider-log.el
+++ b/lisp/cider-log.el
@@ -209,7 +209,6 @@ It will not be used if the package hasn't been installed."
 
 (defun cider-request:log-add-consumer (framework appender consumer &optional callback)
   "Add CONSUMER to the APPENDER of FRAMEWORK and call CALLBACK on log events."
-  (cider-ensure-op-supported "cider/log-add-consumer")
   (thread-first `("op" "cider/log-add-consumer"
                   "framework" ,(cider-log-framework-id framework)
                   "appender" ,(cider-log-appender-id appender)
@@ -218,7 +217,6 @@ It will not be used if the package hasn't been installed."
 
 (defun cider-sync-request:log-update-consumer (framework appender consumer)
   "Add CONSUMER to the APPENDER of FRAMEWORK and call CALLBACK on log events."
-  (cider-ensure-op-supported "cider/log-update-consumer")
   (thread-first `("op" "cider/log-update-consumer"
                   "framework" ,(cider-log-framework-id framework)
                   "appender" ,(cider-log-appender-id appender)
@@ -229,7 +227,6 @@ It will not be used if the package hasn't been installed."
 
 (defun cider-sync-request:log-add-appender (framework appender)
   "Add the APPENDER to the log FRAMEWORK."
-  (cider-ensure-op-supported "cider/log-add-appender")
   (thread-first `("op" "cider/log-add-appender"
                   "framework" ,(cider-log-framework-id framework)
                   "appender" ,(cider-log-appender-id appender)
@@ -241,7 +238,6 @@ It will not be used if the package hasn't been installed."
 
 (defun cider-sync-request:log-update-appender (framework appender)
   "Update the APPENDER of the log FRAMEWORK."
-  (cider-ensure-op-supported "cider/log-update-appender")
   (thread-first `("op" "cider/log-update-appender"
                   "framework" ,(cider-log-framework-id framework)
                   "appender" ,(cider-log-appender-id appender)
@@ -253,7 +249,6 @@ It will not be used if the package hasn't been installed."
 
 (defun cider-sync-request:log-clear (framework appender)
   "Clear the log events for FRAMEWORK and APPENDER."
-  (cider-ensure-op-supported "cider/log-clear-appender")
   (thread-first `("op" "cider/log-clear-appender"
                   "framework" ,(cider-log-framework-id framework)
                   "appender" ,(cider-log-appender-id appender))
@@ -262,7 +257,6 @@ It will not be used if the package hasn't been installed."
 
 (defun cider-sync-request:log-inspect-event (framework appender event)
   "Inspect the log event with the ID in the APPENDER of the log FRAMEWORK."
-  (cider-ensure-op-supported "cider/log-inspect-event")
   (thread-first `("op" "cider/log-inspect-event"
                   "framework" ,(cider-log-framework-id framework)
                   "appender" ,(cider-log-appender-id appender)
@@ -272,7 +266,6 @@ It will not be used if the package hasn't been installed."
 
 (defun cider-sync-request:log-format-event (framework appender event)
   "Format the log EVENT from the APPENDER of the log FRAMEWORK."
-  (cider-ensure-op-supported "cider/log-format-event")
   (thread-first
     `("op" "cider/log-format-event"
       "framework" ,(cider-log-framework-id framework)
@@ -284,14 +277,12 @@ It will not be used if the package hasn't been installed."
 
 (defun cider-sync-request:log-frameworks ()
   "Return the available log frameworks."
-  (cider-ensure-op-supported "cider/log-frameworks")
   (thread-first `("op" "cider/log-frameworks")
                 (cider-nrepl-send-sync-request)
                 (nrepl-dict-get "cider/log-frameworks")))
 
 (cl-defun cider-sync-request:log-search (framework appender &key filters limit offset)
   "Search log events of FRAMEWORK and APPENDER using FILTERS, LIMIT and OFFSET."
-  (cider-ensure-op-supported "cider/log-search")
   (thread-first `("op" "cider/log-search"
                   "framework" ,(cider-log-framework-id framework)
                   "appender" ,(cider-log-appender-id appender)
@@ -303,7 +294,6 @@ It will not be used if the package hasn't been installed."
 
 (defun cider-sync-request:log-exceptions (framework appender)
   "Return the Cider log exceptions for FRAMEWORK and APPENDER."
-  (cider-ensure-op-supported "cider/log-exceptions")
   (thread-first `("op" "cider/log-exceptions"
                   "framework" ,(cider-log-framework-id framework)
                   "appender" ,(cider-log-appender-id appender))
@@ -312,7 +302,6 @@ It will not be used if the package hasn't been installed."
 
 (defun cider-sync-request:log-levels (framework appender)
   "Return the Cider log levels for FRAMEWORK and APPENDER."
-  (cider-ensure-op-supported "cider/log-levels")
   (thread-first `("op" "cider/log-levels"
                   "framework" ,(cider-log-framework-id framework)
                   "appender" ,(cider-log-appender-id appender))
@@ -321,7 +310,6 @@ It will not be used if the package hasn't been installed."
 
 (defun cider-sync-request:log-loggers (framework appender)
   "Return the Cider loggers for FRAMEWORK and APPENDER."
-  (cider-ensure-op-supported "cider/log-loggers")
   (thread-first `("op" "cider/log-loggers"
                   "framework" ,(cider-log-framework-id framework)
                   "appender" ,(cider-log-appender-id appender))
@@ -330,7 +318,6 @@ It will not be used if the package hasn't been installed."
 
 (defun cider-sync-request:log-remove-appender (framework appender)
   "Remove the APPENDER from the log FRAMEWORK."
-  (cider-ensure-op-supported "cider/log-remove-appender")
   (thread-first `("op" "cider/log-remove-appender"
                   "framework" ,(cider-log-framework-id framework)
                   "appender" ,(cider-log-appender-id appender))
@@ -339,7 +326,6 @@ It will not be used if the package hasn't been installed."
 
 (defun cider-sync-request:log-remove-consumer (framework appender consumer)
   "Remove the CONSUMER from the APPENDER of the log FRAMEWORK."
-  (cider-ensure-op-supported "cider/log-remove-consumer")
   (thread-first `("op" "cider/log-remove-consumer"
                   "framework" ,(cider-log-framework-id framework)
                   "appender" ,(cider-log-appender-id appender)
@@ -349,7 +335,6 @@ It will not be used if the package hasn't been installed."
 
 (defun cider-sync-request:log-threads (framework appender)
   "Return the threads for FRAMEWORK and APPENDER."
-  (cider-ensure-op-supported "cider/log-threads")
   (thread-first `("op" "cider/log-threads"
                   "framework" ,(cider-log-framework-id framework)
                   "appender" ,(cider-log-appender-id appender))

--- a/lisp/cider-macroexpansion.el
+++ b/lisp/cider-macroexpansion.el
@@ -71,7 +71,6 @@ Possible values are:
   "Macroexpand, using EXPANDER, the given EXPR.
 The default for DISPLAY-NAMESPACES is taken from
 `cider-macroexpansion-display-namespaces'."
-  (cider-ensure-op-supported "cider/macroexpand")
   (let ((result (thread-first `("op" "cider/macroexpand"
                                 "expander" ,expander
                                 "code" ,expr

--- a/lisp/cider-macrostep.el
+++ b/lisp/cider-macrostep.el
@@ -147,7 +147,6 @@ popup rather than merely leave `cider-macrostep-mode' as it does inline.")
   "Return the macroexpansion of CODE in the current namespace.
 EXPANDER is a `cider/macroexpand' expander name, such as \"macroexpand-1\"
 \(one level) or \"macroexpand-all\" (fully, recursively)."
-  (cider-ensure-op-supported "cider/macroexpand")
   (let ((result (thread-first `("op" "cider/macroexpand"
                                 "expander" ,expander
                                 "code" ,code

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -177,7 +177,6 @@ VAR is a fully qualified Clojure variable name as a string."
   "Run -main or FUNCTION, prompting for its namespace if necessary.
 With a prefix argument, prompt for function to run instead of -main."
   (interactive (list (when current-prefix-arg (read-string "Function name: "))))
-  (cider-ensure-connected)
   (let ((name (or function "-main")))
     (when-let* ((response (cider-nrepl-send-sync-request
                            `("op" "cider/ns-list-vars-by-name"

--- a/lisp/cider-ns.el
+++ b/lisp/cider-ns.el
@@ -361,7 +361,6 @@ With a negative prefix argument, or if MODE is `inhibit-fns', prevent any
 refresh functions (defined in `cider-ns-refresh-before-fn' and
 `cider-ns-refresh-after-fn') from being invoked."
   (interactive "p")
-  (cider-ensure-connected)
   (let ((clear? (member mode '(clear 16)))
         (all? (member mode '(refresh-all 4)))
         (inhibit-refresh-fns (member mode '(inhibit-fns -1))))

--- a/lisp/cider-profile.el
+++ b/lisp/cider-profile.el
@@ -86,7 +86,6 @@ current ns."
 Defaults to the symbol at point.
 With prefix arg or no symbol at point, prompts for a var."
   (interactive "P")
-  (cider-ensure-op-supported "cider/profile-toggle-var")
   (cider-read-symbol-name
    "Toggle profiling for var: "
    (lambda (sym)
@@ -105,7 +104,6 @@ With prefix arg or no symbol at point, prompts for a var."
 (defun cider-profile-summary ()
   "Display a summary of currently collected profile data."
   (interactive)
-  (cider-ensure-op-supported "cider/profile-summary")
   (cider-inspector--render-value
    (cider-nrepl-send-sync-request '("op" "cider/profile-summary"))))
 
@@ -113,7 +111,6 @@ With prefix arg or no symbol at point, prompts for a var."
 (defun cider-profile-clear ()
   "Clear any collected profile data."
   (interactive)
-  (cider-ensure-op-supported "cider/profile-clear")
   (cider-nrepl-send-request
    '("op" "cider/profile-clear")
    (cider-profile--make-response-handler

--- a/lisp/cider-profile.el
+++ b/lisp/cider-profile.el
@@ -67,7 +67,6 @@ current buffer, is used by the global nREPL handlers (e.g. error)."
 If optional argument QUERY is non-nil, prompt for ns.  Otherwise use
 current ns."
   (interactive "P")
-  (cider-ensure-op-supported "cider/profile-toggle-ns")
   (let ((ns (if query
                 (completing-read "Toggle profiling for ns: "
                                  (cider-sync-request:ns-list))

--- a/lisp/cider-session.el
+++ b/lisp/cider-session.el
@@ -101,7 +101,12 @@ Set interactively with `cider-set-default-session'.")
   (process-live-p (get-buffer-process (cider-current-repl))))
 
 (defun cider-ensure-connected ()
-  "Ensure there is a linked CIDER session."
+  "Signal a `user-error' unless there is a linked CIDER session.
+The CIDER-level nREPL senders (e.g. `cider-nrepl-send-request',
+`cider-nrepl-sync-request') already ensure a connection - they resolve the
+REPL with `cider-current-repl' ENSURE - so commands don't need this for
+correctness.  Use it only to fail fast, before doing interactive or
+side-effecting work, rather than at the point of the first request."
   (sesman-ensure-session 'CIDER))
 
 

--- a/lisp/cider-tracing.el
+++ b/lisp/cider-tracing.el
@@ -60,7 +60,6 @@ Prompts for the symbol to use, or uses the symbol at point, depending on
 the value of `cider-prompt-for-symbol'.  With prefix arg ARG, does the
 opposite of what that option dictates."
   (interactive "P")
-  (cider-ensure-op-supported "cider/toggle-trace-var")
   (funcall (cider-prompt-for-symbol-function arg)
            "Toggle trace for var"
            #'cider--toggle-trace-var))
@@ -117,7 +116,6 @@ Defaults to the current ns.  With prefix arg QUERY, prompts for a ns."
 (defun cider-list-traced ()
   "Display the vars and namespaces that are currently traced."
   (interactive)
-  (cider-ensure-op-supported "cider/list-traced")
   (let* ((response (cider-sync-request:list-traced))
          (vars (nrepl-dict-get response "traced-vars"))
          (nses (nrepl-dict-get response "traced-nses")))
@@ -129,7 +127,6 @@ Defaults to the current ns.  With prefix arg QUERY, prompts for a ns."
 (defun cider-untrace-all ()
   "Untrace all currently traced vars and namespaces."
   (interactive)
-  (cider-ensure-op-supported "cider/untrace-all")
   (let* ((response (cider-nrepl-send-sync-request '("op" "cider/untrace-all")))
          (count (or (nrepl-dict-get response "untraced-count") 0)))
     (message "Untraced %d var%s" count (if (= count 1) "" "s"))))
@@ -354,7 +351,6 @@ Trace functions with `cider-toggle-trace-var' or `cider-toggle-trace-ns'
 and call them; their calls and return values stream here instead of
 cluttering the REPL.  Killing the buffer stops the streaming."
   (interactive)
-  (cider-ensure-op-supported "cider/trace-subscribe")
   (let ((connection (cider-current-repl nil 'ensure))
         (buffer (get-buffer-create cider-trace-buffer)))
     (with-current-buffer buffer

--- a/lisp/cider-xref-backend.el
+++ b/lisp/cider-xref-backend.el
@@ -95,13 +95,11 @@ These are used for presentation purposes."
 
 (cl-defmethod xref-backend-definitions ((_backend (eql cider)) var)
   "Find definitions of VAR."
-  (cider-ensure-connected)
   (when-let* ((loc (cider--var-to-xref-location var)))
     (list (xref-make var loc))))
 
 (cl-defmethod xref-backend-identifier-completion-table ((_backend (eql cider)))
   "Return the completion table for identifiers."
-  (cider-ensure-connected)
   (when-let* ((ns (cider-current-ns)))
     (cider-sync-request:ns-vars ns)))
 
@@ -199,11 +197,6 @@ compiler generated from macros, which leave no textual trace for the scan."
 The runtime side (the `fn-refs' op) only sees loaded namespaces; the source
 side covers code on disk that hasn't been evaluated yet.  In `both' mode the
 two are combined, with runtime hits the source search already covers dropped."
-  (cider-ensure-connected)
-  ;; Without the source search the `fn-refs' op is the only source of results,
-  ;; so insist on it; otherwise the search degrades gracefully without it.
-  (when (eq cider-xref-references-mode 'runtime)
-    (cider-ensure-op-supported "cider/fn-refs"))
   (let* ((ns (cider-current-ns))
          (source (when (memq cider-xref-references-mode '(source both))
                    (cider-xref--var-source-references var)))
@@ -215,8 +208,6 @@ two are combined, with runtime hits the source search already covers dropped."
 
 (cl-defmethod xref-backend-apropos ((_backend (eql cider)) pattern)
   "Find all symbols that match regexp PATTERN."
-  (cider-ensure-connected)
-  (cider-ensure-op-supported "cider/apropos")
   (when-let* ((ns (cider-current-ns))
               (results (cider-apropos-request pattern
                                               :search-ns ns

--- a/lisp/cider-xref-tree.el
+++ b/lisp/cider-xref-tree.el
@@ -71,13 +71,12 @@ loop forever."
                     (lambda ()
                       (cider-xref-tree--children var op ns (cons var ancestors)))))))
 
-(defun cider-xref-tree--browse (symbol op op-name buffer-name title-fmt noun)
+(defun cider-xref-tree--browse (symbol op buffer-name title-fmt noun)
   "Open a call-graph tree rooted at SYMBOL, expanding via OP.
-OP-NAME is the nREPL op SYMBOL's children come from; BUFFER-NAME and TITLE-FMT
-name and describe the buffer; NOUN names the search for the prompt.  Resolves
-SYMBOL up front, signalling a typo/unloaded-namespace hint when it can't be."
+BUFFER-NAME and TITLE-FMT name and describe the buffer; NOUN names the search
+for the prompt.  Resolves SYMBOL up front, signalling a typo/unloaded-namespace
+hint when it can't be.  OP's availability is enforced by the sender when sent."
   (cider-ensure-connected)
-  (cider-ensure-op-supported op-name)
   (let* ((symbol (or symbol (cider-symbol-at-point)
                      (read-string (format "%s: " noun))))
          (info (or (cider-var-info symbol)
@@ -97,7 +96,7 @@ SYMBOL up front, signalling a typo/unloaded-namespace hint when it can't be."
 Expand a node to reveal its own callers and walk the call graph upward.  Uses
 the runtime `fn-refs' op, so it covers loaded Clojure-on-the-JVM code."
   (interactive)
-  (cider-xref-tree--browse symbol #'cider-sync-request:fn-refs "cider/fn-refs"
+  (cider-xref-tree--browse symbol #'cider-sync-request:fn-refs
                            "*cider-who-calls*" "Callers of %s" "Who calls"))
 
 ;;;###autoload
@@ -106,7 +105,7 @@ the runtime `fn-refs' op, so it covers loaded Clojure-on-the-JVM code."
 Expand a node to reveal what it calls in turn and walk the call graph downward.
 Uses the runtime `fn-deps' op, so it covers loaded Clojure-on-the-JVM code."
   (interactive)
-  (cider-xref-tree--browse symbol #'cider-sync-request:fn-deps "cider/fn-deps"
+  (cider-xref-tree--browse symbol #'cider-sync-request:fn-deps
                            "*cider-who-is-called*" "Called by %s" "What is called by"))
 
 

--- a/lisp/cider-xref.el
+++ b/lisp/cider-xref.el
@@ -126,8 +126,6 @@ namespace is a likelier cause than a var that genuinely has none."
 (defun cider-xref-fn-refs (&optional ns symbol)
   "Show all functions that reference the var matching NS and SYMBOL."
   (interactive)
-  (cider-ensure-connected)
-  (cider-ensure-op-supported "cider/fn-refs")
   (let ((ns (or ns (cider-current-ns)))
         (symbol (or symbol (cider-symbol-at-point))))
     (unless symbol (user-error "No symbol at point"))
@@ -179,8 +177,6 @@ function `cider-who-calls' is usually the better tool."
 (defun cider-xref-fn-deps (&optional ns symbol)
   "Show all functions referenced by the var matching NS and SYMBOL."
   (interactive)
-  (cider-ensure-connected)
-  (cider-ensure-op-supported "cider/fn-deps")
   (let ((ns (or ns (cider-current-ns)))
         (symbol (or symbol (cider-symbol-at-point))))
     (unless symbol (user-error "No symbol at point"))
@@ -205,8 +201,6 @@ function `cider-who-calls' is usually the better tool."
 (defun cider-xref-fn-refs-select (&optional ns symbol)
   "Display the references for NS and SYMBOL using completing read."
   (interactive)
-  (cider-ensure-connected)
-  (cider-ensure-op-supported "cider/fn-refs")
   (let ((ns (or ns (cider-current-ns)))
         (symbol (or symbol (cider-symbol-at-point))))
     (unless symbol (user-error "No symbol at point"))
@@ -219,8 +213,6 @@ function `cider-who-calls' is usually the better tool."
 (defun cider-xref-fn-deps-select (&optional ns symbol)
   "Display the function dependencies for NS and SYMBOL using completing read."
   (interactive)
-  (cider-ensure-connected)
-  (cider-ensure-op-supported "cider/fn-deps")
   (let ((ns (or ns (cider-current-ns)))
         (symbol (or symbol (cider-symbol-at-point))))
     (unless symbol (user-error "No symbol at point"))

--- a/test/cider-browse-spec-tests.el
+++ b/test/cider-browse-spec-tests.el
@@ -68,7 +68,10 @@
     (expect (cider-browse-spec--browse ":example/customer") :to-throw 'user-error))
 
   (it "raises user-error when the `spec-form' op is not supported."
+    ;; Op support is now enforced centrally by the nREPL senders, so the
+    ;; connection resolves and the check fires when the send is attempted.
     (spy-on 'sesman-current-session :and-return-value t)
+    (spy-on 'cider-current-repl :and-return-value (current-buffer))
     (spy-on 'cider-nrepl-op-supported-p :and-return-value nil)
     (expect (cider-browse-spec--browse ":example/customer") :to-throw 'user-error))
 

--- a/test/cider-client-tests.el
+++ b/test/cider-client-tests.el
@@ -372,6 +372,10 @@
     (expect (cider--fallback-op "completions" :fake-conn) :to-equal "completions")))
 
 (describe "cider--resolve-op-in-request"
+  (before-each
+    ;; the op-support check now runs first; treat ops as supported here
+    (spy-on 'cider-nrepl-op-supported-p :and-return-value t))
+
   (it "rewrites the op in the request when falling back"
     (spy-on 'cider--fallback-op :and-return-value "info")
     (let ((result (cider--resolve-op-in-request '("op" "cider/info" "ns" "user") :fake-conn)))
@@ -383,6 +387,28 @@
     (let* ((request '("op" "cider/info" "ns" "user"))
            (result (cider--resolve-op-in-request request :fake-conn)))
       (expect result :to-equal request))))
+
+(describe "cider--ensure-request-op-supported"
+  (it "signals a user-error when a namespaced op isn't supported"
+    (spy-on 'cider-nrepl-op-supported-p :and-return-value nil)
+    (expect (cider--ensure-request-op-supported '("op" "cider/apropos") :conn)
+            :to-throw 'user-error))
+
+  (it "passes when the op is supported"
+    (spy-on 'cider-nrepl-op-supported-p :and-return-value t)
+    (expect (cider--ensure-request-op-supported '("op" "cider/apropos") :conn)
+            :not :to-throw))
+
+  (it "ignores core (non-namespaced) ops"
+    (spy-on 'cider-nrepl-op-supported-p :and-return-value nil)
+    (expect (cider--ensure-request-op-supported '("op" "eval") :conn)
+            :not :to-throw))
+
+  (it "is bypassed by `cider--skip-op-ensure'"
+    (spy-on 'cider-nrepl-op-supported-p :and-return-value nil)
+    (let ((cider--skip-op-ensure t))
+      (expect (cider--ensure-request-op-supported '("op" "cider/apropos") :conn)
+              :not :to-throw))))
 
 (describe "cider-ns-form-p"
   (it "doesn't match ns in a string"

--- a/test/cider-transport-lint-tests.el
+++ b/test/cider-transport-lint-tests.el
@@ -1,0 +1,66 @@
+;;; cider-transport-lint-tests.el --- Lint: keep nREPL sends on the cider layer  -*- lexical-binding: t; -*-
+
+;; Copyright © 2026 Bozhidar Batsov and CIDER contributors
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; A source lint, not a behavior test.  Commands talk to nREPL through the
+;; cider-level senders (`cider-nrepl-send-request' and friends), which ensure a
+;; connection and op support centrally (so commands need no explicit
+;; `cider-ensure-connected' / `cider-ensure-op-supported').  Reaching for the
+;; low-level `nrepl-*' senders bypasses that enforcement.  This keeps such usage
+;; confined to the transport layer plus a small, reviewed allowlist, so new
+;; bypasses are caught.
+
+;;; Code:
+
+(require 'buttercup)
+(require 'cl-lib)
+
+(describe "low-level nREPL sender usage"
+  (it "is confined to the transport layer and a known allowlist"
+    ;; These two files *are* the transport layers, so they legitimately call the
+    ;; low-level senders.
+    (let* ((layer-files '("nrepl-client.el" "cider-client.el"))
+           ;; The generic, arbitrary-op low-level senders.  Their `:foo' variants
+           ;; (e.g. `nrepl-sync-request:eval') and the `-timeout' variable are
+           ;; distinct symbols: the boundary below requires the call name to be
+           ;; followed by whitespace or a closing paren, so they aren't matched.
+           (senders '("nrepl-send-request"
+                      "nrepl-sync-request"
+                      "nrepl-send-sync-request"
+                      "nrepl-send-eval-request"))
+           ;; (FILE . SENDER) sites allowed to bypass the cider layer.  Each one
+           ;; resolves and ensures its own connection before the low-level send.
+           (allowlist '(("cider-repl.el" . "nrepl-send-sync-request")))
+           (found '()))
+      (expect (file-directory-p "lisp") :to-be-truthy)
+      (dolist (file (directory-files "lisp" t "\\.el\\'"))
+        (let ((base (file-name-nondirectory file)))
+          (unless (member base layer-files)
+            (with-temp-buffer
+              (insert-file-contents file)
+              (dolist (s senders)
+                (goto-char (point-min))
+                (while (re-search-forward (concat "(" (regexp-quote s) "[ \t\n)]") nil t)
+                  (cl-pushnew (cons base s) found :test #'equal)))))))
+      ;; Anything found that isn't allowlisted is a new bypass: route it through
+      ;; a `cider-nrepl-send-*' sender, or add it here with a justification.
+      (expect (cl-set-difference found allowlist :test #'equal) :to-equal nil))))
+
+(provide 'cider-transport-lint-tests)
+
+;;; cider-transport-lint-tests.el ends here


### PR DESCRIPTION
Centralizes the `cider-ensure-connected` / `cider-ensure-op-supported` guards so they can't be forgotten per-command, then sweeps the now-redundant explicit calls and adds a lint to keep it that way. Builds on the research in the thread.

### Mechanism
- **Op support:** every CIDER-level send routes through `cider--resolve-op-in-request`, which now calls `cider--ensure-request-op-supported`: a namespaced middleware op the connection doesn't advertise fails with the same friendly `user-error`, regardless of which command sent it. `cider--skip-op-ensure` is the opt-out (callers that probe `cider-nrepl-op-supported-p` first - completion, eldoc - never reach it).
- **Connection:** already centralized - every sender resolves the REPL with `(cider-current-repl 'infer 'ensure)`, and the eval path is guarded at `cider-interactive-eval`. Documented that role on `cider-ensure-connected`.

### The sweep
- Removed **all** explicit `cider-ensure-op-supported` calls (48).
- Removed the redundant `cider-ensure-connected` calls whose command sends immediately, keeping the ones that fail fast before a **body prompt / popup / side-effect** (e.g. `cider-apropos-documentation`, the `who-*` browsers, `cider-classpath`, `cider-load-all-project-ns`, and `cider-interactive-eval` whose `:auto` dispatch is intentionally lenient). Kept 21.
- Dropped the now-dead `op-name` arg from `cider-xref-tree--browse`.

### The rule (now enforced + linted)
- Op support: never check explicitly - the senders enforce it.
- Connection: rely on the senders; add an explicit `cider-ensure-connected` only to fail fast before a prompt or side-effecting work.
- Op *probing* (`cider-nrepl-op-supported-p`, the use-op-or-fallback branches) is untouched - it probes, it doesn't send.

### Lint
`test/cider-transport-lint-tests.el` fails if a command reaches for the low-level `nrepl-*` senders (the only way to bypass enforcement) outside the transport layer + a small reviewed allowlist.

Full suite green (920 specs, 0 failed); clean `--warnings-as-errors` compile.