### PR TITLE
Restructure the ClojureScript and alternative-platform docs

### DIFF
--- a/doc/modules/ROOT/nav.adoc
+++ b/doc/modules/ROOT/nav.adoc
@@ -9,12 +9,14 @@
 ** xref:cljs/configuration.adoc[Configuration]
 ** xref:cljs/figwheel.adoc[Using Figwheel]
 ** xref:cljs/shadow-cljs.adoc[Using shadow-cljs]
+** xref:cljs/krell.adoc[Using Krell]
 ** xref:cljs/other_repls.adoc[Using Other REPLs]
 * Alternative Platforms
 ** xref:platforms/overview.adoc[Overview]
 ** xref:platforms/babashka.adoc[Babashka]
 ** xref:platforms/nbb.adoc[Nbb]
 ** xref:platforms/basilisp.adoc[Basilisp]
+** xref:platforms/clojureclr.adoc[ClojureCLR]
 ** xref:platforms/other_platforms.adoc[Other Platforms]
 * Using CIDER
 ** xref:usage/interactive_programming.adoc[Interactive Programming]

--- a/doc/modules/ROOT/pages/cljs/other_repls.adoc
+++ b/doc/modules/ROOT/pages/cljs/other_repls.adoc
@@ -48,22 +48,14 @@ documentation lookup, the namespace browser, and macroexpansion).
 
 TIP: For more information on Weasel you should consult its https://github.com/nrepl/weasel/blob/master/README.md[documentation].
 
-== nbb (node.js babashka)
+== Node-based ClojureScript runtimes
 
-CIDER has built-in support for `nbb`. You can either jack in to an nbb project with `M-x clojure-jack-in-cljs`.
+Some ClojureScript runtimes - such as xref:platforms/nbb.adoc[nbb] - run on
+Node and bring their own nREPL server, so they don't go through Piggieback.
+They're still reached through the ClojureScript commands: jack in with
+kbd:[M-x] `cider-jack-in-cljs`, or connect to an already-running server with
+kbd:[M-x] `cider-connect-cljs`.
 
-or start its bundled nREPL server:
-
-  $ nbb nrepl-server
-
-and connect to it afterwards using `M-x cider-connect-cljs`.
-
-See the xref:platforms/nbb.adoc[dedicated page] for more details.
-
-== Other Self-hosted REPLs
-
-For all other self-hosted REPLs you can follow the instructions xref:platforms/other_platforms.adoc[here]. This will work fine with any well-behaved nREPL implementation, like those of:
-
-* https://github.com/babashka/nbb[nbb]
-* https://github.com/babashka/scittle[scittle]
-* https://github.com/BetterThanTomorrow/joyride[joyride]
+These runtimes live in the xref:platforms/overview.adoc[Alternative Platforms]
+section of this manual, since they're full Clojure-like runtimes rather than
+just another ClojureScript REPL flavor.

--- a/doc/modules/ROOT/pages/cljs/overview.adoc
+++ b/doc/modules/ROOT/pages/cljs/overview.adoc
@@ -6,14 +6,11 @@ compile-on-the-JVM, run-in-a-JavaScript-runtime model means a few Clojure
 features can't apply to it. See <<Feature support>> below for what works,
 what doesn't, and what to reach for instead.
 
-Unlike the Clojure ecosystem that is dominated by a single REPL, the
-ClojureScript ecosystem has a number of different choices for REPLs
-(e.g. `browser`, `node`, `weasel`, `figwheel` and `shadow-cljs`). You'll have to
-decide which one you want to run and how you want CIDER to interact with it.
-
-In this section we'll take a look at how ClojureScript support is implemented in CIDER,
-and in the subsequent sections we'll discuss how to launch a ClojureScript REPL
-and how to setup the most popular ClojureScript REPLs.
+Unlike the Clojure ecosystem, which is dominated by a single REPL, the
+ClojureScript ecosystem offers several different REPLs (e.g. `browser`, `node`,
+`weasel`, `figwheel` and `shadow-cljs`). This section explains how ClojureScript
+support is implemented in CIDER and helps you pick one; the subsequent sections
+cover launching and configuring the most popular ones.
 
 == nREPL and ClojureScript
 
@@ -29,11 +26,49 @@ Piggieback works in the following manner:
 This means that jacking-in is a two-fold process for ClojureScript, compared to Clojure,
 as now we have the extra REPL "upgrade" step.
 
-On the bright side - this also means that you can host side by side Clojure and ClojureScript
-REPLs in a single nREPL connection! This opens up all sorts of interesting possibilities
-that we'll discuss later on.
+On the bright side - this also means that a single CIDER session can hold both a
+Clojure and a ClojureScript REPL at once, sharing one nREPL connection. That's
+the reason commands like `cider-jack-in-clj&cljs` and the "sibling" connection
+commands exist: they set up both REPLs together, and CIDER routes each
+evaluation to the right one. See xref:usage/managing_connections.adoc[Managing
+Connections] for how sessions group these REPLs and how to control where code
+gets evaluated.
 
 NOTE: `shadow-cljs`'s REPL is implemented in a very similar fashion, but its mechanism is provided by its own nREPL middleware - not Piggieback.
+
+== Choosing a ClojureScript REPL
+
+You'll have to decide which ClojureScript REPL to run and how you want CIDER to
+interact with it. Here's a quick map of the most common choices:
+
+[cols="1,2,1"]
+|===
+| REPL | How CIDER drives it | Setup
+
+| `browser` / `node`
+| Vanilla ClojureScript REPLs upgraded in place via Piggieback. `node` evaluates
+  in a Node.js process; `browser` waits for a browser tab to connect.
+| xref:cljs/other_repls.adoc[Other REPLs]
+
+| https://figwheel.org[Figwheel Main]
+| A Piggieback-style upgrade, with Figwheel's hot-reloading and build tooling on
+  top. CIDER checks that Figwheel is on the classpath before upgrading.
+| xref:cljs/figwheel.adoc[Using Figwheel]
+
+| https://github.com/thheller/shadow-cljs[shadow-cljs]
+| Uses shadow-cljs's own nREPL middleware rather than Piggieback; CIDER prompts
+  for the build to connect to.
+| xref:cljs/shadow-cljs.adoc[Using shadow-cljs]
+
+| https://github.com/nrepl/weasel[Weasel]
+| A browser-connected REPL over a WebSocket, upgraded via Piggieback. Maintained
+  under the nREPL org, alongside CIDER.
+| xref:cljs/other_repls.adoc[Other REPLs]
+|===
+
+TIP: Node-based ClojureScript runtimes such as xref:platforms/nbb.adoc[nbb] are
+reached through the same ClojureScript commands, even though they aren't
+Piggieback-based.
 
 == Feature support
 

--- a/doc/modules/ROOT/pages/index.adoc
+++ b/doc/modules/ROOT/pages/index.adoc
@@ -9,6 +9,14 @@ https://github.com/clojure-emacs/clojure-mode[clojure-mode] and https://github.c
 While `clojure-mode` supports editing Clojure source files, `cider-mode` adds support for interacting with a running Clojure process for
 compilation, debugging, definition and documentation lookup, running tests and so on.
 
+CIDER is a *Clojure* programming environment first and foremost, but because all
+of its runtime interaction goes through nREPL it also works well with
+*ClojureScript* and reasonably well with other *Clojure-like* languages that
+provide nREPL support. It's deliberately not a universal nREPL client, though -
+see xref:platforms/overview.adoc[Alternative Platforms] for what that means in
+practice (and https://github.com/nrepl/neat[Neat] if you're after a
+language-agnostic nREPL client).
+
 *Please consider
 xref:contributing/funding.adoc[supporting financially CIDER's ongoing development].*
 
@@ -77,7 +85,7 @@ CIDER packs plenty of features. Here are some of them (in no particular order):
 * Integration with Java logging frameworks
 * Profiling & tracing
 * ClojureScript support
-* Support for xref:platforms/overview.adoc[alternative Clojure platforms] (e.g. ClojureCLR, babashka and nbb)
+* Support for xref:platforms/overview.adoc[Clojure-like languages] (e.g. babashka, nbb, Basilisp and ClojureCLR)
 
 And many many more... The rest of this manual will be exploring CIDER's features in great detail.
 

--- a/doc/modules/ROOT/pages/platforms/other_platforms.adoc
+++ b/doc/modules/ROOT/pages/platforms/other_platforms.adoc
@@ -2,29 +2,27 @@
 
 == Overview
 
-Here "other platforms" essentially means any (Clojure) platforms that haven't
-been mentioned specifically earlier in a dedicated section of the documentation.
-
-As noted earlier in the documentation, down the road CIDER might support non-Clojure
-platforms as well. As things stand today, however, that's not particularly high on our
-list of priorities.
+Here "other platforms" means any Clojure-like runtime that ships an nREPL
+server but doesn't have a dedicated section of its own earlier in this
+documentation. These runtimes typically implement only the core nREPL protocol,
+without the `cider-nrepl` middleware, so you get evaluation, loading and the
+other core-nREPL basics, but not CIDER's `cider-nrepl`-powered features. See the
+xref:platforms/overview.adoc[overview] for the bigger picture.
 
 == Usage
 
-As of CIDER 1.6, the default CIDER connection command `cider-connect-clj` is
-capable of connecting to any nREPL server that implements the core nREPL
-protocol interface. So, all you need to do is the following:
+The default connection command `cider-connect-clj` can connect to any nREPL
+server that implements the core nREPL protocol, so all you need to do is:
 
-* Start an nREPL server (the project's README  usually has a section
-on starting a nREPL server).
+* Start the runtime's nREPL server (its README usually explains how).
 * kbd:[M-x `cider-connect-clj` <RET>]
 
-And that's it! You'll get every feature that's implemented by the nREPL server
-you're using.
+That's it. You'll get every feature the nREPL server you're connecting to
+implements.
 
-== Supported Platform
+== Supported platforms
 
-Here's an incomplete list of Clojure platforms that you can use as described above.
+Here's an incomplete list of Clojure-like runtimes you can use as described above:
 
 * https://github.com/babashka/nbb[nbb]
 * https://github.com/babashka/scittle[scittle]
@@ -33,8 +31,9 @@ Here's an incomplete list of Clojure platforms that you can use as described abo
 
 NOTE: For `nbb` you can alternatively connect via `cider-connect-cljs`, see xref:platforms/nbb.adoc[nbb].
 
-== Limitations & Caveats
+== Limitations & caveats
 
-* Everything will be treated as a Clojure connection, regardless of the underlying platform.
-* Errors will be displayed only as overlays. (The default CIDER error buffer is not implemented currently).
-* The amount of functionality you'll get will be dependent on how well the nREPL server you're using implements the core nREPL protocol.
+* Everything is treated as a Clojure connection, regardless of the underlying runtime.
+* Errors are displayed only as overlays (the dedicated CIDER error buffer isn't wired up for these connections).
+* How much functionality you get depends on how completely the runtime implements the core nREPL protocol.
+* Advanced, `cider-nrepl`-powered features (debugger, inspector, test runner, tracing, profiling, and so on) are unavailable unless the runtime bundles a compatible middleware.

--- a/doc/modules/ROOT/pages/platforms/overview.adoc
+++ b/doc/modules/ROOT/pages/platforms/overview.adoc
@@ -1,42 +1,64 @@
 = Overview
 
-NOTE: This section is work in progress.
+CIDER is first and foremost a *Clojure* programming environment. Because all of
+its interaction with a running program goes through https://nrepl.org[nREPL],
+it also works well with *ClojureScript* (see the xref:cljs/overview.adoc[ClojureScript]
+section) and reasonably well with other *Clojure-like* languages that ship an
+nREPL server - babashka, nbb, Basilisp, ClojureCLR, scittle, joyride and so on.
 
-While CIDER was created to serve as a Clojure(Script) programming environment, due to the flexibility of the nREPL
-protocol it can actually be used with other programming languages/platforms as well.
+This section covers those other Clojure-like runtimes. ClojureScript, being a
+much bigger and more deeply integrated story, has a xref:cljs/overview.adoc[section of its own].
 
-== Challenges
+== Scope
 
-The biggest problem with supporting multiple programming languages are the assumptions that CIDER has that it's being
-used together with Clojure. In practice this translates to CIDER evaluating Clojure code in some cases to power its
-functionality. One simple example here would be switching the REPL's namespace - CIDER simply evals `in-ns` behind the curtains to achieve this.
+CIDER is *not* a universal nREPL client. Its focus is Clojure and Clojure-like
+languages; supporting arbitrary nREPL runtimes (or other REPL protocols such as
+the Clojure socket REPL and prepl) is an explicit non-goal.
 
-You also have to keep in mind that much of the advanced functionality (e.g. everything related to debugging) is not part
-of the core nREPL protocol and is provided by the `cider-nrepl` middleware. Other platforms will need to provide
-compatible implementation of that functionality, so that CIDER would work with.
+If you're after a language-agnostic nREPL client, reach for
+https://github.com/nrepl/neat[Neat], a sibling project that came out of exactly
+this line of exploration. (For prepl there's also
+https://github.com/clojure-emacs/port[Port], a minimalist prepl client.)
 
-Another problem is that some of the functionality is specific to Clojure and doesn't make much sense in other languages, but that's
-something that functionality can be simply ignored when non-applicable. There's also some coupling with `clojure-mode`, but that's
-not that hard to overcome. Some examples here would be the REPL (which uses `clojure-mode` syntax table and indentation rules),
-the logic for finding the current namespace (which uses `clojure-find-ns`), and so on. All such instances will need to be replaced
-eventually with more generic versions that dispatch on the type of the nREPL connection (e.g. Clojure, Racket, Fennel, etc).
+NOTE: This wasn't always the case. Older versions of CIDER's roadmap had a
+prominent "make CIDER somewhat Clojure-agnostic" goal, but that itch was
+ultimately scratched by Neat and Port. That left CIDER free to focus on what
+it's always been best at: a deep, opinionated nREPL-based IDE for Clojure and
+Clojure-like languages.
 
-== Current Status
+== How much works
 
-Right now CIDER supports to some extent the following:
+How much of CIDER lights up depends on what the runtime implements:
+
+* *Clojure* runs the full `cider-nrepl` middleware, so you get every advanced,
+  tooling-heavy feature - the debugger, the inspector, the test runner,
+  tracing, profiling, and so on.
+* *ClojureScript* also runs `cider-nrepl`, so it gets the editor-facing features
+  (completion, documentation lookup, navigation, the test runner,
+  macroexpansion), but the features that instrument or introspect a JVM at
+  runtime have nothing to attach to in a JavaScript runtime. See the
+  xref:cljs/overview.adoc[ClojureScript feature-support matrix] for the specifics.
+* *Most other runtimes* expose only *core nREPL* operations (evaluation, loading
+  code, and sometimes completion). You get a solid interactive-programming
+  experience, but the `cider-nrepl`-powered features are unavailable - unless
+  the runtime bundles a compatible middleware. Babashka, for instance, ships a
+  curated subset of `cider-nrepl`, so it lights up more of CIDER than a bare
+  core-nREPL server would.
+
+In short: the closer a runtime is to Clojure - and the more of `cider-nrepl` it
+can run - the more of CIDER you get. When you invoke a command a runtime can't
+support, CIDER aims to tell you so rather than fail obscurely.
+
+== Supported runtimes
+
+CIDER has dedicated support and documentation for the following Clojure-like runtimes:
 
 * xref:platforms/babashka.adoc[Babashka]
 * xref:platforms/nbb.adoc[nbb]
-* xref:platforms/clojureclr.adoc[ClojureCLR]
-* xref:platforms/other_platforms.adoc[scittle, joyride & friends]
 * xref:platforms/basilisp.adoc[Basilisp]
+* xref:platforms/clojureclr.adoc[ClojureCLR]
+* xref:platforms/other_platforms.adoc[scittle, joyride and other core-nREPL runtimes]
 
-All of them are derived from Clojure, so supporting them didn't really require much work.
-
-== Future Plans
-
-While not a very high priority, making CIDER usable with any nREPL server is certainly on the project's roadmap.
-https://github.com/clojure-emacs/cider/issues/2848[Here] you can find a discussion about the changes needed to
-get CIDER to work with Fennel, plus a couple of commits that illustrate them.
-
-Any help on that front would be greatly appreciated!
+NOTE: ClojureScript runtimes that happen to run on Node (like nbb) are reachable
+through the ClojureScript jack-in/connect commands as well; see the
+xref:cljs/overview.adoc[ClojureScript] section.


### PR DESCRIPTION
The ClojureScript and alternative-platform docs had drifted into a bit of a mess, and the platforms overview in particular still said things the roadmap and FAQ had walked back (like "making CIDER usable with any nREPL server is on the roadmap"). This realigns them and makes CIDER's positioning explicit.

- **Positioning** (index + platforms overview): CIDER is a Clojure environment first, works well with ClojureScript and reasonably with other Clojure-like languages that speak nREPL, and is deliberately *not* a universal nREPL client. For that there's [Neat](https://github.com/nrepl/neat).
- **Platforms overview rewrite**: dropped the stale "work in progress / support any nREPL server / Fennel" framing and explained the core-nREPL vs `cider-nrepl` reality that decides how much of CIDER a given runtime lights up (e.g. babashka ships a curated subset of `cider-nrepl`).
- **ClojureScript**: added a "Choosing a ClojureScript REPL" table (browser, node, Figwheel, shadow-cljs, Weasel) describing how CIDER drives each, and linked the clj+cljs single-session story to the Sessions docs - the *why* behind `cider-jack-in-clj&cljs` and sibling connections.
- **De-duplication**: nbb/scittle/joyride were documented in both the cljs "Other REPLs" page and the platforms section; the cljs page now cross-references platforms instead.
- **Nav**: surfaced the previously orphaned Krell and ClojureCLR pages.

Docs-only; all internal xrefs verified to resolve.