### PR TITLE
Point the ClojureScript debugger message at the alternatives

### DIFF
--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -996,8 +996,8 @@ command `cider-debug-defun-at-point'."
   (let ((inline-debug (eq 16 (car-safe debug-it))))
     (when debug-it
       (when (cider-clojurescript-major-mode-p)
-        (when (y-or-n-p "The debugger doesn't support ClojureScript yet, and we need help with that.  \nWould you like to read the Feature Request?")
-          (browse-url "https://github.com/clojure-emacs/cider/issues/1416"))
+        (when (y-or-n-p "The debugger isn't available for ClojureScript.  Read about the alternatives (Cider Storm, browser DevTools)? ")
+          (browse-url "https://docs.cider.mx/cider/cljs/overview.html"))
         (user-error "The debugger does not support ClojureScript"))
       (when inline-debug
         (cider--prompt-and-insert-inline-dbg)))


### PR DESCRIPTION
Step 2 of the ClojureScript support plan (promote-in-their-place). The debugger guard told cljs users it isn't supported "yet, and we need help with that," and offered to open the feature request (#1416).

A native cljs step debugger can't work over nREPL - it instruments forms and pauses a JVM thread, and there's no hook into the JS runtime (this is why the ecosystem uses Cider Storm / browser DevTools instead). So this stops implying it's coming and points users at the real alternatives via the cljs overview docs (which #4041 just gave a Feature support section).