### PR TITLE
Fix connection passed positionally to the keyword sync sender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### Bugs fixed
 
+- [#4030](https://github.com/clojure-emacs/cider/pull/4030): Fix `cider-sync-request:classpath` and `cider-sync-request:lookup` against an explicit connection, broken in #4029 by passing the connection positionally to the keyword-argument `cider-nrepl-sync-request`.
 - [#4026](https://github.com/clojure-emacs/cider/pull/4026): `cider-macroexpand-1` and friends now work in ClojureScript for user-defined macros (fixed in `cider-nrepl`, delivered via the 0.61.0-alpha1 bump) ([#2099](https://github.com/clojure-emacs/cider/issues/2099)).
 - [#4016](https://github.com/clojure-emacs/cider/pull/4016): Show the REPL prompt right away when a server (e.g. jank) sends `value` and `("done")` in the same response, instead of only after the next keypress ([#3869](https://github.com/clojure-emacs/cider/issues/3869)).
 - [#4019](https://github.com/clojure-emacs/cider/pull/4019): Stop the dynamic local-variable font-locking from mistaking a `def`'s value for an arglist, which tagged literals, function names and other non-locals as locals (`cider-locals` false positives) ([#3657](https://github.com/clojure-emacs/cider/issues/3657)).

--- a/lisp/cider-client.el
+++ b/lisp/cider-client.el
@@ -850,7 +850,7 @@ prefer the keyword-argument `cider-apropos-request'."
   "Return a list of classpath entries for CONNECTION."
   (thread-first
     '("op" "cider/classpath")
-    (cider-nrepl-sync-request connection)
+    (cider-nrepl-sync-request :connection connection)
     (nrepl-dict-get "classpath")))
 
 (defun cider--get-abs-path (path project)
@@ -950,7 +950,7 @@ prefer the keyword-argument `cider-info-request'."
                                   "ns" ,(cider-current-ns)
                                   ,@(when symbol `("sym" ,symbol))
                                   ,@(when lookup-fn `("lookup-fn" ,lookup-fn)))
-                                (cider-nrepl-sync-request (cider-current-repl)))))
+                                (cider-nrepl-sync-request :connection (cider-current-repl)))))
     (if (member "lookup-error" (nrepl-dict-get var-info "status"))
         nil
       (nrepl-dict-get var-info "info"))))

--- a/test/cider-client-tests.el
+++ b/test/cider-client-tests.el
@@ -332,6 +332,24 @@
         (expect (plist-get kwargs :privates-p) :to-be t)
         (expect (plist-get kwargs :case-sensitive-p) :to-be t)))))
 
+(describe "cider-sync-request:classpath"
+  ;; Regression: the connection must be passed as the :connection keyword, not
+  ;; positionally (the keyword-form `cider-nrepl-sync-request' takes it as a key).
+  (it "passes the connection as a keyword argument"
+    (spy-on 'cider-nrepl-sync-request :and-return-value (nrepl-dict "classpath" '("a")))
+    (cider-sync-request:classpath 'fake-conn)
+    (expect 'cider-nrepl-sync-request :to-have-been-called-with
+            '("op" "cider/classpath") :connection 'fake-conn)))
+
+(describe "cider-sync-request:lookup"
+  (it "passes the connection as a keyword argument"
+    (spy-on 'cider-current-repl :and-return-value 'fake-conn)
+    (spy-on 'cider-current-ns :and-return-value "user")
+    (spy-on 'cider-nrepl-sync-request :and-return-value (nrepl-dict "info" (nrepl-dict)))
+    (cider-sync-request:lookup "foo")
+    (expect 'cider-nrepl-sync-request :to-have-been-called-with
+            '("op" "lookup" "ns" "user" "sym" "foo") :connection 'fake-conn)))
+
 (describe "cider-request:load-file"
   (it "delegates to cider-load-file-request with positional args mapped to keywords"
     (let (captured)


### PR DESCRIPTION
Regression from #4029. `cider-sync-request:classpath` and `cider-sync-request:lookup` pass the connection to `cider-nrepl-sync-request` via `thread-first`, e.g. `(cider-nrepl-sync-request REQUEST connection)` - but the keyword form takes `connection` as `:connection`, so it was being parsed as a stray keyword argument and would error against an explicit (non-default) connection.

These two slipped through the migration's arg-count scan because the threaded request makes the connection look like the sole argument. Fixed both to use `:connection`, and added regression specs asserting the keyword is used.

(The earlier suite stayed green only because these helpers aren't exercised with an explicit connection in the tests - the new specs close that gap.)