### PR TITLE
Finish the keyword-argument request-API migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 
 ### Changes
 
+- [#4029](https://github.com/clojure-emacs/cider/pull/4029): Finish migrating to the keyword-argument request APIs and deprecate the positional shims: `cider-nrepl-send-sync-request` -> `cider-nrepl-sync-request`, `cider-nrepl-request:eval` -> `cider-nrepl-send-eval-request`, `nrepl-send-sync-request` -> `nrepl-sync-request`, `nrepl-request:eval` -> `nrepl-send-eval-request`.
 - [#4028](https://github.com/clojure-emacs/cider/pull/4028): Deprecate `cider-ensure-op-supported`; op support is now enforced automatically by the nREPL senders, so commands no longer need an explicit check.
 - [#4026](https://github.com/clojure-emacs/cider/pull/4026): Bump the injected `cider-nrepl` to 0.61.0-alpha1, which provides ClojureScript test support, the `clojure-only` op signal and the ClojureScript macroexpansion fix.
 - [#4026](https://github.com/clojure-emacs/cider/pull/4026): Show a clear message when a Clojure-only operation (apropos, xref, trace, profile, refresh, reload, undef, spec) is invoked under a ClojureScript REPL, instead of failing confusingly or returning JVM-only results (requires a recent enough `cider-nrepl`) ([#2198](https://github.com/clojure-emacs/cider/issues/2198)).

--- a/lisp/cider-client.el
+++ b/lisp/cider-client.el
@@ -333,6 +333,8 @@ prefer the keyword-argument `cider-nrepl-sync-request'."
                            :abort-on-input abort-on-input
                            :callback callback))
 
+(make-obsolete 'cider-nrepl-send-sync-request 'cider-nrepl-sync-request "1.23.0")
+
 (defun cider-nrepl-send-unhandled-request (request &optional connection)
   "Send REQUEST to the nREPL CONNECTION and ignore any responses.
 Immediately mark the REQUEST as done.  Return the id of the sent message."
@@ -383,6 +385,8 @@ prefer the keyword-argument `cider-nrepl-send-eval-request'."
                                  :ns ns :line line :column column
                                  :additional-params additional-params
                                  :connection connection))
+
+(make-obsolete 'cider-nrepl-request:eval 'cider-nrepl-send-eval-request "1.23.0")
 
 (defun cider-nrepl-sync-request:eval (input &optional connection ns)
   "Send the INPUT to the nREPL CONNECTION synchronously.
@@ -846,7 +850,7 @@ prefer the keyword-argument `cider-apropos-request'."
   "Return a list of classpath entries for CONNECTION."
   (thread-first
     '("op" "cider/classpath")
-    (cider-nrepl-send-sync-request connection)
+    (cider-nrepl-sync-request connection)
     (nrepl-dict-get "classpath")))
 
 (defun cider--get-abs-path (path project)
@@ -946,7 +950,7 @@ prefer the keyword-argument `cider-info-request'."
                                   "ns" ,(cider-current-ns)
                                   ,@(when symbol `("sym" ,symbol))
                                   ,@(when lookup-fn `("lookup-fn" ,lookup-fn)))
-                                (cider-nrepl-send-sync-request (cider-current-repl)))))
+                                (cider-nrepl-sync-request (cider-current-repl)))))
     (if (member "lookup-error" (nrepl-dict-get var-info "status"))
         nil
       (nrepl-dict-get var-info "info"))))
@@ -993,7 +997,7 @@ returned."
   (thread-first `("op" "cider/spec-list"
                   "filter-regex" ,filter-regex
                   "ns" ,(cider-current-ns))
-                (cider-nrepl-send-sync-request)
+                (cider-nrepl-sync-request)
                 (nrepl-dict-get "spec-list")))
 
 (defun cider-sync-request:spec-form (spec)
@@ -1001,28 +1005,28 @@ returned."
   (thread-first `("op" "cider/spec-form"
                   "spec-name" ,spec
                   "ns" ,(cider-current-ns))
-                (cider-nrepl-send-sync-request)
+                (cider-nrepl-sync-request)
                 (nrepl-dict-get "spec-form")))
 
 (defun cider-sync-request:spec-example (spec)
   "Get an example for SPEC."
   (thread-first `("op" "cider/spec-example"
                   "spec-name" ,spec)
-                (cider-nrepl-send-sync-request)
+                (cider-nrepl-sync-request)
                 (nrepl-dict-get "spec-example")))
 
 (defun cider-sync-request:ns-list ()
   "Get a list of the available namespaces."
   (thread-first `("op" "cider/ns-list"
                   "exclude-regexps" ,cider-filtered-namespaces-regexps)
-                (cider-nrepl-send-sync-request)
+                (cider-nrepl-sync-request)
                 (nrepl-dict-get "ns-list")))
 
 (defun cider-sync-request:ns-vars (ns)
   "Get a list of the vars in NS."
   (thread-first `("op" "cider/ns-vars"
                   "ns" ,ns)
-                (cider-nrepl-send-sync-request)
+                (cider-nrepl-sync-request)
                 (nrepl-dict-get "ns-vars")))
 
 (defun cider-sync-request:ns-path (ns &optional favor-url)
@@ -1042,7 +1046,7 @@ Note that even when favoring a url, the url itself might be nil,
 in which case we'll fall back to the resource name."
   (unless ns
     (error "No ns provided"))
-  (let ((response (cider-nrepl-send-sync-request `("op" "cider/ns-path"
+  (let ((response (cider-nrepl-sync-request `("op" "cider/ns-path"
                                                    "ns" ,ns))))
     (nrepl-dbind-response response (path url)
       (if (and favor-url url)
@@ -1053,7 +1057,7 @@ in which case we'll fall back to the resource name."
   "Get a map of the vars in NS to its metadata information."
   (thread-first `("op" "cider/ns-vars-with-meta"
                   "ns" ,ns)
-                (cider-nrepl-send-sync-request)
+                (cider-nrepl-sync-request)
                 (nrepl-dict-get "ns-vars-with-meta")))
 
 (defun cider-sync-request:private-ns-vars-with-meta (ns)
@@ -1062,27 +1066,27 @@ in which case we'll fall back to the resource name."
                   "ns" ,ns
                   "var-query" ,(nrepl-dict "private?" "t"
                                            "include-meta-key" '("private")))
-                (cider-nrepl-send-sync-request)
+                (cider-nrepl-sync-request)
                 (nrepl-dict-get "ns-vars-with-meta")))
 
 (defun cider-sync-request:ns-load-all ()
   "Load all project namespaces."
   (thread-first '("op" "cider/ns-load-all")
-                (cider-nrepl-send-sync-request)
+                (cider-nrepl-sync-request)
                 (nrepl-dict-get "loaded-ns")))
 
 (defun cider-sync-request:resource (name)
   "Perform nREPL \"resource\" op with resource name NAME."
   (thread-first `("op" "cider/resource"
                   "name" ,name)
-                (cider-nrepl-send-sync-request)
+                (cider-nrepl-sync-request)
                 (nrepl-dict-get "resource-path")))
 
 (defun cider-sync-request:resources-list ()
   "Return a list of all resources on the classpath.
 The result entries are relative to the classpath."
   (when-let* ((resources (thread-first '("op" "cider/resources-list")
-                                       (cider-nrepl-send-sync-request)
+                                       (cider-nrepl-sync-request)
                                        (nrepl-dict-get "resources-list"))))
     (seq-map (lambda (resource) (nrepl-dict-get resource "relpath")) resources)))
 
@@ -1091,7 +1095,7 @@ The result entries are relative to the classpath."
   (thread-first `("op" "cider/fn-refs"
                   "ns" ,ns
                   "sym" ,sym)
-                (cider-nrepl-send-sync-request)
+                (cider-nrepl-sync-request)
                 (nrepl-dict-get "fn-refs")))
 
 (defun cider-sync-request:fn-deps (ns sym)
@@ -1099,7 +1103,7 @@ The result entries are relative to the classpath."
   (thread-first `("op" "cider/fn-deps"
                   "ns" ,ns
                   "sym" ,sym)
-                (cider-nrepl-send-sync-request)
+                (cider-nrepl-sync-request)
                 (nrepl-dict-get "fn-deps")))
 
 (defun cider-sync-request:who-implements (ns sym)
@@ -1110,7 +1114,7 @@ The result is a dict with a \"kind\" of \"protocol\", \"multimethod\" or
   (thread-first `("op" "cider/who-implements"
                   "ns" ,ns
                   "sym" ,sym)
-                (cider-nrepl-send-sync-request)
+                (cider-nrepl-sync-request)
                 (nrepl-dict-get "who-implements")))
 
 (defun cider-sync-request:type-protocols (ns sym)
@@ -1119,7 +1123,7 @@ Each is a dict with a \"name\" and source location."
   (thread-first `("op" "cider/type-protocols"
                   "ns" ,ns
                   "sym" ,sym)
-                (cider-nrepl-send-sync-request)
+                (cider-nrepl-sync-request)
                 (nrepl-dict-get "type-protocols")))
 
 (defun cider-sync-request:protocols-with-method (method)
@@ -1127,7 +1131,7 @@ Each is a dict with a \"name\" and source location."
 Each is a dict with a \"name\" and source location."
   (thread-first `("op" "cider/protocols-with-method"
                   "method" ,method)
-                (cider-nrepl-send-sync-request)
+                (cider-nrepl-sync-request)
                 (nrepl-dict-get "protocols-with-method")))
 
 (defun cider-sync-request:format-code (code &optional format-options)
@@ -1136,7 +1140,7 @@ FORMAT-OPTIONS is an optional configuration map for cljfmt."
   (let* ((request `("op" "cider/format-code"
                     "options" ,(cider--nrepl-format-code-request-options format-options)
                     "code" ,code))
-         (response (cider-nrepl-send-sync-request request))
+         (response (cider-nrepl-sync-request request))
          (err (nrepl-dict-get response "err")))
     (when err
       ;; err will be a stacktrace with a first line that looks like:
@@ -1149,7 +1153,7 @@ FORMAT-OPTIONS is an optional configuration map for cljfmt."
   (let* ((request `("op" "cider/format-edn"
                     "edn" ,edn
                     ,@(cider--nrepl-print-request-plist right-margin)))
-         (response (cider-nrepl-send-sync-request request))
+         (response (cider-nrepl-sync-request request))
          (err (nrepl-dict-get response "err")))
     (when err
       ;; err will be a stacktrace with a first line that looks like:

--- a/lisp/cider-clojuredocs.el
+++ b/lisp/cider-clojuredocs.el
@@ -43,13 +43,13 @@
   (thread-first `("op" "cider/clojuredocs-lookup"
                   "ns" ,ns
                   "sym" ,sym)
-                (cider-nrepl-send-sync-request)
+                (cider-nrepl-sync-request)
                 (nrepl-dict-get "clojuredocs")))
 
 (defun cider-sync-request:clojuredocs-refresh ()
   "Refresh the ClojureDocs cache."
   (thread-first '("op" "cider/clojuredocs-refresh-cache")
-                (cider-nrepl-send-sync-request)
+                (cider-nrepl-sync-request)
                 (nrepl-dict-get "status")))
 
 (defun cider-clojuredocs--lookup-async (ns sym callback)

--- a/lisp/cider-debug.el
+++ b/lisp/cider-debug.el
@@ -88,7 +88,7 @@ configure `cider-debug-prompt' instead."
 (defun cider-browse-instrumented-defs ()
   "List all instrumented definitions."
   (interactive)
-  (if-let* ((all (thread-first (cider-nrepl-send-sync-request '("op" "cider/debug-instrumented-defs"))
+  (if-let* ((all (thread-first (cider-nrepl-sync-request '("op" "cider/debug-instrumented-defs"))
                                (nrepl-dict-get "list"))))
       (with-current-buffer (cider-popup-buffer cider-browse-ns-buffer t)
         (let ((inhibit-read-only t))

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -1139,7 +1139,7 @@ passing arguments."
 (defun cider-undef-all (&optional ns)
   "Undefine all symbols and aliases from the namespace NS."
   (interactive)
-  (cider-nrepl-send-sync-request
+  (cider-nrepl-sync-request
    `("op" "cider/undef-all"
      "ns" ,(or ns (cider-current-ns)))))
 

--- a/lisp/cider-inspector.el
+++ b/lisp/cider-inspector.el
@@ -313,13 +313,13 @@ In particular, it does not read `cider-sexp-at-point'."
 (defun cider-inspector-pop ()
   "Pop the last value off the inspector stack and render it."
   (interactive)
-  (let ((result (cider-nrepl-send-sync-request `("op" "cider/inspect-pop"))))
+  (let ((result (cider-nrepl-sync-request `("op" "cider/inspect-pop"))))
     (when (nrepl-dict-get result "value")
       (cider-inspector--render-value result :pop))))
 
 (defun cider-inspector-push (idx)
   "Inspect the value at IDX in the inspector stack and render it."
-  (let ((result (cider-nrepl-send-sync-request `("op" "cider/inspect-push"
+  (let ((result (cider-nrepl-sync-request `("op" "cider/inspect-push"
                                                  "idx" ,idx))))
     (when (nrepl-dict-get result "value")
       (push (point) cider-inspector-location-stack)
@@ -329,7 +329,7 @@ In particular, it does not read `cider-sexp-at-point'."
   "Inspect the exception in the cause stack identified by INDEX.
 If EX-DATA is true, inspect ex-data of the exception instead."
   (cl-assert (numberp index))
-  (let ((result (cider-nrepl-send-sync-request
+  (let ((result (cider-nrepl-sync-request
                  `("op" "cider/inspect-last-exception"
                    "index" ,index
                    ,@(when ex-data
@@ -341,21 +341,21 @@ If EX-DATA is true, inspect ex-data of the exception instead."
 (defun cider-inspector-previous-sibling ()
   "Inspect the previous sibling value within a sequential parent."
   (interactive)
-  (let ((result (cider-nrepl-send-sync-request `("op" "cider/inspect-previous-sibling"))))
+  (let ((result (cider-nrepl-sync-request `("op" "cider/inspect-previous-sibling"))))
     (when (nrepl-dict-get result "value")
       (cider-inspector--render-value result))))
 
 (defun cider-inspector-next-sibling ()
   "Inspect the next sibling value within a sequential parent."
   (interactive)
-  (let ((result (cider-nrepl-send-sync-request `("op" "cider/inspect-next-sibling"))))
+  (let ((result (cider-nrepl-sync-request `("op" "cider/inspect-next-sibling"))))
     (when (nrepl-dict-get result "value")
       (cider-inspector--render-value result))))
 
 (defun cider-inspector--refresh-with-opts (&rest opts)
   "Invokes `inspect-refresh' op with supplied extra OPTS.
 Re-renders the currently inspected value."
-  (let ((result (cider-nrepl-send-sync-request `("op" "cider/inspect-refresh" ,@opts))))
+  (let ((result (cider-nrepl-sync-request `("op" "cider/inspect-refresh" ,@opts))))
     (when (nrepl-dict-get result "value")
       (cider-inspector--render-value result))))
 
@@ -369,7 +369,7 @@ Re-renders the currently inspected value."
 
 Does nothing if already on the last page."
   (interactive)
-  (let ((result (cider-nrepl-send-sync-request '("op" "cider/inspect-next-page"))))
+  (let ((result (cider-nrepl-sync-request '("op" "cider/inspect-next-page"))))
     (when (nrepl-dict-get result "value")
       (cider-inspector--render-value result))))
 
@@ -378,7 +378,7 @@ Does nothing if already on the last page."
 
 Does nothing if already on the first page."
   (interactive)
-  (let ((result (cider-nrepl-send-sync-request '("op" "cider/inspect-prev-page"))))
+  (let ((result (cider-nrepl-sync-request '("op" "cider/inspect-prev-page"))))
     (when (nrepl-dict-get result "value")
       (cider-inspector--render-value result))))
 
@@ -409,7 +409,7 @@ MAX-NESTED-DEPTH is the new value."
 (defun cider-inspector-display-analytics ()
   "Toggle the display of analytics for the inspected object."
   (interactive)
-  (let ((result (cider-nrepl-send-sync-request `("op" "cider/inspect-display-analytics"))))
+  (let ((result (cider-nrepl-sync-request `("op" "cider/inspect-display-analytics"))))
     (when (nrepl-dict-get result "value")
       (cider-inspector--render-value result :next-inspectable))))
 
@@ -443,7 +443,7 @@ MAX-NESTED-DEPTH is the new value."
 (defun cider-inspector-toggle-view-mode ()
   "Toggle the view mode of the inspector between normal and object view mode."
   (interactive)
-  (let ((result (cider-nrepl-send-sync-request `("op" "cider/inspect-toggle-view-mode"))))
+  (let ((result (cider-nrepl-sync-request `("op" "cider/inspect-toggle-view-mode"))))
     (when (nrepl-dict-get result "value")
       (cider-inspector--render-value result :next-inspectable))))
 
@@ -475,7 +475,7 @@ current-namespace."
   (interactive (let ((ns (cider-current-ns)))
                  (list (cider-inspector--read-var-name-from-user ns)
                        ns)))
-  (when-let* ((result (cider-nrepl-send-sync-request `("op" "cider/inspect-def-current-value"
+  (when-let* ((result (cider-nrepl-sync-request `("op" "cider/inspect-def-current-value"
                                                        "ns" ,ns
                                                        "var-name" ,var-name))))
     (cider-inspector--render-value result)
@@ -494,7 +494,7 @@ current-namespace."
 (defun cider-inspector-tap-current-val ()
   "Sends the current Inspector current value to `tap>'."
   (interactive)
-  (let ((response (cider-nrepl-send-sync-request '("op" "cider/inspect-tap-current-value"))))
+  (let ((response (cider-nrepl-sync-request '("op" "cider/inspect-tap-current-value"))))
     (nrepl-dbind-response response (value err)
       (if value
           (message "Successfully tapped the current Inspector value")
@@ -507,7 +507,7 @@ current-namespace."
     (pcase property
       (`cider-value-idx
        (cl-assert value)
-       (nrepl-dbind-response (cider-nrepl-send-sync-request `("op" "cider/inspect-tap-indexed"
+       (nrepl-dbind-response (cider-nrepl-sync-request `("op" "cider/inspect-tap-indexed"
                                                               "idx" ,value))
            (value err)
          (if value
@@ -521,7 +521,7 @@ current-namespace."
   "Evaluate EXPR in context of NS and inspect its result.
 The pagination and truncation options are taken from the
 `cider-inspector-*' defcustoms."
-  (cider-nrepl-send-sync-request
+  (cider-nrepl-sync-request
    (append (nrepl--eval-request expr ns)
            `("inspect" "true"
              ,@(when cider-inspector-page-size

--- a/lisp/cider-log.el
+++ b/lisp/cider-log.el
@@ -222,7 +222,7 @@ It will not be used if the package hasn't been installed."
                   "appender" ,(cider-log-appender-id appender)
                   "consumer" ,(cider-log-consumer-id consumer)
                   "filters" ,(cider-log-consumer-filters consumer))
-                (cider-nrepl-send-sync-request)
+                (cider-nrepl-sync-request)
                 (nrepl-dict-get "cider/log-update-consumer")))
 
 (defun cider-sync-request:log-add-appender (framework appender)
@@ -233,7 +233,7 @@ It will not be used if the package hasn't been installed."
                   "filters" ,(cider-log-appender-filters appender)
                   "size" ,(cider-log-appender-size appender)
                   "threshold" ,(cider-log-appender-threshold appender))
-                (cider-nrepl-send-sync-request)
+                (cider-nrepl-sync-request)
                 (nrepl-dict-get "cider/log-add-appender")))
 
 (defun cider-sync-request:log-update-appender (framework appender)
@@ -244,7 +244,7 @@ It will not be used if the package hasn't been installed."
                   "filters" ,(cider-log-appender-filters appender)
                   "size" ,(cider-log-appender-size appender)
                   "threshold" ,(cider-log-appender-threshold appender))
-                (cider-nrepl-send-sync-request)
+                (cider-nrepl-sync-request)
                 (nrepl-dict-get "cider/log-update-appender")))
 
 (defun cider-sync-request:log-clear (framework appender)
@@ -252,7 +252,7 @@ It will not be used if the package hasn't been installed."
   (thread-first `("op" "cider/log-clear-appender"
                   "framework" ,(cider-log-framework-id framework)
                   "appender" ,(cider-log-appender-id appender))
-                (cider-nrepl-send-sync-request)
+                (cider-nrepl-sync-request)
                 (nrepl-dict-get "cider/log-clear-appender")))
 
 (defun cider-sync-request:log-inspect-event (framework appender event)
@@ -261,7 +261,7 @@ It will not be used if the package hasn't been installed."
                   "framework" ,(cider-log-framework-id framework)
                   "appender" ,(cider-log-appender-id appender)
                   "event" ,(cider-log-event-id event))
-                (cider-nrepl-send-sync-request)
+                (cider-nrepl-sync-request)
                 (nrepl-dict-get "value")))
 
 (defun cider-sync-request:log-format-event (framework appender event)
@@ -272,13 +272,13 @@ It will not be used if the package hasn't been installed."
       "appender" ,(cider-log-appender-id appender)
       "event" ,(cider-log-event-id event)
       ,@(cider--nrepl-print-request-plist fill-column))
-    (cider-nrepl-send-sync-request)
+    (cider-nrepl-sync-request)
     (nrepl-dict-get "cider/log-format-event")))
 
 (defun cider-sync-request:log-frameworks ()
   "Return the available log frameworks."
   (thread-first `("op" "cider/log-frameworks")
-                (cider-nrepl-send-sync-request)
+                (cider-nrepl-sync-request)
                 (nrepl-dict-get "cider/log-frameworks")))
 
 (cl-defun cider-sync-request:log-search (framework appender &key filters limit offset)
@@ -289,7 +289,7 @@ It will not be used if the package hasn't been installed."
                   "filters" ,filters
                   "limit" ,limit
                   "offset" ,offset)
-                (cider-nrepl-send-sync-request)
+                (cider-nrepl-sync-request)
                 (nrepl-dict-get "cider/log-search")))
 
 (defun cider-sync-request:log-exceptions (framework appender)
@@ -297,7 +297,7 @@ It will not be used if the package hasn't been installed."
   (thread-first `("op" "cider/log-exceptions"
                   "framework" ,(cider-log-framework-id framework)
                   "appender" ,(cider-log-appender-id appender))
-                (cider-nrepl-send-sync-request)
+                (cider-nrepl-sync-request)
                 (nrepl-dict-get "cider/log-exceptions")))
 
 (defun cider-sync-request:log-levels (framework appender)
@@ -305,7 +305,7 @@ It will not be used if the package hasn't been installed."
   (thread-first `("op" "cider/log-levels"
                   "framework" ,(cider-log-framework-id framework)
                   "appender" ,(cider-log-appender-id appender))
-                (cider-nrepl-send-sync-request)
+                (cider-nrepl-sync-request)
                 (nrepl-dict-get "cider/log-levels")))
 
 (defun cider-sync-request:log-loggers (framework appender)
@@ -313,7 +313,7 @@ It will not be used if the package hasn't been installed."
   (thread-first `("op" "cider/log-loggers"
                   "framework" ,(cider-log-framework-id framework)
                   "appender" ,(cider-log-appender-id appender))
-                (cider-nrepl-send-sync-request)
+                (cider-nrepl-sync-request)
                 (nrepl-dict-get "cider/log-loggers")))
 
 (defun cider-sync-request:log-remove-appender (framework appender)
@@ -321,7 +321,7 @@ It will not be used if the package hasn't been installed."
   (thread-first `("op" "cider/log-remove-appender"
                   "framework" ,(cider-log-framework-id framework)
                   "appender" ,(cider-log-appender-id appender))
-                (cider-nrepl-send-sync-request)
+                (cider-nrepl-sync-request)
                 (nrepl-dict-get "cider/log-remove-appender")))
 
 (defun cider-sync-request:log-remove-consumer (framework appender consumer)
@@ -330,7 +330,7 @@ It will not be used if the package hasn't been installed."
                   "framework" ,(cider-log-framework-id framework)
                   "appender" ,(cider-log-appender-id appender)
                   "consumer" ,(cider-log-consumer-id consumer))
-                (cider-nrepl-send-sync-request)
+                (cider-nrepl-sync-request)
                 (nrepl-dict-get "cider/log-remove-consumer")))
 
 (defun cider-sync-request:log-threads (framework appender)
@@ -338,7 +338,7 @@ It will not be used if the package hasn't been installed."
   (thread-first `("op" "cider/log-threads"
                   "framework" ,(cider-log-framework-id framework)
                   "appender" ,(cider-log-appender-id appender))
-                (cider-nrepl-send-sync-request)
+                (cider-nrepl-sync-request)
                 (nrepl-dict-get "cider/log-threads")))
 
 (defun cider-log--completion-extra-properties (keys &optional separator)

--- a/lisp/cider-macroexpansion.el
+++ b/lisp/cider-macroexpansion.el
@@ -79,7 +79,7 @@ The default for DISPLAY-NAMESPACES is taken from
                                                           (symbol-name cider-macroexpansion-display-namespaces)))
                               (nconc (when cider-macroexpansion-print-metadata
                                        '("print-meta" "true")))
-                              (cider-nrepl-send-sync-request))))
+                              (cider-nrepl-sync-request))))
     (nrepl-dbind-response result (expansion status)
       (if (member "macroexpand-error" status)
           (user-error "Macroexpansion failed.  Check *cider-error* for more details")

--- a/lisp/cider-macrostep.el
+++ b/lisp/cider-macrostep.el
@@ -152,7 +152,7 @@ EXPANDER is a `cider/macroexpand' expander name, such as \"macroexpand-1\"
                                 "code" ,code
                                 "ns" ,(cider-current-ns)
                                 "display-namespaces" ,(symbol-name cider-macrostep-display-namespaces))
-                              (cider-nrepl-send-sync-request))))
+                              (cider-nrepl-sync-request))))
     (nrepl-dbind-response result (expansion status)
       (if (member "macroexpand-error" status)
           (user-error "Macroexpansion failed.  Check *cider-error* for more details")
@@ -256,7 +256,7 @@ skipped."
 
 (defun cider-macrostep--classify (symbols)
   "Return the classification dict for SYMBOLS resolved in the current namespace."
-  (let ((result (cider-nrepl-send-sync-request
+  (let ((result (cider-nrepl-sync-request
                  `("op" "cider/classify-symbols"
                    "symbols" ,symbols
                    "ns" ,(cider-current-ns)))))

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -178,7 +178,7 @@ VAR is a fully qualified Clojure variable name as a string."
 With a prefix argument, prompt for function to run instead of -main."
   (interactive (list (when current-prefix-arg (read-string "Function name: "))))
   (let ((name (or function "-main")))
-    (when-let* ((response (cider-nrepl-send-sync-request
+    (when-let* ((response (cider-nrepl-sync-request
                            `("op" "cider/ns-list-vars-by-name"
                              "name" ,name))))
       (if-let* ((vars (split-string (substring (nrepl-dict-get response "var-list") 1 -1))))

--- a/lisp/cider-ns.el
+++ b/lisp/cider-ns.el
@@ -379,7 +379,7 @@ refresh functions (defined in `cider-ns-refresh-before-fn' and
                                           nil
                                           t))
           (when clear?
-            (cider-nrepl-send-sync-request `("op" ,(cider-ns--reload-op "reload-clear")) conn))
+            (cider-nrepl-sync-request `("op" ,(cider-ns--reload-op "reload-clear")) :connection conn))
           (let ((reloading (list nil)))
             (cider-nrepl-send-request
              `("op" ,(cider-ns--reload-op (if all? "reload-all" "reload"))

--- a/lisp/cider-profile.el
+++ b/lisp/cider-profile.el
@@ -105,7 +105,7 @@ With prefix arg or no symbol at point, prompts for a var."
   "Display a summary of currently collected profile data."
   (interactive)
   (cider-inspector--render-value
-   (cider-nrepl-send-sync-request '("op" "cider/profile-summary"))))
+   (cider-nrepl-sync-request '("op" "cider/profile-summary"))))
 
 ;;;###autoload
 (defun cider-profile-clear ()

--- a/lisp/cider-repl.el
+++ b/lisp/cider-repl.el
@@ -264,7 +264,7 @@ This cache is stored in the connection buffer.")
   (interactive)
   (let* ((current-repl (cider-current-repl 'infer 'ensure))
          (require-code (cdr (assoc (cider-repl-type current-repl) cider-repl-require-repl-utils-code))))
-    (nrepl-send-sync-request
+    (nrepl-sync-request
      (cider-plist-put
       (nrepl--eval-request require-code (cider-current-ns))
       "inhibit-cider-middleware" "true")
@@ -1452,7 +1452,7 @@ command will prompt for the name of the namespace to switch to."
                           (with-current-buffer connection
                             cider-repl-type))
                    ;; For cljs, don't use cider-tooling-eval, because Piggieback will later change the ns (issue #3503):
-                   #'cider-nrepl-request:eval
+                   #'cider-nrepl-send-eval-request
                  ;; When possible, favor cider-tooling-eval because it preserves *1, etc (commit 5f705b):
                  #'cider-tooling-eval)))
         (funcall f (format "(in-ns '%s)" ns)

--- a/lisp/cider-tracing.el
+++ b/lisp/cider-tracing.el
@@ -41,7 +41,7 @@
   (thread-first `("op" "cider/toggle-trace-var"
                   "ns" ,(cider-current-ns)
                   "sym" ,sym)
-                (cider-nrepl-send-sync-request)))
+                (cider-nrepl-sync-request)))
 
 (defun cider--toggle-trace-var (sym)
   "Toggle var tracing for SYM."
@@ -68,7 +68,7 @@ opposite of what that option dictates."
   "Toggle namespace tracing for NS."
   (thread-first `("op" "cider/toggle-trace-ns"
                   "ns" ,ns)
-                (cider-nrepl-send-sync-request)))
+                (cider-nrepl-sync-request)))
 
 ;;;###autoload
 (defun cider-toggle-trace-ns (query)
@@ -94,7 +94,7 @@ Defaults to the current ns.  With prefix arg QUERY, prompts for a ns."
 (defun cider-sync-request:list-traced ()
   "Return the vars and namespaces that are currently traced."
   (thread-first `("op" "cider/list-traced")
-                (cider-nrepl-send-sync-request)))
+                (cider-nrepl-sync-request)))
 
 (defun cider-list-traced--render (nses vars)
   "Render the traced NSES and VARS in `cider-traced-buffer'."
@@ -127,7 +127,7 @@ Defaults to the current ns.  With prefix arg QUERY, prompts for a ns."
 (defun cider-untrace-all ()
   "Untrace all currently traced vars and namespaces."
   (interactive)
-  (let* ((response (cider-nrepl-send-sync-request '("op" "cider/untrace-all")))
+  (let* ((response (cider-nrepl-sync-request '("op" "cider/untrace-all")))
          (count (or (nrepl-dict-get response "untraced-count") 0)))
     (message "Untraced %d var%s" count (if (= count 1) "" "s"))))
 

--- a/lisp/nrepl-client.el
+++ b/lisp/nrepl-client.el
@@ -971,6 +971,8 @@ prefer the keyword-argument `nrepl-sync-request'."
                       :tooling tooling
                       :callback callback))
 
+(make-obsolete 'nrepl-send-sync-request 'nrepl-sync-request "1.23.0")
+
 (defun nrepl-request:stdin (input callback connection)
   "Send a :stdin request with INPUT using CONNECTION.
 Register CALLBACK as the response handler."
@@ -1041,6 +1043,8 @@ prefer the keyword-argument `nrepl-send-eval-request'."
                            :ns ns :line line :column column
                            :additional-params additional-params :tooling tooling))
 
+(make-obsolete 'nrepl-request:eval 'nrepl-send-eval-request "1.23.0")
+
 (defvar nrepl-client-name "nrepl.el"
   "Name of the nREPL client, sent in clone requests.")
 
@@ -1066,16 +1070,16 @@ from CONNECTION."
 
 (defun nrepl-sync-request:describe (connection)
   "Perform a :describe request for CONNECTION."
-  (nrepl-send-sync-request '("op" "describe")
+  (nrepl-sync-request '("op" "describe")
                            connection))
 
 (defun nrepl-sync-request:ls-sessions (connection)
   "Perform :ls-sessions request for CONNECTION."
-  (nrepl-send-sync-request '("op" "ls-sessions") connection))
+  (nrepl-sync-request '("op" "ls-sessions") connection))
 
 (defun nrepl-sync-request:ls-middleware (connection)
   "Perform :ls-middleware request for CONNECTION."
-  (nrepl-send-sync-request '("op" "ls-middleware") connection))
+  (nrepl-sync-request '("op" "ls-middleware") connection))
 
 (defun nrepl-sync-request:eval (input connection &optional ns tooling)
   "Send the INPUT to the nREPL server synchronously.

--- a/test/cider-client-tests.el
+++ b/test/cider-client-tests.el
@@ -275,8 +275,9 @@
                                      :ns "user" :line 1 :column 2
                                      :additional-params '("a" "b")
                                      :connection :fake-conn)
-      (cider-nrepl-request:eval "(+ 1 1)" #'ignore
-                                "user" 1 2 '("a" "b") :fake-conn)
+      (with-suppressed-warnings ((obsolete cider-nrepl-request:eval))
+        (cider-nrepl-request:eval "(+ 1 1)" #'ignore
+                                  "user" 1 2 '("a" "b") :fake-conn))
       (expect (length calls) :to-equal 2)
       ;; the wrapped callback is a fresh closure each call, so compare
       ;; everything except it: the input and the connection + keyword args
@@ -288,7 +289,8 @@
     (let (captured)
       (spy-on 'cider-nrepl-sync-request :and-call-fake
               (lambda (request &rest kwargs) (setq captured (list request kwargs))))
-      (cider-nrepl-send-sync-request '("op" "x") :fake-conn 'abort #'ignore)
+      (with-suppressed-warnings ((obsolete cider-nrepl-send-sync-request))
+        (cider-nrepl-send-sync-request '("op" "x") :fake-conn 'abort #'ignore))
       (cl-destructuring-bind (request kwargs) captured
         (expect request :to-equal '("op" "x"))
         (expect (plist-get kwargs :connection) :to-be :fake-conn)

--- a/test/cider-macroexpansion-tests.el
+++ b/test/cider-macroexpansion-tests.el
@@ -35,7 +35,7 @@
   (it "sends the expander, code and namespace and returns the expansion"
     (let (captured)
       (cl-letf (((symbol-function 'cider-current-ns) (lambda () "user"))
-                ((symbol-function 'cider-nrepl-send-sync-request)
+                ((symbol-function 'cider-nrepl-sync-request)
                  (lambda (request)
                    (setq captured request)
                    (nrepl-dict "expansion" "(if x (do y))" "status" '("done")))))
@@ -53,7 +53,7 @@
   (it "requests metadata when `cider-macroexpansion-print-metadata' is on"
     (let (captured)
       (cl-letf (((symbol-function 'cider-current-ns) (lambda () "user"))
-                ((symbol-function 'cider-nrepl-send-sync-request)
+                ((symbol-function 'cider-nrepl-sync-request)
                  (lambda (request)
                    (setq captured request)
                    (nrepl-dict "expansion" "x" "status" '("done")))))
@@ -63,7 +63,7 @@
 
   (it "signals a user-error when the middleware reports a macroexpand-error"
     (cl-letf (((symbol-function 'cider-current-ns) (lambda () "user"))
-              ((symbol-function 'cider-nrepl-send-sync-request)
+              ((symbol-function 'cider-nrepl-sync-request)
                (lambda (_request) (nrepl-dict "status" '("macroexpand-error")))))
       (expect (cider-sync-request:macroexpand "macroexpand-1" "(boom)")
               :to-throw 'user-error))))
@@ -73,7 +73,7 @@
     (let (codes)
       (cl-letf (((symbol-function 'cider-current-ns) (lambda () "user"))
                 ((symbol-function 'cider-initialize-macroexpansion-buffer) #'ignore)
-                ((symbol-function 'cider-nrepl-send-sync-request)
+                ((symbol-function 'cider-nrepl-sync-request)
                  (lambda (request)
                    (push (cadr (member "code" request)) codes)
                    (nrepl-dict "expansion" "EXPANDED" "status" '("done")))))

--- a/test/cider-repl-tests.el
+++ b/test/cider-repl-tests.el
@@ -328,7 +328,7 @@ PROPERTY should be a symbol of either 'text, 'ansi-context or
   (before-each
     (spy-on 'cider-current-repl :and-return-value nil)
     (spy-on 'nrepl--eval-request)
-    (spy-on 'nrepl-send-sync-request :and-return-value nil))
+    (spy-on 'nrepl-sync-request :and-return-value nil))
   (it "requires clj utils in a clj buffer"
     (spy-on 'cider-repl-type :and-return-value 'clj)
     (cider-repl-require-repl-utils)

--- a/test/cider-tests--no-auto.el
+++ b/test/cider-tests--no-auto.el
@@ -46,7 +46,7 @@ leading line of all dashes and trailing nil (when no doc is present) are removed
 from the latter. Remaining content is compared for string equality."
   (let ((repl-doc (with-temp-buffer
                     (let ((form (format "(clojure.repl/doc %s)" sym)))
-                      (insert (nrepl-dict-get (cider-nrepl-send-sync-request form)
+                      (insert (nrepl-dict-get (cider-nrepl-sync-request form)
                                               "out"))
                       (goto-char (point-min))
                       (while (re-search-forward "^  nil\n" nil t)

--- a/test/cider-tracing-tests.el
+++ b/test/cider-tracing-tests.el
@@ -49,7 +49,7 @@
 
 (describe "cider-untrace-all"
   (it "reports the number of untraced vars"
-    (spy-on 'cider-nrepl-send-sync-request :and-return-value
+    (spy-on 'cider-nrepl-sync-request :and-return-value
             (nrepl-dict "untraced-count" 3))
     (spy-on 'message)
     (cider-untrace-all)

--- a/test/cider-transport-lint-tests.el
+++ b/test/cider-transport-lint-tests.el
@@ -45,7 +45,7 @@
                       "nrepl-send-eval-request"))
            ;; (FILE . SENDER) sites allowed to bypass the cider layer.  Each one
            ;; resolves and ensures its own connection before the low-level send.
-           (allowlist '(("cider-repl.el" . "nrepl-send-sync-request")))
+           (allowlist '(("cider-repl.el" . "nrepl-sync-request")))
            (found '()))
       (expect (file-directory-p "lisp") :to-be-truthy)
       (dolist (file (directory-files "lisp" t "\\.el\\'"))

--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -315,8 +315,9 @@
         (nrepl-send-eval-request "(+ 1 1)" cb :fake-conn
                                  :ns "user" :line 1 :column 2
                                  :additional-params '("foo" "bar") :tooling 'tooling)
-        (nrepl-request:eval "(+ 1 1)" cb :fake-conn
-                            "user" 1 2 '("foo" "bar") 'tooling))
+        (with-suppressed-warnings ((obsolete nrepl-request:eval))
+          (nrepl-request:eval "(+ 1 1)" cb :fake-conn
+                              "user" 1 2 '("foo" "bar") 'tooling)))
       (expect (length calls) :to-equal 2)
       (expect (nth 0 calls) :to-equal (nth 1 calls)))))
 
@@ -326,7 +327,8 @@
       (spy-on 'nrepl-sync-request :and-call-fake
               (lambda (request connection &rest kwargs)
                 (setq captured (list request connection kwargs))))
-      (nrepl-send-sync-request '("op" "x") :fake-conn 'abort 'tooling #'ignore)
+      (with-suppressed-warnings ((obsolete nrepl-send-sync-request))
+        (nrepl-send-sync-request '("op" "x") :fake-conn 'abort 'tooling #'ignore))
       (cl-destructuring-bind (request connection kwargs) captured
         (expect request :to-equal '("op" "x"))
         (expect connection :to-be :fake-conn)


### PR DESCRIPTION
Drives the recently-started keyword-API migration to the finish line. Every caller now uses the keyword-argument request forms, and the positional shims are deprecated via `make-obsolete` so the byte-compiler flags any new use (same enforcement pattern as #4028's `cider-ensure-op-supported`).

Migrated (all call sites) and deprecated:
- `cider-nrepl-send-sync-request` -> `cider-nrepl-sync-request` (62 call sites)
- `cider-nrepl-request:eval` -> `cider-nrepl-send-eval-request`
- `nrepl-send-sync-request` -> `nrepl-sync-request`
- `nrepl-request:eval` -> `nrepl-send-eval-request`

The shims still work for external callers - only their internal use is gone.

Notes:
- The cider-level keyword sync form takes `connection` as a `:keyword`; only one call site (`cider-ns.el`) passed it positionally and was converted. The low-level form keeps `connection` positional, so those were plain renames.
- Test spies/stubs were repointed to the keyword forms (otherwise they'd no longer intercept). The shim-delegation specs are kept (wrapped in `with-suppressed-warnings`) so we still verify the shims forward correctly while deprecated.
- Updated the transport-lint allowlist - `cider-repl-require-repl-utils` now uses `nrepl-sync-request`.

Clean `--warnings-as-errors` compile (no obsolete warnings, since nothing internal calls the shims) and full suite green.