### PR TITLE
Deprecate cider-ensure-op-supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 
 ### Changes
 
+- [#4028](https://github.com/clojure-emacs/cider/pull/4028): Deprecate `cider-ensure-op-supported`; op support is now enforced automatically by the nREPL senders, so commands no longer need an explicit check.
 - [#4026](https://github.com/clojure-emacs/cider/pull/4026): Bump the injected `cider-nrepl` to 0.61.0-alpha1, which provides ClojureScript test support, the `clojure-only` op signal and the ClojureScript macroexpansion fix.
 - [#4026](https://github.com/clojure-emacs/cider/pull/4026): Show a clear message when a Clojure-only operation (apropos, xref, trace, profile, refresh, reload, undef, spec) is invoked under a ClojureScript REPL, instead of failing confusingly or returning JVM-only results (requires a recent enough `cider-nrepl`) ([#2198](https://github.com/clojure-emacs/cider/issues/2198)).
 - [#4022](https://github.com/clojure-emacs/cider/pull/4022): `cider-inspect-last-sexp` now inspects the tagged class when point is on a type tag (e.g. `^String`), instead of the form the tag applies to ([#3679](https://github.com/clojure-emacs/cider/issues/3679)).

--- a/lisp/cider-client.el
+++ b/lisp/cider-client.el
@@ -239,6 +239,11 @@ Signal an error if it is not supported."
   (unless (cider-nrepl-op-supported-p op connection)
     (user-error "`%s' requires the nREPL op \"%s\" (provided by cider-nrepl)" this-command op)))
 
+(make-obsolete 'cider-ensure-op-supported
+               "op support is now enforced automatically by the nREPL senders, \
+so commands no longer need an explicit check."
+               "1.23.0")
+
 (defvar cider--skip-op-ensure nil
   "When non-nil, skip the automatic op-support check in CIDER's nREPL senders.
 Background or best-effort callers that should degrade silently when an op

--- a/test/cider-apropos-tests.el
+++ b/test/cider-apropos-tests.el
@@ -35,17 +35,9 @@
 (describe "cider-apropos"
   (it "raises user-error when cider is not connected."
     (spy-on 'cider-connected-p :and-return-value nil)
-    (expect (cider-apropos "test") :to-throw 'user-error))
-
-  (it "raises user-error when the `apropos' op is not supported."
-    (spy-on 'cider-ensure-op-supported :and-return-value nil)
     (expect (cider-apropos "test") :to-throw 'user-error)))
 
 (describe "cider-apropos-documentation"
   (it "raises user-error when cider is not connected."
     (spy-on 'cider-connected-p :and-return-value nil)
-    (expect (cider-apropos-documentation) :to-throw 'user-error))
-
-  (it "raises user-error when the `apropos' op is not supported."
-    (spy-on 'cider-ensure-op-supported :and-return-value nil)
     (expect (cider-apropos-documentation) :to-throw 'user-error)))

--- a/test/cider-classpath-tests.el
+++ b/test/cider-classpath-tests.el
@@ -35,17 +35,9 @@
 (describe "cider-classpath"
   (it "raises user-error when cider is not connected."
     (spy-on 'cider-connected-p :and-return-value nil)
-    (expect (cider-classpath) :to-throw 'user-error))
-
-  (it "raises user-error when the `classpath' op is not supported."
-    (spy-on 'cider-ensure-op-supported :and-return-value nil)
     (expect (cider-classpath) :to-throw 'user-error)))
 
 (describe "cider-open-classpath-entry"
   (it "raises user-error when cider is not connected."
     (spy-on 'cider-connected-p :and-return-value nil)
-    (expect (cider-open-classpath-entry) :to-throw 'user-error))
-
-  (it "raises user-error when the `classpath' op is not supported."
-    (spy-on 'cider-ensure-op-supported :and-return-value nil)
     (expect (cider-open-classpath-entry) :to-throw 'user-error)))

--- a/test/cider-client-tests.el
+++ b/test/cider-client-tests.el
@@ -343,14 +343,8 @@
         (expect (plist-get kwargs :connection) :to-be :fake-conn)
         (expect (plist-get kwargs :callback) :to-be #'ignore)))))
 
-(describe "cider-ensure-op-supported"
-  (it "returns nil when the op is supported"
-    (spy-on 'cider-nrepl-op-supported-p :and-return-value t)
-    (expect (cider-ensure-op-supported "foo") :to-be nil))
-  (it "raises a user-error if the op is not supported"
-    (spy-on 'cider-nrepl-op-supported-p :and-return-value nil)
-    (expect (cider-ensure-op-supported "foo")
-            :to-throw 'user-error)))
+;; `cider-ensure-op-supported' is deprecated - op support is enforced centrally
+;; by the senders, covered by the `cider--ensure-request-op-supported' specs.
 
 (describe "cider--fallback-op"
   (it "returns the namespaced op when it is supported"

--- a/test/cider-macroexpansion-tests.el
+++ b/test/cider-macroexpansion-tests.el
@@ -34,8 +34,7 @@
 (describe "cider-sync-request:macroexpand"
   (it "sends the expander, code and namespace and returns the expansion"
     (let (captured)
-      (cl-letf (((symbol-function 'cider-ensure-op-supported) #'ignore)
-                ((symbol-function 'cider-current-ns) (lambda () "user"))
+      (cl-letf (((symbol-function 'cider-current-ns) (lambda () "user"))
                 ((symbol-function 'cider-nrepl-send-sync-request)
                  (lambda (request)
                    (setq captured request)
@@ -53,8 +52,7 @@
 
   (it "requests metadata when `cider-macroexpansion-print-metadata' is on"
     (let (captured)
-      (cl-letf (((symbol-function 'cider-ensure-op-supported) #'ignore)
-                ((symbol-function 'cider-current-ns) (lambda () "user"))
+      (cl-letf (((symbol-function 'cider-current-ns) (lambda () "user"))
                 ((symbol-function 'cider-nrepl-send-sync-request)
                  (lambda (request)
                    (setq captured request)
@@ -64,8 +62,7 @@
           (expect (cadr (member "print-meta" captured)) :to-equal "true")))))
 
   (it "signals a user-error when the middleware reports a macroexpand-error"
-    (cl-letf (((symbol-function 'cider-ensure-op-supported) #'ignore)
-              ((symbol-function 'cider-current-ns) (lambda () "user"))
+    (cl-letf (((symbol-function 'cider-current-ns) (lambda () "user"))
               ((symbol-function 'cider-nrepl-send-sync-request)
                (lambda (_request) (nrepl-dict "status" '("macroexpand-error")))))
       (expect (cider-sync-request:macroexpand "macroexpand-1" "(boom)")
@@ -74,8 +71,7 @@
 (describe "cider-macroexpand-again"
   (it "re-expands the stored expression instead of redisplaying the input"
     (let (codes)
-      (cl-letf (((symbol-function 'cider-ensure-op-supported) #'ignore)
-                ((symbol-function 'cider-current-ns) (lambda () "user"))
+      (cl-letf (((symbol-function 'cider-current-ns) (lambda () "user"))
                 ((symbol-function 'cider-initialize-macroexpansion-buffer) #'ignore)
                 ((symbol-function 'cider-nrepl-send-sync-request)
                  (lambda (request)

--- a/test/cider-tracing-tests.el
+++ b/test/cider-tracing-tests.el
@@ -49,7 +49,6 @@
 
 (describe "cider-untrace-all"
   (it "reports the number of untraced vars"
-    (spy-on 'cider-ensure-op-supported)
     (spy-on 'cider-nrepl-send-sync-request :and-return-value
             (nrepl-dict "untraced-count" 3))
     (spy-on 'message)
@@ -62,7 +61,6 @@
       (kill-buffer cider-traced-buffer)))
 
   (it "reports when nothing is traced"
-    (spy-on 'cider-ensure-op-supported)
     (spy-on 'cider-sync-request:list-traced :and-return-value
             (nrepl-dict "traced-vars" nil "traced-nses" nil))
     (spy-on 'message)
@@ -71,7 +69,6 @@
     (expect (get-buffer cider-traced-buffer) :to-be nil))
 
   (it "renders the traced vars and namespaces in a buffer"
-    (spy-on 'cider-ensure-op-supported)
     (spy-on 'cider-sync-request:list-traced :and-return-value
             (nrepl-dict "traced-vars" '("#'foo/bar") "traced-nses" '("baz.ns")))
     (cider-list-traced)


### PR DESCRIPTION
Follow-up to the guard-centralization work (#4027). Op support is now enforced centrally by the nREPL senders (`cider--ensure-request-op-supported`), so no command calls `cider-ensure-op-supported` anymore.

Rather than add a custom lint asserting it has zero callers, just `make-obsolete` it: the byte-compiler then flags any new use, and the compile job runs `--warnings-as-errors`, so a new internal call fails CI for free. Simpler and more idiomatic. The function still works for any external callers.

Also drops the now-dead test references left over from the sweep: the spies/stubs on it (no-ops, since commands no longer call it) and the per-command "op not supported" specs - that behavior is covered by the central `cider--ensure-request-op-supported` tests.

Clean `eldev -dtT compile --warnings-as-errors` (no obsolete warnings, since our own code has no callers) and full suite green.