### PR TITLE
Add cider-clojure-cli-powershell-options for Windows jack-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- [#4055](https://github.com/clojure-emacs/cider/pull/4055): Add `cider-clojure-cli-powershell-options` to pass extra options (e.g. `-noprofile -executionpolicy bypass`) to the PowerShell executable used for jack-in on Windows ([#2879](https://github.com/clojure-emacs/cider/issues/2879)).
 - [#4048](https://github.com/clojure-emacs/cider/pull/4048): Open a transient menu for each command group instead of a bare prefix keymap (`cider-eval-menu` at `C-c C-v`, `cider-doc-menu` at `C-c C-d`, and likewise for test, ns, insert, macroexpand, profile, trace and references), plus a top-level `cider-menu` dispatch. Existing keybindings are preserved; the menus just make the commands discoverable.
 - [#4044](https://github.com/clojure-emacs/cider/pull/4044): Add `cider-tap`, a buffer that streams the values sent to `tap>` and lets you inspect Clojure values with `RET` (reusing the inspector). ClojureScript taps stream too ([#4045](https://github.com/clojure-emacs/cider/pull/4045)) but aren't inspectable (their value lives in the JS runtime). Requires a recent enough `cider-nrepl` (with the `tap` middleware).
 - [#4026](https://github.com/clojure-emacs/cider/pull/4026): Run ClojureScript tests with the regular test commands (e.g. `cider-test-run-ns-tests`) when a ClojureScript REPL is active, instead of refusing them; requires a recent enough `cider-nrepl` (asynchronous `cljs.test/async` tests included).

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -270,6 +270,11 @@ platforms. Using `PowerShell` will Base64 encode the clojure launch
 command before passing it to PowerShell and avoids shell-escaping
 issues.
 
+Set `cider-clojure-cli-powershell-options` to pass extra options to the
+PowerShell executable itself (inserted before the encoded command). For
+example, `-noprofile -executionpolicy bypass` skips the user profile and
+works around a https://github.com/clojure/tools.deps.alpha/wiki/clj-on-Windows#install-fails-due-to-permission-errors[restrictive execution policy].
+
 The functionality of `cider-clojure-cli-command` has been verified
 with the following alternatives
 

--- a/lisp/cider-jack-in.el
+++ b/lisp/cider-jack-in.el
@@ -98,6 +98,20 @@ using rlwrap."
   :safe #'stringp
   :package-version '(cider . "1.8.0"))
 
+(defcustom cider-clojure-cli-powershell-options
+  nil
+  "PowerShell options inserted before the encoded jack-in command on Windows.
+When CIDER jacks in via PowerShell (see `cider-clojure-cli-command'), this
+string is passed to the PowerShell executable ahead of its
+`-encodedCommand' argument.  For example, \"-noprofile -executionpolicy
+bypass\" avoids loading the user profile and works around a restrictive
+execution policy."
+  :type '(choice (const :tag "None" nil)
+                 (string :tag "Options"))
+  :group 'cider
+  :safe (lambda (s) (or (null s) (stringp s)))
+  :package-version '(cider . "1.23.0"))
+
 (defcustom cider-clojure-cli-aliases
   nil
   "A list of aliases to include when using the clojure cli.
@@ -554,8 +568,12 @@ rules to quote it."
          ;;
          ;; https://stackoverflow.com/a/59036879
          (command (format "$PSNativeCommandArgumentPassing = 'Legacy'; clojure %s" quoted-params))
-         (utf-16le-command (encode-coding-string command 'utf-16le)))
-    (format "-encodedCommand %s" (base64-encode-string utf-16le-command t))))
+         (utf-16le-command (encode-coding-string command 'utf-16le))
+         (options (if (or (null cider-clojure-cli-powershell-options)
+                          (string-empty-p cider-clojure-cli-powershell-options))
+                      ""
+                    (concat cider-clojure-cli-powershell-options " "))))
+    (format "%s-encodedCommand %s" options (base64-encode-string utf-16le-command t))))
 
 
 (defun cider--combined-aliases ()

--- a/test/cider-jack-in-tests.el
+++ b/test/cider-jack-in-tests.el
@@ -501,7 +501,21 @@
     (expect (cider--powershell-encode-command "\"cmd-params\"")
             :to-equal (concat "-encodedCommand "
                               ;; Eval to reproduce reference string below: (base64-encode-string (encode-coding-string "clojure "\"cmd-params\""" 'utf-16le) t)
-                              "JABQAFMATgBhAHQAaQB2AGUAQwBvAG0AbQBhAG4AZABBAHIAZwB1AG0AZQBuAHQAUABhAHMAcwBpAG4AZwAgAD0AIAAnAEwAZQBnAGEAYwB5ACcAOwAgAGMAbABvAGoAdQByAGUAIAAiAGMAbQBkAC0AcABhAHIAYQBtAHMAIgA="))))
+                              "JABQAFMATgBhAHQAaQB2AGUAQwBvAG0AbQBhAG4AZABBAHIAZwB1AG0AZQBuAHQAUABhAHMAcwBpAG4AZwAgAD0AIAAnAEwAZQBnAGEAYwB5ACcAOwAgAGMAbABvAGoAdQByAGUAIAAiAGMAbQBkAC0AcABhAHIAYQBtAHMAIgA=")))
+
+  (it "prepends the configured options before -encodedCommand"
+    (let ((cider-clojure-cli-powershell-options "-noprofile -executionpolicy bypass"))
+      (expect (cider--powershell-encode-command "cmd-params")
+              :to-match
+              (rx string-start "-noprofile -executionpolicy bypass -encodedCommand "))))
+
+  (it "leaves the encoded payload unchanged when options are set"
+    (expect (let ((cider-clojure-cli-powershell-options "-noprofile"))
+              (string-remove-prefix
+               "-noprofile " (cider--powershell-encode-command "cmd-params")))
+            :to-equal
+            (let ((cider-clojure-cli-powershell-options nil))
+              (cider--powershell-encode-command "cmd-params")))))
 
 (describe "cider--resolve-command"
   (it "passes the TRAMP host to `executable-find' when default-directory is remote"


### PR DESCRIPTION
Closes #2879.

When CIDER jacks in through PowerShell it Base64-encodes the launch command and passed nothing else to the `powershell` executable, so there was no way to add options like `-noprofile -executionpolicy bypass` (the documented workaround for a restrictive execution policy on Windows). This adds a `cider-clojure-cli-powershell-options` defcustom whose value is inserted before `-encodedCommand`. Defaults to nil, so nothing changes unless you set it.

Includes tests and a note in the jack-in docs. Based on the patch the reporter attached to the issue.