### PR TITLE
Tidy lingering connection/REPL terminology

### DIFF
--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -56,9 +56,9 @@
 
 (defun cider--modeline-info ()
   "Return info for the cider mode modeline.
-Info contains the connection type, project name and host:port endpoint."
-  (if-let* ((current-connection (ignore-errors (cider-current-repl))))
-      (with-current-buffer current-connection
+Info contains the REPL type, project name and host:port endpoint."
+  (if-let* ((current-repl (ignore-errors (cider-current-repl))))
+      (with-current-buffer current-repl
         (concat
          (symbol-name cider-repl-type)
          (when cider-mode-line-show-connection

--- a/lisp/cider-session.el
+++ b/lisp/cider-session.el
@@ -274,17 +274,17 @@ By default it assumes the connection buffer is current."
   (buffer-local-value 'cider-repl-cljs-upgrade-pending repl-buffer))
 
 (defvar-local cider-repl-type-override nil
-  "When non-nil, the connection type (clj, cljs or multi) used for this buffer.
+  "When non-nil, the REPL type (clj, cljs or multi) used for this buffer.
 Overrides the major-mode-based inference in `cider-repl-type-for-buffer'.
 Buffers with no inherent file type - e.g. `*cider-scratch*' - set this to
 control where their evaluations are dispatched.")
 
 (defun cider-repl-type-for-buffer (&optional buffer)
-  "Return the matching connection type (clj or cljs) for BUFFER.
+  "Return the matching REPL type (clj or cljs) for BUFFER.
 BUFFER defaults to the `current-buffer'.  In cljc buffers return
-multi.  This function infers connection type based on the major mode,
+multi.  This function infers the REPL type based on the major mode,
 unless `cider-repl-type-override' is set.
-For the REPL type use the function `cider-repl-type'."
+To get a REPL buffer's own type use the function `cider-repl-type'."
   (with-current-buffer (or buffer (current-buffer))
     (cond
      (cider-repl-type-override cider-repl-type-override)
@@ -578,7 +578,7 @@ no linked session or there is no REPL of TYPE within the current session."
                 sessions)))
 
 (defun cider--extract-connections (sessions)
-  "Return a flattened list of all session buffers in SESSIONS."
+  "Return a flattened list of all REPL buffers in SESSIONS."
   (seq-reduce (lambda (x y)
                 (append x (cdr y)))
               sessions
@@ -655,10 +655,10 @@ REPL's session is used instead of the current one (taking precedence over
 (defun cider-map-repls (which function)
   "Call FUNCTION once for each appropriate REPL as indicated by WHICH.
 The function is called with one argument, the REPL buffer.  The appropriate
-connections are found by inspecting the current buffer.  WHICH is either one of
+REPLs are found by inspecting the current buffer.  WHICH is either one of
 the following keywords or a list starting with one of them followed by names of
 operations that the REPL is expected to support:
- :auto - Act on the connections whose type matches the current buffer.  In
+ :auto - Act on the REPLs whose type matches the current buffer.  In
      `cljc' files, mapping happens over both types of REPLs.
  :clj (:cljs) - Map over clj (cljs)) REPLs only.
  :clj-strict (:cljs-strict) - Map over clj (cljs) REPLs but signal a

--- a/lisp/cider-tracing.el
+++ b/lisp/cider-tracing.el
@@ -139,8 +139,8 @@ Defaults to the current ns.  With prefix arg QUERY, prompts for a ns."
 (defvar-local cider-trace--subscription nil
   "Id of this buffer's active trace subscription, or nil.")
 
-(defvar-local cider-trace--connection nil
-  "The REPL connection this trace buffer is subscribed through.")
+(defvar-local cider-trace--repl nil
+  "The REPL buffer this trace buffer is subscribed through.")
 
 (defvar-local cider-trace--open-calls nil
   "Hash table of call id -> marker at the start of that call's children.
@@ -289,13 +289,13 @@ EVENT is the mouse event, when invoked with the mouse."
   "Tear down this buffer's trace subscription, if any.
 Fires a best-effort async request, since this runs from `kill-buffer-hook'."
   (when (and cider-trace--subscription
-             (buffer-live-p cider-trace--connection))
+             (buffer-live-p cider-trace--repl))
     (ignore-errors
       (cider-nrepl-send-request
        (list "op" "cider/trace-unsubscribe"
              "subscription" cider-trace--subscription)
        #'ignore
-       cider-trace--connection))
+       cider-trace--repl))
     (setq cider-trace--subscription nil)))
 
 (defun cider-trace-clear ()
@@ -356,7 +356,7 @@ cluttering the REPL.  Killing the buffer stops the streaming."
     (with-current-buffer buffer
       (unless (eq major-mode 'cider-trace-mode)
         (cider-trace-mode))
-      (setq cider-trace--connection connection)
+      (setq cider-trace--repl connection)
       (unless cider-trace--subscription
         (cider-nrepl-send-request
          '("op" "cider/trace-subscribe")


### PR DESCRIPTION
Follow-up to the connection -> REPL/session rename, from a terminology audit of the session layer. Aligns the internal names and docstrings that still said "connection" where a REPL buffer is actually meant - no behavior change, no public API touched:

- rename the internal `cider-trace--connection` var to `cider-trace--repl`
- rename the `current-connection` local in `cider--modeline-info` to `current-repl`
- docstring wording in `cider-map-repls` (a `-repls` function that said "connections"), `cider-repl-type-for-buffer` / `cider-repl-type-override` ("connection type" -> "REPL type"), `cider--extract-connections`, and the modeline helper

Deliberately left alone: the public `*-connection*` surface (`cider-describe-connection`, `cider-connected-p`, `cider-connect-*`, the `cider-connected-hook`/`cider-disconnected-hook` defcustoms, etc.) - a connection genuinely is a real concept (1:1 with a REPL by CIDER's own definition) and these are API/keybindings. The one public symbol whose *name* arguably contradicts its concept is `cider-ensure-connected` (it ensures a *session*); left as-is since renaming public API needs an alias + deprecation cycle - flagging it for a separate decision.