### PR TITLE
Add a print-function flag to the pretty-print transient menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- [#4065](https://github.com/clojure-emacs/cider/pull/4065): Add a `--print-fn=` flag to the pretty-print transient menu (`cider-eval-pprint-menu`) to pick the printer (pr/pprint/fipp/puget/zprint or a custom var) per invocation.
 - [#4063](https://github.com/clojure-emacs/cider/pull/4063): Add test-selector flags to the test transient menu (`cider-test-menu`): `--include=` and `--exclude=`, so a selector filter can be set once and reused across the namespace/loaded/project run commands.
 - [#4062](https://github.com/clojure-emacs/cider/pull/4062): Add refresh-mode flags to the namespace transient menu (`cider-ns-menu`): `--all`, `--clear` and `--inhibit-fns`, making `cider-ns-refresh`'s otherwise prefix-argument-only modes explicit and combinable.
 - [#4062](https://github.com/clojure-emacs/cider/pull/4062): Add display flags to the macroexpand transient menu (`cider-macroexpand-menu`): `--ns=` (tidy/qualified/none) and `--meta`, to control the popup expansion's rendering per invocation.

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -1305,19 +1305,73 @@ passing arguments."
 ;; including the C-<letter> duplicates (hidden from the menu), so muscle memory
 ;; like C-c C-v C-r keeps working unchanged.
 
+(defun cider-eval-pprint-menu--read-print-fn (prompt initial-input history)
+  "Read a print function for the pretty-print transient.
+PROMPT, INITIAL-INPUT and HISTORY are as for `completing-read'.  A value
+outside the known printers is treated as a namespace-qualified var name."
+  (completing-read (or prompt "Print function: ")
+                   '("pr" "pprint" "fipp" "puget" "zprint")
+                   nil nil initial-input history))
+
+(defun cider-eval-pprint-menu--print-fn (value)
+  "Convert VALUE, a string, into a `cider-print-fn' value.
+The known printers become symbols so `cider--print-fn' recognizes them;
+any other value (a custom var name) is kept as a string."
+  (if (member value '("pr" "pprint" "fipp" "puget" "zprint"))
+      (intern value)
+    value))
+
+(defun cider-eval-pprint-menu--apply-args (args command)
+  "Call pretty-print COMMAND with the `cider-eval-pprint-menu' ARGS applied.
+The chosen printer is `let'-bound around the call, for this invocation only."
+  (let ((cider-print-fn
+         (if-let* ((fn (transient-arg-value "--print-fn=" args)))
+             (cider-eval-pprint-menu--print-fn fn)
+           cider-print-fn)))
+    (funcall command)))
+
+(transient-define-suffix cider-eval-pprint-menu--last-sexp (args)
+  "Pretty-print the last sexp, applying the menu's ARGS."
+  (interactive (list (transient-args 'cider-eval-pprint-menu)))
+  (cider-eval-pprint-menu--apply-args args #'cider-pprint-eval-last-sexp))
+
+(transient-define-suffix cider-eval-pprint-menu--defun (args)
+  "Pretty-print the defun at point, applying the menu's ARGS."
+  (interactive (list (transient-args 'cider-eval-pprint-menu)))
+  (cider-eval-pprint-menu--apply-args args #'cider-pprint-eval-defun-at-point))
+
+(transient-define-suffix cider-eval-pprint-menu--last-sexp-to-comment (args)
+  "Pretty-print the last sexp into a comment, applying the menu's ARGS."
+  (interactive (list (transient-args 'cider-eval-pprint-menu)))
+  (cider-eval-pprint-menu--apply-args args #'cider-pprint-eval-last-sexp-to-comment))
+
+(transient-define-suffix cider-eval-pprint-menu--defun-to-comment (args)
+  "Pretty-print the defun at point into a comment, applying the menu's ARGS."
+  (interactive (list (transient-args 'cider-eval-pprint-menu)))
+  (cider-eval-pprint-menu--apply-args args #'cider-pprint-eval-defun-to-comment))
+
+(transient-define-suffix cider-eval-pprint-menu--last-sexp-to-repl (args)
+  "Pretty-print the last sexp into the REPL, applying the menu's ARGS."
+  (interactive (list (transient-args 'cider-eval-pprint-menu)))
+  (cider-eval-pprint-menu--apply-args args #'cider-pprint-eval-last-sexp-to-repl))
+
 ;;;###autoload (autoload 'cider-eval-pprint-menu "cider-eval" "Menu for CIDER's pretty-printing eval commands." t)
 (transient-define-prefix cider-eval-pprint-menu ()
-  "Transient menu for CIDER's pretty-printing eval commands."
+  "Transient menu for CIDER's pretty-printing eval commands.
+The print-function argument picks the printer (pr, pprint, fipp, puget,
+zprint, or a custom var) for this invocation only."
+  ["Argument"
+   ("-p" "Print function" "--print-fn=" :reader cider-eval-pprint-menu--read-print-fn)]
   [["Pretty-print"
-    ("e" "Last sexp" cider-pprint-eval-last-sexp)
-    ("d" "Defun at point" cider-pprint-eval-defun-at-point)]
+    ("e" "Last sexp" cider-eval-pprint-menu--last-sexp)
+    ("d" "Defun at point" cider-eval-pprint-menu--defun)]
    ["Send pretty-printed value to"
-    ("c" "Comment (last sexp)" cider-pprint-eval-last-sexp-to-comment)
-    ("D" "Comment (defun)" cider-pprint-eval-defun-to-comment)
-    ("r" "REPL (last sexp)" cider-pprint-eval-last-sexp-to-repl)]]
+    ("c" "Comment (last sexp)" cider-eval-pprint-menu--last-sexp-to-comment)
+    ("D" "Comment (defun)" cider-eval-pprint-menu--defun-to-comment)
+    ("r" "REPL (last sexp)" cider-eval-pprint-menu--last-sexp-to-repl)]]
   [:hide (lambda () t)
-   ("C-e" "Last sexp" cider-pprint-eval-last-sexp)
-   ("C-d" "Defun at point" cider-pprint-eval-defun-at-point)])
+   ("C-e" "Last sexp" cider-eval-pprint-menu--last-sexp)
+   ("C-d" "Defun at point" cider-eval-pprint-menu--defun)])
 
 ;;;###autoload (autoload 'cider-eval-menu "cider-eval" "Menu for CIDER's evaluation commands." t)
 (transient-define-prefix cider-eval-menu ()

--- a/test/cider-eval-tests.el
+++ b/test/cider-eval-tests.el
@@ -381,3 +381,25 @@
         ;; the animation timer is cancelled (no longer scheduled)
         (expect (memq (overlay-get ov 'cider-pending-timer) timer-list)
                 :to-be nil)))))
+
+(describe "cider-eval-pprint-menu--print-fn"
+  (it "interns a known printer to a symbol"
+    (expect (cider-eval-pprint-menu--print-fn "pprint") :to-equal 'pprint)
+    (expect (cider-eval-pprint-menu--print-fn "fipp") :to-equal 'fipp))
+  (it "keeps a custom var name as a string"
+    (expect (cider-eval-pprint-menu--print-fn "my.ns/printer") :to-equal "my.ns/printer")))
+
+(describe "cider-eval-pprint-menu--apply-args"
+  (it "binds the printer from the --print-fn= argument"
+    (let (captured)
+      (cider-eval-pprint-menu--apply-args
+       '("--print-fn=fipp")
+       (lambda () (setq captured cider-print-fn)))
+      (expect captured :to-equal 'fipp)))
+
+  (it "keeps the configured printer when no argument is set"
+    (let ((cider-print-fn 'pprint) captured)
+      (cider-eval-pprint-menu--apply-args
+       nil
+       (lambda () (setq captured cider-print-fn)))
+      (expect captured :to-equal 'pprint))))


### PR DESCRIPTION
Finishes the transient-flags survey (after #4061, #4062, #4063) with the last pick: the pretty-print menu.

Adds a `--print-fn=` infix to `cider-eval-pprint-menu` to choose the printer - `pr`, `pprint`, `fipp`, `puget`, `zprint`, or a custom namespace-qualified var - for this invocation. The pretty-print suffixes read the arg and `let`-bind `cider-print-fn`. This is the menu where per-invocation printer choice actually makes sense (these commands exist specifically to pretty-print).

Known printers are interned to symbols so `cider--print-fn`'s pcase recognizes them; anything else is kept as a string (the custom-var case). Same thin-wrapper pattern; tested the conversion and arg translation.