### PR TITLE
Bump the injected cider-nrepl to 0.62.0-alpha1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,9 +60,9 @@
 
 ### Changes
 
-- Bump the default `cider-repl-history-size` from 500 to 5000.
+- Bump the injected `cider-nrepl` to 0.62.0-alpha1, which carries the hardened content-type/slurp middleware backing the rich-content revival below.
 - Enable rich content in the REPL by default (`cider-repl-use-content-types` is now t): image results render inline, and results naming external content (files, URLs) render a `[show content]` button that fetches and renders it on demand. The automatic fetching that got the feature disabled back in 0.25 ([#2825](https://github.com/clojure-emacs/cider/issues/2825)) is gone - nothing is transferred until the button is pressed - and the server side is hardened in `cider-nrepl` 0.62 (URL-scheme allowlist, size caps, graceful fetch errors).
-- Bump the default `cider-repl-history-size` from 500 to 5000 and the default `cider-print-buffer-size` from 4K to 16K (fewer, larger chunks when streaming big results).
+- Bump the default `cider-repl-history-size` from 500 to 5000.
 - Rename the REPL history browser from `cider-repl-history` to `cider-history` (command, mode and options), so its names no longer clash with the REPL's unrelated input-history settings (`cider-repl-history-file`, `cider-repl-history-size`); the old names keep working as obsolete aliases.
 - Color the nREPL messages buffer with theme-aware faces (`nrepl-message-faces`, eight faces inheriting from standard font-lock faces) instead of a hardcoded color list; `nrepl-message-colors` is now obsolete, but still takes precedence when customized.
 - Consolidate the per-buffer auto-select options into a single `cider-auto-select-buffer`, which can be `t`, `nil` or a list of the popup buffers to select (e.g. `'(error inspector)`); the old options (`cider-auto-select-error-buffer`, `cider-auto-select-test-report-buffer`, `cider-doc-auto-select-buffer`, `cider-inspector-auto-select-buffer`, `cider-cheatsheet-auto-select-buffer` and `cider-log-auto-select-frameworks-buffer`) are now obsolete, but still take precedence when customized.

--- a/lisp/cider-jack-in.el
+++ b/lisp/cider-jack-in.el
@@ -341,7 +341,7 @@ the artifact.")
 
 Used when `cider-jack-in-auto-inject-clojure' is set to `latest'.")
 
-(defconst cider-required-middleware-version "0.61.0"
+(defconst cider-required-middleware-version "0.62.0-alpha1"
   "The CIDER nREPL version that's known to work properly with CIDER.")
 
 (defcustom cider-injected-middleware-version cider-required-middleware-version


### PR DESCRIPTION
Ships the hardened content-type/slurp middleware to jack-in users, so
the newly default-on rich content is backed by the scheme allowlist,
size caps and graceful fetch errors.  Also drop a duplicated CHANGELOG
entry that survived a rebase.
