### PR TITLE
Show a spinner overlay at the form while an evaluation is pending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- [#4057](https://github.com/clojure-emacs/cider/pull/4057): Show an animated spinner overlay at the form being evaluated (where its result will appear) while an interactive evaluation is pending, instead of the mode-line spinner, when result overlays are enabled ([#3516](https://github.com/clojure-emacs/cider/issues/3516)).
 - [#4055](https://github.com/clojure-emacs/cider/pull/4055): Add `cider-clojure-cli-powershell-options` to pass extra options (e.g. `-noprofile -executionpolicy bypass`) to the PowerShell executable used for jack-in on Windows ([#2879](https://github.com/clojure-emacs/cider/issues/2879)).
 - [#4048](https://github.com/clojure-emacs/cider/pull/4048): Open a transient menu for each command group instead of a bare prefix keymap (`cider-eval-menu` at `C-c C-v`, `cider-doc-menu` at `C-c C-d`, and likewise for test, ns, insert, macroexpand, profile, trace and references), plus a top-level `cider-menu` dispatch. Existing keybindings are preserved; the menus just make the commands discoverable.
 - [#4044](https://github.com/clojure-emacs/cider/pull/4044): Add `cider-tap`, a buffer that streams the values sent to `tap>` and lets you inspect Clojure values with `RET` (reusing the inspector). ClojureScript taps stream too ([#4045](https://github.com/clojure-emacs/cider/pull/4045)) but aren't inspectable (their value lives in the JS runtime). Requires a recent enough `cider-nrepl` (with the `tap` middleware).

--- a/lisp/cider-client.el
+++ b/lisp/cider-client.el
@@ -64,6 +64,11 @@ Value is a symbol.  The possible values are the symbols in the
   :group 'cider
   :package-version '(cider . "0.10.0"))
 
+(defvar cider--eval-spinner-inhibit-mode-line nil
+  "When non-nil, `cider-nrepl-send-eval-request' skips the mode-line spinner.
+Bound by `cider-interactive-eval' when it shows a spinner overlay at the
+evaluated form instead, so a single evaluation never spins in two places.")
+
 (defcustom cider-spinner-delay 1
   "Amount of time, in seconds, after which the spinner will be shown."
   :type 'integer
@@ -373,7 +378,8 @@ positional shim retained for backward compatibility."
                              connection
                              :ns ns :line line :column column
                              :additional-params additional-params)
-    (cider-spinner-start eval-buffer)))
+    (unless cider--eval-spinner-inhibit-mode-line
+      (cider-spinner-start eval-buffer))))
 
 (defun cider-nrepl-request:eval (input callback &optional ns line column additional-params connection)
   "Send the request INPUT and register the CALLBACK as the response handler.

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -48,6 +48,7 @@
 (require 'subr-x)
 
 (require 'clojure-mode)
+(require 'spinner)
 (require 'transient)
 
 (require 'nrepl-client)
@@ -335,6 +336,71 @@ and by the namespace reloading commands once they finish."
     (run-hooks 'cider-file-loaded-hook)))
 
 
+;;; Pending-evaluation spinner overlay
+(defvar-local cider--eval-pending-overlays nil
+  "List of pending-evaluation spinner overlays in the current buffer.")
+
+(defun cider--eval-pending-spinner-frames ()
+  "Return the animation frames for the pending-evaluation spinner overlay.
+Reuse `cider-spinner-type', falling back to `progress-bar'."
+  (or (alist-get cider-spinner-type spinner-types)
+      (alist-get 'progress-bar spinner-types)))
+
+(defun cider--eval-pending-overlay-p (callback end)
+  "Return non-nil if a spinner overlay should mark a pending evaluation.
+Only when the spinner is enabled, the result is bound for an overlay (see
+`cider-eval-result-display'), the default handler is in use (CALLBACK is
+nil) and the form's END position is known."
+  (and cider-show-spinner
+       (null callback)
+       (number-or-marker-p end)
+       (memq (cider--eval-result-display) '(overlay both))))
+
+(defun cider--eval-pending-overlay-start (end)
+  "Show a spinner overlay where the result of the form ending at END will go.
+The spinner appears after `cider-spinner-delay' seconds, at the position
+dictated by `cider-eval-result-position', and animates until
+`cider--eval-pending-overlay-remove' clears it.  Return the overlay."
+  (let* ((frames (cider--eval-pending-spinner-frames))
+         (buffer (current-buffer))
+         (pos (save-excursion
+                (goto-char end)
+                (skip-chars-backward "\r\n[:blank:]")
+                (pcase cider-eval-result-position
+                  ('at-eol (line-end-position))
+                  (_ (point)))))
+         (ov (make-overlay pos pos))
+         (index 0)
+         timer)
+    (overlay-put ov 'category 'cider-eval-pending)
+    (overlay-put ov 'cider-temporary t)
+    (setq timer
+          (run-at-time
+           cider-spinner-delay (/ 1.0 10)
+           (lambda ()
+             (if (not (overlay-buffer ov))
+                 (cancel-timer timer)
+               (overlay-put
+                ov 'after-string
+                (propertize (concat " " cider-eval-result-prefix
+                                    (aref frames (% index (length frames))))
+                            'face 'cider-result-overlay-face))
+               (setq index (1+ index))))))
+    (overlay-put ov 'cider-pending-timer timer)
+    (with-current-buffer buffer
+      (push ov cider--eval-pending-overlays))
+    ov))
+
+(defun cider--eval-pending-overlay-remove ()
+  "Clear the pending-evaluation spinner overlays in the current buffer.
+Cancel their animation timers and delete the overlays."
+  (dolist (ov cider--eval-pending-overlays)
+    (when-let* ((timer (overlay-get ov 'cider-pending-timer)))
+      (cancel-timer timer))
+    (when (overlay-buffer ov)
+      (delete-overlay ov)))
+  (setq cider--eval-pending-overlays nil))
+
 (declare-function cider-inspect-last-result "cider-inspector")
 (defun cider-interactive-eval-handler (&optional buffer place)
   "Make an interactive eval handler for BUFFER.
@@ -354,6 +420,9 @@ when `cider-auto-inspect-after-eval' is non-nil."
     (cider-make-eval-handler
      :buffer (or buffer eval-buffer)
      :on-value (lambda (value)
+                 (when (buffer-live-p eval-buffer)
+                   (with-current-buffer eval-buffer
+                     (cider--eval-pending-overlay-remove)))
                  (setq res (concat res value))
                  (cider--display-interactive-eval-result res 'value end))
      :on-stdout #'cider-emit-interactive-eval-output
@@ -366,6 +435,11 @@ when `cider-auto-inspect-after-eval' is non-nil."
                    ;; jump brings us to the beginning of the same form anyway.
                    t))
      :on-done (lambda ()
+                ;; Clear the spinner overlay for evaluations that finish
+                ;; without a value (e.g. side-effecting forms or errors).
+                (when (buffer-live-p eval-buffer)
+                  (with-current-buffer eval-buffer
+                    (cider--eval-pending-overlay-remove)))
                 (if beg
                     (unless fringed
                       (cider--make-fringe-overlays-for-region beg end)
@@ -583,19 +657,24 @@ arguments and only proceed with evaluation if it returns nil."
       ;; command fail silently with no connection at all, so guard the
       ;; dispatch with an explicit connection check.
       (cider-ensure-session)
-      (cider-map-repls :auto
-        (lambda (connection)
-          (cider--prep-interactive-eval form connection)
-          (cider-nrepl-send-eval-request
-           form
-           (or callback (cider-interactive-eval-handler nil bounds))
-           ;; always eval ns forms in the user namespace
-           ;; otherwise trying to eval ns form for the first time will produce an error
-           :ns (if (cider-ns-form-p form) "user" (cider-current-ns))
-           :line (when start (line-number-at-pos start))
-           :column (when start (cider-column-number-at-pos start))
-           :additional-params additional-params
-           :connection connection))))))
+      ;; Mark the form with a spinner overlay while the evaluation is pending,
+      ;; and suppress the mode-line spinner so it doesn't spin in two places.
+      (let* ((pending (when (cider--eval-pending-overlay-p callback end)
+                        (cider--eval-pending-overlay-start end)))
+             (cider--eval-spinner-inhibit-mode-line (and pending t)))
+        (cider-map-repls :auto
+          (lambda (connection)
+            (cider--prep-interactive-eval form connection)
+            (cider-nrepl-send-eval-request
+             form
+             (or callback (cider-interactive-eval-handler nil bounds))
+             ;; always eval ns forms in the user namespace
+             ;; otherwise trying to eval ns form for the first time will produce an error
+             :ns (if (cider-ns-form-p form) "user" (cider-current-ns))
+             :line (when start (line-number-at-pos start))
+             :column (when start (cider-column-number-at-pos start))
+             :additional-params additional-params
+             :connection connection)))))))
 
 (defun cider-eval-region (start end)
   "Evaluate the region between START and END."

--- a/test/cider-client-tests.el
+++ b/test/cider-client-tests.el
@@ -549,4 +549,13 @@
               ;; the originating (source) buffer, not the connection.
               (cider-nrepl-send-eval-request "(+ 1 1)" #'ignore :connection repl)
               (expect 'cider-spinner-start :to-have-been-called-with source)))
+        (kill-buffer repl))))
+
+  (it "skips the mode-line spinner when it is inhibited"
+    (let ((repl (generate-new-buffer " *repl*"))
+          (cider--eval-spinner-inhibit-mode-line t))
+      (unwind-protect
+          (with-temp-buffer
+            (cider-nrepl-send-eval-request "(+ 1 1)" #'ignore :connection repl)
+            (expect 'cider-spinner-start :not :to-have-been-called))
         (kill-buffer repl)))))

--- a/test/cider-eval-tests.el
+++ b/test/cider-eval-tests.el
@@ -340,3 +340,44 @@
                               "status" ("namespace-not-found")
                               "ns" "missing.ns")))
     (expect 'message :to-have-been-called-with "Namespace `%s' not found." "missing.ns")))
+
+(describe "cider--eval-pending-overlay-p"
+  (it "is non-nil for an overlay-bound result with the default handler"
+    (let ((cider-show-spinner t)
+          (cider-eval-result-display 'both))
+      (expect (cider--eval-pending-overlay-p nil 10) :to-be-truthy))
+    (let ((cider-show-spinner t)
+          (cider-eval-result-display 'overlay))
+      (expect (cider--eval-pending-overlay-p nil 10) :to-be-truthy)))
+
+  (it "is nil when the spinner is disabled"
+    (let ((cider-show-spinner nil)
+          (cider-eval-result-display 'both))
+      (expect (cider--eval-pending-overlay-p nil 10) :to-be nil)))
+
+  (it "is nil when the result only goes to the echo area"
+    (let ((cider-show-spinner t)
+          (cider-eval-result-display 'echo))
+      (expect (cider--eval-pending-overlay-p nil 10) :to-be nil)))
+
+  (it "is nil with a custom callback or an unknown position"
+    (let ((cider-show-spinner t)
+          (cider-eval-result-display 'both))
+      (expect (cider--eval-pending-overlay-p #'ignore 10) :to-be nil)
+      (expect (cider--eval-pending-overlay-p nil nil) :to-be nil))))
+
+(describe "cider--eval-pending-overlay-start / -remove"
+  (it "registers a spinner overlay and clears it on removal"
+    (with-temp-buffer
+      (insert "(+ 1 1)")
+      (let* ((cider-spinner-delay 1)
+             (ov (cider--eval-pending-overlay-start (point-max))))
+        (expect (overlayp ov) :to-be-truthy)
+        (expect (memq ov cider--eval-pending-overlays) :to-be-truthy)
+        (expect (timerp (overlay-get ov 'cider-pending-timer)) :to-be-truthy)
+        (cider--eval-pending-overlay-remove)
+        (expect cider--eval-pending-overlays :to-be nil)
+        (expect (overlay-buffer ov) :to-be nil)
+        ;; the animation timer is cancelled (no longer scheduled)
+        (expect (memq (overlay-get ov 'cider-pending-timer) timer-list)
+                :to-be nil)))))


### PR DESCRIPTION
Follow-up to #3516 (option C from the discussion there).

When interactive-eval results are shown as overlays, a slow evaluation now shows an animated spinner right where its result will land, instead of in the mode line. Your eyes are already there waiting for the value, and it morphs into the result overlay when it arrives.

Details:
- No new option: it kicks in whenever result overlays (`cider-eval-result-display`) and the spinner (`cider-show-spinner`) are both enabled, using the same `cider-spinner-delay` gate so fast evals don't flicker.
- Reuses `cider-spinner-type`'s frames and `cider-eval-result-position` for placement.
- The mode-line spinner is suppressed for that evaluation (via `cider--eval-spinner-inhibit-mode-line`) so it never spins in two places. REPL evals, eval-to-buffer, pprint popups and echo-only display keep the mode-line spinner.
- Cleared on value/done (and on error/interrupt, which finish with `done`); the animation timer self-cancels if the overlay or buffer goes away.

Unit tests cover the predicate, the overlay start/remove lifecycle, and the mode-line suppression. The animation itself is worth an eyeball in a live REPL.