### PR TITLE
Tidy up cider-stacktrace.el ahead of 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 
 ### Bugs fixed
 
+- [#4081](https://github.com/clojure-emacs/cider/pull/4081): Make `cider-stacktrace-suppressed-errors` customizable again (its `:type` described a fixed one-element list) and stop the stacktrace renderer from leaving a stray `fill-prefix` in the `*cider-error*` buffer.
 - [#4078](https://github.com/clojure-emacs/cider/issues/4078): Fix the menu-bar showing a duplicated "CIDER" menu when `cider-mode` is active.
 - Fix the debugger's `O` (force step-out) key, which aborted the session with an error because it sent an invalid `:force-out` command instead of a forced `:out`.
 - Fix the debugger's menu-bar menu: it advertised the wrong key for "Inject value" (`i` instead of `j`) and was missing entries for stepping in, showing the stacktrace, and tracing.
@@ -66,6 +67,7 @@
 
 ### Changes
 
+- [#4081](https://github.com/clojure-emacs/cider/pull/4081): Remove the long-obsolete (no-op since 1.18) `cider-stacktrace-analyze-at-point` and `cider-stacktrace-analyze-in-region` commands.
 - Bump the injected `cider-nrepl` to 0.62.0-alpha2, which carries the hardened content-type/slurp middleware backing the rich-content revival below (and no longer double-sends `value` alongside content-typed responses).
 - Enable rich content in the REPL by default (`cider-repl-use-content-types` is now t): image results render inline, and results naming external content (files, URLs) render a `[show content]` button that fetches and renders it on demand. The automatic fetching that got the feature disabled back in 0.25 ([#2825](https://github.com/clojure-emacs/cider/issues/2825)) is gone - nothing is transferred until the button is pressed - and the server side is hardened in `cider-nrepl` 0.62 (URL-scheme allowlist, size caps, graceful fetch errors).
 - Rename `cider-log-buffer-clear-p` to `cider-log-buffer-has-content-p` - the old name read as the opposite of its behavior; it remains as an obsolete alias.

--- a/lisp/cider-stacktrace.el
+++ b/lisp/cider-stacktrace.el
@@ -67,17 +67,19 @@ Pick nil if you prefer the same window as *cider-error*."
 (defvar cider-stacktrace-detail-max 2
   "The maximum detail level for causes.")
 
-(defvar-local cider-stacktrace-hidden-frame-count 0)
-(defvar-local cider-stacktrace-filters nil)
-(defvar-local cider-stacktrace-cause-visibility nil)
-(defvar-local cider-stacktrace-positive-filters nil)
+(defvar-local cider-stacktrace-hidden-frame-count 0
+  "Number of stack frames currently hidden by the active filters.")
+(defvar-local cider-stacktrace-filters nil
+  "List of the currently active stack-frame filters.")
+(defvar-local cider-stacktrace-cause-visibility nil
+  "Vector mapping each cause's index to its visibility level (0-2).")
 
 (defconst cider-error-buffer "*cider-error*")
 
 (defcustom cider-stacktrace-suppressed-errors '()
   "Errors that won't make the stacktrace buffer pop over your active window.
 The error types are represented as strings."
-  :type '(list string)
+  :type '(repeat string)
   :package-version '(cider . "0.12.0"))
 
 ;; Faces
@@ -407,9 +409,10 @@ grouped with a suppressed error type."
 (defun cider-stacktrace-cycle-cause (num &optional level)
   "Update element NUM of `cider-stacktrace-cause-visibility'.
 If LEVEL is specified, it is used, otherwise its current value is incremented.
-When it reaches 3, it wraps to 0."
+When it passes `cider-stacktrace-detail-max', it wraps back to 0."
   (let ((level (or level (1+ (elt cider-stacktrace-cause-visibility num)))))
-    (aset cider-stacktrace-cause-visibility num (mod level 3))
+    (aset cider-stacktrace-cause-visibility num
+          (mod level (1+ cider-stacktrace-detail-max)))
     (cider-stacktrace-apply-cause-visibility)))
 
 (defun cider-stacktrace-cycle-all-causes ()
@@ -426,7 +429,7 @@ When it reaches 3, it wraps to 0."
       (let* ((num (get-text-property (point) 'cause))
              (level (1+ (elt cider-stacktrace-cause-visibility num))))
         (setq-local cider-stacktrace-cause-visibility
-                    (make-vector 10 (mod level 3)))
+                    (make-vector 10 (mod level (1+ cider-stacktrace-detail-max))))
         (cider-stacktrace-apply-cause-visibility)))))
 
 (defun cider-stacktrace-cycle-current-cause ()
@@ -615,10 +618,13 @@ length given by `current-column'."
       (insert indent)
       (forward-line))
     (when (and fill cider-stacktrace-fill-column)
-      (when (and (numberp cider-stacktrace-fill-column))
-        (setq-local fill-column cider-stacktrace-fill-column))
-      (setq-local fill-prefix indent)
-      (fill-region beg (point)))))
+      ;; Bind rather than `setq-local' so the error buffer isn't left with a
+      ;; stray `fill-prefix'/`fill-column' after rendering.
+      (let ((fill-column (if (numberp cider-stacktrace-fill-column)
+                             cider-stacktrace-fill-column
+                           fill-column))
+            (fill-prefix indent))
+        (fill-region beg (point))))))
 
 (defun cider-stacktrace-render-filters (buffer special-filters filters)
   "Emit into BUFFER toggle buttons for each of the FILTERS.
@@ -698,7 +704,7 @@ This associates text properties to enable filtering and source navigation."
                                         (if (member 'clj flags) ns class)
                                         (if (member 'clj flags) fn method))
                                 'var var 'class class 'method method
-                                'name name 'file file 'file-url file-url 'line line
+                                'file file 'file-url file-url 'line line
                                 'flags flags 'follow-link t
                                 'action #'cider-stacktrace-navigate
                                 'help-echo (cider-stacktrace-tooltip
@@ -964,20 +970,6 @@ through the `cider-stacktrace-suppressed-errors' variable."
             (setq num (1- num))))))
     (cider-stacktrace-initialize causes)
     (font-lock-refresh-defaults)))
-
-(defun cider-stacktrace-analyze-at-point ()
-  "Removed."
-  (interactive)
-  (message "This function has been removed.
-You can jump to functions and methods directly from the printed stacktrace now."))
-(make-obsolete 'cider-stacktrace-analyze-at-point nil "1.18")
-
-(defun cider-stacktrace-analyze-in-region (&rest _)
-  "Removed."
-  (interactive)
-  (message "This function has been removed.
-You can jump to functions and methods directly from the printed stacktrace now."))
-(make-obsolete 'cider-stacktrace-analyze-in-region nil "1.18")
 
 (provide 'cider-stacktrace)
 

--- a/test/cider-stacktrace-tests.el
+++ b/test/cider-stacktrace-tests.el
@@ -299,3 +299,14 @@
         (cider-stacktrace-navigate button)
         (expect 'cider-var-info :to-have-been-called-with "repro/named")
         (expect 'cider--jump-to-loc-from-info :to-have-been-called)))))
+
+(describe "cider-stacktrace-emit-indented"
+  (it "does not leak fill-prefix or a buffer-local fill-column after filling"
+    (with-temp-buffer
+      (let ((cider-stacktrace-fill-column 40))
+        (cider-stacktrace-emit-indented
+         "a fairly long line of text that the filler will wrap onto several lines"
+         "  " t nil)
+        ;; the fill state must be bound, not set-local, so nothing lingers.
+        (expect fill-prefix :to-be nil)
+        (expect (local-variable-p 'fill-column) :to-be nil)))))


### PR DESCRIPTION
A safe cleanup pass over `cider-stacktrace.el` (one of the oldest, least-touched modules), from the pre-2.0 audit. No behavior change beyond the two bug fixes; the ClojureScript rendering gaps (the substantive #4043 work) are deliberately left for a separate PR.

**Bug fixes**
- `cider-stacktrace-emit-indented` used `setq-local` for `fill-column`/`fill-prefix` and never restored them, leaving a stray `fill-prefix` in `*cider-error*`. Now bound around `fill-region`.
- `cider-stacktrace-suppressed-errors` had `:type '(list string)` (a fixed one-element list widget), so `M-x customize` couldn't edit it. Now `(repeat string)`.

**Cleanup**
- Derive the cause-visibility cycle modulus from `cider-stacktrace-detail-max` instead of a magic `3` (equivalent), and fix the stale docstring.
- Remove dead code: the unused `cider-stacktrace-positive-filters` var, the write-only `name` button property, and the obsolete-since-1.18 `cider-stacktrace-analyze-at-point`/`-in-region` no-op stubs.
- Add docstrings to the internal buffer-local vars.

Tests: added a spec asserting `emit-indented` no longer leaks fill state; existing stacktrace specs pass. Clean compile (`--warnings-as-errors`) + lint.