### PR TITLE
Add selector flags to the test transient menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- [#4063](https://github.com/clojure-emacs/cider/pull/4063): Add test-selector flags to the test transient menu (`cider-test-menu`): `--include=` and `--exclude=`, so a selector filter can be set once and reused across the namespace/loaded/project run commands.
 - [#4062](https://github.com/clojure-emacs/cider/pull/4062): Add refresh-mode flags to the namespace transient menu (`cider-ns-menu`): `--all`, `--clear` and `--inhibit-fns`, making `cider-ns-refresh`'s otherwise prefix-argument-only modes explicit and combinable.
 - [#4062](https://github.com/clojure-emacs/cider/pull/4062): Add display flags to the macroexpand transient menu (`cider-macroexpand-menu`): `--ns=` (tidy/qualified/none) and `--meta`, to control the popup expansion's rendering per invocation.
 - [#4061](https://github.com/clojure-emacs/cider/pull/4061): The jack-in/connect keybindings are now a transient menu (`cider-start-menu`, `C-c C-x`), with argument flags for the settings that vary per session: aliases (`-a`), the ClojureScript REPL type (`-l`) and editing the command before running (`-e`) ([#3317](https://github.com/clojure-emacs/cider/issues/3317)).

--- a/lisp/cider-test.el
+++ b/lisp/cider-test.el
@@ -173,15 +173,60 @@ to work against the correct REPL session.")
     ["Configure testing" (customize-group 'cider-test)])
   "CIDER test submenu (for the menu bar).")
 
+(defun cider-test-menu--read-selectors (prompt initial-input history)
+  "Read space-separated test selectors for the test transient.
+PROMPT, INITIAL-INPUT and HISTORY are as for `read-string'."
+  (read-string (or prompt "Selectors (space separated, e.g. :integration): ")
+               initial-input history))
+
+(defun cider-test-menu--selectors (value)
+  "Split VALUE into a list of selector strings, stripping leading colons.
+Return nil when VALUE is nil."
+  (when value
+    (mapcar (lambda (selector) (replace-regexp-in-string "\\`:+" "" selector))
+            (split-string value))))
+
+(defun cider-test-menu--apply-args (args thunk)
+  "Call THUNK with the `cider-test-menu' selector ARGS applied.
+The include/exclude selectors are `let'-bound around the call, so the run
+commands filter by them for this invocation only."
+  (let ((cider-test-default-include-selectors
+         (or (cider-test-menu--selectors (transient-arg-value "--include=" args))
+             cider-test-default-include-selectors))
+        (cider-test-default-exclude-selectors
+         (or (cider-test-menu--selectors (transient-arg-value "--exclude=" args))
+             cider-test-default-exclude-selectors)))
+    (funcall thunk)))
+
+(transient-define-suffix cider-test-menu--run-ns (args)
+  "Run the current namespace's tests, applying the menu's selector ARGS."
+  (interactive (list (transient-args 'cider-test-menu)))
+  (cider-test-menu--apply-args args (lambda () (cider-test-run-ns-tests nil))))
+
+(transient-define-suffix cider-test-menu--run-loaded (args)
+  "Run the loaded namespaces' tests, applying the menu's selector ARGS."
+  (interactive (list (transient-args 'cider-test-menu)))
+  (cider-test-menu--apply-args args (lambda () (cider-test-run-loaded-tests nil))))
+
+(transient-define-suffix cider-test-menu--run-project (args)
+  "Run the project's tests, applying the menu's selector ARGS."
+  (interactive (list (transient-args 'cider-test-menu)))
+  (cider-test-menu--apply-args args (lambda () (cider-test-run-project-tests nil))))
+
 ;;;###autoload (autoload 'cider-test-menu "cider-test" "Menu for CIDER's test commands." t)
 (transient-define-prefix cider-test-menu ()
-  "Transient menu for CIDER's test commands."
+  "Transient menu for CIDER's test commands.
+The selector arguments filter which tests the namespace, loaded and
+project run commands execute, without prompting."
+  ["Selectors"
+   ("-i" "Include" "--include=" :reader cider-test-menu--read-selectors)
+   ("-x" "Exclude" "--exclude=" :reader cider-test-menu--read-selectors)]
   [["Run"
     ("t" "Test at point" cider-test-run-test)
-    ("n" "Namespace tests" cider-test-run-ns-tests)
-    ("s" "Namespace tests (filtered)" cider-test-run-ns-tests-with-filters)
-    ("l" "Loaded tests" cider-test-run-loaded-tests)
-    ("p" "Project tests" cider-test-run-project-tests)]
+    ("n" "Namespace tests" cider-test-menu--run-ns)
+    ("s" "Namespace tests (prompt for filters)" cider-test-run-ns-tests-with-filters)
+    ("l" "Loaded tests" cider-test-menu--run-loaded)
+    ("p" "Project tests" cider-test-menu--run-project)]
    ["Rerun / report"
     ("r" "Rerun failed" cider-test-rerun-failed-tests)
     ("a" "Rerun last test" cider-test-rerun-test)
@@ -190,10 +235,10 @@ to work against the correct REPL session.")
   ;; Control-variant duplicates, hidden from the menu, preserving muscle memory.
   [:hide (lambda () t)
    ("C-t" "Test at point" cider-test-run-test)
-   ("C-n" "Namespace tests" cider-test-run-ns-tests)
-   ("C-s" "Namespace tests (filtered)" cider-test-run-ns-tests-with-filters)
-   ("C-l" "Loaded tests" cider-test-run-loaded-tests)
-   ("C-p" "Project tests" cider-test-run-project-tests)
+   ("C-n" "Namespace tests" cider-test-menu--run-ns)
+   ("C-s" "Namespace tests (prompt for filters)" cider-test-run-ns-tests-with-filters)
+   ("C-l" "Loaded tests" cider-test-menu--run-loaded)
+   ("C-p" "Project tests" cider-test-menu--run-project)
    ("C-r" "Rerun failed" cider-test-rerun-failed-tests)
    ("C-a" "Rerun last test" cider-test-rerun-test)
    ("C-b" "Show report" cider-test-show-report)

--- a/test/cider-test-tests.el
+++ b/test/cider-test-tests.el
@@ -162,3 +162,30 @@
       (insert "x")
       (cider-test--add-fringe-indicator (current-buffer) nil t)
       (expect (overlays-in (point-min) (point-max)) :to-be nil))))
+
+(describe "cider-test-menu--selectors"
+  (it "splits on whitespace and strips leading colons"
+    (expect (cider-test-menu--selectors ":integration :slow")
+            :to-equal '("integration" "slow")))
+  (it "returns nil when given nil"
+    (expect (cider-test-menu--selectors nil) :to-be nil)))
+
+(describe "cider-test-menu--apply-args"
+  (it "binds the include and exclude selectors from the args"
+    (let (include exclude)
+      (cider-test-menu--apply-args
+       '("--include=:integration" "--exclude=:slow :flaky")
+       (lambda () (setq include cider-test-default-include-selectors
+                        exclude cider-test-default-exclude-selectors)))
+      (expect include :to-equal '("integration"))
+      (expect exclude :to-equal '("slow" "flaky"))))
+
+  (it "keeps the configured defaults when no selector args are set"
+    (let ((cider-test-default-include-selectors '("keep"))
+          (cider-test-default-exclude-selectors '("skip"))
+          captured)
+      (cider-test-menu--apply-args
+       nil
+       (lambda () (setq captured (list cider-test-default-include-selectors
+                                       cider-test-default-exclude-selectors))))
+      (expect captured :to-equal '(("keep") ("skip"))))))


### PR DESCRIPTION
Continues the transient-flags theme (after #4061, #4062) with the test menu, per the infix survey.

Adds `--include=` and `--exclude=` selector infixes to `cider-test-menu`. The namespace/loaded/project run suffixes read those args and `let`-bind `cider-test-default-include-selectors` / `-exclude-selectors`, so you set a filter (e.g. include `:integration`, exclude `:slow`) once and reuse it across all the run commands - instead of re-answering the prompt every time via `cider-test-run-ns-tests-with-filters` (still available as `s`).

Same thin-wrapper pattern; selectors are split on whitespace with leading colons stripped, mirroring the existing prompt. Tested the parsing and arg translation. Left `cider-test-fail-fast` as its existing toggle command (it's a persistent setting, not per-invocation).