### PR TITLE
Bump the development version to 2.0.0-snapshot

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -135,7 +135,7 @@ a clickable, inspectable object you can send back to the REPL.
 ### Stepwise macroexpansion
 
 In-place, stepwise macro expansion (à la
-[macrostep](https://github.com/joddie/macrostep)) shipped in CIDER 1.23:
+[macrostep](https://github.com/joddie/macrostep)) shipped in CIDER 2.0:
 `cider-macrostep-expand` expands the form at point one level inline, you can
 step into nested forms and collapse back (`cider-macrostep-mode`), the
 further-expandable heads are highlighted with `n`/`p` navigation, and the

--- a/doc/modules/ROOT/pages/repl/basic_usage.adoc
+++ b/doc/modules/ROOT/pages/repl/basic_usage.adoc
@@ -42,7 +42,7 @@ reference covering the common REPL interactions, loading code, switching
 namespaces and moving between the REPL and your source.  Set
 `cider-repl-display-help-banner` to nil to drop the hint from new REPLs.
 
-TIP: Since CIDER 1.23 the REPL transcript no longer dumps the full jack-in
+TIP: Since CIDER 2.0 the REPL transcript no longer dumps the full jack-in
 command or the ClojureScript REPL init form on startup (a ClojureScript REPL
 just notes its type).  Run `cider-repl-describe-startup` (the `,startup`
 shortcut) to see those launch details - project, endpoint, the jack-in command

--- a/lisp/cider-cheatsheet.el
+++ b/lisp/cider-cheatsheet.el
@@ -62,12 +62,12 @@ from ClojureDocs or any other function accepting a var as an argument."
 (defface cider-cheatsheet-section
   '((t (:inherit font-lock-keyword-face :weight bold)))
   "Face for top-level sections in the cheatsheet buffer."
-  :package-version '(cider . "1.23.0"))
+  :package-version '(cider . "2.0.0"))
 
 (defface cider-cheatsheet-subsection
   '((t (:weight bold)))
   "Face for nested sections in the cheatsheet buffer."
-  :package-version '(cider . "1.23.0"))
+  :package-version '(cider . "2.0.0"))
 
 (defconst cider-cheatsheet-hierarchy
   '(("Documentation"

--- a/lisp/cider-client.el
+++ b/lisp/cider-client.el
@@ -247,7 +247,7 @@ Signal an error if it is not supported."
 (make-obsolete 'cider-ensure-op-supported
                "op support is now enforced automatically by the nREPL senders, \
 so commands no longer need an explicit check."
-               "1.23.0")
+               "2.0.0")
 
 (defvar cider--skip-op-ensure nil
   "When non-nil, skip the automatic op-support check in CIDER's nREPL senders.
@@ -338,7 +338,7 @@ prefer the keyword-argument `cider-nrepl-sync-request'."
                            :abort-on-input abort-on-input
                            :callback callback))
 
-(make-obsolete 'cider-nrepl-send-sync-request 'cider-nrepl-sync-request "1.23.0")
+(make-obsolete 'cider-nrepl-send-sync-request 'cider-nrepl-sync-request "2.0.0")
 
 (defun cider-nrepl-send-unhandled-request (request &optional connection)
   "Send REQUEST to the nREPL CONNECTION and ignore any responses.
@@ -395,7 +395,7 @@ prefer the keyword-argument `cider-nrepl-send-eval-request'."
                                  :additional-params additional-params
                                  :connection connection))
 
-(make-obsolete 'cider-nrepl-request:eval 'cider-nrepl-send-eval-request "1.23.0")
+(make-obsolete 'cider-nrepl-request:eval 'cider-nrepl-send-eval-request "2.0.0")
 
 (defun cider-nrepl-sync-request:eval (input &optional connection ns)
   "Send the INPUT to the nREPL CONNECTION synchronously.

--- a/lisp/cider-doc.el
+++ b/lisp/cider-doc.el
@@ -65,14 +65,14 @@ appends them to the `*cider-doc*' buffer.  When nil, the buffer instead shows
 a button (and the \\`e' key) to fetch them on demand."
   :type 'boolean
   :group 'cider-doc
-  :package-version '(cider . "1.23.0"))
+  :package-version '(cider . "2.0.0"))
 
 (defcustom cider-doc-clojuredocs-max-examples 3
   "Maximum number of ClojureDocs examples to show inline in the doc buffer.
 A link to the full ClojureDocs entry is shown when more examples exist."
   :type 'integer
   :group 'cider-doc
-  :package-version '(cider . "1.23.0"))
+  :package-version '(cider . "2.0.0"))
 
 (declare-function cider-apropos "cider-apropos")
 (declare-function cider-apropos-select "cider-apropos")

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -132,7 +132,7 @@ If t, save the file without confirmation."
 
 (defconst cider-output-buffer "*cider-out*")
 
-(define-obsolete-variable-alias 'cider-interactive-eval-output-destination 'cider-eval-output-destination "1.23.0")
+(define-obsolete-variable-alias 'cider-interactive-eval-output-destination 'cider-eval-output-destination "2.0.0")
 
 (defcustom cider-eval-output-destination 'repl-buffer
   "The destination for stdout and stderr produced from interactive evaluation.
@@ -141,7 +141,7 @@ If `output-buffer', it's sent to a dedicated `*cider-out*' buffer."
   :type '(choice (const :tag "REPL buffer" repl-buffer)
                  (const :tag "Dedicated output buffer" output-buffer))
   :group 'cider
-  :package-version '(cider . "1.23.0"))
+  :package-version '(cider . "2.0.0"))
 
 (defcustom cider-comment-prefix ";; => "
   "The prefix to insert before the first line of commented output."
@@ -179,7 +179,7 @@ and use their own fixed formatting."
                  (const :tag "Reader ignore form (#_)" ignore)
                  (const :tag "Comment form (comment ...)" comment))
   :group 'cider
-  :package-version '(cider . "1.23.0"))
+  :package-version '(cider . "2.0.0"))
 
 (defun cider--comment-format ()
   "Return the comment formatting for `cider-comment-style'.

--- a/lisp/cider-jack-in.el
+++ b/lisp/cider-jack-in.el
@@ -110,7 +110,7 @@ execution policy."
                  (string :tag "Options"))
   :group 'cider
   :safe (lambda (s) (or (null s) (stringp s)))
-  :package-version '(cider . "1.23.0"))
+  :package-version '(cider . "2.0.0"))
 
 (defcustom cider-clojure-cli-aliases
   nil

--- a/lisp/cider-macroexpansion.el
+++ b/lisp/cider-macroexpansion.el
@@ -44,7 +44,7 @@
 This makes it more obvious that the buffer's contents changed."
   :type 'boolean
   :group 'cider
-  :package-version '(cider . "1.23.0"))
+  :package-version '(cider . "2.0.0"))
 
 (defcustom cider-macroexpansion-display-namespaces 'tidy
   "Determines if namespaces are displayed in the macroexpansion buffer.

--- a/lisp/cider-macrostep.el
+++ b/lisp/cider-macrostep.el
@@ -58,13 +58,13 @@ Possible values are:
                  (const :tag "Show fully-qualified namespaces" qualified)
                  (const :tag "Show namespace aliases" tidy))
   :group 'cider
-  :package-version '(cider . "1.23.0"))
+  :package-version '(cider . "2.0.0"))
 
 (defcustom cider-macrostep-highlight-expansion t
   "Whether to briefly highlight (pulse) a freshly inserted inline expansion."
   :type 'boolean
   :group 'cider
-  :package-version '(cider . "1.23.0"))
+  :package-version '(cider . "2.0.0"))
 
 (defcustom cider-macrostep-highlight-expandable t
   "Whether to highlight the operators of further-expandable sub-forms.
@@ -74,7 +74,7 @@ a macro are underlined, and `n'/`p' navigate between them.  Requires the
 silently skipped."
   :type 'boolean
   :group 'cider
-  :package-version '(cider . "1.23.0"))
+  :package-version '(cider . "2.0.0"))
 
 (defcustom cider-macrostep-color-gensyms t
   "Whether to colorize the gensyms introduced by a macro expansion.
@@ -83,7 +83,7 @@ expansion gets its own color from `cider-macrostep-gensym-colors', so a
 binding introduced by the macro can be tracked through the expansion."
   :type 'boolean
   :group 'cider
-  :package-version '(cider . "1.23.0"))
+  :package-version '(cider . "2.0.0"))
 
 (defcustom cider-macrostep-gensym-colors
   '("#d33682" "#268bd2" "#859900" "#b58900" "#6c71c4" "#2aa198" "#cb4b16")
@@ -92,7 +92,7 @@ Each distinct gensym in an expansion is assigned the next color in this
 list, wrapping around when an expansion has more gensyms than colors."
   :type '(repeat color)
   :group 'cider
-  :package-version '(cider . "1.23.0"))
+  :package-version '(cider . "2.0.0"))
 
 (defface cider-macrostep-expansion-face
   '((((min-colors 16777216) (background light)) :background "#eef3fb" :extend t)
@@ -101,13 +101,13 @@ list, wrapping around when an expansion has more gensyms than colors."
     (((background dark)) :background "gray22" :extend t))
   "Face for the background of an inline macro expansion."
   :group 'cider
-  :package-version '(cider . "1.23.0"))
+  :package-version '(cider . "2.0.0"))
 
 (defface cider-macrostep-expandable-face
   '((t :underline t :weight bold))
   "Face for the operator of a sub-form that can be expanded further."
   :group 'cider
-  :package-version '(cider . "1.23.0"))
+  :package-version '(cider . "2.0.0"))
 
 (defvar-local cider-macrostep--overlays nil
   "Stack of overlays for the current `cider-macrostep-mode' session.

--- a/lisp/cider-ns-state.el
+++ b/lisp/cider-ns-state.el
@@ -56,13 +56,13 @@ For per-form staleness, use the evaluation fringe indicators instead (see
   :type '(set (const :tag "Mode-line marker" mode-line)
               (const :tag "Fringe marker" fringe))
   :group 'cider
-  :package-version '(cider . "1.23.0"))
+  :package-version '(cider . "2.0.0"))
 
 (defface cider-ns-load-state-face
   '((t :inherit warning))
   "Face for the namespace load-state marker (mode line and fringe)."
   :group 'cider
-  :package-version '(cider . "1.23.0"))
+  :package-version '(cider . "2.0.0"))
 
 (defconst cider-ns-state--fringe-marker
   (propertize " " 'display '(left-fringe empty-line cider-ns-load-state-face))

--- a/lisp/cider-overlays.el
+++ b/lisp/cider-overlays.el
@@ -53,10 +53,10 @@ lower priority than the syntax highlighting."
   :group 'cider
   :package-version '(cider "0.25.0"))
 
-(define-obsolete-variable-alias 'cider-result-use-clojure-font-lock 'cider-eval-result-font-lock "1.23.0")
-(define-obsolete-variable-alias 'cider-overlays-use-font-lock 'cider-eval-result-font-lock "1.23.0")
-(define-obsolete-variable-alias 'cider-use-overlays 'cider-eval-result-display "1.23.0")
-(define-obsolete-variable-alias 'cider-result-overlay-position 'cider-eval-result-position "1.23.0")
+(define-obsolete-variable-alias 'cider-result-use-clojure-font-lock 'cider-eval-result-font-lock "2.0.0")
+(define-obsolete-variable-alias 'cider-overlays-use-font-lock 'cider-eval-result-font-lock "2.0.0")
+(define-obsolete-variable-alias 'cider-use-overlays 'cider-eval-result-display "2.0.0")
+(define-obsolete-variable-alias 'cider-result-overlay-position 'cider-eval-result-position "2.0.0")
 
 (defcustom cider-eval-result-font-lock 'clojure
   "How to highlight interactive evaluation results.
@@ -71,7 +71,7 @@ This replaces the older `cider-result-use-clojure-font-lock' and
   :group 'cider
   :type '(choice (const :tag "Highlight as Clojure" clojure)
                  (const :tag "Use the result overlay face" nil))
-  :package-version '(cider . "1.23.0"))
+  :package-version '(cider . "2.0.0"))
 
 (defcustom cider-eval-result-display 'both
   "Where to display interactive evaluation results.
@@ -92,7 +92,7 @@ see `cider-debug-use-overlays'."
                  (const :tag "Both" both)
                  (const :tag "Overlay for errors only" errors-only))
   :group 'cider
-  :package-version '(cider . "1.23.0"))
+  :package-version '(cider . "2.0.0"))
 
 (defcustom cider-eval-result-position 'at-eol
   "Where to place result overlays for inline evaluation and the debugger.
@@ -101,7 +101,7 @@ If `at-point', place at the end of the evaluated sexp."
   :group 'cider
   :type '(choice (const :tag "End of line" at-eol)
                  (const :tag "End of sexp" at-point))
-  :package-version '(cider . "1.23.0"))
+  :package-version '(cider . "2.0.0"))
 
 (defcustom cider-eval-result-prefix "=> "
   "The prefix displayed before an interactive evaluation result.
@@ -177,7 +177,7 @@ This function also removes itself from `post-command-hook'."
     (((class color) (background dark)) :foreground "orange"))
   "Face used on the fringe indicator for a form edited since it was evaluated."
   :group 'cider
-  :package-version '(cider . "1.23.0"))
+  :package-version '(cider . "2.0.0"))
 
 (defconst cider--fringe-overlay-good
   (propertize " " 'display '(left-fringe empty-line cider-fringe-good-face))
@@ -192,13 +192,13 @@ This function also removes itself from `post-command-hook'."
     (((class color) (background dark)) :foreground "red1"))
   "Face used on the fringe indicator for a failing test."
   :group 'cider
-  :package-version '(cider . "1.23.0"))
+  :package-version '(cider . "2.0.0"))
 
 (defconst cider--fringe-overlay-bad
   (propertize " " 'display '(left-fringe empty-line cider-fringe-bad-face))
   "The before-string property that adds a red indicator on the fringe.")
 
-(define-obsolete-variable-alias 'cider-use-fringe-indicators 'cider-fringe-indicators "1.23.0")
+(define-obsolete-variable-alias 'cider-use-fringe-indicators 'cider-fringe-indicators "2.0.0")
 
 (defcustom cider-fringe-indicators t
   "Whether to display indicators on the left fringe.
@@ -218,7 +218,7 @@ Recognized kinds:
                  (set :tag "Selected kinds"
                       (const :tag "Evaluated forms" eval)
                       (const :tag "Test results" test)))
-  :package-version '(cider . "1.23.0"))
+  :package-version '(cider . "2.0.0"))
 
 (defun cider--use-fringe-indicators-p (kind)
   "Return non-nil when fringe indicators are enabled for KIND.
@@ -237,7 +237,7 @@ the form restores the in-sync indicator."
   :safe #'booleanp
   :group 'cider
   :type 'boolean
-  :package-version '(cider . "1.23.0"))
+  :package-version '(cider . "2.0.0"))
 
 (defun cider--fringe-overlay-mark-stale (ov after-p _beg _end &optional _len)
   "Recolor fringe indicator overlay OV to the stale face once its form is edited.

--- a/lisp/cider-repl.el
+++ b/lisp/cider-repl.el
@@ -410,7 +410,7 @@ The full getting-started help now lives in `cider-repl-help'."
   '((t :inherit bold :underline t))
   "Face for the section headings in the `cider-repl-help' buffer."
   :group 'cider
-  :package-version '(cider . "1.23.0"))
+  :package-version '(cider . "2.0.0"))
 
 (defvar cider-repl-help-mode-map
   (let ((map (make-sparse-keymap)))
@@ -2258,7 +2258,7 @@ in an unexpected place."
     ;; Deprecated REPL-only aliases; the canonical bindings live in the
     ;; `C-c C-x' start map, shared with `cider-mode'.
     ;; Soft-deprecated since the `C-c C-x' start map landed in 0.18.0; now
-    ;; formally warned (the warning mechanism itself arrived in 1.23.0).
+    ;; formally warned (the warning mechanism itself arrived in 2.0.0).
     (cider--define-deprecated-key map "C-c M-j" #'cider-jack-in-clj "C-c C-x j j" "0.18.0")
     (cider--define-deprecated-key map "C-c M-J" #'cider-jack-in-cljs "C-c C-x j s" "0.18.0")
     (cider--define-deprecated-key map "C-c M-c" #'cider-connect-clj "C-c C-x c j" "0.18.0")

--- a/lisp/cider-session.el
+++ b/lisp/cider-session.el
@@ -109,7 +109,7 @@ correctness.  Use it only to fail fast, before doing interactive or
 side-effecting work, rather than at the point of the first request."
   (sesman-ensure-session 'CIDER))
 
-(define-obsolete-function-alias 'cider-ensure-connected #'cider-ensure-session "1.23.0")
+(define-obsolete-function-alias 'cider-ensure-connected #'cider-ensure-session "2.0.0")
 
 
 ;;; Connection Parameters
@@ -696,10 +696,10 @@ session."
 (defalias 'cider-connections #'cider-repls)
 (defalias 'cider-map-connections #'cider-map-repls)
 (defalias 'cider-connection-type-for-buffer #'cider-repl-type-for-buffer)
-(make-obsolete 'cider-current-connection #'cider-current-repl "1.23.0")
-(make-obsolete 'cider-connections #'cider-repls "1.23.0")
-(make-obsolete 'cider-map-connections #'cider-map-repls "1.23.0")
-(make-obsolete 'cider-connection-type-for-buffer #'cider-repl-type-for-buffer "1.23.0")
+(make-obsolete 'cider-current-connection #'cider-current-repl "2.0.0")
+(make-obsolete 'cider-connections #'cider-repls "2.0.0")
+(make-obsolete 'cider-map-connections #'cider-map-repls "2.0.0")
+(make-obsolete 'cider-connection-type-for-buffer #'cider-repl-type-for-buffer "2.0.0")
 
 
 (provide 'cider-session)

--- a/lisp/cider-util.el
+++ b/lisp/cider-util.el
@@ -801,7 +801,7 @@ The command still runs either way; this only controls the one-time message
 nudging you toward the replacement binding."
   :type 'boolean
   :group 'cider
-  :package-version '(cider . "1.23.0"))
+  :package-version '(cider . "2.0.0"))
 
 (defvar cider--deprecated-keybindings nil
   "Registry of CIDER's deprecated keybindings.

--- a/lisp/cider-xref-backend.el
+++ b/lisp/cider-xref-backend.el
@@ -128,7 +128,7 @@ compiler generated from macros, which leave no textual trace for the scan."
                  (const :tag "Runtime references only" runtime)
                  (const :tag "Runtime and source matches combined" both))
   :group 'cider
-  :package-version '(cider . "1.23.0"))
+  :package-version '(cider . "2.0.0"))
 
 (defun cider--fn-refs-xrefs (ns var)
   "Find references of VAR in NS via runtime introspection (the `fn-refs' op).

--- a/lisp/cider-xref-source.el
+++ b/lisp/cider-xref-source.el
@@ -62,7 +62,7 @@
 Each entry is an extension without the leading dot."
   :type '(repeat string)
   :group 'cider
-  :package-version '(cider . "1.23.0"))
+  :package-version '(cider . "2.0.0"))
 
 (defconst cider-xref--symbol-chars "[:alnum:]_'*+!?<>=&$%./:-"
   "The Clojure symbol-constituent characters, as the body of a bracket expression.

--- a/lisp/cider.el
+++ b/lisp/cider.el
@@ -14,7 +14,7 @@
 ;; Homepage: https://www.github.com/clojure-emacs/cider
 ;; Keywords: languages, clojure, cider
 ;;
-;; Version: 1.23.0-snapshot
+;; Version: 2.0.0-snapshot
 ;; Package-Requires: (
 ;;     (emacs "28")
 ;;     (clojure-mode "5.19")
@@ -108,7 +108,7 @@
 (require 'seq)
 (require 'sesman)
 
-(defconst cider-version "1.23.0-snapshot"
+(defconst cider-version "2.0.0-snapshot"
   "The current version of CIDER.")
 
 (defconst cider-codename "Terceira"

--- a/lisp/nrepl-client.el
+++ b/lisp/nrepl-client.el
@@ -106,7 +106,7 @@ directly."
 The countdown resets whenever the ssh process produces output, so an
 interactive password or 2FA prompt won't trip the timeout."
   :type 'integer
-  :package-version '(cider . "1.23.0"))
+  :package-version '(cider . "2.0.0"))
 
 (defcustom nrepl-sync-request-timeout 10
   "The number of seconds to wait for a sync response.
@@ -1020,7 +1020,7 @@ prefer the keyword-argument `nrepl-sync-request'."
                       :tooling tooling
                       :callback callback))
 
-(make-obsolete 'nrepl-send-sync-request 'nrepl-sync-request "1.23.0")
+(make-obsolete 'nrepl-send-sync-request 'nrepl-sync-request "2.0.0")
 
 (defun nrepl-request:stdin (input callback connection)
   "Send a :stdin request with INPUT using CONNECTION.
@@ -1092,7 +1092,7 @@ prefer the keyword-argument `nrepl-send-eval-request'."
                            :ns ns :line line :column column
                            :additional-params additional-params :tooling tooling))
 
-(make-obsolete 'nrepl-request:eval 'nrepl-send-eval-request "1.23.0")
+(make-obsolete 'nrepl-request:eval 'nrepl-send-eval-request "2.0.0")
 
 (defvar nrepl-client-name "nrepl.el"
   "Name of the nREPL client, sent in clone requests.")

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -553,11 +553,11 @@ and some other vars (like clojure.core/filter).
   (it "binds the key to a command and registers the deprecation"
     (let ((map (make-sparse-keymap))
           (cider--deprecated-keybindings nil))
-      (cider--define-deprecated-key map "C-c X" #'ignore "C-c C-x y" "1.23")
+      (cider--define-deprecated-key map "C-c X" #'ignore "C-c C-x y" "2.0")
       (expect (commandp (lookup-key map (kbd "C-c X"))) :to-be-truthy)
       (let ((entry (car cider--deprecated-keybindings)))
         (expect (plist-get entry :replacement) :to-equal "C-c C-x y")
-        (expect (plist-get entry :since) :to-equal "1.23"))))
+        (expect (plist-get entry :since) :to-equal "2.0"))))
 
   (it "runs the underlying command when invoked"
     (let ((map (make-sparse-keymap))


### PR DESCRIPTION
Renames the current development cycle from 1.23.0 to 2.0.0, since the changes this cycle warrant a major bump.

- `Version:` header and `cider-version` -> `2.0.0-snapshot`
- Every `:package-version '(cider . "1.23.0")` and `make-obsolete`/`define-obsolete-*` "1.23.0" tag retargeted to `2.0.0` (these were all added this cycle and never released under 1.23.0)
- Doc/roadmap/test references to 1.23 updated

`doc/antora.yml` stays `~` (the dev placeholder; it's set to the major.minor at release time). Historical CHANGELOG entries and older version tags are untouched. Full byte-compile (warnings-as-errors) and lint are clean.