### PR TITLE
Use public cider-sessions in cider-debug-sesman-friendly-session-p

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 
 ### Changes
 
+- [#4059](https://github.com/clojure-emacs/cider/pull/4059): Use the public `sesman-sessions` (via `cider-sessions`) instead of a private sesman function in `cider-debug-sesman-friendly-session-p` ([#4037](https://github.com/clojure-emacs/cider/issues/4037)).
 - [#4056](https://github.com/clojure-emacs/cider/pull/4056): Show the interactive-evaluation spinner in the buffer you evaluated from (the source buffer, or the REPL when evaluating at its prompt) instead of always in the REPL buffer, which is often not even visible ([#3516](https://github.com/clojure-emacs/cider/issues/3516)).
 - [#4052](https://github.com/clojure-emacs/cider/pull/4052): Rename the inline evaluation-result options into a consistent `cider-eval-result-*` family: `cider-use-overlays` -> `cider-eval-result-display`, `cider-result-overlay-position` -> `cider-eval-result-position`, `cider-result-use-clojure-font-lock` and `cider-overlays-use-font-lock` -> `cider-eval-result-font-lock`, `cider-interactive-eval-output-destination` -> `cider-eval-output-destination`, and `cider-use-fringe-indicators` -> `cider-fringe-indicators`. The old names remain as obsolete aliases.
 - [#4050](https://github.com/clojure-emacs/cider/pull/4050): Bump the injected `cider-nrepl` to 0.61.0 (and `piggieback` to 0.6.2). Code formatting now honors the project's cljfmt configuration, and the default `pprint` printer is backed by `orchard.pp`.

--- a/lisp/cider-repl.el
+++ b/lisp/cider-repl.el
@@ -2176,7 +2176,10 @@ in an unexpected place."
   (interactive)
   (message (prin1-to-string (mapcar (lambda (session)
                                       (cider--sesman-friendly-session-p session t))
-                                    (sesman--all-system-sessions 'CIDER)))))
+                                    ;; `cider-sessions' wraps the public
+                                    ;; `sesman-sessions', which returns the same
+                                    ;; set as the private `sesman--all-system-sessions'.
+                                    (cider-sessions)))))
 
 (cl-defmethod sesman-friendly-session-p ((_system (eql CIDER)) session)
   "Check if SESSION is a friendly session."

--- a/test/cider-repl-tests.el
+++ b/test/cider-repl-tests.el
@@ -632,3 +632,12 @@ PROPERTY should be a symbol of either 'text, 'ansi-context or
       (insert "keep after\n")
       (cider-repl-clear-help-banner)
       (expect (buffer-string) :to-equal "keep before\nkeep after\n"))))
+
+(describe "cider-debug-sesman-friendly-session-p"
+  (it "queries sessions through the public `cider-sessions'"
+    (spy-on 'cider-sessions :and-return-value '(session-a session-b))
+    (spy-on 'cider--sesman-friendly-session-p :and-return-value t)
+    (spy-on 'message)
+    (cider-debug-sesman-friendly-session-p)
+    (expect 'cider-sessions :to-have-been-called)
+    (expect 'cider--sesman-friendly-session-p :to-have-been-called-times 2)))


### PR DESCRIPTION
Addresses the easy half of #4037.

`cider-debug-sesman-friendly-session-p` reached into the private `sesman--all-system-sessions`; that maps cleanly to the public `sesman-sessions` (which we already wrap as `cider-sessions`) - verified they return the same set for the nil/all case.

The other private use, `sesman--linked-sessions` in `cider-repl--state-handler`, deliberately excludes friendly sessions and has no drop-in public equivalent, so I've left it (and noted it in the issue for a possible upstream sesman addition). Not closing #4037.