### PR TITLE
Add argument flags to the jack-in transient menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- [#4061](https://github.com/clojure-emacs/cider/pull/4061): The jack-in/connect keybindings are now a transient menu (`cider-start-menu`, `C-c C-x`), with argument flags for the settings that vary per session: aliases (`-a`), the ClojureScript REPL type (`-l`) and editing the command before running (`-e`) ([#3317](https://github.com/clojure-emacs/cider/issues/3317)).
 - [#4060](https://github.com/clojure-emacs/cider/pull/4060): Hint at jack-in time when no Clojure CLI aliases are set, so newcomers discover aliases like `:dev`/`:test`; set `cider-clojure-cli-aliases` to `:nil-no-warn` to silence it ([#3317](https://github.com/clojure-emacs/cider/issues/3317)).
 - [#4057](https://github.com/clojure-emacs/cider/pull/4057): Show an animated spinner overlay at the form being evaluated (where its result will appear) while an interactive evaluation is pending, instead of the mode-line spinner, when result overlays are enabled ([#3516](https://github.com/clojure-emacs/cider/issues/3516)).
 - [#4055](https://github.com/clojure-emacs/cider/pull/4055): Add `cider-clojure-cli-powershell-options` to pass extra options (e.g. `-noprofile -executionpolicy bypass`) to the PowerShell executable used for jack-in on Windows ([#2879](https://github.com/clojure-emacs/cider/issues/2879)).

--- a/lisp/cider.el
+++ b/lisp/cider.el
@@ -169,15 +169,80 @@
     map)
   "CIDER jack-in and connect keymap.")
 
+(defun cider-start-menu--read-aliases (prompt initial-input history)
+  "Read Clojure CLI aliases for the jack-in transient.
+PROMPT, INITIAL-INPUT and HISTORY are as for `read-string'."
+  (read-string (or prompt "Aliases (e.g. :dev:test): ")
+               (or initial-input
+                   (and (stringp cider-clojure-cli-aliases)
+                        cider-clojure-cli-aliases))
+               history))
+
+(defun cider-start-menu--read-cljs-repl (prompt initial-input history)
+  "Read a ClojureScript REPL type for the jack-in transient.
+PROMPT, INITIAL-INPUT and HISTORY are as for `completing-read'."
+  (completing-read (or prompt "ClojureScript REPL type: ")
+                   (mapcar (lambda (type) (symbol-name (car type)))
+                           cider-cljs-repl-types)
+                   nil t initial-input history))
+
+(defun cider-start-menu--apply-args (args command)
+  "Call jack-in COMMAND with the `cider-start-menu' ARGS applied.
+Each active argument is translated into a `let'-binding of the matching
+option, so the underlying commands stay usable outside the transient."
+  (let ((cider-clojure-cli-aliases
+         (or (transient-arg-value "--aliases=" args)
+             cider-clojure-cli-aliases))
+        (cider-default-cljs-repl
+         (if-let* ((repl (transient-arg-value "--cljs-repl=" args)))
+             (intern repl)
+           cider-default-cljs-repl))
+        (cider-edit-jack-in-command
+         (or (and (member "--edit-command" args) t)
+             cider-edit-jack-in-command)))
+    (funcall command nil)))
+
+(transient-define-suffix cider-start-menu--jack-in-clj (args)
+  "Jack in to a Clojure REPL, applying the menu's ARGS."
+  (interactive (list (transient-args 'cider-start-menu)))
+  (cider-start-menu--apply-args args #'cider-jack-in-clj))
+
+(transient-define-suffix cider-start-menu--jack-in-cljs (args)
+  "Jack in to a ClojureScript REPL, applying the menu's ARGS."
+  (interactive (list (transient-args 'cider-start-menu)))
+  (cider-start-menu--apply-args args #'cider-jack-in-cljs))
+
+(transient-define-suffix cider-start-menu--jack-in-clj&cljs (args)
+  "Jack in to a Clojure and a ClojureScript REPL, applying the menu's ARGS."
+  (interactive (list (transient-args 'cider-start-menu)))
+  (cider-start-menu--apply-args args #'cider-jack-in-clj&cljs))
+
+(transient-define-suffix cider-start-menu--jack-in-universal (args)
+  "Jack in based on the project type, applying the menu's ARGS."
+  (interactive (list (transient-args 'cider-start-menu)))
+  (cider-start-menu--apply-args args #'cider-jack-in-universal))
+
+(transient-define-suffix cider-start-menu--start-nrepl-server (args)
+  "Start an nREPL server without connecting, applying the menu's ARGS."
+  (interactive (list (transient-args 'cider-start-menu)))
+  (cider-start-menu--apply-args args #'cider-start-nrepl-server))
+
 ;;;###autoload (autoload 'cider-start-menu "cider" "Menu for starting CIDER sessions." t)
 (transient-define-prefix cider-start-menu ()
-  "Transient menu for starting CIDER sessions (jack-in and connect)."
+  "Transient menu for starting CIDER sessions (jack-in and connect).
+The arguments at the top apply to the jack-in commands: set aliases, pick
+a ClojureScript REPL type, or opt to edit the final command before it
+runs.  They only affect this invocation, not your saved configuration."
+  ["Arguments"
+   ("-a" "Aliases" "--aliases=" :reader cider-start-menu--read-aliases)
+   ("-l" "ClojureScript REPL type" "--cljs-repl=" :reader cider-start-menu--read-cljs-repl)
+   ("-e" "Edit command before running" "--edit-command")]
   [["Jack-in (start server + connect)"
-    ("jj" "Clojure" cider-jack-in-clj)
-    ("js" "ClojureScript" cider-jack-in-cljs)
-    ("jm" "Clojure + ClojureScript" cider-jack-in-clj&cljs)
-    ("ju" "Universal (by project type)" cider-jack-in-universal)
-    ("jn" "Start server only" cider-start-nrepl-server)]
+    ("jj" "Clojure" cider-start-menu--jack-in-clj)
+    ("js" "ClojureScript" cider-start-menu--jack-in-cljs)
+    ("jm" "Clojure + ClojureScript" cider-start-menu--jack-in-clj&cljs)
+    ("ju" "Universal (by project type)" cider-start-menu--jack-in-universal)
+    ("jn" "Start server only" cider-start-menu--start-nrepl-server)]
    ["Connect (to a running server)"
     ("cj" "Clojure" cider-connect-clj)
     ("cs" "ClojureScript" cider-connect-cljs)

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -224,4 +224,43 @@
             ;; kill server
             (delete-process (get-buffer-process client-buffer))))))))
 
+(describe "cider-start-menu--apply-args"
+  (it "binds the aliases from the --aliases= argument"
+    (let (captured)
+      (cider-start-menu--apply-args
+       '("--aliases=:dev:test")
+       (lambda (_) (setq captured cider-clojure-cli-aliases)))
+      (expect captured :to-equal ":dev:test")))
+
+  (it "binds the ClojureScript REPL type from --cljs-repl="
+    (let (captured)
+      (cider-start-menu--apply-args
+       '("--cljs-repl=shadow")
+       (lambda (_) (setq captured cider-default-cljs-repl)))
+      (expect captured :to-equal 'shadow)))
+
+  (it "enables command editing from --edit-command"
+    (let (captured)
+      (cider-start-menu--apply-args
+       '("--edit-command")
+       (lambda (_) (setq captured cider-edit-jack-in-command)))
+      (expect captured :to-be-truthy)))
+
+  (it "keeps the configured defaults when no arguments are set"
+    (let ((cider-clojure-cli-aliases ":global")
+          (cider-default-cljs-repl 'node)
+          (cider-edit-jack-in-command nil)
+          captured)
+      (cider-start-menu--apply-args
+       nil
+       (lambda (_) (setq captured (list cider-clojure-cli-aliases
+                                        cider-default-cljs-repl
+                                        cider-edit-jack-in-command))))
+      (expect captured :to-equal '(":global" node nil))))
+
+  (it "calls the command with nil params"
+    (let (received)
+      (cider-start-menu--apply-args nil (lambda (p) (setq received (list :called p))))
+      (expect received :to-equal '(:called nil)))))
+
 ;;; cider-tests.el ends here


### PR DESCRIPTION
Builds on the jack-in/connect transient (`cider-start-menu`) by giving it magit-style argument flags for the settings that actually vary per-invocation:

- **`-a` Aliases** (`--aliases=`) - set the Clojure CLI aliases for this jack-in without touching config. This is a nicer answer to #3317 than the hint alone: aliases become visible and settable right where you start the REPL.
- **`-l` ClojureScript REPL type** (`--cljs-repl=`) - pick shadow/figwheel-main/node/browser/... for this cljs jack-in.
- **`-e` Edit command before running** (`--edit-command`) - the discoverable replacement for the `C-u` prefix trick.

The jack-in suffixes are thin `transient-define-suffix` wrappers that read `transient-args` and `let`-bind the matching options (`cider-clojure-cli-aliases`, `cider-default-cljs-repl`, `cider-edit-jack-in-command`), so `cider-jack-in-clj` and friends stay fully usable outside the transient. Follows the existing `cider-doc-menu` infix pattern.

Unit-tested the arg translation; the interactive menu itself is worth an eyeball. (Also fills in the CHANGELOG for the jack-in transient, which landed undocumented.)