### PR TITLE
Hint at jack-in when no Clojure CLI aliases are set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- [#4060](https://github.com/clojure-emacs/cider/pull/4060): Hint at jack-in time when no Clojure CLI aliases are set, so newcomers discover aliases like `:dev`/`:test`; set `cider-clojure-cli-aliases` to `:nil-no-warn` to silence it ([#3317](https://github.com/clojure-emacs/cider/issues/3317)).
 - [#4057](https://github.com/clojure-emacs/cider/pull/4057): Show an animated spinner overlay at the form being evaluated (where its result will appear) while an interactive evaluation is pending, instead of the mode-line spinner, when result overlays are enabled ([#3516](https://github.com/clojure-emacs/cider/issues/3516)).
 - [#4055](https://github.com/clojure-emacs/cider/pull/4055): Add `cider-clojure-cli-powershell-options` to pass extra options (e.g. `-noprofile -executionpolicy bypass`) to the PowerShell executable used for jack-in on Windows ([#2879](https://github.com/clojure-emacs/cider/issues/2879)).
 - [#4048](https://github.com/clojure-emacs/cider/pull/4048): Open a transient menu for each command group instead of a bare prefix keymap (`cider-eval-menu` at `C-c C-v`, `cider-doc-menu` at `C-c C-d`, and likewise for test, ns, insert, macroexpand, profile, trace and references), plus a top-level `cider-menu` dispatch. Existing keybindings are preserved; the menus just make the commands discoverable.

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -262,6 +262,8 @@ command of your own, see <<Overriding the Jack-In Command>> below.
 * `cider-clojure-cli-aliases` - a list of project-specific aliases to be used at jack-in time (it's meant to be set via `.dir-locals.el`)
 * `cider-clojure-cli-global-aliases` - a list of global aliases that are appended to project-specific `cider-clojure-cli-aliases`
 
+TIP: When `cider-clojure-cli-aliases` is unset, CIDER hints at jack-in time that you may want to activate an alias (e.g. `:dev` or `:test`). If you deliberately jack in without aliases, set `cider-clojure-cli-aliases` to `:nil-no-warn` to silence the hint.
+
 On MS-Windows, CIDER will employ `PowerShell` to execute Clojure if no
 `clojure` executable is found in the PATH (e.g. like the one supplied
 by https://github.com/borkdude/deps.clj[deps.clj]). The default

--- a/lisp/cider-jack-in.el
+++ b/lisp/cider-jack-in.el
@@ -117,10 +117,15 @@ execution policy."
   "A list of aliases to include when using the clojure cli.
 Alias names should be of the form \":foo:bar\".
 Leading \"-A\" \"-M\" \"-T\" or \"-X\" are stripped from aliases
-then concatenated into the \"-M[your-aliases]:cider/nrepl\" form."
-  :type 'string
+then concatenated into the \"-M[your-aliases]:cider/nrepl\" form.
+
+When nil, CIDER hints at jack-in time that you may want to activate an
+alias.  Set this to `:nil-no-warn' to keep it unset without the hint."
+  :type '(choice (const :tag "None (hint at jack-in)" nil)
+                 (const :tag "None (no hint)" :nil-no-warn)
+                 (string :tag "Aliases"))
   :group 'cider
-  :safe #'stringp
+  :safe (lambda (x) (or (null x) (eq x :nil-no-warn) (stringp x)))
   :package-version '(cider . "1.1"))
 
 (defcustom cider-clojure-cli-global-aliases
@@ -576,17 +581,24 @@ rules to quote it."
     (format "%s-encodedCommand %s" options (base64-encode-string utf-16le-command t))))
 
 
+(defun cider--clojure-cli-aliases ()
+  "Return `cider-clojure-cli-aliases', treating `:nil-no-warn' as nil.
+The `:nil-no-warn' value means \"no aliases, and don't hint about it\"."
+  (unless (eq cider-clojure-cli-aliases :nil-no-warn)
+    cider-clojure-cli-aliases))
+
 (defun cider--combined-aliases ()
   "Create the combined aliases as a string separated by ':'."
-  (let ((final-cider-clojure-cli-aliases
-         (cond ((and cider-clojure-cli-global-aliases cider-clojure-cli-aliases)
-                ;; both are documented to be of the `:foo:bar' form, so drop a
-                ;; leading colon from the local aliases before joining, lest the
-                ;; junction end up with a `::' (a malformed alias keyword).
-                (concat cider-clojure-cli-global-aliases ":"
-                        (string-remove-prefix ":" cider-clojure-cli-aliases)))
-               (cider-clojure-cli-global-aliases cider-clojure-cli-global-aliases)
-               (t cider-clojure-cli-aliases))))
+  (let* ((local-aliases (cider--clojure-cli-aliases))
+         (final-cider-clojure-cli-aliases
+          (cond ((and cider-clojure-cli-global-aliases local-aliases)
+                 ;; both are documented to be of the `:foo:bar' form, so drop a
+                 ;; leading colon from the local aliases before joining, lest the
+                 ;; junction end up with a `::' (a malformed alias keyword).
+                 (concat cider-clojure-cli-global-aliases ":"
+                         (string-remove-prefix ":" local-aliases)))
+                (cider-clojure-cli-global-aliases cider-clojure-cli-global-aliases)
+                (t local-aliases))))
     (if final-cider-clojure-cli-aliases
         ;; remove exec-opts flags -A -M -T or -X from cider-clojure-cli-aliases
         ;; concatenated with :cider/nrepl to ensure :cider/nrepl comes last
@@ -596,12 +608,24 @@ rules to quote it."
             (concat ":" aliases)))
       "")))
 
+(defun cider--clojure-cli-aliases-hint ()
+  "Hint at jack-in that no Clojure CLI aliases are active.
+Only when neither `cider-clojure-cli-aliases' nor
+`cider-clojure-cli-global-aliases' is set; silenced by setting
+`cider-clojure-cli-aliases' to `:nil-no-warn' (which is non-nil)."
+  (when (and (null cider-clojure-cli-aliases)
+             (null cider-clojure-cli-global-aliases))
+    (message (concat "`cider-clojure-cli-aliases' is unset; you may want to "
+                     "activate an alias (e.g. via `.dir-locals.el').  "
+                     "Set it to `:nil-no-warn' to silence this hint."))))
+
 (defun cider-clojure-cli-jack-in-dependencies (params dependencies &optional command)
   "Create Clojure tools.deps jack-in dependencies.
 Does so by concatenating DEPENDENCIES and PARAMS into a suitable `clojure`
 invocation and quoting, also accounting for COMMAND if provided.  The main
 is placed in an inline alias :cider/nrepl so that if your aliases contain
 any mains, the cider/nrepl one will be the one used."
+  (cider--clojure-cli-aliases-hint)
   (let* ((all-deps (thread-last dependencies
                                 (append (cider--jack-in-required-dependencies))
                                 ;; Duplicates are never OK since they would result in

--- a/test/cider-jack-in-tests.el
+++ b/test/cider-jack-in-tests.el
@@ -98,7 +98,42 @@
     ;; malformed `-M:dev::test:cider/nrepl').
     (let ((cider-clojure-cli-global-aliases ":dev")
           (cider-clojure-cli-aliases ":test"))
-      (expect (cider--combined-aliases) :to-equal ":dev:test"))))
+      (expect (cider--combined-aliases) :to-equal ":dev:test")))
+  (it "treats the `:nil-no-warn' sentinel as no local aliases"
+    (let ((cider-clojure-cli-global-aliases nil)
+          (cider-clojure-cli-aliases :nil-no-warn))
+      (expect (cider--combined-aliases) :to-equal ""))))
+
+(describe "cider--clojure-cli-aliases"
+  (it "treats the `:nil-no-warn' sentinel as nil"
+    (let ((cider-clojure-cli-aliases :nil-no-warn))
+      (expect (cider--clojure-cli-aliases) :to-be nil)))
+  (it "returns the configured aliases otherwise"
+    (let ((cider-clojure-cli-aliases ":dev:test"))
+      (expect (cider--clojure-cli-aliases) :to-equal ":dev:test"))))
+
+(describe "cider--clojure-cli-aliases-hint"
+  (before-each (spy-on 'message))
+  (it "hints when neither local nor global aliases are set"
+    (let ((cider-clojure-cli-aliases nil)
+          (cider-clojure-cli-global-aliases nil))
+      (cider--clojure-cli-aliases-hint)
+      (expect 'message :to-have-been-called)))
+  (it "stays quiet when local aliases are set"
+    (let ((cider-clojure-cli-aliases ":dev")
+          (cider-clojure-cli-global-aliases nil))
+      (cider--clojure-cli-aliases-hint)
+      (expect 'message :not :to-have-been-called)))
+  (it "stays quiet when global aliases are set"
+    (let ((cider-clojure-cli-aliases nil)
+          (cider-clojure-cli-global-aliases ":prod"))
+      (cider--clojure-cli-aliases-hint)
+      (expect 'message :not :to-have-been-called)))
+  (it "stays quiet when silenced with `:nil-no-warn'"
+    (let ((cider-clojure-cli-aliases :nil-no-warn)
+          (cider-clojure-cli-global-aliases nil))
+      (cider--clojure-cli-aliases-hint)
+      (expect 'message :not :to-have-been-called))))
 
 (describe "cider--jack-in-required-dependencies"
   (it "lists nrepl and cider-nrepl at the injected versions"


### PR DESCRIPTION
Closes #3317.

Activating an alias (`:dev`, `:test`, ...) at jack-in is a common need that trips up newcomers, and the prefix-arg trick isn't discoverable. When jacking in with the Clojure CLI and neither `cider-clojure-cli-aliases` nor `cider-clojure-cli-global-aliases` is set, CIDER now emits a one-line hint pointing at aliases and `.dir-locals.el`. Setting `cider-clojure-cli-aliases` to `:nil-no-warn` keeps it unset without the hint (the sentinel is normalized to nil wherever aliases are consumed).

This is the non-blocking hint that you and vemv converged on in the thread. I skipped the heavier deps.edn-parsing / interactive-prompt variant (explicitly out of scope). Note the hint fires on every aliasless Clojure CLI jack-in; `:nil-no-warn` is the opt-out. Includes tests and a docs note.