### PR TITLE
Render ClojureScript stack frames' ns/fn instead of nil/nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 
 ### Bugs fixed
 
+- [#4082](https://github.com/clojure-emacs/cider/pull/4082): Render a stack frame's `ns/fn` when it carries them (e.g. ClojureScript frames) instead of degrading to `nil/nil` for frames not tagged as Clojure ([#4043](https://github.com/clojure-emacs/cider/issues/4043)).
 - [#4081](https://github.com/clojure-emacs/cider/pull/4081): Make `cider-stacktrace-suppressed-errors` customizable again (its `:type` described a fixed one-element list) and stop the stacktrace renderer from leaving a stray `fill-prefix` in the `*cider-error*` buffer.
 - [#4078](https://github.com/clojure-emacs/cider/issues/4078): Fix the menu-bar showing a duplicated "CIDER" menu when `cider-mode` is active.
 - Fix the debugger's `O` (force step-out) key, which aborted the session with an error because it sent an invalid `:force-out` command instead of a forced `:out`.

--- a/lisp/cider-stacktrace.el
+++ b/lisp/cider-stacktrace.el
@@ -699,10 +699,15 @@ This associates text properties to enable filtering and source navigation."
       (nrepl-dbind-response frame (file file-url line flags class method name var ns fn)
         (when (or class file fn method ns name)
           (let ((flags (mapcar #'intern flags))) ; strings -> symbols
+            ;; Show the Clojure(Script) `ns/fn' when the frame carries it,
+            ;; otherwise the Java `class/method'.  Keying on the presence of
+            ;; `ns'/`fn' rather than the `clj' flag means ClojureScript frames
+            ;; (which aren't `clj'-flagged but do carry `ns'/`fn') render their
+            ;; names instead of `nil/nil' (#4043).
             (insert-text-button (format "%26s:%5d  %s/%s"
                                         (if (member 'repl flags) "REPL" file) (or line -1)
-                                        (if (member 'clj flags) ns class)
-                                        (if (member 'clj flags) fn method))
+                                        (or ns class)
+                                        (or fn method))
                                 'var var 'class class 'method method
                                 'file file 'file-url file-url 'line line
                                 'flags flags 'follow-link t

--- a/test/cider-stacktrace-tests.el
+++ b/test/cider-stacktrace-tests.el
@@ -310,3 +310,31 @@
         ;; the fill state must be bound, not set-local, so nothing lingers.
         (expect fill-prefix :to-be nil)
         (expect (local-variable-p 'fill-column) :to-be nil)))))
+
+(describe "cider-stacktrace-render-frame"
+  (it "renders a Clojure frame's ns/fn"
+    (with-temp-buffer
+      (cider-stacktrace-render-frame
+       (current-buffer)
+       (nrepl-dict "ns" "clojure.core" "fn" "map" "file" "core.clj" "line" 1
+                   "flags" '("clj") "class" "clojure.core$map" "method" "invoke"))
+      (expect (buffer-string) :to-match "clojure\\.core/map")))
+
+  (it "renders a Java frame's class/method"
+    (with-temp-buffer
+      (cider-stacktrace-render-frame
+       (current-buffer)
+       (nrepl-dict "class" "java.lang.Thread" "method" "run" "file" "Thread.java"
+                   "line" 1 "flags" '("java")))
+      (expect (buffer-string) :to-match "java\\.lang\\.Thread/run")))
+
+  (it "renders a ClojureScript frame's ns/fn even without the clj flag (#4043)"
+    (with-temp-buffer
+      ;; cljs frames carry ns/fn but no `clj' flag and no class/method; they
+      ;; must not degrade to `nil/nil'.
+      (cider-stacktrace-render-frame
+       (current-buffer)
+       (nrepl-dict "ns" "my.app.core" "fn" "handler" "file" "core.cljs"
+                   "line" 42 "flags" '("cljs")))
+      (expect (buffer-string) :to-match "my\\.app\\.core/handler")
+      (expect (buffer-string) :not :to-match "nil/nil"))))


### PR DESCRIPTION
Part of #4043.

`cider-stacktrace-render-frame` derived a frame's display name from the `clj` flag: `(if (member 'clj flags) ns class)` / `(… fn method)`. A frame that carries `ns`/`fn` but isn't `clj`-flagged - i.e. a ClojureScript frame - fell through to `class`/`method`, which are nil for such frames, rendering `nil/nil`. Now keyed on presence: `(or ns class)` / `(or fn method)`.

Verified behavior-preserving against real captured frames: Clojure frames (ns present) → `ns/fn` as before; Java frames (ns nil) → `class/method` as before; only frames with `ns`/`fn` and no `clj` flag change (from `nil/nil` to `ns/fn`). Tests cover all three shapes.

**Scope note from reproducing this live:** I stood up a node/piggieback cljs REPL and threw both runtime and compile errors. A cljs **runtime** error surfaces as a wrapped `java.lang.Error` whose analyzed stacktrace is entirely JVM piggieback/nREPL frames - there are *no* cljs frames on that path (the cljs location is only in the `:err` text), so that half of #4043 is really a cider-nrepl/piggieback concern, not client-fixable. cljs macro-level **compile** errors reuse `clojure.lang.Compiler$CompilerException` and already render fine. This PR is the safe, correct client-side piece: when a structured cljs frame *does* arrive (shadow-cljs, or future middleware), it now renders its name.