### PR TITLE
Make eldoc asynchronous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 
 ### Changes
 
+- [#4046](https://github.com/clojure-emacs/cider/pull/4046): Make eldoc asynchronous - the arglist/var lookup no longer blocks Emacs on an nREPL round-trip as you move the cursor (it uses eldoc's callback protocol and delivers the result when it arrives). Declines the eldoc slot when CIDER has nothing, so other sources (e.g. clojure-lsp) compose cleanly.
 - [#4035](https://github.com/clojure-emacs/cider/pull/4035): Rename `cider-ensure-connected` to `cider-ensure-session` (it ensures a linked CIDER session); the old name remains as an obsolete alias.
 - [#4033](https://github.com/clojure-emacs/cider/pull/4033): Deprecate the legacy connection-named aliases `cider-current-connection`, `cider-connections`, `cider-map-connections` and `cider-connection-type-for-buffer` in favor of their `cider-repl` counterparts.
 - [#4029](https://github.com/clojure-emacs/cider/pull/4029): Finish migrating to the keyword-argument request APIs and deprecate the positional shims: `cider-nrepl-send-sync-request` -> `cider-nrepl-sync-request`, `cider-nrepl-request:eval` -> `cider-nrepl-send-eval-request`, `nrepl-send-sync-request` -> `nrepl-sync-request`, `nrepl-request:eval` -> `nrepl-send-eval-request`.

--- a/lisp/cider-eldoc.el
+++ b/lisp/cider-eldoc.el
@@ -340,46 +340,59 @@ It can be `fn', `special-form', `macro', `method' or `var'."
         ("variable" 'var))
       'fn))
 
-(defun cider-eldoc-info-at-point ()
-  "Return eldoc info at point.
+(defun cider-eldoc-info-at-point (k)
+  "Compute eldoc info at point and call K with the sexp-eldoc plist (or nil).
 First go to the beginning of the sexp and check if the eldoc is to be
 considered (i.e sexp is a method call) and not a map or vector literal.
-Then go back to the point and return its eldoc."
+Then go back to the point and look up its eldoc."
   (save-excursion
-    (unless (cider-in-comment-p)
-      (let* ((current-point (point)))
+    (if (cider-in-comment-p)
+        (funcall k nil)
+      (let ((current-point (point)))
         (cider-eldoc-beginning-of-sexp)
-        (unless (member (or (char-before (point)) 0) '(?\" ?\{ ?\[))
+        (if (member (or (char-before (point)) 0) '(?\" ?\{ ?\[))
+            (funcall k nil)
           (goto-char current-point)
-          (when-let* ((eldoc-info (cider-eldoc-info
-                                   (cider--eldoc-remove-dot (cider-symbol-at-point)))))
-            `("eldoc-info" ,eldoc-info
-              "thing" ,(cider-symbol-at-point)
-              "pos" 0)))))))
+          (let ((thing (cider-symbol-at-point)))
+            (cider-eldoc-info-async
+             (cider--eldoc-remove-dot thing)
+             (lambda (eldoc-info)
+               (funcall k (when eldoc-info
+                            `("eldoc-info" ,eldoc-info
+                              "thing" ,thing
+                              "pos" 0)))))))))))
 
-(defun cider-eldoc-info-at-sexp-beginning ()
-  "Return eldoc info for first symbol in the sexp."
+(defun cider-eldoc-info-at-sexp-beginning (k)
+  "Compute eldoc info for the first symbol in the sexp; call K with it (or nil)."
   (save-excursion
-    (when-let* ((beginning-of-sexp (cider-eldoc-beginning-of-sexp))
-                ;; If we are at the beginning of function name, this will be -1
-                (argument-index (max 0 (1- beginning-of-sexp))))
-      (unless (or (memq (or (char-before (point)) 0)
-                        '(?\" ?\{ ?\[))
+    (let ((beginning-of-sexp (cider-eldoc-beginning-of-sexp)))
+      (if (not beginning-of-sexp)
+          (funcall k nil)
+        ;; If we are at the beginning of function name, this will be -1
+        (let ((argument-index (max 0 (1- beginning-of-sexp))))
+          (if (or (memq (or (char-before (point)) 0) '(?\" ?\{ ?\[))
                   (cider-in-comment-p))
-        (when-let* ((eldoc-info (cider-eldoc-info
-                                 (cider--eldoc-remove-dot (cider-symbol-at-point)))))
-          `("eldoc-info" ,eldoc-info
-            "thing" ,(cider-symbol-at-point)
-            "pos" ,argument-index))))))
+              (funcall k nil)
+            (let ((thing (cider-symbol-at-point)))
+              (cider-eldoc-info-async
+               (cider--eldoc-remove-dot thing)
+               (lambda (eldoc-info)
+                 (funcall k (when eldoc-info
+                              `("eldoc-info" ,eldoc-info
+                                "thing" ,thing
+                                "pos" ,argument-index))))))))))))
 
-(defun cider-eldoc-info-in-current-sexp ()
-  "Return eldoc information from the sexp.
-If `cider-eldoc-display-for-symbol-at-point' is non-nil and
-the symbol at point has a valid eldoc available, return that.
-Otherwise return the eldoc of the first symbol of the sexp."
-  (or (when cider-eldoc-display-for-symbol-at-point
-        (cider-eldoc-info-at-point))
-      (cider-eldoc-info-at-sexp-beginning)))
+(defun cider-eldoc-info-in-current-sexp (k)
+  "Compute eldoc information from the sexp and call K with the plist (or nil).
+If `cider-eldoc-display-for-symbol-at-point' is non-nil and the symbol at
+point has a valid eldoc, use that; otherwise use the first symbol of the sexp."
+  (if cider-eldoc-display-for-symbol-at-point
+      (cider-eldoc-info-at-point
+       (lambda (info)
+         (if info
+             (funcall k info)
+           (cider-eldoc-info-at-sexp-beginning k))))
+    (cider-eldoc-info-at-sexp-beginning k)))
 
 (defun cider-eldoc--convert-ns-keywords (thing)
   "Convert THING values that match ns macro keywords to function names."
@@ -390,78 +403,131 @@ Otherwise return the eldoc of the first symbol of the sexp."
     (":refer" "clojure.core/refer")
     (_ thing)))
 
+(defun cider-eldoc--lookup-applicable-p (thing)
+  "Return non-nil when an eldoc lookup makes sense for THING."
+  (and (cider-nrepl-op-supported-p "cider/eldoc")
+       thing
+       ;; ignore blank things
+       (not (string-blank-p thing))
+       ;; ignore string literals
+       (not (string-prefix-p "\"" thing))
+       ;; ignore regular expressions
+       (not (string-prefix-p "#" thing))
+       ;; ignore chars
+       (not (string-prefix-p "\\" thing))
+       ;; ignore numbers
+       (not (string-match-p "^[0-9]" thing))))
+
+(defun cider-eldoc--local-info (thing)
+  "Return a locally-computed eldoc plist for THING, without an nREPL round-trip.
+Handles map-access keywords, `Classname.' constructors, and the cached last
+symbol.  Returns nil when a server lookup is needed."
+  (cond
+   ;; handle keywords for map access
+   ((string-prefix-p ":" thing)
+    (list "symbol" thing "type" "function"
+          "arglists" '(("map") ("map" "not-found"))))
+   ;; handle Classname. by displaying the eldoc for new
+   ((string-match-p "^[A-Z].+\\.$" thing)
+    (list "symbol" thing "type" "function"
+          "arglists" '(("args*"))))
+   ;; reuse the cached lookup (see `cider-eldoc--build-info')
+   ((equal thing (car cider-eldoc-last-symbol))
+    (cadr cider-eldoc-last-symbol))))
+
+(defun cider-eldoc--build-info (thing eldoc-info)
+  "Build (and cache) the eldoc plist for THING from the ELDOC-INFO response dict."
+  (let* ((arglists (nrepl-dict-get eldoc-info "eldoc"))
+         (docstring (nrepl-dict-get eldoc-info "docstring"))
+         (type (nrepl-dict-get eldoc-info "type"))
+         (ns (nrepl-dict-get eldoc-info "ns"))
+         (class (nrepl-dict-get eldoc-info "class"))
+         (name (nrepl-dict-get eldoc-info "name"))
+         (member (nrepl-dict-get eldoc-info "member"))
+         (ns-or-class (if (and ns (not (string= ns "")))
+                          ns
+                        class))
+         (name-or-member (if (and name (not (string= name "")))
+                             name
+                           (format ".%s" member)))
+         (eldoc-plist (list "ns" ns-or-class
+                            "class" class
+                            "symbol" name-or-member
+                            "arglists" arglists
+                            "docstring" docstring
+                            "doc-fragments" (nrepl-dict-get eldoc-info "doc-fragments")
+                            "doc-first-sentence-fragments" (nrepl-dict-get eldoc-info
+                                                                           "doc-first-sentence-fragments")
+                            "doc-block-tags-fragments" (nrepl-dict-get eldoc-info
+                                                                       "doc-block-tags-fragments")
+                            "type" type)))
+    ;; add context dependent args if requested by defcustom
+    ;; do not cache this eldoc info to avoid showing info
+    ;; of the previous context
+    (if cider-eldoc-display-context-dependent-info
+        (cond
+         ;; add inputs of datomic query
+         ((and (equal ns-or-class "datomic.api")
+               (equal name-or-member "q"))
+          (cider-plist-put eldoc-plist "arglists"
+                           (cider--eldoc-add-datomic-query-inputs-to-arglists
+                            (cider-plist-get eldoc-plist "arglists"))))
+         ;; if none of the clauses is successful, do cache the eldoc
+         (t (setq cider-eldoc-last-symbol (list thing eldoc-plist))))
+      ;; middleware eldoc lookups are expensive, so we cache the last lookup.
+      ;; This eliminates the need for extra middleware requests within the same sexp.
+      (setq cider-eldoc-last-symbol (list thing eldoc-plist)))
+    eldoc-plist))
+
 (defun cider-eldoc-info (thing)
-  "Return the info for THING (as string).
-This includes the arglist and ns and symbol name (if available)."
+  "Return the eldoc info plist for THING, synchronously.
+This includes the arglist and ns and symbol name (if available).  On the
+eldoc hot path prefer `cider-eldoc-info-async', which doesn't block; this
+synchronous variant is kept for callers like company's docsig that need an
+immediate result."
   (let ((thing (cider-eldoc--convert-ns-keywords thing)))
-    (when (and (cider-nrepl-op-supported-p "cider/eldoc")
-               thing
-               ;; ignore blank things
-               (not (string-blank-p thing))
-               ;; ignore string literals
-               (not (string-prefix-p "\"" thing))
-               ;; ignore regular expressions
-               (not (string-prefix-p "#" thing))
-               ;; ignore chars
-               (not (string-prefix-p "\\" thing))
-               ;; ignore numbers
-               (not (string-match-p "^[0-9]" thing)))
-      ;; check if we can used the cached eldoc info
-      (cond
-       ;; handle keywords for map access
-       ((string-prefix-p ":" thing) (list "symbol" thing
-                                          "type" "function"
-                                          "arglists" '(("map") ("map" "not-found"))))
-       ;; handle Classname. by displaying the eldoc for new
-       ((string-match-p "^[A-Z].+\\.$" thing) (list "symbol" thing
-                                                    "type" "function"
-                                                    "arglists" '(("args*"))))
-       ;; generic case
-       (t (if (equal thing (car cider-eldoc-last-symbol))
-              (cadr cider-eldoc-last-symbol)
-            (when-let* ((eldoc-info (cider-eldoc-request :sym thing :context (cider-completion-get-context t))))
-              (let* ((arglists (nrepl-dict-get eldoc-info "eldoc"))
-                     (docstring (nrepl-dict-get eldoc-info "docstring"))
-                     (type (nrepl-dict-get eldoc-info "type"))
-                     (ns (nrepl-dict-get eldoc-info "ns"))
-                     (class (nrepl-dict-get eldoc-info "class"))
-                     (name (nrepl-dict-get eldoc-info "name"))
-                     (member (nrepl-dict-get eldoc-info "member"))
-                     (ns-or-class (if (and ns (not (string= ns "")))
-                                      ns
-                                    class))
-                     (name-or-member (if (and name (not (string= name "")))
-                                         name
-                                       (format ".%s" member)))
-                     (eldoc-plist (list "ns" ns-or-class
-                                        "class" class
-                                        "symbol" name-or-member
-                                        "arglists" arglists
-                                        "docstring" docstring
-                                        "doc-fragments" (nrepl-dict-get eldoc-info "doc-fragments")
-                                        "doc-first-sentence-fragments" (nrepl-dict-get eldoc-info
-                                                                                       "doc-first-sentence-fragments")
-                                        "doc-block-tags-fragments" (nrepl-dict-get eldoc-info
-                                                                                   "doc-block-tags-fragments")
-                                        "type" type)))
-                ;; add context dependent args if requested by defcustom
-                ;; do not cache this eldoc info to avoid showing info
-                ;; of the previous context
-                (if cider-eldoc-display-context-dependent-info
-                    (cond
-                     ;; add inputs of datomic query
-                     ((and (equal ns-or-class "datomic.api")
-                           (equal name-or-member "q"))
-                      (let ((arglists (cider-plist-get eldoc-plist "arglists")))
-                        (cider-plist-put eldoc-plist "arglists"
-                                         (cider--eldoc-add-datomic-query-inputs-to-arglists arglists))))
-                     ;; if none of the clauses is successful, do cache the eldoc
-                     (t (setq cider-eldoc-last-symbol (list thing eldoc-plist))))
-                  ;; middleware eldoc lookups are expensive, so we
-                  ;; cache the last lookup.  This eliminates the need
-                  ;; for extra middleware requests within the same sexp.
-                  (setq cider-eldoc-last-symbol (list thing eldoc-plist)))
-                eldoc-plist))))))))
+    (when (cider-eldoc--lookup-applicable-p thing)
+      (or (cider-eldoc--local-info thing)
+          (when-let* ((eldoc-info (cider-eldoc-request
+                                   :sym thing
+                                   :context (cider-completion-get-context t))))
+            (cider-eldoc--build-info thing eldoc-info))))))
+
+(defun cider-eldoc--request-async (thing k)
+  "Request `cider/eldoc' for THING asynchronously and call K with the dict or nil.
+Unlike the synchronous path this never blocks Emacs, so it needs no
+`abort-on-input'."
+  (if-let* ((connection (cider-current-repl)))
+      (let ((accumulated nil))
+        (cider-nrepl-send-request
+         `("op" "cider/eldoc"
+           "ns" ,(cider-current-ns)
+           "sym" ,thing
+           "context" ,(cider-completion-get-context t))
+         (lambda (response)
+           (setq accumulated (if accumulated
+                                 (nrepl-dict-merge accumulated response)
+                               response))
+           (when (member "done" (nrepl-dict-get response "status"))
+             (funcall k accumulated)))
+         connection))
+    (funcall k nil)))
+
+(defun cider-eldoc-info-async (thing k)
+  "Asynchronously compute the eldoc info plist for THING and call K with it.
+K receives the plist, or nil when there's nothing to show.  It may be called
+synchronously (for local/cached cases) or later, once the nREPL response
+arrives, so this never blocks the eldoc hot path."
+  (let ((thing (cider-eldoc--convert-ns-keywords thing)))
+    (if (not (cider-eldoc--lookup-applicable-p thing))
+        (funcall k nil)
+      (if-let* ((local (cider-eldoc--local-info thing)))
+          (funcall k local)
+        (cider-eldoc--request-async
+         thing
+         (lambda (eldoc-info)
+           (funcall k (when eldoc-info
+                        (cider-eldoc--build-info thing eldoc-info)))))))))
 
 (defun cider--eldoc-remove-dot (sym)
   "Remove the preceding \".\" from a namespace qualified SYM and return sym.
@@ -490,17 +556,12 @@ Only useful for interop forms.  Clojure forms would be returned unchanged."
           arglists))
     arglists))
 
-(defun cider-eldoc (&rest _ignored)
-  "Backend function for eldoc to show argument list in the echo area."
-  (when (and (cider-connected-p)
-             ;; don't clobber an error message in the minibuffer
-             (not (member last-command '(next-error previous-error)))
-             ;; don't try to provide eldoc in EDN buffers
-             (not (cider--eldoc-edn-file-p buffer-file-name)))
-    (let* ((sexp-eldoc-info (cider-eldoc-info-in-current-sexp))
-           (eldoc-info (cider-plist-get sexp-eldoc-info "eldoc-info"))
-           (pos (cider-plist-get sexp-eldoc-info "pos"))
-           (thing (cider-plist-get sexp-eldoc-info "thing")))
+(defun cider-eldoc--render (sexp-eldoc-info)
+  "Render SEXP-ELDOC-INFO into an eldoc string, or nil when there's nothing."
+  (when sexp-eldoc-info
+    (let ((eldoc-info (cider-plist-get sexp-eldoc-info "eldoc-info"))
+          (pos (cider-plist-get sexp-eldoc-info "pos"))
+          (thing (cider-plist-get sexp-eldoc-info "thing")))
       (when eldoc-info
         (cond
          ((eq (cider-eldoc-thing-type eldoc-info) 'var)
@@ -509,14 +570,26 @@ Only useful for interop forms.  Clojure forms would be returned unchanged."
           (cider-eldoc-format-special-form thing pos eldoc-info))
          (t (cider-eldoc-format-function thing pos eldoc-info)))))))
 
+(defun cider-eldoc (callback &rest _ignored)
+  "Backend for `eldoc-documentation-functions' showing the arglist in the echo area.
+The doc is fetched asynchronously and handed to CALLBACK, so moving the cursor
+never blocks on an nREPL round-trip.  Returns nil (declining the slot) when
+CIDER can't help, so other eldoc sources still get a turn."
+  (when (and (cider-connected-p)
+             ;; don't clobber an error message in the minibuffer
+             (not (member last-command '(next-error previous-error)))
+             ;; don't try to provide eldoc in EDN buffers
+             (not (cider--eldoc-edn-file-p buffer-file-name)))
+    (cider-eldoc-info-in-current-sexp
+     (lambda (sexp-eldoc-info)
+       (funcall callback (cider-eldoc--render sexp-eldoc-info))))
+    ;; tell eldoc the result will arrive (possibly nil) via the callback
+    t))
+
 (defun cider-eldoc-setup ()
   "Setup eldoc in the current buffer.
 eldoc mode has to be enabled for this to have any effect."
-  ;; Emacs 28.1 changes the way eldoc is setup.
-  ;; There you can have multiple eldoc functions.
-  (if (boundp 'eldoc-documentation-functions)
-      (add-hook 'eldoc-documentation-functions #'cider-eldoc nil t)
-    (setq-local eldoc-documentation-function #'cider-eldoc))
+  (add-hook 'eldoc-documentation-functions #'cider-eldoc nil t)
   (apply #'eldoc-add-command cider-extra-eldoc-commands))
 
 (provide 'cider-eldoc)

--- a/test/cider-eldoc-tests.el
+++ b/test/cider-eldoc-tests.el
@@ -195,14 +195,21 @@
     (expect (cider--eldoc-remove-dot "map")
             :to-equal "map")))
 
+(defun cider-eldoc-tests--current-sexp ()
+  "Synchronously resolve `cider-eldoc-info-in-current-sexp' for tests.
+Relies on the spied `cider-eldoc-info-async' invoking its callback synchronously."
+  (let (captured)
+    (cider-eldoc-info-in-current-sexp (lambda (result) (setq captured result)))
+    captured))
+
 (describe "cider-eldoc-info-in-current-sexp"
   (before-each
     (spy-on 'cider-connected-p :and-return-value t)
-    (spy-on 'cider-eldoc-info :and-call-fake
-            (lambda (thing)
-              (pcase thing
-                ("map" '("clojure.core" "map" (("f") ("f" "coll"))))
-                ("inc" '("clojure.core" "inc" (("x"))))))))
+    (spy-on 'cider-eldoc-info-async :and-call-fake
+            (lambda (thing k)
+              (funcall k (pcase thing
+                           ("map" '("clojure.core" "map" (("f") ("f" "coll"))))
+                           ("inc" '("clojure.core" "inc" (("x")))))))))
 
   (it "considers sym-at-point before the sym-at-sexp-beginning"
     (with-temp-buffer
@@ -210,18 +217,18 @@
       (save-excursion (insert "(map inc [1 2 3])"))
       ;; when cursor is on map, display its eldoc
       (search-forward "map")
-      (expect (cider-eldoc-info-in-current-sexp) :to-equal
+      (expect (cider-eldoc-tests--current-sexp) :to-equal
               '("eldoc-info" ("clojure.core" "map" (("f") ("f" "coll"))) "thing" "map" "pos" 0))
       ;; when cursor is on inc, display its eldoc
       (search-forward "inc")
-      (expect (cider-eldoc-info-in-current-sexp) :to-equal
+      (expect (cider-eldoc-tests--current-sexp) :to-equal
               '("eldoc-info" ("clojure.core" "inc" (("x"))) "thing" "inc" "pos" 0))
       ;; eldoc can be nil
       (search-forward "1")
-      (expect (cider-eldoc-info-in-current-sexp) :to-be nil)
+      (expect (cider-eldoc-tests--current-sexp) :to-be nil)
       ;; when cursor is at the end of sexp, display eldoc of first symbol
       (search-forward "]")
-      (expect (cider-eldoc-info-in-current-sexp) :to-equal
+      (expect (cider-eldoc-tests--current-sexp) :to-equal
               '("eldoc-info" ("clojure.core" "map" (("f") ("f" "coll"))) "thing" "map" "pos" 2))))
 
   (it "respects the value of `cider-eldoc-display-for-symbol-at-point'"
@@ -231,28 +238,28 @@
         (save-excursion (insert "(map inc [1 2 3])"))
         ;; when cursor is on map, display its eldoc
         (search-forward "map")
-        (expect (cider-eldoc-info-in-current-sexp) :to-equal
+        (expect (cider-eldoc-tests--current-sexp) :to-equal
                 '("eldoc-info" ("clojure.core" "map" (("f") ("f" "coll"))) "thing" "map" "pos" 0))
         ;; when cursor is on inc, still display eldoc of map
         (search-forward "inc")
-        (expect (cider-eldoc-info-in-current-sexp) :to-equal
+        (expect (cider-eldoc-tests--current-sexp) :to-equal
                 '("eldoc-info" ("clojure.core" "map" (("f") ("f" "coll"))) "thing" "map" "pos" 1))
         ;; eldoc can be nil
         (search-forward "1")
-        (expect (cider-eldoc-info-in-current-sexp) :to-be nil)
+        (expect (cider-eldoc-tests--current-sexp) :to-be nil)
         ;; when cursor is at the end of sexp, display eldoc of first symbol
         (search-forward "]")
-        (expect (cider-eldoc-info-in-current-sexp) :to-equal
+        (expect (cider-eldoc-tests--current-sexp) :to-equal
                 '("eldoc-info" ("clojure.core" "map" (("f") ("f" "coll"))) "thing" "map" "pos" 2)))))
 
   (describe "interop forms"
     (before-each
       (spy-on 'cider-connected-p :and-return-value t)
-      (spy-on 'cider-eldoc-info :and-call-fake
-              (lambda (thing)
-                (pcase thing
-                  (".length" '(("java.lang.String" "java.lang.StringBuffer" "java.lang.CharSequence" "java.lang.StringBuilder") ".length" (("this"))))
-                  ("java.lang.String/length" '(("java.lang.String") ".length" (("this"))))))))
+      (spy-on 'cider-eldoc-info-async :and-call-fake
+              (lambda (thing k)
+                (funcall k (pcase thing
+                             (".length" '(("java.lang.String" "java.lang.StringBuffer" "java.lang.CharSequence" "java.lang.StringBuilder") ".length" (("this"))))
+                             ("java.lang.String/length" '(("java.lang.String") ".length" (("this")))))))))
 
     (describe "when class name is not given before interop forms"
       (it "includes all possible class names in eldoc"
@@ -260,7 +267,7 @@
           (clojure-mode)
           (save-excursion (insert "(.length \"abc\")"))
           (search-forward ".length")
-          (expect (cider-eldoc-info-in-current-sexp) :to-equal
+          (expect (cider-eldoc-tests--current-sexp) :to-equal
                   '("eldoc-info" (("java.lang.String" "java.lang.StringBuffer" "java.lang.CharSequence" "java.lang.StringBuilder") ".length" (("this"))) "thing" ".length" "pos" 0)))))
 
     (describe "when class name is given before interop forms"
@@ -269,39 +276,43 @@
           (clojure-mode)
           (save-excursion (insert "(java.lang.String/.length \"abc\")"))
           (search-forward ".length")
-          (expect (cider-eldoc-info-in-current-sexp) :to-equal
+          (expect (cider-eldoc-tests--current-sexp) :to-equal
                   '("eldoc-info" (("java.lang.String") ".length" (("this"))) "thing" "java.lang.String/.length" "pos" 0)))))))
 
 (describe "cider-eldoc"
   (before-each
     (spy-on 'cider-connected-p :and-return-value t)
-    (spy-on 'cider-eldoc--edn-file-p :and-return-value nil))
+    (spy-on 'cider--eldoc-edn-file-p :and-return-value nil))
   (it "Should call cider-eldoc-format-variable for vars"
     (let* ((info '("ns" "clojure.core" "symbol" "foo" "type" "variable" "docstring" "test docstring")))
-      (spy-on 'cider-eldoc-info-in-current-sexp :and-return-value `("thing" "foo" "pos" 0 "eldoc-info" ,info))
+      (spy-on 'cider-eldoc-info-in-current-sexp :and-call-fake
+              (lambda (k) (funcall k `("thing" "foo" "pos" 0 "eldoc-info" ,info))))
       (spy-on 'cider-eldoc-format-variable)
-      (cider-eldoc)
+      (cider-eldoc #'ignore)
       (expect 'cider-eldoc-format-variable :to-have-been-called-with "foo" info)))
 
   (it "Should call cider-eldoc-format-special-form for special forms"
     (let* ((info '("ns" "clojure.core" "symbol" "if" "type" "special-form" "arglists" ("special form arglist"))))
-      (spy-on 'cider-eldoc-info-in-current-sexp :and-return-value `("thing" "if" "pos" 0 "eldoc-info" ,info))
+      (spy-on 'cider-eldoc-info-in-current-sexp :and-call-fake
+              (lambda (k) (funcall k `("thing" "if" "pos" 0 "eldoc-info" ,info))))
       (spy-on 'cider-eldoc-format-special-form)
-      (cider-eldoc)
+      (cider-eldoc #'ignore)
       (expect 'cider-eldoc-format-special-form :to-have-been-called-with "if" 0 info)))
 
   (it "Should call cider-eldoc-format-function for functions"
     (let* ((info '("ns" "foo.bar" "symbol" "a-fn" "type" "function" "arglists" ("function arglist"))))
-      (spy-on 'cider-eldoc-info-in-current-sexp :and-return-value `("thing" "a-fn" "pos" 0 "eldoc-info" ,info))
+      (spy-on 'cider-eldoc-info-in-current-sexp :and-call-fake
+              (lambda (k) (funcall k `("thing" "a-fn" "pos" 0 "eldoc-info" ,info))))
       (spy-on 'cider-eldoc-format-function)
-      (cider-eldoc)
+      (cider-eldoc #'ignore)
       (expect 'cider-eldoc-format-function :to-have-been-called-with "a-fn" 0 info)))
 
   (it "Should call cider-eldoc-format-function for macros"
     (let* ((info '("ns" "clojure.core" "symbol" "a-macro" "type" "macro" "arglists" ("macro arglist"))))
-      (spy-on 'cider-eldoc-info-in-current-sexp :and-return-value `("thing" "a-macro" "pos" 0 "eldoc-info" ,info))
+      (spy-on 'cider-eldoc-info-in-current-sexp :and-call-fake
+              (lambda (k) (funcall k `("thing" "a-macro" "pos" 0 "eldoc-info" ,info))))
       (spy-on 'cider-eldoc-format-function)
-      (cider-eldoc)
+      (cider-eldoc #'ignore)
       (expect 'cider-eldoc-format-function :to-have-been-called-with "a-macro" 0 info))))
 
 (describe "cider-eldoc-format-sym-doc"


### PR DESCRIPTION
First piece of the eldoc/docview improvement plan. CIDER's eldoc fired a **synchronous** nREPL round-trip on every cursor move (softened only by `abort-on-input`), so on a slow or busy REPL, moving the cursor could stutter.

This adopts eldoc's async **callback protocol**: `cider-eldoc` kicks off the lookup, returns immediately, and delivers the result via the callback when the response arrives - no blocking.

- The thing/position detection and the formatting are unchanged; only the request becomes non-blocking (the detection functions are threaded with a continuation).
- `cider-eldoc-info` stays **synchronous** (company's docsig needs an immediate result) and now shares its plist-building, cache and guards with the new `cider-eldoc-info-async` via small helpers (`cider-eldoc--lookup-applicable-p`, `--local-info`, `--build-info`).
- Since the minimum is Emacs 28, the dead pre-28.1 `eldoc-documentation-function` branch and the now-unnecessary `abort-on-input` are dropped.
- When CIDER has no doc, it **declines the eldoc slot** (returns nil / calls back with nil), so other sources like clojure-lsp compose cleanly.

Tests updated to the async/CPS shape (the sexp-resolution describe drives a synchronous spy of `cider-eldoc-info-async`; the dispatch describe spies the now-CPS `cider-eldoc-info-in-current-sexp`). Clean `--warnings-as-errors` compile, full suite green.

Next up in the plan: the docview polish (Clojure-docstring markdown, see-also consistency).