### PR TITLE
Rename the inline-eval result options into a consistent family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 ### Changes
 
+- [#4052](https://github.com/clojure-emacs/cider/pull/4052): Rename the inline evaluation-result options into a consistent `cider-eval-result-*` family: `cider-use-overlays` -> `cider-eval-result-display`, `cider-result-overlay-position` -> `cider-eval-result-position`, `cider-result-use-clojure-font-lock` and `cider-overlays-use-font-lock` -> `cider-eval-result-font-lock`, `cider-interactive-eval-output-destination` -> `cider-eval-output-destination`, and `cider-use-fringe-indicators` -> `cider-fringe-indicators`. The old names remain as obsolete aliases.
 - [#4050](https://github.com/clojure-emacs/cider/pull/4050): Bump the injected `cider-nrepl` to 0.61.0 (and `piggieback` to 0.6.2). Code formatting now honors the project's cljfmt configuration, and the default `pprint` printer is backed by `orchard.pp`.
 - [#4047](https://github.com/clojure-emacs/cider/pull/4047): Render the doc buffer's "See also" section as a bulleted list (one entry per line) instead of an inline space-separated run, matching the ClojureDocs buffer.
 - [#4046](https://github.com/clojure-emacs/cider/pull/4046): Make eldoc asynchronous - the arglist/var lookup no longer blocks Emacs on an nREPL round-trip as you move the cursor (it uses eldoc's callback protocol and delivers the result when it arrives). Declines the eldoc slot when CIDER has nothing, so other sources (e.g. clojure-lsp) compose cleanly.

--- a/doc/modules/ROOT/pages/testing/running_tests.adoc
+++ b/doc/modules/ROOT/pages/testing/running_tests.adoc
@@ -161,14 +161,14 @@ in the left fringe: green (`cider-fringe-good-face`) when all of the var's
 assertions passed, red (`cider-fringe-bad-face`) when any failed or errored.
 The markers are cleared when you re-run the tests.
 
-These are governed by `cider-use-fringe-indicators` (the same option used for
+These are governed by `cider-fringe-indicators` (the same option used for
 the xref:usage/code_evaluation.adoc#per-form-fringe-indicators[evaluation
 markers]), which is `t` by default. To keep the evaluation markers but turn the
 test ones off, set it to a list of the kinds you want:
 
 [source,lisp]
 ----
-(setq cider-use-fringe-indicators '(eval))
+(setq cider-fringe-indicators '(eval))
 ----
 
 === Running a callback on errors

--- a/doc/modules/ROOT/pages/usage/cider_mode.adoc
+++ b/doc/modules/ROOT/pages/usage/cider_mode.adoc
@@ -134,7 +134,7 @@ Here's a list of the key bindings of `cider-mode`:
 | `cider-eval-last-sexp`
 | kbd:[C-x C-e] +
 kbd:[C-c C-e]
-| Evaluate the form preceding point and display the result in the echo area and/or in a buffer overlay (according to `cider-use-overlays`).  If invoked with a prefix argument, insert the result into the current buffer.
+| Evaluate the form preceding point and display the result in the echo area and/or in a buffer overlay (according to `cider-eval-result-display`).  If invoked with a prefix argument, insert the result into the current buffer.
 
 | `cider-eval-last-sexp-and-replace`
 | kbd:[C-c C-v w]

--- a/doc/modules/ROOT/pages/usage/code_evaluation.adoc
+++ b/doc/modules/ROOT/pages/usage/code_evaluation.adoc
@@ -185,25 +185,23 @@ NOTE: CIDER uses internally the excellent package https://github.com/Malabarba/s
 
 === Syntax Highlighting of Results
 
-By default the results of interactive evaluation (both those displayed in the minibuffer and in overlays) are font-locked as Clojure code.
-You can disable this by tweaking the configuration option `cider-result-use-clojure-font-lock`:
+By default the results of interactive evaluation (both those shown in the echo
+area and in overlays) are font-locked as Clojure code.  You can turn that off
+with `cider-eval-result-font-lock`, in which case results are shown using the
+plain `cider-result-overlay-face` instead of being syntax-highlighted:
 
 [source,lisp]
 ----
-(setq cider-result-use-clojure-font-lock nil)
+(setq cider-eval-result-font-lock nil)
 ----
+
+NOTE: This option replaces the older `cider-result-use-clojure-font-lock` and
+`cider-overlays-use-font-lock`, which together controlled the same thing.
 
 === Overlays
 
 When you evaluate code in Clojure files, the result is displayed in the buffer
-itself, in an overlay right after the evaluated code.  If you want this overlay
-to be font-locked (syntax-highlighted) like Clojure code, set the following
-variable.
-
-[source,lisp]
-----
-(setq cider-overlays-use-font-lock t)
-----
+itself, in an overlay right after the evaluated code.
 
 Overlays will be shown for errors,
 as long as they are not already displayed by `cider-stacktrace-mode`.
@@ -218,19 +216,19 @@ please customize:
 If you only want to see overlays for errors (and not for successful evaluations),
 you can restrict overlays to only be shown for errors
 (and display non-error results in the echo area at the bottom)
-by customizing the `cider-use-overlays` variable:
+by customizing the `cider-eval-result-display` variable:
 
 [source,lisp]
 ----
-(setq cider-use-overlays 'errors-only)
+(setq cider-eval-result-display 'errors-only)
 ----
 
 You can disable overlays entirely (and display results in the echo area at the
-bottom) with the `cider-use-overlays` variable:
+bottom) with the same variable:
 
 [source,lisp]
 ----
-(setq cider-use-overlays nil)
+(setq cider-eval-result-display 'echo)
 ----
 
 Overlays that indicate errors are by default trimmed of file/line/phase information.
@@ -245,13 +243,13 @@ You can prevent any trimming by customizing instead:
 ----
 
 By default, result overlays are displayed at the end of the line. You can set
-the variable `cider-result-overlay-position` to display results at the end of
+the variable `cider-eval-result-position` to display results at the end of
 their respective forms instead.
 Note that this also affects the position of debugger overlays.
 
 [source,lisp]
 ----
-(setq cider-result-overlay-position 'at-point)
+(setq cider-eval-result-position 'at-point)
 ----
 
 You can also customize how overlays are persisted using the variable
@@ -290,10 +288,10 @@ This is on by default.  To turn the indicators off entirely:
 
 [source,lisp]
 ----
-(setq cider-use-fringe-indicators nil)
+(setq cider-fringe-indicators nil)
 ----
 
-`cider-use-fringe-indicators` also accepts a list of the indicator kinds to
+`cider-fringe-indicators` also accepts a list of the indicator kinds to
 show, so you can enable some but not others.  The recognized kinds are `eval`
 (the per-form evaluation markers described here) and `test` (the
 xref:testing/running_tests.adoc#test-fringe-indicators[test pass/fail markers]).
@@ -301,7 +299,7 @@ For example, to keep only the evaluation markers:
 
 [source,lisp]
 ----
-(setq cider-use-fringe-indicators '(eval))
+(setq cider-fringe-indicators '(eval))
 ----
 
 To keep the indicators but restore the older behavior, where editing an
@@ -397,11 +395,11 @@ options and use their own fixed formatting.
 
 === Change the Output Destination
 
-By default CIDER will display the output produced by some evaluation in the REPL buffer, but you can also funnel the output to a dedicated buffer. You can configure this behavior via `cider-interactive-eval-output-destination`.
+By default CIDER will display the output produced by some evaluation in the REPL buffer, but you can also funnel the output to a dedicated buffer. You can configure this behavior via `cider-eval-output-destination`.
 
 [source,lisp]
 ----
-(setq cider-interactive-eval-output-destination 'output-buffer)
+(setq cider-eval-output-destination 'output-buffer)
 ----
 
 Additionally, there's the variable `cider-redirect-server-output-to-repl` that captures output that would normally end up in the `\*nrepl-server*` buffer (provided it has been started via `cider-jack-in`) and redirects it to the REPL buffer. You can disable this redirection like this:
@@ -553,7 +551,7 @@ Below is a listing of most keybindings for evaluation commands:
 | `cider-eval-last-sexp`
 | kbd:[C-x C-e] +
 kbd:[C-c C-e]
-| Evaluate the form preceding point and display the result in the echo area and/or in a buffer overlay (according to `cider-use-overlays`).  If invoked with a prefix argument, insert the result into the current buffer.
+| Evaluate the form preceding point and display the result in the echo area and/or in a buffer overlay (according to `cider-eval-result-display`).  If invoked with a prefix argument, insert the result into the current buffer.
 
 | `cider-tap-last-sexp`
 | kbd:[C-c C-v q] +

--- a/doc/modules/ROOT/pages/usage/dealing_with_errors.adoc
+++ b/doc/modules/ROOT/pages/usage/dealing_with_errors.adoc
@@ -23,7 +23,7 @@ temporary overlay or in the echo area:
 (setq cider-show-error-buffer nil)
 ----
 
-NOTE: you will only see the overlay if `cider-use-overlays` is non-nil.
+NOTE: you will only see the overlay if `cider-eval-result-display` is set to show overlays (anything other than `echo`).
 
 Starting from CIDER 1.8.0, only runtime exceptions (and not compilation errors)
 will cause a stacktrace buffer to be shown. This better follows Clojure 1.10's

--- a/lisp/cider-compilation.el
+++ b/lisp/cider-compilation.el
@@ -116,7 +116,7 @@ When set to nil, don't jump at all."
 
 (defcustom cider-inline-error-message-function #'cider--shorten-error-message
   "A function that will shorten a given error message,
-as shown in overlays / the minibuffer (per `cider-use-overlays').
+as shown in overlays / the minibuffer (per `cider-eval-result-display').
 
 The function takes a single arg.  You may want to use `identity',
 for leaving the message as-is."
@@ -299,7 +299,7 @@ https://clojure.org/reference/repl_and_main#_at_repl"
 
 (defun cider--display-error-unobtrusively (buffer err)
   "Display ERR as a minibuffer message and/or as a temporary overlay in BUFFER."
-  (let ((cider-result-use-clojure-font-lock nil)
+  (let ((cider-eval-result-font-lock nil)
         (trimmed-err (funcall cider-inline-error-message-function err)))
     (with-current-buffer buffer
       (cider--display-interactive-eval-result trimmed-err

--- a/lisp/cider-debug.el
+++ b/lisp/cider-debug.el
@@ -72,8 +72,8 @@ If nil, don't list available keys at all."
 
 (defcustom cider-debug-use-overlays t
   "Whether to highlight debugging information with overlays.
-Takes the same possible values as `cider-use-overlays', but only applies to
-values displayed during debugging sessions.
+Takes the same possible values as `cider-eval-result-display', but only applies
+to values displayed during debugging sessions.
 To control the overlay that lists possible keys above the current function,
 configure `cider-debug-prompt' instead."
   :type '(choice (const :tag "End of line" t)

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -131,12 +131,16 @@ If t, save the file without confirmation."
 
 (defconst cider-output-buffer "*cider-out*")
 
-(defcustom cider-interactive-eval-output-destination 'repl-buffer
-  "The destination for stdout and stderr produced from interactive evaluation."
-  :type '(choice (const output-buffer)
-                 (const repl-buffer))
+(define-obsolete-variable-alias 'cider-interactive-eval-output-destination 'cider-eval-output-destination "1.23.0")
+
+(defcustom cider-eval-output-destination 'repl-buffer
+  "The destination for stdout and stderr produced from interactive evaluation.
+If `repl-buffer' (the default), the output is sent to the current REPL buffer.
+If `output-buffer', it's sent to a dedicated `*cider-out*' buffer."
+  :type '(choice (const :tag "REPL buffer" repl-buffer)
+                 (const :tag "Dedicated output buffer" output-buffer))
   :group 'cider
-  :package-version '(cider . "0.7.0"))
+  :package-version '(cider . "1.23.0"))
 
 (defcustom cider-comment-prefix ";; => "
   "The prefix to insert before the first line of commented output."
@@ -280,29 +284,29 @@ The handler simply inserts the result value in BUFFER."
 (defun cider--emit-interactive-eval-output (output repl-emit-function)
   "Emit output resulting from interactive code evaluation.
 The OUTPUT can be sent to either a dedicated output buffer or the current
-REPL buffer.  This is controlled by `cider-interactive-eval-output-destination'.
+REPL buffer.  This is controlled by `cider-eval-output-destination'.
 REPL-EMIT-FUNCTION emits the OUTPUT."
-  (pcase cider-interactive-eval-output-destination
+  (pcase cider-eval-output-destination
     (`output-buffer (let ((output-buffer (or (get-buffer cider-output-buffer)
                                              (cider-popup-buffer cider-output-buffer t))))
                       (cider-emit-into-popup-buffer output-buffer output)
                       (pop-to-buffer output-buffer)))
     (`repl-buffer (funcall repl-emit-function output))
-    (_ (error "Unsupported value %s for `cider-interactive-eval-output-destination'"
-              cider-interactive-eval-output-destination))))
+    (_ (error "Unsupported value %s for `cider-eval-output-destination'"
+              cider-eval-output-destination))))
 
 (defun cider-emit-interactive-eval-output (output)
   "Emit OUTPUT resulting from interactive code evaluation.
 The output can be send to either a dedicated output buffer or the current
 REPL buffer.  This is controlled via
-`cider-interactive-eval-output-destination'."
+`cider-eval-output-destination'."
   (cider--emit-interactive-eval-output output 'cider-repl-emit-interactive-stdout))
 
 (defun cider-emit-interactive-eval-err-output (output)
   "Emit err OUTPUT resulting from interactive code evaluation.
 The output can be send to either a dedicated output buffer or the current
 REPL buffer.  This is controlled via
-`cider-interactive-eval-output-destination'."
+`cider-eval-output-destination'."
   (cider--emit-interactive-eval-output output 'cider-repl-emit-interactive-stderr))
 
 (defun cider--make-fringe-overlays-for-region (beg end)

--- a/lisp/cider-ns-state.el
+++ b/lisp/cider-ns-state.el
@@ -52,7 +52,7 @@ A list of presentations to enable (an empty list disables the indicator):
                 namespace isn't loaded.
 
 For per-form staleness, use the evaluation fringe indicators instead (see
-`cider-use-fringe-indicators' and `cider-mark-stale-after-edit')."
+`cider-fringe-indicators' and `cider-mark-stale-after-edit')."
   :type '(set (const :tag "Mode-line marker" mode-line)
               (const :tag "Fringe marker" fringe))
   :group 'cider

--- a/lisp/cider-ns.el
+++ b/lisp/cider-ns.el
@@ -171,7 +171,7 @@ Present the error message as an overlay."
                                     ;; `reverse' the causes as the first one typically is a CompilerException, which the second one is the actual exception:
                                     (reverse error))))
         (with-current-buffer buf
-          (let ((cider-result-use-clojure-font-lock nil)
+          (let ((cider-eval-result-font-lock nil)
                 (trimmed-err (funcall cider-inline-error-message-function message)))
             (cider--display-interactive-eval-result trimmed-err
                                                     'error

--- a/lisp/cider-overlays.el
+++ b/lisp/cider-overlays.el
@@ -37,8 +37,8 @@
     (((class color) (background dark))
      :background "grey10" :box (:line-width -1 :color "black")))
   "Face used to display evaluation results at the end of line.
-If `cider-overlays-use-font-lock' is non-nil, this face is
-applied with lower priority than the syntax highlighting."
+When `cider-eval-result-font-lock' is `clojure', this face is applied with
+lower priority than the syntax highlighting."
   :group 'cider
   :package-version '(cider "0.9.1"))
 
@@ -53,48 +53,59 @@ applied with lower priority than the syntax highlighting."
   :group 'cider
   :package-version '(cider "0.25.0"))
 
-(defcustom cider-result-use-clojure-font-lock t
-  "If non-nil, interactive eval results are font-locked as Clojure code."
-  :group 'cider
-  :type 'boolean
-  :package-version '(cider . "0.10.0"))
+(define-obsolete-variable-alias 'cider-result-use-clojure-font-lock 'cider-eval-result-font-lock "1.23.0")
+(define-obsolete-variable-alias 'cider-overlays-use-font-lock 'cider-eval-result-font-lock "1.23.0")
+(define-obsolete-variable-alias 'cider-use-overlays 'cider-eval-result-display "1.23.0")
+(define-obsolete-variable-alias 'cider-result-overlay-position 'cider-eval-result-position "1.23.0")
 
-(defcustom cider-overlays-use-font-lock t
-  "If non-nil, results overlays are font-locked as Clojure code.
-If nil, apply `cider-result-overlay-face' to the entire overlay instead of
-font-locking it."
-  :group 'cider
-  :type 'boolean
-  :package-version '(cider . "0.10.0"))
+(defcustom cider-eval-result-font-lock 'clojure
+  "How to highlight interactive evaluation results.
+If `clojure' (the default), the result is font-locked as Clojure code, both in
+the echo area and in the result overlay (where the syntax highlighting shows
+beneath `cider-result-overlay-face').
+If nil, the result is not syntax-highlighted: the overlay is shown using
+`cider-result-overlay-face' and the echo-area result is shown as plain text.
 
-(defcustom cider-use-overlays 'both
-  "Whether to display evaluation results with overlays.
-If t, use overlays determined by `cider-result-overlay-position'.
-If `errors-only', use overlays determined by `cider-result-overlay-position',
-but only for error messages - other messages will be displayed on the echo area.
-If nil, display on the echo area.
-If `both', display on both places.
+This replaces the older `cider-result-use-clojure-font-lock' and
+`cider-overlays-use-font-lock' options, which together covered the same ground."
+  :group 'cider
+  :type '(choice (const :tag "Highlight as Clojure" clojure)
+                 (const :tag "Use the result overlay face" nil))
+  :package-version '(cider . "1.23.0"))
+
+(defcustom cider-eval-result-display 'both
+  "Where to display interactive evaluation results.
+If `overlay', show the result in an overlay (positioned per
+`cider-eval-result-position').
+If `echo', show it in the echo area.
+If `both' (the default), show it in both places.
+If `errors-only', use an overlay only for error results and the echo area for
+everything else.
+
+For backward compatibility the legacy values t (overlay) and nil (echo) are
+still accepted.
 
 Only applies to evaluation commands.  To configure the debugger overlays,
 see `cider-debug-use-overlays'."
-  :type '(choice (const :tag "Display using overlays" t)
-                 (const :tag "Display in echo area" nil)
-                 (const :tag "Use overlays only for errors" errors-only)
-                 (const :tag "Both" both))
+  :type '(choice (const :tag "Overlay" overlay)
+                 (const :tag "Echo area" echo)
+                 (const :tag "Both" both)
+                 (const :tag "Overlay for errors only" errors-only))
   :group 'cider
-  :package-version '(cider . "0.10.0"))
+  :package-version '(cider . "1.23.0"))
 
-(defcustom cider-result-overlay-position 'at-eol
-  "Where to display result overlays for inline evaluation and the debugger.
-If `at-eol', display at the end of the line.
-If `at-point', display at the end of the respective sexp."
+(defcustom cider-eval-result-position 'at-eol
+  "Where to place result overlays for inline evaluation and the debugger.
+If `at-eol', place at the end of the line.
+If `at-point', place at the end of the evaluated sexp."
   :group 'cider
   :type '(choice (const :tag "End of line" at-eol)
                  (const :tag "End of sexp" at-point))
-  :package-version '(cider . "0.23.0"))
+  :package-version '(cider . "1.23.0"))
 
 (defcustom cider-eval-result-prefix "=> "
-  "The prefix displayed in the minibuffer before a result value."
+  "The prefix displayed before an interactive evaluation result.
+Used both in the echo area and in result overlays."
   :type 'string
   :group 'cider
   :package-version '(cider . "0.5.0"))
@@ -104,13 +115,20 @@ If `at-point', display at the end of the respective sexp."
 If nil, overlays last indefinitely.
 If the symbol `command', they're erased after the next command.
 If the symbol `change', they last until the next change to the buffer.
-Also see `cider-use-overlays'."
+Also see `cider-eval-result-display'."
   :type '(choice (integer :tag "Duration in seconds")
                  (const :tag "Until next command" command)
                  (const :tag "Until next buffer change" change)
                  (const :tag "Last indefinitely" nil))
   :group 'cider
   :package-version '(cider . "0.10.0"))
+
+(defun cider--eval-result-display ()
+  "Return `cider-eval-result-display', normalizing the legacy t/nil values."
+  (pcase cider-eval-result-display
+    ('t 'overlay)
+    ('nil 'echo)
+    (value value)))
 
 
 ;;; Overlay logic
@@ -180,7 +198,9 @@ This function also removes itself from `post-command-hook'."
   (propertize " " 'display '(left-fringe empty-line cider-fringe-bad-face))
   "The before-string property that adds a red indicator on the fringe.")
 
-(defcustom cider-use-fringe-indicators t
+(define-obsolete-variable-alias 'cider-use-fringe-indicators 'cider-fringe-indicators "1.23.0")
+
+(defcustom cider-fringe-indicators t
   "Whether to display indicators on the left fringe.
 The value selects which kinds of indicators are shown:
   t      - all kinds (the default);
@@ -198,14 +218,14 @@ Recognized kinds:
                  (set :tag "Selected kinds"
                       (const :tag "Evaluated forms" eval)
                       (const :tag "Test results" test)))
-  :package-version '(cider . "0.13.0"))
+  :package-version '(cider . "1.23.0"))
 
 (defun cider--use-fringe-indicators-p (kind)
   "Return non-nil when fringe indicators are enabled for KIND.
-KIND is `eval' or `test'.  See `cider-use-fringe-indicators'."
-  (cond ((null cider-use-fringe-indicators) nil)
-        ((listp cider-use-fringe-indicators)
-         (memq kind cider-use-fringe-indicators))
+KIND is `eval' or `test'.  See `cider-fringe-indicators'."
+  (cond ((null cider-fringe-indicators) nil)
+        ((listp cider-fringe-indicators)
+         (memq kind cider-fringe-indicators))
         (t t)))
 
 (defcustom cider-mark-stale-after-edit t
@@ -268,7 +288,7 @@ return the overlay otherwise.
 This function takes some optional keyword arguments:
 
   If WHERE is a number or a marker, apply the overlay as determined by
-  `cider-result-overlay-position'.  If it is a cons cell, the car and cdr
+  `cider-eval-result-position'.  If it is a cons cell, the car and cdr
   determine the start and end of the overlay.
   DURATION takes the same possible values as the
   `cider-eval-result-duration' variable.
@@ -299,7 +319,7 @@ overlay."
                         (point))))
                (end (if (consp where)
                         (cdr where)
-                      (pcase cider-result-overlay-position
+                      (pcase cider-eval-result-position
                         ('at-eol (line-end-position))
                         ('at-point (point)))))
                ;; Specify `default' face, otherwise unformatted text will
@@ -311,7 +331,7 @@ overlay."
           ;; Remove any overlay at the position we're creating a new one, if it
           ;; exists.
           (remove-overlays beg end 'category type)
-          (funcall (if cider-overlays-use-font-lock
+          (funcall (if cider-eval-result-font-lock
                        #'font-lock-prepend-text-property
                      #'put-text-property)
                    0 (length display-string)
@@ -378,21 +398,21 @@ VALUE is syntax-highlighted and displayed in the echo area.
 VALUE-TYPE is one of: `value', `error'.
 OVERLAY-FACE is the face applied to the overlay, which defaults to
 `cider-result-overlay-face' if nil.
-If POINT and `cider-use-overlays' are non-nil, it is also displayed in an
-overlay at the end of the line containing POINT.
+If POINT is non-nil and `cider-eval-result-display' calls for an overlay, the
+result is also displayed in an overlay at the end of the line containing POINT.
 Note that, while POINT can be a number, it's preferable to be a marker, as
 that will better handle some corner cases where the original buffer is not
 focused."
   (cl-assert (symbolp value-type)) ;; We assert because for avoiding confusion with the optional args.
   (let* ((value (string-trim-right value))
-         (font-value (if cider-result-use-clojure-font-lock
+         (font-value (if cider-eval-result-font-lock
                          (cider-font-lock-as-clojure value)
                        value))
+         (display-mode (cider--eval-result-display))
          (used-overlay (when (and point
-                                  cider-use-overlays
                                   (if (equal 'error value-type)
-                                      t
-                                    (not (equal 'errors-only cider-use-overlays))))
+                                      (memq display-mode '(overlay both errors-only))
+                                    (memq display-mode '(overlay both))))
                          (cider--make-result-overlay font-value
                            :where point
                            :duration cider-eval-result-duration
@@ -410,7 +430,7 @@ focused."
                  ;; displays it in the Messages buffer. We only hide the message
                  ;; if the user wants to AND if the overlay succeeded.
                  'invisible (and used-overlay
-                                 (not (eq cider-use-overlays 'both)))))))
+                                 (not (eq display-mode 'both)))))))
 
 
 ;;; Fragile buttons

--- a/lisp/cider-test.el
+++ b/lisp/cider-test.el
@@ -700,7 +700,7 @@ when LINE is nil."
 
 (defun cider-test-highlight-problems (results)
   "Highlight all non-passing tests in the test RESULTS.
-When `cider-use-fringe-indicators' enables them for tests, also mark every
+When `cider-fringe-indicators' enables them for tests, also mark every
 tested var with a green (all passed) or red (any failure) fringe indicator."
   (nrepl-dict-map
    (lambda (ns vars)

--- a/test/cider-overlay-tests.el
+++ b/test/cider-overlay-tests.el
@@ -223,24 +223,47 @@ being set that way"
 
 (describe "cider--use-fringe-indicators-p"
   (it "treats t as all kinds enabled"
-    (let ((cider-use-fringe-indicators t))
+    (let ((cider-fringe-indicators t))
       (expect (cider--use-fringe-indicators-p 'eval) :to-be-truthy)
       (expect (cider--use-fringe-indicators-p 'test) :to-be-truthy)))
   (it "treats nil as nothing enabled"
-    (let ((cider-use-fringe-indicators nil))
+    (let ((cider-fringe-indicators nil))
       (expect (cider--use-fringe-indicators-p 'eval) :not :to-be-truthy)
       (expect (cider--use-fringe-indicators-p 'test) :not :to-be-truthy)))
   (it "treats a list as only the listed kinds"
-    (let ((cider-use-fringe-indicators '(eval)))
+    (let ((cider-fringe-indicators '(eval)))
       (expect (cider--use-fringe-indicators-p 'eval) :to-be-truthy)
       (expect (cider--use-fringe-indicators-p 'test) :not :to-be-truthy))
-    (let ((cider-use-fringe-indicators '(eval test)))
+    (let ((cider-fringe-indicators '(eval test)))
       (expect (cider--use-fringe-indicators-p 'eval) :to-be-truthy)
       (expect (cider--use-fringe-indicators-p 'test) :to-be-truthy))))
 
+(describe "cider--eval-result-display"
+  (it "passes the canonical values through unchanged"
+    (dolist (mode '(overlay echo both errors-only))
+      (let ((cider-eval-result-display mode))
+        (expect (cider--eval-result-display) :to-be mode))))
+  (it "maps the legacy t/nil values to overlay/echo"
+    (let ((cider-eval-result-display t))
+      (expect (cider--eval-result-display) :to-be 'overlay))
+    (let ((cider-eval-result-display nil))
+      (expect (cider--eval-result-display) :to-be 'echo))))
+
+(describe "renamed eval-result options (back-compat aliases)"
+  (it "routes the obsolete display/font-lock/fringe vars to their replacements"
+    (let ((cider-eval-result-display 'both))
+      (with-no-warnings (setq cider-use-overlays 'errors-only))
+      (expect cider-eval-result-display :to-be 'errors-only))
+    (let ((cider-eval-result-font-lock 'clojure))
+      (with-no-warnings (setq cider-result-use-clojure-font-lock nil))
+      (expect cider-eval-result-font-lock :to-be nil))
+    (let ((cider-fringe-indicators t))
+      (with-no-warnings (setq cider-use-fringe-indicators '(eval)))
+      (expect cider-fringe-indicators :to-equal '(eval)))))
+
 (describe "cider--make-fringe-overlay"
   (it "doesn't place an eval indicator when eval indicators are disabled"
-    (let ((cider-use-fringe-indicators '(test)))
+    (let ((cider-fringe-indicators '(test)))
       (with-temp-buffer
         (clojure-mode)
         (insert "(def x 1)")
@@ -248,7 +271,7 @@ being set that way"
         (expect (overlays-in (point-min) (point-max)) :to-be nil))))
 
   (it "flips the indicator to stale when the evaluated form is edited"
-    (let ((cider-use-fringe-indicators t)
+    (let ((cider-fringe-indicators t)
           (cider-mark-stale-after-edit t))
       (with-temp-buffer
         (clojure-mode)
@@ -262,7 +285,7 @@ being set that way"
           (expect (overlay-buffer ov) :not :to-be nil)))))   ; kept, not deleted
 
   (it "keeps the old delete-on-edit behavior when `cider-mark-stale-after-edit' is nil"
-    (let ((cider-use-fringe-indicators t)
+    (let ((cider-fringe-indicators t)
           (cider-mark-stale-after-edit nil))
       (with-temp-buffer
         (clojure-mode)
@@ -274,7 +297,7 @@ being set that way"
           (expect (overlay-buffer ov) :to-be nil)))))       ; deleted
 
   (it "replaces a prior (stale) indicator when the form is re-evaluated"
-    (let ((cider-use-fringe-indicators t)
+    (let ((cider-fringe-indicators t)
           (cider-mark-stale-after-edit t))
       (with-temp-buffer
         (clojure-mode)


### PR DESCRIPTION
The options that control how interactive evaluation results are displayed had drifted into inconsistent names that you couldn't guess or tab-complete (`cider-use-overlays`, `cider-result-overlay-position`, two overlapping font-lock flags, `cider-interactive-eval-output-destination`, ...). This regroups them under a `cider-eval-result-*` family, with old names kept as obsolete aliases.

| Old | New |
|---|---|
| `cider-use-overlays` | `cider-eval-result-display` (`overlay`/`echo`/`both`/`errors-only`; legacy `t`/`nil` still accepted) |
| `cider-result-overlay-position` | `cider-eval-result-position` |
| `cider-result-use-clojure-font-lock` + `cider-overlays-use-font-lock` | `cider-eval-result-font-lock` (`clojure`/nil) |
| `cider-interactive-eval-output-destination` | `cider-eval-output-destination` |
| `cider-use-fringe-indicators` | `cider-fringe-indicators` |

Notes:

- All renames go through `define-obsolete-variable-alias`, so existing configs keep working and users get the standard "use NEW instead" hint.
- The two font-lock booleans only ever toggled "highlight as Clojure" vs "use the flat overlay face", so they collapse cleanly into one `cider-eval-result-font-lock`. The one behavior this drops is the rare combination of a syntax-highlighted echo-area result alongside a flat overlay (or vice versa) - results are now highlighted (or not) consistently across both.
- `cider-use-overlays`'s `t`/`nil` values are still honored (mapped to `overlay`/`echo`) for back-compat, on top of the clearer named values.
- Also fixes the `cider-eval-result-prefix` docstring (it's used for overlays too, not just the minibuffer).
- Docs and a few cross-referencing docstrings updated; added specs for the value normalization and the alias routing.

Compiles clean with `--warnings-as-errors`, checkdoc clean, full suite green (930/932, 0 failed).