### PR TITLE
Rename cider-ensure-connected to cider-ensure-session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 
 ### Changes
 
+- [#4035](https://github.com/clojure-emacs/cider/pull/4035): Rename `cider-ensure-connected` to `cider-ensure-session` (it ensures a linked CIDER session); the old name remains as an obsolete alias.
 - [#4033](https://github.com/clojure-emacs/cider/pull/4033): Deprecate the legacy connection-named aliases `cider-current-connection`, `cider-connections`, `cider-map-connections` and `cider-connection-type-for-buffer` in favor of their `cider-repl` counterparts.
 - [#4029](https://github.com/clojure-emacs/cider/pull/4029): Finish migrating to the keyword-argument request APIs and deprecate the positional shims: `cider-nrepl-send-sync-request` -> `cider-nrepl-sync-request`, `cider-nrepl-request:eval` -> `cider-nrepl-send-eval-request`, `nrepl-send-sync-request` -> `nrepl-sync-request`, `nrepl-request:eval` -> `nrepl-send-eval-request`.
 - [#4028](https://github.com/clojure-emacs/cider/pull/4028): Deprecate `cider-ensure-op-supported`; op support is now enforced automatically by the nREPL senders, so commands no longer need an explicit check.

--- a/lisp/cider-apropos.el
+++ b/lisp/cider-apropos.el
@@ -29,7 +29,7 @@
 (require 'cider-find) ; for cider--find-var
 (require 'cider-util)
 (require 'subr-x)
-(require 'cider-session) ; for cider-ensure-connected
+(require 'cider-session) ; for cider-ensure-session
 
 (require 'cider-client)
 (require 'cider-popup)
@@ -159,7 +159,7 @@ optionally search doc strings (based on DOCS-P), include private vars
 (defun cider-apropos-documentation ()
   "Shortcut for (cider-apropos <query> nil t)."
   (interactive)
-  (cider-ensure-connected)
+  (cider-ensure-session)
   (cider-apropos (read-string "Search for Clojure documentation (a regular expression): ") nil t))
 
 (defun cider-apropos-act-on-symbol (symbol)
@@ -200,7 +200,7 @@ optionally search doc strings (based on DOCS-P), include private vars
 (defun cider-apropos-documentation-select ()
   "Shortcut for (cider-apropos-select <query> nil t)."
   (interactive)
-  (cider-ensure-connected)
+  (cider-ensure-session)
   (cider-apropos-select (read-string "Search for Clojure documentation (a regular expression): ") nil t))
 
 (provide 'cider-apropos)

--- a/lisp/cider-browse-spec.el
+++ b/lisp/cider-browse-spec.el
@@ -449,7 +449,7 @@ Generates a new example for the current spec."
 (defun cider-browse-spec-regex (regex)
   "Open the list of specs that matches REGEX in a popup buffer.
 Displays all specs when REGEX is nil."
-  (cider-ensure-connected)
+  (cider-ensure-session)
   (let ((filter-regex (or regex "")))
     (with-current-buffer (cider-popup-buffer cider-browse-spec-buffer 'select nil 'ancillary)
       (let ((specs (cider-sync-request:spec-list filter-regex)))

--- a/lisp/cider-classpath.el
+++ b/lisp/cider-classpath.el
@@ -89,7 +89,7 @@
 (defun cider-classpath ()
   "List all classpath entries."
   (interactive)
-  (cider-ensure-connected)
+  (cider-ensure-session)
   (with-current-buffer (cider-popup-buffer cider-classpath-buffer 'select nil 'ancillary)
     (cider-classpath-list (current-buffer)
                           (mapcar (lambda (name)
@@ -100,7 +100,7 @@
 (defun cider-open-classpath-entry ()
   "Open a classpath entry."
   (interactive)
-  (cider-ensure-connected)
+  (cider-ensure-session)
   (when-let* ((entry (completing-read "Classpath entries: " (cider-classpath-entries))))
     (find-file-other-window entry)))
 

--- a/lisp/cider-connection.el
+++ b/lisp/cider-connection.el
@@ -414,7 +414,7 @@ REPL defaults to the current REPL."
 (defun cider-describe-nrepl-session ()
   "Describe an nREPL session."
   (interactive)
-  (cider-ensure-connected)
+  (cider-ensure-session)
   (let* ((repl (cider-current-repl 'infer 'ensure))
          (selected-session (completing-read "Describe nREPL session: " (nrepl-sessions repl))))
     (when (and selected-session (not (equal selected-session "")))
@@ -436,7 +436,7 @@ REPL defaults to the current REPL."
 (defun cider-list-nrepl-middleware ()
   "List the loaded nREPL middleware."
   (interactive)
-  (cider-ensure-connected)
+  (cider-ensure-session)
   (let* ((repl (cider-current-repl 'infer 'ensure))
          (middleware (nrepl-middleware repl)))
     (with-current-buffer (cider-popup-buffer "*cider-nrepl-middleware*" 'select nil 'ancillary)

--- a/lisp/cider-doc.el
+++ b/lisp/cider-doc.el
@@ -248,7 +248,7 @@ Prompts for the symbol to use, or uses the symbol at point, depending on
 the value of `cider-prompt-for-symbol'.  With prefix arg ARG, does the
 opposite of what that option dictates."
   (interactive "P")
-  (cider-ensure-connected)
+  (cider-ensure-session)
   (funcall (cider-prompt-for-symbol-function arg)
            "Javadoc for"
            #'cider-javadoc-handler))
@@ -432,7 +432,7 @@ Prompts for the symbol to use, or uses the symbol at point, depending on
 the value of `cider-prompt-for-symbol'.  With prefix arg ARG, does the
 opposite of what that option dictates."
   (interactive "P")
-  (cider-ensure-connected)
+  (cider-ensure-session)
   (funcall (cider-prompt-for-symbol-function arg)
            "Doc for"
            #'cider-doc-lookup))

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -577,7 +577,7 @@ arguments and only proceed with evaluation if it returns nil."
       ;; can skip missing REPL types).  That made every `cider-eval-*'
       ;; command fail silently with no connection at all, so guard the
       ;; dispatch with an explicit connection check.
-      (cider-ensure-connected)
+      (cider-ensure-session)
       (cider-map-repls :auto
         (lambda (connection)
           (cider--prep-interactive-eval form connection)
@@ -1306,7 +1306,7 @@ all ns aliases and var mappings from the namespaces being reloaded"
 (defun cider-load-all-project-ns ()
   "Load all namespaces in the current project."
   (interactive)
-  (cider-ensure-connected)
+  (cider-ensure-session)
   (when (y-or-n-p "Are you sure you want to load all namespaces in the project? ")
     (message "Loading all project namespaces...")
     (let ((loaded-ns-count (length (cider-sync-request:ns-load-all))))

--- a/lisp/cider-find.el
+++ b/lisp/cider-find.el
@@ -191,7 +191,7 @@ Optionally open it in a different window if OTHER-WINDOW is truthy."
 A prefix ARG of `-` or a double prefix argument causes
 the results to be displayed in a different window."
   (interactive "P")
-  (cider-ensure-connected)
+  (cider-ensure-session)
   (if ns
       (cider--find-ns ns)
     (let* ((namespaces (cider-sync-request:ns-list))
@@ -270,7 +270,7 @@ A single or double prefix argument inverts the meaning of
 the results to be displayed in a different window.  The default value is
 thing at point."
   (interactive "P")
-  (cider-ensure-connected)
+  (cider-ensure-session)
   (let* ((kw (let ((kw-at-point (cider-symbol-at-point 'look-back)))
                (if (or cider-prompt-for-symbol arg)
                    (read-string

--- a/lisp/cider-inspector.el
+++ b/lisp/cider-inspector.el
@@ -484,7 +484,7 @@ current-namespace."
 (defun cider-inspector-print-current-value ()
   "Print the current value of the inspector."
   (interactive)
-  (cider-ensure-connected)
+  (cider-ensure-session)
   (let ((buffer (cider-popup-buffer cider-result-buffer nil 'clojure-mode 'ancillary)))
     (cider-nrepl-send-request
      `("op" "cider/inspect-print-current-value"

--- a/lisp/cider-macrostep.el
+++ b/lisp/cider-macrostep.el
@@ -439,7 +439,7 @@ Place point right after the form, as with `\\[cider-eval-last-sexp]'.
 Start a `cider-macrostep-mode' session when one isn't active; further
 expansions and collapses then use that mode's key bindings."
   (interactive)
-  (cider-ensure-connected)
+  (cider-ensure-session)
   (pcase-let ((`(,beg . ,end) (or (cider-macrostep--form-bounds)
                                   (user-error "No sexp before point to expand"))))
     (let ((operator (cider-macrostep--operator beg)))
@@ -463,7 +463,7 @@ Like `cider-macrostep-expand', this starts a `cider-macrostep-mode' session
 when one isn't active.  It does not require the form's head to be a macro,
 since a fully-recursive expansion can reach macros in nested sub-forms."
   (interactive)
-  (cider-ensure-connected)
+  (cider-ensure-session)
   (pcase-let ((`(,beg . ,end) (or (cider-macrostep--form-bounds)
                                   (user-error "No sexp before point to expand"))))
     (let* ((code (buffer-substring-no-properties beg end))
@@ -508,7 +508,7 @@ the form, as with `\\[cider-eval-last-sexp]'.
 The session uses the same overlay engine and key bindings as the inline
 flow, except that `q' dismisses the whole popup in one step."
   (interactive)
-  (cider-ensure-connected)
+  (cider-ensure-session)
   (pcase-let ((`(,beg . ,end) (or (cider-macrostep--form-bounds)
                                   (user-error "No sexp before point to expand"))))
     (let ((operator (cider-macrostep--operator beg)))

--- a/lisp/cider-session.el
+++ b/lisp/cider-session.el
@@ -100,7 +100,7 @@ Set interactively with `cider-set-default-session'.")
   "Return t if CIDER is currently connected, nil otherwise."
   (process-live-p (get-buffer-process (cider-current-repl))))
 
-(defun cider-ensure-connected ()
+(defun cider-ensure-session ()
   "Signal a `user-error' unless there is a linked CIDER session.
 The CIDER-level nREPL senders (e.g. `cider-nrepl-send-request',
 `cider-nrepl-sync-request') already ensure a connection - they resolve the
@@ -108,6 +108,8 @@ REPL with `cider-current-repl' ENSURE - so commands don't need this for
 correctness.  Use it only to fail fast, before doing interactive or
 side-effecting work, rather than at the point of the first request."
   (sesman-ensure-session 'CIDER))
+
+(define-obsolete-function-alias 'cider-ensure-connected #'cider-ensure-session "1.23.0")
 
 
 ;;; Connection Parameters

--- a/lisp/cider-xref-tree.el
+++ b/lisp/cider-xref-tree.el
@@ -76,7 +76,7 @@ loop forever."
 BUFFER-NAME and TITLE-FMT name and describe the buffer; NOUN names the search
 for the prompt.  Resolves SYMBOL up front, signalling a typo/unloaded-namespace
 hint when it can't be.  OP's availability is enforced by the sender when sent."
-  (cider-ensure-connected)
+  (cider-ensure-session)
   (let* ((symbol (or symbol (cider-symbol-at-point)
                      (read-string (format "%s: " noun))))
          (info (or (cider-var-info symbol)
@@ -259,7 +259,7 @@ With cider-nrepl's `cider/who-implements' op this includes inline
 Without it, a client-side fallback lists `extend'-style targets and dispatch
 values only.  Clojure-on-the-JVM only."
   (interactive)
-  (cider-ensure-connected)
+  (cider-ensure-session)
   (let* ((symbol (or symbol (cider-symbol-at-point)
                      (read-string "Implementations of: ")))
          (info (or (cider-var-info symbol)
@@ -360,7 +360,7 @@ Covers both `extend'-style and inline `defrecord'/`deftype' implementations.
 Point should be on a type's name (a record/class) or a dotted class name; only
 loaded Clojure-on-the-JVM code is visible."
   (interactive)
-  (cider-ensure-connected)
+  (cider-ensure-session)
   (let ((symbol (or symbol (cider-symbol-at-point)
                     (read-string "Protocols of type: "))))
     (cider-xref-tree--show-protocols
@@ -375,7 +375,7 @@ loaded Clojure-on-the-JVM code is visible."
 With no argument, uses the (unqualified) name at point.  Only loaded
 Clojure-on-the-JVM code is visible."
   (interactive)
-  (cider-ensure-connected)
+  (cider-ensure-session)
   (let* ((method (or method (cider-symbol-at-point)
                      (read-string "Protocols with method: ")))
          ;; drop a namespace qualifier (m/area -> area) but keep a bare `/'

--- a/test/cider-connection-tests.el
+++ b/test/cider-connection-tests.el
@@ -37,7 +37,7 @@
 
 ;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
 
-(describe "cider-ensure-connected"
+(describe "cider-ensure-session"
   :var (sesman-sessions-hashmap sesman-links-alist ses-name ses-name2)
 
   (before-each
@@ -49,11 +49,11 @@
   (it "returns nil when a cider connection is available"
     (let ((default-directory (expand-file-name "/tmp/a-dir")))
       (with-repl-buffer "cider-ensure-session" 'clj b
-        (expect (cider-ensure-connected) :to-equal
+        (expect (cider-ensure-session) :to-equal
                 (list "cider-ensure-session" b)))))
 
   (it "raises a user-error in the absence of a connection"
-    (expect (cider-ensure-connected) :to-throw 'user-error)))
+    (expect (cider-ensure-session) :to-throw 'user-error)))
 
 (describe "cider-current-repl"
 

--- a/test/cider-eval-tests.el
+++ b/test/cider-eval-tests.el
@@ -61,14 +61,14 @@
       (expect (cider--auto-inspect-after-eval-p 'repl) :not :to-be-truthy))))
 (describe "cider-interactive-eval"
   (it "ensures a connection before dispatching to REPLs (#3028)"
-    (spy-on 'cider-ensure-connected)
+    (spy-on 'cider-ensure-session)
     (spy-on 'cider-map-repls)
     (cider-interactive-eval "42")
-    (expect 'cider-ensure-connected :to-have-been-called))
+    (expect 'cider-ensure-session :to-have-been-called))
 
   (it "doesn't dispatch when there's no connection (#3028)"
     ;; Before this guard, `cider-eval-*' commands failed silently with no REPL.
-    (spy-on 'cider-ensure-connected :and-call-fake
+    (spy-on 'cider-ensure-session :and-call-fake
             (lambda () (user-error "No linked CIDER sessions")))
     (spy-on 'cider-map-repls)
     (expect (cider-interactive-eval "42") :to-throw 'user-error)

--- a/test/cider-find-tests.el
+++ b/test/cider-find-tests.el
@@ -56,7 +56,7 @@
   ;; docstring.  Previously the raw prefix arg was passed straight to
   ;; `cider-jump-to', so any prefix opened another window.
   (it "dispatches to another window only for `-' or a double prefix"
-    (spy-on 'cider-ensure-connected :and-return-value t)
+    (spy-on 'cider-ensure-session :and-return-value t)
     (spy-on 'read-string :and-return-value "::foo")
     (spy-on 'cider-symbol-at-point :and-return-value "::foo")
     (spy-on 'cider--find-keyword-loc :and-return-value
@@ -85,7 +85,7 @@
 more
 stuff"
       (let* ((sample-buffer (current-buffer)))
-        (spy-on 'cider-ensure-connected :and-return-value t)
+        (spy-on 'cider-ensure-session :and-return-value t)
         (spy-on 'cider-sync-request:ns-path :and-call-fake (lambda (kw-ns _)
                                                              kw-ns))
         (spy-on 'cider-resolve-alias :and-call-fake (lambda (_ns ns-qualifier)

--- a/test/cider-interaction-tests.el
+++ b/test/cider-interaction-tests.el
@@ -104,7 +104,7 @@
     ;; no-connection path is covered in cider-eval-tests.el.  Stub the
     ;; connection check so the test doesn't depend on resolving the session
     ;; from an unlinked temp buffer (which is platform-dependent).
-    (spy-on 'cider-ensure-connected)
+    (spy-on 'cider-ensure-session)
     (let ((default-directory "/tmp/a-dir"))
       (with-repl-buffer "interaction-session" 'clj _b
         (with-temp-buffer

--- a/test/cider-macrostep-tests.el
+++ b/test/cider-macrostep-tests.el
@@ -230,7 +230,7 @@
 
 (describe "cider-macrostep-expand-all"
   (before-each
-    (spy-on 'cider-ensure-connected)
+    (spy-on 'cider-ensure-session)
     (spy-on 'cider-macrostep--refresh-overlays))
 
   (it "fully expands the form before point inline via macroexpand-all"
@@ -267,7 +267,7 @@
       (expect (point) :to-equal (point-max))))
 
   (it "runs the stepping session in the popup, leaving the source untouched"
-    (spy-on 'cider-ensure-connected)
+    (spy-on 'cider-ensure-session)
     (spy-on 'cider-ensure-macro)
     (spy-on 'cider-current-ns :and-return-value "user")
     (spy-on 'cider-macrostep--expand :and-return-value "(if x (do a))")

--- a/test/cider-transport-lint-tests.el
+++ b/test/cider-transport-lint-tests.el
@@ -20,7 +20,7 @@
 ;; A source lint, not a behavior test.  Commands talk to nREPL through the
 ;; cider-level senders (`cider-nrepl-send-request' and friends), which ensure a
 ;; connection and op support centrally (so commands need no explicit
-;; `cider-ensure-connected' / `cider-ensure-op-supported').  Reaching for the
+;; `cider-ensure-session' / `cider-ensure-op-supported').  Reaching for the
 ;; low-level `nrepl-*' senders bypasses that enforcement.  This keeps such usage
 ;; confined to the transport layer plus a small, reviewed allowlist, so new
 ;; bypasses are caught.

--- a/test/cider-xref-tree-tests.el
+++ b/test/cider-xref-tree-tests.el
@@ -88,7 +88,7 @@
 
 (describe "cider-who-implements (eval fallback)"
   (before-each
-    (spy-on 'cider-ensure-connected)
+    (spy-on 'cider-ensure-session)
     (spy-on 'cider-nrepl-op-supported-p :and-return-value nil)
     (spy-on 'cider-current-ns :and-return-value "my.ns")
     (spy-on 'cider-var-info :and-return-value
@@ -194,7 +194,7 @@
 
 (describe "cider-type-protocols"
   (before-each
-    (spy-on 'cider-ensure-connected)
+    (spy-on 'cider-ensure-session)
     (spy-on 'cider-nrepl-op-supported-p :and-return-value nil)
     (spy-on 'cider-current-ns :and-return-value "user"))
 
@@ -212,7 +212,7 @@
 
 (describe "cider-protocols-with-method"
   (before-each
-    (spy-on 'cider-ensure-connected)
+    (spy-on 'cider-ensure-session)
     (spy-on 'cider-nrepl-op-supported-p :and-return-value nil)
     (spy-on 'cider-current-ns :and-return-value "user"))
 

--- a/test/clojure-ts-mode/cider-find-ts-tests.el
+++ b/test/clojure-ts-mode/cider-find-ts-tests.el
@@ -40,7 +40,7 @@
 more
 stuff"
       (let* ((sample-buffer (current-buffer)))
-        (spy-on 'cider-ensure-connected :and-return-value t)
+        (spy-on 'cider-ensure-session :and-return-value t)
         (spy-on 'cider-sync-request:ns-path :and-call-fake (lambda (kw-ns _)
                                                              kw-ns))
         (spy-on 'cider-resolve-alias :and-call-fake (lambda (_ns ns-qualifier)


### PR DESCRIPTION
From the terminology audit: `cider-ensure-connected` is a thin wrapper over `sesman-ensure-session` that signals when there's no linked CIDER session - so its name was describing the wrong concept. `cider-ensure-session` names what it actually does, and it stops conflating with `cider-connected-p` (which genuinely checks process liveness).

- `cider-ensure-connected` -> `cider-ensure-session`; old name kept as an obsolete alias (`define-obsolete-function-alias`).
- All 22 internal callers and the test spies move to the new name (spies had to be repointed or they'd silently stop intercepting).

Clean `--warnings-as-errors` compile and full suite green.