### PR TITLE
Add argument flags to the namespace and macroexpand transient menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New features
 
+- [#4062](https://github.com/clojure-emacs/cider/pull/4062): Add refresh-mode flags to the namespace transient menu (`cider-ns-menu`): `--all`, `--clear` and `--inhibit-fns`, making `cider-ns-refresh`'s otherwise prefix-argument-only modes explicit and combinable.
+- [#4062](https://github.com/clojure-emacs/cider/pull/4062): Add display flags to the macroexpand transient menu (`cider-macroexpand-menu`): `--ns=` (tidy/qualified/none) and `--meta`, to control the popup expansion's rendering per invocation.
 - [#4061](https://github.com/clojure-emacs/cider/pull/4061): The jack-in/connect keybindings are now a transient menu (`cider-start-menu`, `C-c C-x`), with argument flags for the settings that vary per session: aliases (`-a`), the ClojureScript REPL type (`-l`) and editing the command before running (`-e`) ([#3317](https://github.com/clojure-emacs/cider/issues/3317)).
 - [#4060](https://github.com/clojure-emacs/cider/pull/4060): Hint at jack-in time when no Clojure CLI aliases are set, so newcomers discover aliases like `:dev`/`:test`; set `cider-clojure-cli-aliases` to `:nil-no-warn` to silence it ([#3317](https://github.com/clojure-emacs/cider/issues/3317)).
 - [#4057](https://github.com/clojure-emacs/cider/pull/4057): Show an animated spinner overlay at the form being evaluated (where its result will appear) while an interactive evaluation is pending, instead of the mode-line spinner, when result overlays are enabled ([#3516](https://github.com/clojure-emacs/cider/issues/3516)).

--- a/lisp/cider-macroexpansion.el
+++ b/lisp/cider-macroexpansion.el
@@ -310,12 +310,47 @@ Keys 1 and a open the macroexpansion buffer on one level or the full expansion;
 e and E expand inline (a single step, or all the way) via `cider-macrostep'; b
 runs an inline-style stepping session in a dedicated popup buffer.")
 
+(defun cider-macroexpand-menu--read-display-ns (prompt initial-input history)
+  "Read a namespace-display style for the macroexpand transient.
+PROMPT, INITIAL-INPUT and HISTORY are as for `completing-read'."
+  (completing-read (or prompt "Namespace display: ")
+                   '("tidy" "qualified" "none") nil t initial-input history))
+
+(defun cider-macroexpand-menu--apply-args (args command)
+  "Call macroexpand COMMAND with the `cider-macroexpand-menu' ARGS applied.
+The display arguments are `let'-bound around the call, so the popup
+macroexpansion honors them for this invocation only."
+  (let ((cider-macroexpansion-display-namespaces
+         (if-let* ((ns (transient-arg-value "--ns=" args)))
+             (intern ns)
+           cider-macroexpansion-display-namespaces))
+        (cider-macroexpansion-print-metadata
+         (or (and (member "--meta" args) t)
+             cider-macroexpansion-print-metadata)))
+    (funcall command)))
+
+(transient-define-suffix cider-macroexpand-menu--expand-1 (args)
+  "Macroexpand-1 into a popup buffer, applying the menu's ARGS."
+  (interactive (list (transient-args 'cider-macroexpand-menu)))
+  (cider-macroexpand-menu--apply-args args #'cider-macroexpand-1))
+
+(transient-define-suffix cider-macroexpand-menu--expand-all (args)
+  "Fully macroexpand into a popup buffer, applying the menu's ARGS."
+  (interactive (list (transient-args 'cider-macroexpand-menu)))
+  (cider-macroexpand-menu--apply-args args #'cider-macroexpand-all))
+
 ;;;###autoload (autoload 'cider-macroexpand-menu "cider-macroexpansion" "Menu for CIDER's macroexpansion commands." t)
 (transient-define-prefix cider-macroexpand-menu ()
-  "Transient menu for CIDER's macroexpansion commands."
+  "Transient menu for CIDER's macroexpansion commands.
+The display arguments control how the popup macroexpansion renders
+namespaces and metadata for this invocation."
+  ["Display"
+   ("-n" "Namespaces (tidy/qualified/none)" "--ns="
+    :reader cider-macroexpand-menu--read-display-ns)
+   ("-m" "Include metadata" "--meta")]
   [["Macroexpand (popup buffer)"
-    ("1" "Macroexpand-1" cider-macroexpand-1)
-    ("a" "Macroexpand all" cider-macroexpand-all)]
+    ("1" "Macroexpand-1" cider-macroexpand-menu--expand-1)
+    ("a" "Macroexpand all" cider-macroexpand-menu--expand-all)]
    ["Inline (macrostep)"
     ("e" "Expand-1 inline" cider-macrostep-expand)
     ("E" "Expand all inline" cider-macrostep-expand-all)

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -522,15 +522,31 @@ If invoked with a prefix ARG eval the expression after inserting it."
   "CIDER NS keymap.")
 
 ;;;###autoload (autoload 'cider-ns-menu "cider-mode" "Menu for CIDER's namespace commands." t)
+(transient-define-suffix cider-ns-menu--refresh (args)
+  "Refresh namespaces, applying the menu's refresh ARGS.
+`--all', `--clear' and `--inhibit-fns' map to the corresponding
+`cider-ns-refresh' modes; with none set it does a smart reload."
+  (interactive (list (transient-args 'cider-ns-menu)))
+  (cider-ns-refresh
+   (delq nil (list (and (member "--all" args) 'refresh-all)
+                   (and (member "--clear" args) 'clear)
+                   (and (member "--inhibit-fns" args) 'inhibit-fns)))))
+
 (transient-define-prefix cider-ns-menu ()
-  "Transient menu for CIDER's namespace commands."
+  "Transient menu for CIDER's namespace commands.
+The refresh arguments make `cider-ns-refresh's modes (otherwise reached
+via prefix arguments) explicit toggles."
+  ["Refresh arguments"
+   ("-a" "Reload all (unconditionally)" "--all")
+   ("-c" "Clear the tracker first" "--clear")
+   ("-i" "Inhibit refresh functions" "--inhibit-fns")]
   [["Namespace"
     ("b" "Browse namespace" cider-browse-ns)
     ("f" "Find namespace" cider-find-ns)
     ("n" "Set REPL namespace" cider-repl-set-ns)
     ("e" "Eval namespace form" cider-eval-ns-form)]
    ["Reload"
-    ("r" "Refresh (smart reload)" cider-ns-refresh)
+    ("r" "Refresh (smart reload)" cider-ns-menu--refresh)
     ("l" "Require and reload" cider-ns-reload)
     ("L" "Require and reload all" cider-ns-reload-all)]]
   ;; Meta-variant duplicates, hidden from the menu, preserving muscle memory.
@@ -539,7 +555,7 @@ If invoked with a prefix ARG eval the expression after inserting it."
    ("M-f" "Find namespace" cider-find-ns)
    ("M-n" "Set REPL namespace" cider-repl-set-ns)
    ("M-e" "Eval namespace form" cider-eval-ns-form)
-   ("M-r" "Refresh (smart reload)" cider-ns-refresh)
+   ("M-r" "Refresh (smart reload)" cider-ns-menu--refresh)
    ("M-l" "Require and reload all" cider-ns-reload-all)])
 
 ;;;###autoload (autoload 'cider-menu "cider-mode" "Top-level transient menu for CIDER." t)

--- a/lisp/cider-ns.el
+++ b/lisp/cider-ns.el
@@ -359,11 +359,15 @@ unloaded.
 
 With a negative prefix argument, or if MODE is `inhibit-fns', prevent any
 refresh functions (defined in `cider-ns-refresh-before-fn' and
-`cider-ns-refresh-after-fn') from being invoked."
+`cider-ns-refresh-after-fn') from being invoked.
+
+MODE may also be a list combining these symbols (e.g. \\='(refresh-all
+inhibit-fns)), which is how `cider-ns-menu' passes its arguments."
   (interactive "p")
-  (let ((clear? (member mode '(clear 16)))
-        (all? (member mode '(refresh-all 4)))
-        (inhibit-refresh-fns (member mode '(inhibit-fns -1))))
+  (let* ((modes (if (listp mode) mode (list mode)))
+         (clear? (or (memq 'clear modes) (memq 16 modes)))
+         (all? (or (memq 'refresh-all modes) (memq 4 modes)))
+         (inhibit-refresh-fns (or (memq 'inhibit-fns modes) (memq -1 modes))))
     (cider-map-repls '(:clj "cider/refresh" "cider.clj-reload/reload")
       (lambda (conn)
         (cider-ns-refresh--save-modified-buffers conn)

--- a/test/cider-macroexpansion-tests.el
+++ b/test/cider-macroexpansion-tests.el
@@ -143,6 +143,31 @@
     (expect (cider-macroexpansion--operator "(defn- f [])") :to-equal "defn-")
     (expect (cider-macroexpansion--operator "(-> x f)") :to-equal "->")))
 
+(describe "cider-macroexpand-menu--apply-args"
+  (it "binds the namespace display style from --ns="
+    (let (captured)
+      (cider-macroexpand-menu--apply-args
+       '("--ns=qualified")
+       (lambda () (setq captured cider-macroexpansion-display-namespaces)))
+      (expect captured :to-equal 'qualified)))
+
+  (it "enables metadata printing from --meta"
+    (let (captured)
+      (cider-macroexpand-menu--apply-args
+       '("--meta")
+       (lambda () (setq captured cider-macroexpansion-print-metadata)))
+      (expect captured :to-be-truthy)))
+
+  (it "keeps the configured defaults when no arguments are set"
+    (let ((cider-macroexpansion-display-namespaces 'tidy)
+          (cider-macroexpansion-print-metadata nil)
+          captured)
+      (cider-macroexpand-menu--apply-args
+       nil
+       (lambda () (setq captured (list cider-macroexpansion-display-namespaces
+                                       cider-macroexpansion-print-metadata))))
+      (expect captured :to-equal '(tidy nil)))))
+
 (provide 'cider-macroexpansion-tests)
 
 ;;; cider-macroexpansion-tests.el ends here

--- a/test/cider-ns-tests.el
+++ b/test/cider-ns-tests.el
@@ -27,6 +27,7 @@
 
 (require 'buttercup)
 (require 'cider-ns)
+(require 'cider-mode) ; for `cider-ns-menu--refresh'
 (require 'cider-test-utils "test/utils/cider-test-utils")
 
 ;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
@@ -250,3 +251,18 @@
             :to-equal 'cider-ns-refresh))
   (it "provides a menu (#2798)"
     (expect (lookup-key cider-ns-refresh-log-mode-map [menu-bar]) :to-be-truthy)))
+
+(describe "cider-ns-menu--refresh"
+  (before-each (spy-on 'cider-ns-refresh))
+
+  (it "translates the menu switches into a list of refresh modes"
+    (cider-ns-menu--refresh '("--all" "--inhibit-fns"))
+    (expect 'cider-ns-refresh :to-have-been-called-with '(refresh-all inhibit-fns)))
+
+  (it "passes clear on its own"
+    (cider-ns-menu--refresh '("--clear"))
+    (expect 'cider-ns-refresh :to-have-been-called-with '(clear)))
+
+  (it "passes nil for a plain smart reload when no switches are set"
+    (cider-ns-menu--refresh nil)
+    (expect 'cider-ns-refresh :to-have-been-called-with nil)))


### PR DESCRIPTION
Follows up the jack-in transient flags (#4061) by giving two more menus the same treatment - surfacing settings that vary per-invocation as visible infix arguments, from the survey of infix opportunities.

**`cider-ns-menu` - refresh modes** (`--all`, `--clear`, `--inhibit-fns`). These map to `cider-ns-refresh`'s modes, which today are only reachable via the undiscoverable single/double/negative prefix arguments. `cider-ns-refresh` now also accepts a *list* of mode symbols (backward compatible with the scalar symbol/prefix forms), so the orthogonal `inhibit-fns` can combine with `reload-all` or `clear` - something the single-mode prefix couldn't express.

**`cider-macroexpand-menu` - display** (`--ns=tidy|qualified|none`, `--meta`). These map to `cider-macroexpansion-display-namespaces` / `-print-metadata`, so you pick the popup expansion's rendering up front instead of expanding and then cycling with the in-buffer togglers.

Same wrapper pattern as before: thin `transient-define-suffix`es read `transient-args` and `let`-bind the options, so the underlying commands stay usable outside the transients. Two commits, one per menu. Tested the arg translation for both; the menus themselves are worth an eyeball.