### PR TITLE
Jump to the frame's own source in stacktraces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 
 ### Bugs fixed
 
+- [#4066](https://github.com/clojure-emacs/cider/pull/4066): Jump to the actual source when clicking a stack frame for a top-level anonymous function (the `deftest` shape), instead of landing in `clojure.core/fn` ([#3157](https://github.com/clojure-emacs/cider/issues/3157)).
 - [#4058](https://github.com/clojure-emacs/cider/pull/4058): Signal a helpful error when `cider-javadoc` gets an unresolvable (non-absolute) Javadoc URL from the middleware, instead of silently doing nothing ([#2969](https://github.com/clojure-emacs/cider/issues/2969)).
 - [#4054](https://github.com/clojure-emacs/cider/pull/4054): Interrupt every REPL an evaluation is dispatched to. In a `.cljc` buffer `cider-interrupt` previously interrupted only one of the two REPLs ([#4036](https://github.com/clojure-emacs/cider/issues/4036)).
 - [#4053](https://github.com/clojure-emacs/cider/pull/4053): Restore point to the place a debug session was started from when you quit it with `q`, instead of leaving it stranded at the last breakpoint ([#1595](https://github.com/clojure-emacs/cider/issues/1595)).

--- a/lisp/cider-stacktrace.el
+++ b/lisp/cider-stacktrace.el
@@ -543,25 +543,38 @@ Achieved by destructively manipulating `cider-stacktrace-suppressed-errors'."
 
 (defun cider-stacktrace-navigate (button)
   "Navigate to the stack frame source represented by the BUTTON."
-  (let* ((var (button-get button 'var))
-         (class (button-get button 'class))
-         (method (button-get button 'method))
-         (info (or (and var (cider-var-info var))
-                   (and class method (cider-member-info class method))
-                   (nrepl-dict)))
-         ;; Stacktrace returns more accurate line numbers, but if the function's
-         ;; line was unreliable, then so is the stacktrace by the same amount.
-         ;; Set `line-shift' to the number of lines from the beginning of defn.
-         (line-shift (- (or (button-get button 'line) 0)
-                        (or (nrepl-dict-get info "line") 1)))
-         (file (or
-                (nrepl-dict-get info "file")
-                (button-get button 'file)))
-         ;; give priority to `info` files as `info` returns full paths.
-         (info (nrepl-dict-put info "file" file)))
-    (cider--jump-to-loc-from-info info cider-stacktrace-navigate-to-other-window)
-    (forward-line line-shift)
-    (back-to-indentation)))
+  (let ((file-url (button-get button 'file-url))
+        (line (button-get button 'line)))
+    (if (and file-url line)
+        ;; The middleware resolves file-url to an absolute path with an
+        ;; accurate line, even for top-level anonymous functions.  Trust it
+        ;; directly rather than re-resolving the var: for an anonymous
+        ;; `.../fn' frame `cider-var-info' would misresolve `fn' to
+        ;; `clojure.core/fn' and jump there instead (#3157).
+        (cider--jump-to-loc-from-info
+         (nrepl-dict "file" file-url "line" line)
+         cider-stacktrace-navigate-to-other-window)
+      ;; No file-url (e.g. a REPL frame with NO_SOURCE_FILE): fall back to
+      ;; resolving the var or class member.
+      (let* ((var (button-get button 'var))
+             (class (button-get button 'class))
+             (method (button-get button 'method))
+             (info (or (and var (cider-var-info var))
+                       (and class method (cider-member-info class method))
+                       (nrepl-dict)))
+             ;; Stacktrace returns more accurate line numbers, but if the
+             ;; function's line was unreliable, then so is the stacktrace by the
+             ;; same amount.  Set `line-shift' to the number of lines from the
+             ;; beginning of defn.
+             (line-shift (- (or line 0)
+                            (or (nrepl-dict-get info "line") 1)))
+             (file (or (nrepl-dict-get info "file")
+                       (button-get button 'file)))
+             ;; give priority to `info` files as `info` returns full paths.
+             (info (nrepl-dict-put info "file" file)))
+        (cider--jump-to-loc-from-info info cider-stacktrace-navigate-to-other-window)
+        (forward-line line-shift)
+        (back-to-indentation)))))
 
 (declare-function cider-find-var "cider-find")
 
@@ -677,7 +690,7 @@ This associates text properties to enable filtering and source navigation."
                               'url url
                               'follow-link t
                               'action (lambda (x) (browse-url (button-get x 'url)))))
-      (nrepl-dbind-response frame (file line flags class method name var ns fn)
+      (nrepl-dbind-response frame (file file-url line flags class method name var ns fn)
         (when (or class file fn method ns name)
           (let ((flags (mapcar #'intern flags))) ; strings -> symbols
             (insert-text-button (format "%26s:%5d  %s/%s"
@@ -685,7 +698,7 @@ This associates text properties to enable filtering and source navigation."
                                         (if (member 'clj flags) ns class)
                                         (if (member 'clj flags) fn method))
                                 'var var 'class class 'method method
-                                'name name 'file file 'line line
+                                'name name 'file file 'file-url file-url 'line line
                                 'flags flags 'follow-link t
                                 'action #'cider-stacktrace-navigate
                                 'help-echo (cider-stacktrace-tooltip

--- a/test/cider-stacktrace-tests.el
+++ b/test/cider-stacktrace-tests.el
@@ -267,3 +267,35 @@
               :to-be-truthy)
       (expect (or both shown1 shown2)
               :to-be nil))))
+
+(describe "cider-stacktrace-navigate"
+  (it "jumps via the frame's file-url without re-resolving the var (#3157)"
+    (spy-on 'cider--jump-to-loc-from-info)
+    (spy-on 'cider-var-info)
+    (with-temp-buffer
+      ;; An anonymous-fn frame: the var `repro/fn' would misresolve to
+      ;; `clojure.core/fn', but the frame carries a resolved file-url + line.
+      (let ((button (insert-text-button "frame"
+                                        'var "repro/fn"
+                                        'file-url "file:/tmp/repro.clj"
+                                        'file "repro.clj"
+                                        'line 12)))
+        (cider-stacktrace-navigate button)
+        (expect 'cider-var-info :not :to-have-been-called)
+        (let ((info (car (car (spy-calls-all-args 'cider--jump-to-loc-from-info)))))
+          (expect (nrepl-dict-get info "file") :to-equal "file:/tmp/repro.clj")
+          (expect (nrepl-dict-get info "line") :to-equal 12)))))
+
+  (it "falls back to var resolution when the frame has no file-url"
+    (spy-on 'cider--jump-to-loc-from-info)
+    (spy-on 'cider-var-info :and-return-value
+            (nrepl-dict "file" "file:/tmp/core.clj" "line" 100))
+    (with-temp-buffer
+      (let ((button (insert-text-button "frame"
+                                        'var "repro/named"
+                                        'file-url nil
+                                        'file "repro.clj"
+                                        'line 12)))
+        (cider-stacktrace-navigate button)
+        (expect 'cider-var-info :to-have-been-called-with "repro/named")
+        (expect 'cider--jump-to-loc-from-info :to-have-been-called)))))


### PR DESCRIPTION
Closes #3157.

Clicking a stack frame for a top-level anonymous function - the shape `deftest` expands to - jumped to `clojure.core/fn` instead of your code. `cider-stacktrace-navigate` resolved the frame's `.../fn` var via `cider-var-info`, which resolves `fn` to `clojure.core/fn` and lets its file/line override the frame's own correct location.

I reproduced it against **current orchard** (`orchard.stacktrace/analyze` on the exact repro): the anonymous-fn frame now comes back with a populated `:file-url` (an absolute `file:` path) and an accurate `:line` - unlike the 2022 dump in the issue where `:file-url` was nil. So the backend already hands us everything needed; the client was just throwing it away (it didn't even capture `file-url` off the frame).

The fix: prefer the frame's own `file-url` + `line` and skip the var re-resolution. Frames without a `file-url` (REPL evals / `NO_SOURCE_FILE`) keep the existing var/class fallback with its line-shift. Validated on a multi-line fn that the frame's line points at the throwing line, so no line-shift is needed on the file-url path. Unit tests cover both paths.