### PR TITLE
Replace positional list lookups with self-documenting accessors

### DIFF
--- a/lisp/cider-compilation.el
+++ b/lisp/cider-compilation.el
@@ -493,10 +493,10 @@ See `compilation-error-regexp-alist' for help on their format.")
 We do so by starting and the current position and proceeding backwards
 until we find a delimiters that's not inside a string."
   (if (and (looking-back "[])}]" (line-beginning-position))
-           (null (nth 3 (syntax-ppss))))
+           (null (ppss-string-terminator (syntax-ppss))))
       (backward-sexp)
     (while (or (not (looking-at-p "[({[]"))
-               (nth 3 (syntax-ppss)))
+               (ppss-string-terminator (syntax-ppss)))
       (backward-char))))
 
 (defun cider--find-last-error-location (error-info)

--- a/lisp/cider-compilation.el
+++ b/lisp/cider-compilation.el
@@ -538,33 +538,33 @@ buffer.
 If `cider-auto-jump-to-error' is enabled and not NO-JUMP, jump to the
 parsed location."
   (when-let* ((info (cider-extract-error-info cider-compilation-regexp message))
-              (loc (cider--find-last-error-location info))
-              (overlay (make-overlay (nth 0 loc) (nth 1 loc) (nth 2 loc))))
-    (let* ((face (nth 3 info))
-           (note (nth 4 info))
-           (auto-jump (unless no-jump
-                        (if (eq cider-auto-jump-to-error 'errors-only)
-                            (not (or (eq face 'cider-warning-highlight-face)
-                                     (string-match-p "warning" note)))
-                          cider-auto-jump-to-error))))
-      (overlay-put overlay 'cider-note-p t)
-      (overlay-put overlay 'font-lock-face face)
-      (overlay-put overlay 'cider-note note)
-      (overlay-put overlay 'help-echo note)
-      (overlay-put overlay 'modification-hooks
-                   (list (lambda (o &rest _args) (delete-overlay o))))
-      (when auto-jump
-        (with-current-buffer eval-buffer
-          (push-mark)
-          ;; At this stage selected window commonly is *cider-error* and we need to
-          ;; re-select the original user window. If eval-buffer is not
-          ;; visible it was probably covered as a result of a small screen or user
-          ;; configuration (https://github.com/clojure-emacs/cider/issues/847). In
-          ;; that case we don't jump at all in order to avoid covering *cider-error*
-          ;; buffer.
-          (when-let* ((win (get-buffer-window eval-buffer)))
-            (with-selected-window win
-              (cider-jump-to (nth 2 loc) (car loc)))))))))
+              (loc (cider--find-last-error-location info)))
+    (pcase-let ((`(,begin ,end ,buffer) loc)
+                (`(,_file ,_line ,_col ,face ,note) info))
+      (let ((overlay (make-overlay begin end buffer))
+            (auto-jump (unless no-jump
+                         (if (eq cider-auto-jump-to-error 'errors-only)
+                             (not (or (eq face 'cider-warning-highlight-face)
+                                      (string-match-p "warning" note)))
+                           cider-auto-jump-to-error))))
+        (overlay-put overlay 'cider-note-p t)
+        (overlay-put overlay 'font-lock-face face)
+        (overlay-put overlay 'cider-note note)
+        (overlay-put overlay 'help-echo note)
+        (overlay-put overlay 'modification-hooks
+                     (list (lambda (o &rest _args) (delete-overlay o))))
+        (when auto-jump
+          (with-current-buffer eval-buffer
+            (push-mark)
+            ;; At this stage selected window commonly is *cider-error* and we need to
+            ;; re-select the original user window. If eval-buffer is not
+            ;; visible it was probably covered as a result of a small screen or user
+            ;; configuration (https://github.com/clojure-emacs/cider/issues/847). In
+            ;; that case we don't jump at all in order to avoid covering *cider-error*
+            ;; buffer.
+            (when-let* ((win (get-buffer-window eval-buffer)))
+              (with-selected-window win
+                (cider-jump-to buffer begin)))))))))
 
 (provide 'cider-compilation)
 

--- a/lisp/cider-completion-context.el
+++ b/lisp/cider-completion-context.el
@@ -35,7 +35,7 @@
 (defun cider-completion--bounds-of-non-string-symbol-at-point ()
   "Return the bounds of the symbol at point, unless it's inside a string."
   (let ((sap (symbol-at-point)))
-    (when (and sap (not (nth 3 (syntax-ppss))))
+    (when (and sap (not (ppss-string-terminator (syntax-ppss))))
       (bounds-of-thing-at-point 'symbol))))
 
 (defun cider-completion-symbol-start-pos ()

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -1031,7 +1031,7 @@ top-level `comment' form."
       (while (and (not beg)
                   (re-search-backward "^(comment\\_>" nil t))
         ;; ignore matches that sit inside a string or a line comment
-        (unless (nth 8 (syntax-ppss))
+        (unless (ppss-comment-or-string-start (syntax-ppss))
           (setq beg (point))))
       (when beg
         (goto-char beg)

--- a/lisp/cider-find.el
+++ b/lisp/cider-find.el
@@ -97,7 +97,7 @@ Show results in a different window if OTHER-WINDOW is true."
 Inside a string we assume a resource path and use `thing-at-point'.
 Otherwise we use `cider-symbol-at-point', which recognizes Clojure symbol
 characters such as `?' and `!' that `thing-at-point' filename mode drops."
-  (if (nth 3 (syntax-ppss))
+  (if (ppss-string-terminator (syntax-ppss))
       (thing-at-point 'filename)
     (or (cider-symbol-at-point) (thing-at-point 'filename))))
 

--- a/lisp/cider-macrostep.el
+++ b/lisp/cider-macrostep.el
@@ -305,11 +305,11 @@ or when the `cider/classify-symbols' op isn't available."
                              (seq-uniq (mapcar #'car heads)))))
         ;; `seq-uniq' drops the duplicate hits that overlapping nested
         ;; expansions produce for the same head position.
-        (dolist (head (seq-uniq heads))
+        (pcase-dolist (`(,operator ,head-beg ,head-end) (seq-uniq heads))
           ;; Only macros are expandable today; inline functions will join once
           ;; the expander learns to expand them (a separate effort).
-          (when (equal (nrepl-dict-get classification (car head)) "macro")
-            (let ((ov (make-overlay (nth 1 head) (nth 2 head))))
+          (when (equal (nrepl-dict-get classification operator) "macro")
+            (let ((ov (make-overlay head-beg head-end)))
               (overlay-put ov 'face 'cider-macrostep-expandable-face)
               (overlay-put ov 'priority 100)
               (push ov cider-macrostep--expandable-overlays))))))))

--- a/lisp/cider-macrostep.el
+++ b/lisp/cider-macrostep.el
@@ -260,8 +260,7 @@ skipped."
           ;; with `save-excursion'; otherwise the next `search-forward' would
           ;; re-find this same paren and loop forever.
           (unless (save-excursion
-                    (let ((ppss (syntax-ppss lb)))
-                      (or (nth 3 ppss) (nth 4 ppss))))
+                    (syntax-ppss-context (syntax-ppss lb)))
             (save-excursion
               (goto-char (1+ lb))
               (skip-chars-forward " \t\n")

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -863,7 +863,7 @@ Search is done with the given LIMIT."
     (when (search-forward-regexp cider-reader-conditionals-regexp limit t)
       (let ((start (match-beginning 0))
             (state (syntax-ppss)))
-        (if (or (nth 3 state) (nth 4 state)) ; inside string or comment?
+        (if (syntax-ppss-context state) ; inside string or comment?
             (cider--search-reader-conditionals limit)
           (when (<= (point) limit)
             (ignore-errors
@@ -929,7 +929,7 @@ with the given LIMIT."
      (cider--anchored-search-suppressed-forms
       (save-excursion
         (let* ((state (syntax-ppss))
-               (list-pt (nth 1 state)))
+               (list-pt (ppss-innermost-start state)))
           (when list-pt
             (goto-char list-pt)
             (forward-list)

--- a/lisp/cider-repl.el
+++ b/lisp/cider-repl.el
@@ -1616,20 +1616,20 @@ case."
   "Workhorse for getting locref at point.
 REG-LIST is an entry in `cider-locref-regexp-alist'."
   (beginning-of-line)
-  (when (re-search-forward (nth 1 reg-list) (line-end-position) t)
-    (let ((ix-highlight (or (nth 2 reg-list) 0))
-          (ix-var (nth 3 reg-list))
-          (ix-file (nth 4 reg-list))
-          (ix-line (nth 5 reg-list)))
-      (list
-       :type (car reg-list)
-       :highlight (cons (match-beginning ix-highlight) (match-end ix-highlight))
-       :var  (and ix-var
-                  (replace-regexp-in-string "_" "-"
-                                            (match-string-no-properties ix-var)
-                                            nil t))
-       :file (and ix-file (match-string-no-properties ix-file))
-       :line (and ix-line (string-to-number (match-string-no-properties ix-line)))))))
+  ;; `seq-let' (rather than a `pcase' pattern) so a user-customized entry with
+  ;; missing trailing fields still binds them to nil, as the old `nth' reads did.
+  (seq-let (type regexp highlight var file line) reg-list
+    (when (re-search-forward regexp (line-end-position) t)
+      (let ((highlight (or highlight 0)))
+        (list
+         :type type
+         :highlight (cons (match-beginning highlight) (match-end highlight))
+         :var  (and var
+                    (replace-regexp-in-string "_" "-"
+                                              (match-string-no-properties var)
+                                              nil t))
+         :file (and file (match-string-no-properties file))
+         :line (and line (string-to-number (match-string-no-properties line))))))))
 
 (defun cider-locref-at-point (&optional pos)
   "Return a plist of components of the location reference at POS.

--- a/lisp/cider-util.el
+++ b/lisp/cider-util.el
@@ -136,12 +136,12 @@ directory still has a sensible default."
 (defun cider-in-string-p ()
   "Return non-nil if point is in a string."
   (let ((beg (save-excursion (beginning-of-defun-raw) (point))))
-    (nth 3 (parse-partial-sexp beg (point)))))
+    (ppss-string-terminator (parse-partial-sexp beg (point)))))
 
 (defun cider-in-comment-p ()
   "Return non-nil if point is in a comment."
   (let ((beg (save-excursion (beginning-of-defun-raw) (point))))
-    (nth 4 (parse-partial-sexp beg (point)))))
+    (ppss-comment-depth (parse-partial-sexp beg (point)))))
 
 (defun cider--tooling-file-p (file-name)
   "Return t if FILE-NAME is not a real source file.

--- a/lisp/cider-xref-source.el
+++ b/lisp/cider-xref-source.el
@@ -205,7 +205,7 @@ namespace form's own require declarations."
         (let ((beg (match-beginning 1))
               (end (match-end 1)))
           (goto-char end)
-          (unless (or (nth 8 (syntax-ppss beg))   ; skip strings and comments
+          (unless (or (ppss-comment-or-string-start (syntax-ppss beg)) ; skip strings and comments
                       (and exclude (>= beg (car exclude)) (< beg (cdr exclude))))
             ;; Advance the line counter incrementally so the whole scan stays
             ;; linear instead of calling `line-number-at-pos' per match.
@@ -306,7 +306,7 @@ Matches inside strings and comments are skipped."
         (let ((name-beg (match-beginning 1))
               (name-end (match-end 1)))
           (goto-char name-end)
-          (unless (nth 8 (syntax-ppss name-beg))   ; skip strings and comments
+          (unless (ppss-comment-or-string-start (syntax-ppss name-beg)) ; skip strings and comments
             (setq line (+ line (save-excursion
                                  (goto-char counted)
                                  (let ((n 0))


### PR DESCRIPTION
A small readability follow-up to #4076, in the same spirit: several places pulled fields out of positional lists with `nth`/`car`, which does not convey what each position means. Two independent commits:

**1. Destructure fixed-shape records.**
- `cider--locref-at-point-1` destructures its `(NAME REGEXP HIGHLIGHT VAR FILE LINE)` entry. I used `seq-let` (rather than a `pcase` pattern) so a user-customized `cider-locref-regexp-alist` entry with missing trailing fields still binds them to nil, exactly as the old `nth` reads did.
- `cider-handle-compilation-errors` names the `(begin end buffer)` location tuple and the error info's face/note fields.
- The macrostep expandable-overlay loop names each head's `(operator head-beg head-end)`.

**2. Read `syntax-ppss` state through the `ppss-*` accessors.**
`syntax-ppss`/`parse-partial-sexp` return a positional list that we indexed with `nth 3`/`nth 4`/`nth 8`/`nth 1`. Emacs 26.1 (well under our Emacs 28 floor) added named accessors over that same list; because the struct is `(:type list)` they operate on the existing return value and inline to the very same `nth` through a compiler macro, so there is zero runtime cost. Swapped in `ppss-string-terminator`, `ppss-comment-depth`, `ppss-comment-or-string-start`, `ppss-innermost-start`, and `syntax-ppss-context` for the "in a string or comment" checks (which also retires a couple of explanatory comments).

Both are pure refactors, no behavior change, so no changelog entry. `eldev compile` is clean and the full unit suite (1046 specs) passes.