### PR TITLE
Render the doc buffer's See also as a bulleted list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 
 ### Changes
 
+- [#4047](https://github.com/clojure-emacs/cider/pull/4047): Render the doc buffer's "See also" section as a bulleted list (one entry per line) instead of an inline space-separated run, matching the ClojureDocs buffer.
 - [#4046](https://github.com/clojure-emacs/cider/pull/4046): Make eldoc asynchronous - the arglist/var lookup no longer blocks Emacs on an nREPL round-trip as you move the cursor (it uses eldoc's callback protocol and delivers the result when it arrives). Declines the eldoc slot when CIDER has nothing, so other sources (e.g. clojure-lsp) compose cleanly.
 - [#4035](https://github.com/clojure-emacs/cider/pull/4035): Rename `cider-ensure-connected` to `cider-ensure-session` (it ensures a linked CIDER session); the old name remains as an obsolete alias.
 - [#4033](https://github.com/clojure-emacs/cider/pull/4033): Deprecate the legacy connection-named aliases `cider-current-connection`, `cider-connections`, `cider-map-connections` and `cider-connection-type-for-buffer` in favor of their `cider-repl` counterparts.

--- a/lisp/cider-doc.el
+++ b/lisp/cider-doc.el
@@ -673,19 +673,19 @@ Use a COMPACT format if specified, and FOR-TOOLTIP if specified."
             (insert "Definition location unavailable.")))
         (when (and (not compact)
                    see-also)
-          (insert "\n\n Also see: ")
-          (mapc (lambda (ns-sym)
-                  (let* ((ns-sym-split (split-string ns-sym "/"))
-                         (see-also-ns (car ns-sym-split))
-                         (see-also-sym (cadr ns-sym-split))
-                         ;; if the var belongs to the same namespace,
-                         ;; we omit the namespace to save some screen space
-                         (symbol (if (equal ns see-also-ns) see-also-sym ns-sym)))
-                    (insert-text-button symbol
-                                        'type 'help-xref
-                                        'help-function (apply-partially #'cider-doc-lookup symbol)))
-                  (insert " "))
-                see-also))
+          (insert "\n\nSee also:\n")
+          (dolist (ns-sym see-also)
+            (let* ((ns-sym-split (split-string ns-sym "/"))
+                   (see-also-ns (car ns-sym-split))
+                   (see-also-sym (cadr ns-sym-split))
+                   ;; if the var belongs to the same namespace,
+                   ;; we omit the namespace to save some screen space
+                   (symbol (if (equal ns see-also-ns) see-also-sym ns-sym)))
+              (insert "  * ")
+              (insert-text-button symbol
+                                  'type 'help-xref
+                                  'help-function (apply-partially #'cider-doc-lookup symbol))
+              (insert "\n"))))
         (unless compact
           (cider--doc-make-xrefs))
         (let ((beg (point-min))


### PR DESCRIPTION
Docview polish from the eldoc/docview review. The `*cider-doc*` See also entries were rendered as one inline, space-separated run (` Also see: a b c `); this renders them as a "See also:" header with one bulleted, clickable entry per line - matching the ClojureDocs buffer and making them easier to scan and click.

Small, contained UX consistency fix. Clean compile, doc tests pass.