### PR TITLE
Don't duplicate the CIDER menu-bar menu when cider-mode is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 
 ### Bugs fixed
 
+- [#4078](https://github.com/clojure-emacs/cider/issues/4078): Fix the menu-bar showing a duplicated "CIDER" menu when `cider-mode` is active.
 - Fix the debugger's `O` (force step-out) key, which aborted the session with an error because it sent an invalid `:force-out` command instead of a forced `:out`.
 - Fix the debugger's menu-bar menu: it advertised the wrong key for "Inject value" (`i` instead of `j`) and was missing entries for stepping in, showing the stacktrace, and tracing.
 - Fix `cider-log-kill-appender`'s confirmation message, which had the appender and framework names swapped.

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -711,23 +711,30 @@ higher precedence."
 
 This menu works as an easy entry-point into CIDER.  Even if cider.el isn't
 loaded yet, this will be shown in Clojure buffers next to the Clojure menu."
-  (easy-menu-define cider-clojure-mode-menu-open mode-map
-    "Menu for Clojure mode.
-  This is displayed in `clojure-mode' and `clojure-ts-mode' buffers,
-  if `cider-mode' is not active."
-    `("CIDER" :visible (not cider-mode)
-      ["Start a Clojure REPL" cider-jack-in-clj
-       :help "Starts an nREPL server and connects a Clojure REPL to it."]
-      ["Connect to a Clojure REPL" cider-connect-clj
-       :help "Connects to a REPL that's already running."]
-      ["Start a ClojureScript REPL" cider-jack-in-cljs
-       :help "Starts an nREPL server and connects a ClojureScript REPL to it."]
-      ["Connect to a ClojureScript REPL" cider-connect-cljs
-       :help "Connects to a ClojureScript REPL that's already running."]
-      ["Start a Clojure REPL, and a ClojureScript REPL" cider-jack-in-clj&cljs
-       :help "Starts an nREPL server, connects a Clojure REPL to it, and then a ClojureScript REPL."]
-      "--"
-      ["View user manual" cider-view-manual])))
+  ;; NOTE: This entry-point menu deliberately uses a menu-bar key of its own
+  ;; (`cider-jack-in') rather than the `cider' key used by `cider-mode's own
+  ;; menu (see `cider-mode-menu').  Both menus are labelled "CIDER", and Emacs
+  ;; *merges* same-key menu-bar entries coming from different active keymaps -
+  ;; which would drop the `:visible' guard below and show two "CIDER" menus at
+  ;; once when `cider-mode' is active (see #4078).  A distinct key keeps them
+  ;; separate, so `:visible' alone decides which one is shown.
+  (define-key mode-map [menu-bar cider-jack-in]
+    `(menu-item "CIDER"
+                ,(easy-menu-create-menu
+                  "CIDER"
+                  '(["Start a Clojure REPL" cider-jack-in-clj
+                     :help "Starts an nREPL server and connects a Clojure REPL to it."]
+                    ["Connect to a Clojure REPL" cider-connect-clj
+                     :help "Connects to a REPL that's already running."]
+                    ["Start a ClojureScript REPL" cider-jack-in-cljs
+                     :help "Starts an nREPL server and connects a ClojureScript REPL to it."]
+                    ["Connect to a ClojureScript REPL" cider-connect-cljs
+                     :help "Connects to a ClojureScript REPL that's already running."]
+                    ["Start a Clojure REPL, and a ClojureScript REPL" cider-jack-in-clj&cljs
+                     :help "Starts an nREPL server, connects a Clojure REPL to it, and then a ClojureScript REPL."]
+                    "--"
+                    ["View user manual" cider-view-manual]))
+                :visible (not cider-mode))))
 
 ;;;###autoload
 (with-eval-after-load 'clojure-mode


### PR DESCRIPTION
With `menu-bar-mode` on, a Clojure buffer where `cider-mode` is active shows the "CIDER" menu twice (on macOS it renders as two nested "CIDER" submenus).

The entry-point "CIDER" menu we install in `clojure-mode`/`clojure-ts-mode` buffers was titled "CIDER", same as `cider-mode`'s own menu, so both easy-menus ended up under the same menu-bar key (`cider`). Emacs merges same-key menu-bar entries coming from different active keymaps, and the merge drops the `:visible (not cider-mode)` guard on the entry-point menu, so it never gets hidden once `cider-mode` kicks in.

The fix binds the entry-point menu under its own key (`cider-jack-in`) as a plain `menu-item` that carries the `:visible` guard, so the two menus stay separate and only one shows depending on whether `cider-mode` is active.

This has been around since 1.14.0, when the entry-point menu was added for `clojure-ts-mode`.

Fixes #4078.

-----------------

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)