### PR TITLE
Handle non-inspectable ClojureScript taps in cider-tap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New features
 
-- [#4044](https://github.com/clojure-emacs/cider/pull/4044): Add `cider-tap`, a buffer that streams the values sent to `tap>` and lets you inspect any of them with `RET` (reusing the inspector). Requires a recent enough `cider-nrepl` (with the `tap` middleware); Clojure-only for now.
+- [#4044](https://github.com/clojure-emacs/cider/pull/4044): Add `cider-tap`, a buffer that streams the values sent to `tap>` and lets you inspect Clojure values with `RET` (reusing the inspector). ClojureScript taps stream too ([#4045](https://github.com/clojure-emacs/cider/pull/4045)) but aren't inspectable (their value lives in the JS runtime). Requires a recent enough `cider-nrepl` (with the `tap` middleware).
 - [#4026](https://github.com/clojure-emacs/cider/pull/4026): Run ClojureScript tests with the regular test commands (e.g. `cider-test-run-ns-tests`) when a ClojureScript REPL is active, instead of refusing them; requires a recent enough `cider-nrepl` (asynchronous `cljs.test/async` tests included).
 - [#4023](https://github.com/clojure-emacs/cider/pull/4023): `cider-auto-inspect-after-eval` now accepts `interactive`, `repl` or `all` (in addition to `t`/`nil`), so a visible inspector can also be refreshed after REPL evaluations ([#3636](https://github.com/clojure-emacs/cider/issues/3636)).
 - [#4025](https://github.com/clojure-emacs/cider/pull/4025): Mark each `deftest` with a green (passed) or red (failed) left-fringe indicator after a test run. `cider-use-fringe-indicators` now accepts a list of kinds (`eval`, `test`) for finer control, in addition to `t`/`nil` ([#3721](https://github.com/clojure-emacs/cider/issues/3721)).

--- a/lisp/cider-tap.el
+++ b/lisp/cider-tap.el
@@ -44,8 +44,10 @@
 
 (defun cider-tap--render-value (event)
   "Append the tapped value EVENT to the current buffer, following the tail.
-Each entry is tagged with its `idx' so `cider-tap-inspect-at-point' can
-inspect the retained value behind it."
+Each entry is tagged so navigation finds it.  Clojure entries also carry an
+`idx' so `cider-tap-inspect-at-point' can inspect the retained value behind
+them; ClojureScript entries have none, since their value lives in the JS
+runtime."
   (nrepl-dbind-response event (idx summary type count)
     (let ((inhibit-read-only t)
           (at-end (= (point) (point-max))))
@@ -59,6 +61,7 @@ inspect the retained value behind it."
                                       (if count (format ", %s" count) ""))
                               'face 'shadow))
           (insert "\n")
+          (put-text-property start (point) 'cider-tap-entry t)
           ;; `idx' can be 0, which is a valid (non-nil) property value.
           (when idx
             (put-text-property start (point) 'cider-tap-idx idx))))
@@ -68,28 +71,32 @@ inspect the retained value behind it."
   "Open the tapped value on the current line in the inspector."
   (interactive)
   (let ((idx (get-text-property (point) 'cider-tap-idx)))
-    (unless idx
-      (user-error "No tapped value on this line"))
-    (let ((result (cider-nrepl-sync-request
-                   (list "op" "cider/tap-inspect" "idx" (number-to-string idx))
-                   :connection cider-tap--repl)))
-      (if (nrepl-dict-get result "value")
-          (progn
-            (setq cider-inspector-location-stack nil)
-            (cider-inspector--render-value result :next-inspectable))
-        (user-error "That tapped value is no longer retained")))))
+    (cond
+     (idx
+      (let ((result (cider-nrepl-sync-request
+                     (list "op" "cider/tap-inspect" "idx" (number-to-string idx))
+                     :connection cider-tap--repl)))
+        (if (nrepl-dict-get result "value")
+            (progn
+              (setq cider-inspector-location-stack nil)
+              (cider-inspector--render-value result :next-inspectable))
+          (user-error "That tapped value is no longer retained"))))
+     ((get-text-property (point) 'cider-tap-entry)
+      (user-error "ClojureScript tapped values can't be inspected yet"))
+     (t
+      (user-error "No tapped value on this line")))))
 
 (defun cider-tap-next ()
   "Move point to the next tapped value."
   (interactive)
-  (if-let* ((match (text-property-search-forward 'cider-tap-idx nil nil t)))
+  (if-let* ((match (text-property-search-forward 'cider-tap-entry nil nil t)))
       (goto-char (prop-match-beginning match))
     (user-error "No next tapped value")))
 
 (defun cider-tap-previous ()
   "Move point to the previous tapped value."
   (interactive)
-  (if-let* ((match (text-property-search-backward 'cider-tap-idx nil nil t)))
+  (if-let* ((match (text-property-search-backward 'cider-tap-entry nil nil t)))
       (goto-char (prop-match-beginning match))
     (user-error "No previous tapped value")))
 


### PR DESCRIPTION
Client side of tap Phase 2 (server: clojure-emacs/cider-nrepl#1010). With the cljs tap middleware, ClojureScript `tap>` values now stream into the `*cider-tap*` buffer - but they carry no `idx` (the value lives in the JS runtime and can't be handed to the JVM inspector).

So this tags every entry for navigation, and `RET` on a ClojureScript entry now says "ClojureScript tapped values can't be inspected yet" instead of the misleading "No tapped value on this line." Clojure entries still inspect as before. `n`/`p` navigate all entries.

Needs the cider-nrepl cljs tap support (#1010) to actually receive cljs taps; harmless without it.