### PR TITLE
Add cider-tap for viewing values sent to tap>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- [#4044](https://github.com/clojure-emacs/cider/pull/4044): Add `cider-tap`, a buffer that streams the values sent to `tap>` and lets you inspect any of them with `RET` (reusing the inspector). Requires a recent enough `cider-nrepl` (with the `tap` middleware); Clojure-only for now.
 - [#4026](https://github.com/clojure-emacs/cider/pull/4026): Run ClojureScript tests with the regular test commands (e.g. `cider-test-run-ns-tests`) when a ClojureScript REPL is active, instead of refusing them; requires a recent enough `cider-nrepl` (asynchronous `cljs.test/async` tests included).
 - [#4023](https://github.com/clojure-emacs/cider/pull/4023): `cider-auto-inspect-after-eval` now accepts `interactive`, `repl` or `all` (in addition to `t`/`nil`), so a visible inspector can also be refreshed after REPL evaluations ([#3636](https://github.com/clojure-emacs/cider/issues/3636)).
 - [#4025](https://github.com/clojure-emacs/cider/pull/4025): Mark each `deftest` with a green (passed) or red (failed) left-fringe indicator after a test run. `cider-use-fringe-indicators` now accepts a list of kinds (`eval`, `test`) for finer control, in addition to `t`/`nil` ([#3721](https://github.com/clojure-emacs/cider/issues/3721)).

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -451,6 +451,7 @@ If invoked with a prefix ARG eval the expression after inserting it."
     ,cider-test-menu
     ("Debug"
      ["Inspect" cider-inspect]
+     ["Tap values buffer" cider-tap]
      ["Toggle var tracing" cider-toggle-trace-var]
      ["Toggle ns tracing" cider-toggle-trace-ns]
      ["List traced" cider-list-traced]

--- a/lisp/cider-tap.el
+++ b/lisp/cider-tap.el
@@ -1,0 +1,179 @@
+;;; cider-tap.el --- Viewing values sent to tap> -*- lexical-binding: t -*-
+
+;; Copyright © 2013-2026 Bozhidar Batsov and CIDER contributors
+;;
+;; Author: Bozhidar Batsov <bozhidar@batsov.dev>
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+
+;; A buffer that streams the values sent to `tap>' and lets you inspect them,
+;; so you don't have to leave Emacs for an external tap viewer.
+
+;;; Code:
+
+(require 'cider-client)
+(require 'cider-session) ; for `cider-current-repl' and `cider--ancillary-buffer-repl'
+(require 'cider-inspector) ; for rendering an inspected tap value
+(require 'cider-util) ; for `cider-font-lock-as-clojure'
+(require 'nrepl-dict)
+(require 'text-property-search) ; for navigating the tap buffer
+
+(defconst cider-tap-buffer "*cider-tap*"
+  "The name of the buffer streaming tapped values.")
+
+(defvar-local cider-tap--subscription nil
+  "Id of this buffer's active tap subscription, or nil.")
+
+(defvar-local cider-tap--repl nil
+  "The REPL buffer this tap buffer is subscribed through.")
+
+(defun cider-tap--render-value (event)
+  "Append the tapped value EVENT to the current buffer, following the tail.
+Each entry is tagged with its `idx' so `cider-tap-inspect-at-point' can
+inspect the retained value behind it."
+  (nrepl-dbind-response event (idx summary type count)
+    (let ((inhibit-read-only t)
+          (at-end (= (point) (point-max))))
+      (save-excursion
+        (goto-char (point-max))
+        (let ((start (point)))
+          (insert (propertize (format-time-string "%H:%M:%S  ") 'face 'shadow))
+          (insert (cider-font-lock-as-clojure (or summary "")))
+          (insert (propertize (format "   (%s%s)"
+                                      type
+                                      (if count (format ", %s" count) ""))
+                              'face 'shadow))
+          (insert "\n")
+          ;; `idx' can be 0, which is a valid (non-nil) property value.
+          (when idx
+            (put-text-property start (point) 'cider-tap-idx idx))))
+      (when at-end (goto-char (point-max))))))
+
+(defun cider-tap-inspect-at-point ()
+  "Open the tapped value on the current line in the inspector."
+  (interactive)
+  (let ((idx (get-text-property (point) 'cider-tap-idx)))
+    (unless idx
+      (user-error "No tapped value on this line"))
+    (let ((result (cider-nrepl-sync-request
+                   (list "op" "cider/tap-inspect" "idx" (number-to-string idx))
+                   :connection cider-tap--repl)))
+      (if (nrepl-dict-get result "value")
+          (progn
+            (setq cider-inspector-location-stack nil)
+            (cider-inspector--render-value result :next-inspectable))
+        (user-error "That tapped value is no longer retained")))))
+
+(defun cider-tap-next ()
+  "Move point to the next tapped value."
+  (interactive)
+  (if-let* ((match (text-property-search-forward 'cider-tap-idx nil nil t)))
+      (goto-char (prop-match-beginning match))
+    (user-error "No next tapped value")))
+
+(defun cider-tap-previous ()
+  "Move point to the previous tapped value."
+  (interactive)
+  (if-let* ((match (text-property-search-backward 'cider-tap-idx nil nil t)))
+      (goto-char (prop-match-beginning match))
+    (user-error "No previous tapped value")))
+
+(defun cider-tap-clear ()
+  "Clear the tap buffer."
+  (interactive)
+  (let ((inhibit-read-only t))
+    (erase-buffer)))
+
+(defun cider-tap--handle (buffer msg)
+  "Handle a tap subscription response MSG, rendering into BUFFER."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (nrepl-dbind-response msg (cider/tap-subscribe cider/tap-value)
+        (cond (cider/tap-value
+               (cider-tap--render-value cider/tap-value))
+              (cider/tap-subscribe
+               (setq cider-tap--subscription cider/tap-subscribe)))))))
+
+(defun cider-tap--unsubscribe ()
+  "Tear down this buffer's tap subscription, if any.
+Fires a best-effort async request, since this runs from `kill-buffer-hook'."
+  (when (and cider-tap--subscription
+             (buffer-live-p cider-tap--repl))
+    (ignore-errors
+      (cider-nrepl-send-request
+       (list "op" "cider/tap-unsubscribe"
+             "subscription" cider-tap--subscription)
+       #'ignore
+       cider-tap--repl))
+    (setq cider-tap--subscription nil)))
+
+(defvar cider-tap-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "RET") #'cider-tap-inspect-at-point)
+    (define-key map (kbd "n") #'cider-tap-next)
+    (define-key map (kbd "p") #'cider-tap-previous)
+    (define-key map (kbd "c") #'cider-tap-clear)
+    (define-key map (kbd "q") #'quit-window)
+    (easy-menu-define cider-tap-mode-menu map
+      "Menu for CIDER's tap buffer."
+      '("CIDER Tap"
+        ["Inspect value" cider-tap-inspect-at-point]
+        ["Next value" cider-tap-next]
+        ["Previous value" cider-tap-previous]
+        "--"
+        ["Clear" cider-tap-clear]
+        ["Quit" quit-window]))
+    map)
+  "Keymap for `cider-tap-mode'.")
+
+(define-derived-mode cider-tap-mode special-mode "cider-tap"
+  "Major mode for viewing values sent to `tap>'.
+
+\\{cider-tap-mode-map}"
+  (setq-local truncate-lines nil)
+  (setq-local header-line-format
+              (propertize
+               " RET: inspect   n/p: move   c: clear   q: quit"
+               'face 'shadow))
+  (add-hook 'kill-buffer-hook #'cider-tap--unsubscribe nil 'local))
+
+;;;###autoload
+(defun cider-tap ()
+  "Open a buffer that streams values sent to `tap>'.
+Any `(tap> value)' in your code - or the inspector's tap commands - shows up
+here; press \\<cider-tap-mode-map>\\[cider-tap-inspect-at-point] on an entry to
+inspect it.  Killing the buffer stops the streaming."
+  (interactive)
+  (let ((connection (cider-current-repl nil 'ensure))
+        (buffer (get-buffer-create cider-tap-buffer)))
+    (with-current-buffer buffer
+      (unless (eq major-mode 'cider-tap-mode)
+        (cider-tap-mode))
+      (setq cider-tap--repl connection)
+      ;; Pin the buffer to its REPL so the inspector opened from here resolves
+      ;; to the same connection.
+      (setq-local cider--ancillary-buffer-repl connection)
+      (unless cider-tap--subscription
+        (cider-nrepl-send-request
+         '("op" "cider/tap-subscribe")
+         (lambda (msg) (cider-tap--handle buffer msg))
+         connection)))
+    (pop-to-buffer buffer)))
+
+(provide 'cider-tap)
+;;; cider-tap.el ends here


### PR DESCRIPTION
Client half of a native `tap>` viewer (server side: clojure-emacs/cider-nrepl#1006). `tap>` is the de-facto Clojure inspection workflow (Portal, REBL, shadow Inspect), and CIDER could already *send* to taps but had nowhere to *receive* them.

`M-x cider-tap` opens a `*cider-tap*` buffer that streams every value sent to `tap>` - each as a timestamped one-line summary with a type/size hint - and `RET` on an entry opens it in the regular inspector (so all the inspector navigation works for free).

Implementation mirrors the trace streaming buffer almost exactly: a `cider/tap-subscribe` request stays open and each tapped value arrives as a streamed message; killing the buffer unsubscribes. `RET` sends `cider/tap-inspect` with the entry's index, and the response is rendered with the existing `cider-inspector--render-value`.

Keys: `RET` inspect, `n`/`p` move, `c` clear, `q` quit.

This is a **prototype / first cut** - first-cut decisions (per discussion, to revisit): retention cap 100, on-demand open (no auto-popup), one buffer per connection, complement (not replace) Portal. Needs the cider-nrepl `tap` middleware; until then the op check reports it's unavailable. Clojure-only for now; a cljs path can follow. No keybinding/menu entry yet (kept the prototype focused).

Compiles clean under `--warnings-as-errors`.