### PR TITLE
Render HTML rich content and make external-content URLs clickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- Render fetched `text/html` content as formatted text (via `shr`) in the REPL and the rich-content popup, and make the URL of an external-content result a clickable link that opens in the browser (next to its `[show content]` button).
 - Honor content types for interactive evaluations too ([#2476](https://github.com/clojure-emacs/cider/issues/2476)): a `cider-eval-last-sexp` returning an image can now render it, per the new `cider-eval-rich-content-destination` - `inline` (the default, in the result overlay at point), `repl` (like results of forms typed at the prompt, with the `[show content]` button for external references), `popup` (the `*cider-result*` buffer) or `nil` (plain values, the previous behavior).
 - Add a transient menu to the debugger (`cider-debug-menu`, bound to `?` during a debug session), grouping all the debugger's single-key commands; they are also proper named commands now (e.g. `cider-debug-next`, `cider-debug-quit`), so they can be invoked via `M-x` as well.
 - Add a transient menu to the inspector (`cider-inspector-menu`, bound to `m` in the inspector buffer), grouping all the inspector commands.

--- a/doc/modules/ROOT/pages/repl/configuration.adoc
+++ b/doc/modules/ROOT/pages/repl/configuration.adoc
@@ -280,14 +280,16 @@ width (i.e. any of them except for `pr`) will keep your REPL running smoothly.
 TIP: See xref:usage/pretty_printing.adoc[this section of the documentation] for
 more information on configuring printing.
 
-== Displaying images in the REPL
+== Displaying rich content in the REPL
 
-Expressions that evaluate to images are rendered as images in the REPL.
+Expressions that evaluate to images are rendered as images in the REPL, and
+fetched HTML content is rendered as formatted text (via `shr`).
 Results naming external content - a `java.io.File`, or a `java.net.URI`/`URL`
-with a `file:`, `http:` or `https:` scheme - render as the URL followed by a
-`[show content]` button; press kbd:[RET] (or click) to fetch the content and
-render it in place.  Nothing is transferred until you press the button, so
-merely evaluating a `File` or `URI` has no side effects.
+with a `file:`, `http:` or `https:` scheme - render as a clickable URL (which
+opens in your browser) followed by a `[show content]` button; press kbd:[RET]
+\(or click) to fetch the content and render it in place.  Nothing is
+transferred until you press the button, so merely evaluating a `File` or
+`URI` has no side effects.
 
 This behavior is enabled by default as of CIDER 2.0.  You can disable it like
 this:

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -446,12 +446,13 @@ Cancel their animation timers and delete the overlays."
 (defun cider--rich-content-fallback-string (body content-type)
   "Return a plain-text stand-in for BODY of CONTENT-TYPE.
 Used when rich content can't (or shouldn't) be rendered: external
-references display as their URL, images as a short tag, and anything
-else as its raw body."
+references display as their URL, images as a short tag, HTML as its
+shr-rendered text, and anything else as its raw body."
   (pcase-let ((`(,type ,_attrs) content-type))
     (cond
      ((cider--external-body-url content-type))
      ((assoc type cider--image-content-types) (format "#content[%s]" type))
+     ((equal type "text/html") (cider--render-html-string body))
      (t body))))
 
 (defun cider--render-rich-content-inline (body content-type point)
@@ -495,7 +496,11 @@ Return nil when there's no REPL to render into."
           (insert "\n")
           t))
        ((when-let* ((url (cider--external-body-url content-type)))
-          (insert url " ")
+          (insert-text-button url
+                              'follow-link t
+                              'help-echo "Open in the browser"
+                              'action (lambda (_button) (browse-url url)))
+          (insert " ")
           (insert-text-button "[show content]"
                               'follow-link t
                               'help-echo (format "Fetch %s and render it here" url)
@@ -503,6 +508,8 @@ Return nil when there's no REPL to render into."
                                         (cider--popup-fetch-external-body buffer url)))
           (insert "\n")
           t))
+       ((equal (car content-type) "text/html")
+        (insert (cider--render-html-string body) "\n"))
        (t (insert body "\n"))))))
 
 (defun cider--popup-fetch-external-body (buffer url)
@@ -809,10 +816,13 @@ arguments and only proceed with evaluation if it returns nil."
              :ns (if (cider-ns-form-p form) "user" (cider-current-ns))
              :line (when start (line-number-at-pos start))
              :column (when start (cider-column-number-at-pos start))
-             ;; Opt in to content-typed responses; handlers without an
-             ;; `:on-content-type' slot still see the plain value, since
-             ;; the server sends both.
-             :additional-params (append (when cider-eval-rich-content-destination
+             ;; Opt in to content-typed responses, but only for the default
+             ;; handler (which knows how to render them); custom callbacks
+             ;; (eval-to-comment, pprint flows, third parties) keep getting
+             ;; plain values only, so the server may safely omit `value'
+             ;; from content-typed responses.
+             :additional-params (append (when (and cider-eval-rich-content-destination
+                                                   (null callback))
                                           (list "content-type" "true"))
                                         additional-params)
              :connection connection)))))))

--- a/lisp/cider-repl.el
+++ b/lisp/cider-repl.el
@@ -1162,10 +1162,12 @@ Part of the default `cider-repl-content-type-handler-alist'."
   (cider-nrepl-send-request (list "op" "cider/slurp" "url" url)
                             (cider-repl-handler buffer)))
 
-(defun cider-repl--display-external-body (buffer url &optional show-prefix bol)
-  "Insert URL and a button that fetches its content into BUFFER.
-For compatibility with the rest of CIDER's REPL machinery, supports
-SHOW-PREFIX and BOL."
+(defun cider-repl--emit-verbatim (buffer string &optional show-prefix bol)
+  "Insert STRING into BUFFER's output area, preserving its text properties.
+Unlike `cider-repl-emit-result', the inserted text is not registered as a
+result span, so it's never re-font-locked as Clojure and any faces or
+buttons it carries survive.  SHOW-PREFIX and BOL are as in
+`cider-repl-emit-result'."
   (with-current-buffer buffer
     (save-excursion
       (cider-save-marker cider-repl-output-start
@@ -1175,9 +1177,37 @@ SHOW-PREFIX and BOL."
         (when show-prefix
           (insert-before-markers
            (propertize cider-repl-result-prefix 'font-lock-face 'font-lock-comment-face)))
-        (insert-before-markers
-         (propertize url 'font-lock-face 'cider-repl-result-face)
-         " ")
+        (insert-before-markers string)
+        (unless (bolp)
+          (insert-before-markers "\n"))))))
+
+(defun cider-repl-handle-html (_type buffer html &optional show-prefix bol)
+  "A handler for rendering text/html HTML into the repl BUFFER.
+Part of the default `cider-repl-content-type-handler-alist'."
+  (cider-repl--emit-verbatim buffer (cider--render-html-string html)
+                             show-prefix bol)
+  t)
+
+(defun cider-repl--display-external-body (buffer url &optional show-prefix bol)
+  "Insert URL and a button that fetches its content into BUFFER.
+The URL itself is a link that opens in the browser.  For compatibility
+with the rest of CIDER's REPL machinery, supports SHOW-PREFIX and BOL."
+  (with-current-buffer buffer
+    (save-excursion
+      (cider-save-marker cider-repl-output-start
+        (goto-char cider-repl-output-end)
+        (when (and bol (not (bolp)))
+          (insert-before-markers "\n"))
+        (when show-prefix
+          (insert-before-markers
+           (propertize cider-repl-result-prefix 'font-lock-face 'font-lock-comment-face)))
+        (let ((start (point)))
+          (insert-before-markers url)
+          (make-text-button start (point)
+                            'follow-link t
+                            'help-echo "Open in the browser"
+                            'action (lambda (_button) (browse-url url))))
+        (insert-before-markers " ")
         (let ((start (point)))
           (insert-before-markers "[show content]")
           (make-text-button start (point)
@@ -1203,7 +1233,8 @@ pressed, so merely evaluating a `File' or `URI' has no side effects."
   `(("message/external-body" . ,#'cider-repl-handle-external-body)
     ("image/jpeg" . ,#'cider-repl-handle-jpeg)
     ("image/png" . ,#'cider-repl-handle-png)
-    ("image/svg+xml" . ,#'cider-repl-handle-svg))
+    ("image/svg+xml" . ,#'cider-repl-handle-svg)
+    ("text/html" . ,#'cider-repl-handle-html))
   "Association list from content-types to handlers.
 Handlers must be functions of two required and two optional arguments - the
 REPL buffer to insert into, the value of the given content type as a raw

--- a/lisp/cider-util.el
+++ b/lisp/cider-util.el
@@ -858,6 +858,22 @@ throughout the deprecation window, then is removed in a later release."
                            (format "  (deprecated since %s)" since)
                          "")))))))
 
+(declare-function shr-insert-document "shr" (dom))
+
+(defun cider--render-html-string (html)
+  "Return HTML rendered to displayable text via shr.
+Falls back to the raw HTML when Emacs lacks libxml support."
+  (if (and (fboundp 'libxml-available-p) (libxml-available-p))
+      (progn
+        (require 'shr)
+        (with-temp-buffer
+          (insert html)
+          (let ((dom (libxml-parse-html-region (point-min) (point-max))))
+            (erase-buffer)
+            (shr-insert-document dom)
+            (string-trim (buffer-string)))))
+    html))
+
 (provide 'cider-util)
 
 ;;; cider-util.el ends here

--- a/test/cider-eval-tests.el
+++ b/test/cider-eval-tests.el
@@ -475,3 +475,10 @@
                      (nrepl-dict "access-type" "URL" "URL" "file:/x"))
                42)
               :to-be nil))))
+
+(describe "cider--rich-content-fallback-string for html"
+  (it "renders text/html via shr"
+    (cl-letf (((symbol-function 'cider--render-html-string)
+               (lambda (html) (concat "rendered:" html))))
+      (expect (cider--rich-content-fallback-string "<b>x</b>" (list "text/html" (nrepl-dict)))
+              :to-equal "rendered:<b>x</b>"))))

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -602,3 +602,10 @@ and some other vars (like clojure.core/filter).
       (cider--define-deprecated-key map "C-c X" #'ignore "new")
       (expect (length cider--deprecated-keybindings) :to-equal 1)
       (expect (plist-get (car cider--deprecated-keybindings) :replacement) :to-equal "new"))))
+
+(describe "cider--render-html-string"
+  (it "renders html to plain text when libxml is available"
+    (if (and (fboundp 'libxml-available-p) (libxml-available-p))
+        (expect (substring-no-properties (cider--render-html-string "<p><b>hello</b></p>"))
+                :to-equal "hello")
+      (expect (cider--render-html-string "<b>x</b>") :to-equal "<b>x</b>"))))


### PR DESCRIPTION
Third round of the rich-content work:

- Fetched `text/html` renders as formatted text via `shr` (REPL, popup, and the inline fallback path). Slurping an `.html` file or an `http(s)` page now produces something readable instead of a wall of markup.
- The URL of an external-content result is now itself a button that opens in the browser, next to `[show content]`.
- The interactive-eval `content-type` flag is only sent for the default handler; custom callbacks (eval-to-comment, pprint flows, third-party) never render rich content, so they shouldn't request it. This also clears the way for the middleware to stop double-sending `value` alongside content-typed responses (coming in cider-nrepl alpha2).