### PR TITLE
Give a useful error for unresolvable Javadoc URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 
 ### Bugs fixed
 
+- [#4058](https://github.com/clojure-emacs/cider/pull/4058): Signal a helpful error when `cider-javadoc` gets an unresolvable (non-absolute) Javadoc URL from the middleware, instead of silently doing nothing ([#2969](https://github.com/clojure-emacs/cider/issues/2969)).
 - [#4054](https://github.com/clojure-emacs/cider/pull/4054): Interrupt every REPL an evaluation is dispatched to. In a `.cljc` buffer `cider-interrupt` previously interrupted only one of the two REPLs ([#4036](https://github.com/clojure-emacs/cider/issues/4036)).
 - [#4053](https://github.com/clojure-emacs/cider/pull/4053): Restore point to the place a debug session was started from when you quit it with `q`, instead of leaving it stranded at the last breakpoint ([#1595](https://github.com/clojure-emacs/cider/issues/1595)).
 - [#4049](https://github.com/clojure-emacs/cider/pull/4049): Font-lock streamed REPL results as a whole instead of per chunk, so values that nREPL splits across several chunks (much more common since nREPL 1.5.0's newline-triggered flushing) are highlighted correctly rather than left plain ([nREPL #445](https://github.com/nrepl/nrepl/issues/445)).

--- a/lisp/cider-doc.el
+++ b/lisp/cider-doc.el
@@ -307,9 +307,16 @@ result dict (possibly empty), so toggling visibility never re-fetches.")
   (when symbol-name
     (let* ((info (cider-var-info symbol-name))
            (url (nrepl-dict-get info "javadoc")))
-      (if url
-          (browse-url url)
-        (user-error "No Javadoc available for %s" symbol-name)))))
+      (cond
+       ((null url)
+        (user-error "No Javadoc available for %s" symbol-name))
+       ;; A resolvable Javadoc URL is absolute (it has a URI scheme).  For
+       ;; classes whose Javadoc it can't locate, the middleware sometimes
+       ;; returns a bare resource path (e.g. \"foo/Bar.html\") on which
+       ;; `browse-url' silently fails, so give a useful error instead.
+       ((not (string-match-p "\\`[a-z][a-z0-9+.-]*:" url))
+        (user-error "No resolvable Javadoc for %s (its library ships no Javadoc)" symbol-name))
+       (t (browse-url url))))))
 
 (defun cider-javadoc (arg)
   "Open Javadoc documentation in a popup buffer.

--- a/test/cider-doc-tests.el
+++ b/test/cider-doc-tests.el
@@ -89,3 +89,24 @@
                                '(83 . "")))
             :to-equal
             "*cider-repl ClojureProjects/PPL:localhost:36453(clj:)*")))
+
+(describe "cider-javadoc-handler"
+  (it "browses an absolute Javadoc URL"
+    (spy-on 'browse-url)
+    (spy-on 'cider-var-info :and-return-value
+            (nrepl-dict "javadoc" "https://example.com/Foo.html"))
+    (cider-javadoc-handler "Foo")
+    (expect 'browse-url :to-have-been-called-with "https://example.com/Foo.html"))
+
+  (it "errors helpfully on a non-absolute (unresolvable) Javadoc path"
+    (spy-on 'browse-url)
+    (spy-on 'cider-var-info :and-return-value
+            (nrepl-dict "javadoc" "ezvcard/VCard.html"))
+    (expect (cider-javadoc-handler "VCard") :to-throw 'user-error)
+    (expect 'browse-url :not :to-have-been-called))
+
+  (it "errors when no Javadoc is available at all"
+    (spy-on 'browse-url)
+    (spy-on 'cider-var-info :and-return-value (nrepl-dict))
+    (expect (cider-javadoc-handler "Foo") :to-throw 'user-error)
+    (expect 'browse-url :not :to-have-been-called)))


### PR DESCRIPTION
Addresses part of #2969.

When the middleware can't locate a class's Javadoc (typical for a plain third-party jar), it returns a bare resource path like `ezvcard/VCard.html` rather than a URL, and `browse-url` silently does nothing - leaving the user staring at no feedback. `cider-javadoc` now detects a non-absolute URL (no URI scheme) and signals a helpful `user-error` explaining the library ships no Javadoc.

This is the client-side half. Actually resolving Javadoc for such jars (or letting users register remote Javadoc bases) is an Orchard concern and out of scope here, so I'm not closing the issue.