### PR TITLE
Show the eval spinner in the buffer you evaluated from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 
 ### Changes
 
+- [#4056](https://github.com/clojure-emacs/cider/pull/4056): Show the interactive-evaluation spinner in the buffer you evaluated from (the source buffer, or the REPL when evaluating at its prompt) instead of always in the REPL buffer, which is often not even visible ([#3516](https://github.com/clojure-emacs/cider/issues/3516)).
 - [#4052](https://github.com/clojure-emacs/cider/pull/4052): Rename the inline evaluation-result options into a consistent `cider-eval-result-*` family: `cider-use-overlays` -> `cider-eval-result-display`, `cider-result-overlay-position` -> `cider-eval-result-position`, `cider-result-use-clojure-font-lock` and `cider-overlays-use-font-lock` -> `cider-eval-result-font-lock`, `cider-interactive-eval-output-destination` -> `cider-eval-output-destination`, and `cider-use-fringe-indicators` -> `cider-fringe-indicators`. The old names remain as obsolete aliases.
 - [#4050](https://github.com/clojure-emacs/cider/pull/4050): Bump the injected `cider-nrepl` to 0.61.0 (and `piggieback` to 0.6.2). Code formatting now honors the project's cljfmt configuration, and the default `pprint` printer is backed by `orchard.pp`.
 - [#4047](https://github.com/clojure-emacs/cider/pull/4047): Render the doc buffer's "See also" section as a bulleted list (one entry per line) instead of an inline space-separated run, matching the ClojureDocs buffer.

--- a/lisp/cider-client.el
+++ b/lisp/cider-client.el
@@ -356,12 +356,15 @@ buffer, defaults to (cider-current-repl).
 This is the keyword-argument form; `cider-nrepl-request:eval' is the legacy
 positional shim retained for backward compatibility."
   (let ((connection (or connection (cider-current-repl 'infer 'ensure)))
+        ;; Show the spinner in the buffer the evaluation was initiated from
+        ;; (the source buffer, or the REPL when evaluating at its prompt),
+        ;; rather than always in the REPL, which is often not even visible.
         (eval-buffer (current-buffer)))
     (run-hooks 'cider-before-eval-hook)
     (nrepl-send-eval-request input
                              (lambda (response)
                                (when cider-show-spinner
-                                 (cider-eval-spinner connection response))
+                                 (cider-eval-spinner eval-buffer response))
                                (when (and (buffer-live-p eval-buffer)
                                           (member "done" (nrepl-dict-get response "status")))
                                  (with-current-buffer eval-buffer
@@ -370,7 +373,7 @@ positional shim retained for backward compatibility."
                              connection
                              :ns ns :line line :column column
                              :additional-params additional-params)
-    (cider-spinner-start connection)))
+    (cider-spinner-start eval-buffer)))
 
 (defun cider-nrepl-request:eval (input callback &optional ns line column additional-params connection)
   "Send the request INPUT and register the CALLBACK as the response handler.

--- a/test/cider-client-tests.el
+++ b/test/cider-client-tests.el
@@ -535,3 +535,18 @@
               (expect conns :to-have-same-items-as (list clj-repl cljs-repl))))
         (kill-buffer clj-repl)
         (kill-buffer cljs-repl)))))
+(describe "cider-nrepl-send-eval-request spinner placement"
+  (before-each
+    (spy-on 'nrepl-send-eval-request)
+    (spy-on 'cider-spinner-start))
+
+  (it "starts the spinner in the buffer the evaluation was initiated from"
+    (let ((repl (generate-new-buffer " *repl*")))
+      (unwind-protect
+          (with-temp-buffer
+            (let ((source (current-buffer)))
+              ;; Even with an explicit REPL connection, the spinner belongs in
+              ;; the originating (source) buffer, not the connection.
+              (cider-nrepl-send-eval-request "(+ 1 1)" #'ignore :connection repl)
+              (expect 'cider-spinner-start :to-have-been-called-with source)))
+        (kill-buffer repl)))))


### PR DESCRIPTION
Closes #3516.

The interactive-eval spinner always spun in the REPL buffer, which is often not even visible when you evaluate from a source file. It now shows in the buffer the evaluation was initiated from instead - the source buffer, or the REPL itself when you eval at its prompt.

No new config: the spinner path (`cider-nrepl-send-eval-request`) only carries user-initiated evaluations - background tooling like eldoc/completion/info goes through the tooling session - so "the current buffer" is reliably the buffer you acted in, and there's nothing to opt into.

Known minor limitation: for a `.cljc` eval (which fans out to both REPLs) the single source-buffer spinner stops on the first REPL's `done` rather than the last. It's a rough busy hint, not a progress bar; a ref-count could tighten it later if wanted.

Follow-up: a pending spinner *overlay* co-located with the result (option C from discussion) would be the ideal locality for the overlay-eval case.