### PR TITLE
Mark the clojuredocs lookup request completed on done

### DIFF
--- a/lisp/cider-clojuredocs.el
+++ b/lisp/cider-clojuredocs.el
@@ -60,10 +60,11 @@ the symbol has no ClojureDocs entry, or the middleware is unavailable)."
     (cider-nrepl-send-request
      `("op" "cider/clojuredocs-lookup" "ns" ,ns "sym" ,sym)
      (lambda (response)
-       (nrepl-dbind-response response (clojuredocs status)
+       (nrepl-dbind-response response (clojuredocs status id)
          (when clojuredocs
            (setq result clojuredocs))
          (when (member "done" status)
+           (nrepl--mark-id-completed id)
            (funcall callback result)))))))
 
 (defun cider-clojuredocs-replace-special (name)

--- a/test/cider-clojuredocs-tests.el
+++ b/test/cider-clojuredocs-tests.el
@@ -60,3 +60,16 @@
   (it "leaves unqualified symbols unchanged"
       (expect (cider-clojuredocs--strip-ns "/") :to-equal "/")
       (expect (cider-clojuredocs--strip-ns "subs") :to-equal "subs")))
+
+(describe "cider-clojuredocs--lookup-async"
+  (it "marks the request completed and invokes the callback with the result on done"
+    (let (handler cb-result)
+      (spy-on 'cider-nrepl-send-request :and-call-fake
+              (lambda (_request callback) (setq handler callback)))
+      (spy-on 'nrepl--mark-id-completed)
+      (cider-clojuredocs--lookup-async "clojure.core" "map"
+                                       (lambda (r) (setq cb-result r)))
+      (funcall handler (nrepl-dict "id" "7" "clojuredocs" (nrepl-dict "name" "map")))
+      (funcall handler (nrepl-dict "id" "7" "status" '("done")))
+      (expect 'nrepl--mark-id-completed :to-have-been-called-with "7")
+      (expect cb-result :to-equal (nrepl-dict "name" "map")))))


### PR DESCRIPTION
Small consistency fix surfaced by the request-API deep dive. `cider-clojuredocs--lookup-async` accumulates streamed responses and finishes on `done`, but - unlike the analogous handlers in `cider-compilation` (`analyze-last-stacktrace`) and `cider-test` - it never called `nrepl--mark-id-completed`. So its handler stayed in the pending-requests table, and a late "done" message would re-fire the callback (re-rendering the buffer).

Mark it completed on `done`, matching the other accumulate-then-done handlers. Added a regression spec.

(Note from the deep dive: the other hand-rolled `(lambda (response) ...)` handlers - cider-test, cider-compilation, the trace stream - legitimately read custom op slots that the eval handler builder doesn't model, so there's nothing to convert there. This was the only clear-cut item.)