### PR TITLE
Bump injected cider-nrepl to 0.61.0 and piggieback to 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 ### Changes
 
+- [#4050](https://github.com/clojure-emacs/cider/pull/4050): Bump the injected `cider-nrepl` to 0.61.0 (and `piggieback` to 0.6.2). Code formatting now honors the project's cljfmt configuration, and the default `pprint` printer is backed by `orchard.pp`.
 - [#4047](https://github.com/clojure-emacs/cider/pull/4047): Render the doc buffer's "See also" section as a bulleted list (one entry per line) instead of an inline space-separated run, matching the ClojureDocs buffer.
 - [#4046](https://github.com/clojure-emacs/cider/pull/4046): Make eldoc asynchronous - the arglist/var lookup no longer blocks Emacs on an nREPL round-trip as you move the cursor (it uses eldoc's callback protocol and delivers the result when it arrives). Declines the eldoc slot when CIDER has nothing, so other sources (e.g. clojure-lsp) compose cleanly.
 - [#4035](https://github.com/clojure-emacs/cider/pull/4035): Rename `cider-ensure-connected` to `cider-ensure-session` (it ensures a linked CIDER session); the old name remains as an obsolete alias.

--- a/lisp/cider-client.el
+++ b/lisp/cider-client.el
@@ -435,7 +435,9 @@ defaults to the equivalent of \\=`clojure.core/pr\\=`.
 
 `pr' – to use the equivalent of \\=`clojure.core/pr\\=`.
 
-`pprint' – to use \\=`clojure.pprint/pprint\\=` (this is the default).
+`pprint' – to use cider-nrepl's bundled pretty-printer, which is backed by
+\\=`orchard.pp\\=` (as of cider-nrepl 0.61.0; it used \\=`clojure.pprint/pprint\\=`
+before).  This is the default.
 
 `fipp' – to use the Fast Idiomatic Pretty Printer, approximately 5-10x
 faster than \\=`clojure.core/pprint\\=`.

--- a/lisp/cider-jack-in.el
+++ b/lisp/cider-jack-in.el
@@ -303,7 +303,7 @@ your version of Leiningen is bundling an older one."
   "List of dependencies where elements are lists of artifact name and version.
 Added to `cider-jack-in-dependencies' when doing `cider-jack-in-cljs'.")
 (put 'cider-jack-in-cljs-dependencies 'risky-local-variable t)
-(cider-add-to-alist 'cider-jack-in-cljs-dependencies "cider/piggieback" "0.6.1")
+(cider-add-to-alist 'cider-jack-in-cljs-dependencies "cider/piggieback" "0.6.2")
 
 (defvar cider-jack-in-dependencies-exclusions nil
   "List of exclusions for jack in dependencies.
@@ -322,7 +322,7 @@ the artifact.")
 
 Used when `cider-jack-in-auto-inject-clojure' is set to `latest'.")
 
-(defconst cider-required-middleware-version "0.61.0-alpha1"
+(defconst cider-required-middleware-version "0.61.0"
   "The CIDER nREPL version that's known to work properly with CIDER.")
 
 (defcustom cider-injected-middleware-version cider-required-middleware-version


### PR DESCRIPTION
cider-nrepl 0.61.0 shipped, so require it instead of the 0.61.0-alpha1 pre-release we were injecting, and bump the injected piggieback to 0.6.2 to match.

Also refreshes the `cider-print-fn` docstring: the default `pprint` printer is now backed by `orchard.pp` (cider-nrepl 0.61.0), not `clojure.pprint/pprint`. As a side effect of the bump, code formatting now honors the project's cljfmt configuration.