### PR TITLE
Deprecate the legacy connection-named aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 
 ### Changes
 
+- [#4033](https://github.com/clojure-emacs/cider/pull/4033): Deprecate the legacy connection-named aliases `cider-current-connection`, `cider-connections`, `cider-map-connections` and `cider-connection-type-for-buffer` in favor of their `cider-repl` counterparts.
 - [#4029](https://github.com/clojure-emacs/cider/pull/4029): Finish migrating to the keyword-argument request APIs and deprecate the positional shims: `cider-nrepl-send-sync-request` -> `cider-nrepl-sync-request`, `cider-nrepl-request:eval` -> `cider-nrepl-send-eval-request`, `nrepl-send-sync-request` -> `nrepl-sync-request`, `nrepl-request:eval` -> `nrepl-send-eval-request`.
 - [#4028](https://github.com/clojure-emacs/cider/pull/4028): Deprecate `cider-ensure-op-supported`; op support is now enforced automatically by the nREPL senders, so commands no longer need an explicit check.
 - [#4026](https://github.com/clojure-emacs/cider/pull/4026): Bump the injected `cider-nrepl` to 0.61.0-alpha1, which provides ClojureScript test support, the `clojure-only` op signal and the ClojureScript macroexpansion fix.

--- a/lisp/cider-session.el
+++ b/lisp/cider-session.el
@@ -687,12 +687,17 @@ session."
            (repls (cider-repls type ensure required-ops)))
       (mapcar function repls))))
 
-;; REPLs double as connections in CIDER, so it's useful to be able to refer to
-;; them as connections in certain contexts.
+;; Legacy aliases from before the connection->REPL terminology change.  They have
+;; no remaining users in CIDER itself; keep them working but steer code to the
+;; `cider-repl' names.
 (defalias 'cider-current-connection #'cider-current-repl)
 (defalias 'cider-connections #'cider-repls)
 (defalias 'cider-map-connections #'cider-map-repls)
 (defalias 'cider-connection-type-for-buffer #'cider-repl-type-for-buffer)
+(make-obsolete 'cider-current-connection #'cider-current-repl "1.23.0")
+(make-obsolete 'cider-connections #'cider-repls "1.23.0")
+(make-obsolete 'cider-map-connections #'cider-map-repls "1.23.0")
+(make-obsolete 'cider-connection-type-for-buffer #'cider-repl-type-for-buffer "1.23.0")
 
 
 (provide 'cider-session)


### PR DESCRIPTION
The four `cider-*-connection*` aliases are leftovers from before the connection -> REPL terminology change and have zero callers anywhere in lisp/, test/, or doc/. Mark them obsolete (pointing at the `cider-repl` names) so the byte-compiler nudges any external code off them:

- `cider-current-connection` -> `cider-current-repl`
- `cider-connections` -> `cider-repls`
- `cider-map-connections` -> `cider-map-repls`
- `cider-connection-type-for-buffer` -> `cider-repl-type-for-buffer`

The aliases still work; this just deprecates them (the graceful removal path) rather than hard-deleting public API. Surfaced by the session/connection deep dive. Clean `--warnings-as-errors` compile.