### PR TITLE
Don't fetch remote images when rendering result HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New features
 
-- Render fetched `text/html` content as formatted text (via `shr`) in the REPL and the rich-content popup, and make the URL of an external-content result a clickable link that opens in the browser (next to its `[show content]` button).
+- Render fetched `text/html` content as formatted text (via `shr`) in the REPL and the rich-content popup, and make the URL of an external-content result a clickable link that opens in the browser (next to its `[show content]` button). Remote images in that HTML are not fetched, so rendering a result never makes a network request on its own (only inline `data:` images render).
 - Honor content types for interactive evaluations too ([#2476](https://github.com/clojure-emacs/cider/issues/2476)): a `cider-eval-last-sexp` returning an image can now render it, per the new `cider-eval-rich-content-destination` - `inline` (the default, in the result overlay at point), `repl` (like results of forms typed at the prompt, with the `[show content]` button for external references), `popup` (the `*cider-result*` buffer) or `nil` (plain values, the previous behavior).
 - Add a transient menu to the debugger (`cider-debug-menu`, bound to `?` during a debug session), grouping all the debugger's single-key commands; they are also proper named commands now (e.g. `cider-debug-next`, `cider-debug-quit`), so they can be invoked via `M-x` as well.
 - Add a transient menu to the inspector (`cider-inspector-menu`, bound to `m` in the inspector buffer), grouping all the inspector commands.

--- a/lisp/cider-util.el
+++ b/lisp/cider-util.el
@@ -859,16 +859,25 @@ throughout the deprecation window, then is removed in a later release."
                          "")))))))
 
 (declare-function shr-insert-document "shr" (dom))
+(defvar shr-blocked-images)
 
 (defun cider--render-html-string (html)
   "Return HTML rendered to displayable text via shr.
+Remote images (any `scheme://' URL) are blocked, so rendering a result
+never makes a network request on its own - which would otherwise leak the
+user's IP the moment a result contained a remote `<img>' (a tracking-pixel
+vector), bypassing the on-demand fetch the external-content path requires.
+Inline `data:' images are safe and still render.
 Falls back to the raw HTML when Emacs lacks libxml support."
   (if (and (fboundp 'libxml-available-p) (libxml-available-p))
       (progn
         (require 'shr)
         (with-temp-buffer
           (insert html)
-          (let ((dom (libxml-parse-html-region (point-min) (point-max))))
+          (let ((dom (libxml-parse-html-region (point-min) (point-max)))
+                ;; Block remote image fetching (see the docstring); `data:'
+                ;; URLs have no `//' authority, so they are not matched.
+                (shr-blocked-images "\\`[a-z][-a-z0-9+.]*://"))
             (erase-buffer)
             (shr-insert-document dom)
             (string-trim (buffer-string)))))

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -613,4 +613,19 @@ and some other vars (like clojure.core/filter).
   (it "returns the raw html without libxml support"
     (assume (not (and (fboundp 'libxml-available-p) (libxml-available-p)))
             "libxml support is available")
-    (expect (cider--render-html-string "<b>x</b>") :to-equal "<b>x</b>")))
+    (expect (cider--render-html-string "<b>x</b>") :to-equal "<b>x</b>"))
+
+  (it "blocks remote images (no network) but still renders inline data: images"
+    (assume (and (fboundp 'libxml-available-p) (libxml-available-p))
+            "libxml support not available")
+    (require 'shr)
+    (let (blocked)
+      ;; Capture the `shr-blocked-images' binding in effect during rendering.
+      (spy-on 'shr-insert-document :and-call-fake
+              (lambda (_dom) (setq blocked shr-blocked-images)))
+      (cider--render-html-string "<p>hi</p>")
+      (expect blocked :to-be-truthy)
+      ;; remote images match (blocked); a `data:' URI does not (still renders).
+      (expect (string-match-p blocked "http://example.com/pixel.png") :to-be-truthy)
+      (expect (string-match-p blocked "https://example.com/x.png") :to-be-truthy)
+      (expect (string-match-p blocked "data:image/png;base64,AAAA") :to-be nil))))


### PR DESCRIPTION
Follow-up from reviewing the pre-2.0 sync.

With `cider-repl-use-content-types` now defaulting to `t`, `cider--render-html-string` rendered a `text/html` result via `shr-insert-document` without binding `shr-blocked-images`. shr defaults to fetching remote images, so evaluating anything that returns HTML with a remote `<img src="http://…">` would **silently make a network request** - an IP leak / tracking-pixel vector - which undercuts the guarantee the feature advertises ("nothing is transferred until the button is pressed").

Fix: bind `shr-blocked-images` to block any `scheme://` image URL while still rendering inline `data:` images, so rendering a result never hits the network on its own. Test captures the binding and asserts remote URLs match (blocked) and `data:` doesn't.

No separate changelog entry (the rich-content feature is unreleased); instead the existing HTML-rendering entry now states the no-remote-fetch guarantee explicitly.

Note: the other review finding (stale `cider-autoloads.el`) turned out to be a non-issue - that file is `.gitignore`d and generated locally by Eldev, never committed, so nothing stale ships. Hence this PR is just the HTML fix.