### PR TITLE
Tidy the stale modules: classpath, format, profile, apropos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@
 
 ### Bugs fixed
 
+- [#4083](https://github.com/clojure-emacs/cider/pull/4083): Split the classpath on the platform path separator, fixing `cider-classpath`/`cider-open-classpath-entry` on Windows.
+- [#4083](https://github.com/clojure-emacs/cider/pull/4083): Stop `cider-format-region`/`cider-format-defun` from corrupting multi-line string and regex literals when the region starts at a non-zero column, and give `cider-format-edn-last-sexp` a clean error when there is no sexp at point.
+- [#4083](https://github.com/clojure-emacs/cider/pull/4083): Make `cider-profile-toggle` honor its prefix argument (use the symbol at point unless prefixed), instead of always prompting.
+- [#4083](https://github.com/clojure-emacs/cider/pull/4083): Signal a clear error when `cider-apropos` is used in a ClojureScript context (it is only supported for Clojure), instead of returning misleading results.
 - [#4082](https://github.com/clojure-emacs/cider/pull/4082): Render a stack frame's `ns/fn` when it carries them (e.g. ClojureScript frames) instead of degrading to `nil/nil` for frames not tagged as Clojure ([#4043](https://github.com/clojure-emacs/cider/issues/4043)).
 - [#4081](https://github.com/clojure-emacs/cider/pull/4081): Make `cider-stacktrace-suppressed-errors` customizable again (its `:type` described a fixed one-element list) and stop the stacktrace renderer from leaving a stray `fill-prefix` in the `*cider-error*` buffer.
 - [#4078](https://github.com/clojure-emacs/cider/issues/4078): Fix the menu-bar showing a duplicated "CIDER" menu when `cider-mode` is active.

--- a/doc/modules/ROOT/pages/usage/cider_mode.adoc
+++ b/doc/modules/ROOT/pages/usage/cider_mode.adoc
@@ -128,7 +128,7 @@ defined.  Just rebind the prefix key back to its keymap:
   (keymap-set cider-mode-map "C-c M-n" 'cider-ns-map)             ; namespace
   (keymap-set cider-mode-map "C-c C-j" 'cider-insert-commands-map) ; insert in REPL
   (keymap-set cider-mode-map "C-c M-m" 'cider-macroexpand-map)    ; macroexpansion
-  (keymap-set cider-mode-map "C-c C-=" 'cider-profile-map)        ; profiling
+  (keymap-set cider-mode-map "C-c C-=" 'cider-profile-menu)       ; profiling
   (keymap-set cider-mode-map "C-c C-w" 'cider-who-map))           ; call-graph queries
 ----
 

--- a/doc/modules/ROOT/pages/usage/formatting.adoc
+++ b/doc/modules/ROOT/pages/usage/formatting.adoc
@@ -44,6 +44,13 @@ You can supply additional configuration to `cljfmt` via the configuration variab
         ("alias-map" (("me" "org.me")))))
 ----
 
+As of `cider-nrepl` 0.61, formatting also picks up the project's own `cljfmt`
+configuration (for example a `.cljfmt.edn` file at the project root), so a
+team can share the same formatting rules regardless of editor. You don't
+have to do anything to opt in - the middleware reads it automatically.
+`cider-format-code-options` continues to let you pass extra `cljfmt` options
+from Emacs.
+
 NOTE: CIDER doesn't shell out to `cljfmt` - it interacts with it via nREPL
 (there's `format` middleware in `cider-nrepl`), which is faster than
 shelling out.

--- a/lisp/cider-apropos.el
+++ b/lisp/cider-apropos.el
@@ -52,14 +52,10 @@ the symbol found by the apropos search as argument."
   :group 'cider
   :package-version '(cider . "0.13.0"))
 
-(define-button-type 'apropos-special-form
-  'apropos-label "Special form"
-  'apropos-short-label "s"
-  'face 'font-lock-keyword-face
-  'help-echo "mouse-2, RET: Display more help on this special form"
+(define-button-type 'cider-apropos-label
+  'face 'font-lock-type-face
   'follow-link t
-  'action (lambda (button)
-            (describe-function (button-get button 'apropos-symbol))))
+  'action #'cider-apropos-doc)
 
 (defun cider-apropos-doc (button)
   "Display documentation for the symbol represented at BUTTON."
@@ -106,7 +102,7 @@ and be case-sensitive (based on CASE-SENSITIVE-P)."
       (cider-propertize-region props
         (insert-text-button name 'type 'apropos-symbol)
         (insert "\n  ")
-        (insert-text-button label 'type (intern (concat "apropos-" type)))
+        (insert-text-button label 'type 'cider-apropos-label)
         (insert ": ")
         (let ((beg (point)))
           (if docs-p

--- a/lisp/cider-client.el
+++ b/lisp/cider-client.el
@@ -887,7 +887,9 @@ Sometimes the classpath contains entries like src/main and we need to
 resolve those to absolute paths."
   (when (cider-runtime-clojure-p)
     (let ((classpath (thread-first
-                       "(seq (.split (System/getProperty \"java.class.path\") \":\"))"
+                       ;; Split on the platform path separator (`;' on Windows,
+                       ;; where `:' also appears inside `C:\\...' paths).
+                       "(seq (.split (System/getProperty \"java.class.path\") (System/getProperty \"path.separator\")))"
                        (cider-sync-tooling-eval)
                        (nrepl-dict-get "value")
                        read))

--- a/lisp/cider-client.el
+++ b/lisp/cider-client.el
@@ -833,6 +833,12 @@ Optional arguments include SEARCH-NS, DOCS-P, PRIVATES-P, CASE-SENSITIVE-P.
 
 This is the keyword-argument form; `cider-sync-request:apropos' is the legacy
 positional shim retained for backward compatibility."
+  ;; Apropos resolves symbols against the JVM Clojure runtime (orchard has no
+  ;; ClojureScript branch), so it returns misleading results in a cljs context.
+  ;; Guard on `cider-connected-p' so a disconnected session still gets the
+  ;; regular "no REPL" error rather than this one.
+  (when (and (cider-connected-p) (not (cider-runtime-clojure-p)))
+    (user-error "Apropos is only supported for Clojure, not ClojureScript"))
   (let* ((query (replace-regexp-in-string "[ \t]+" ".+" query))
          (response (cider-nrepl-sync-request
                     `("op" "cider/apropos"

--- a/lisp/cider-format.el
+++ b/lisp/cider-format.el
@@ -30,15 +30,34 @@
 
 (require 'cider-client)
 (require 'cider-util)
+(require 'clojure-mode)
 
 
 ;; Format
 
 (defun cider--format-reindent (formatted start)
-  "Reindent FORMATTED to align with buffer position START."
-  (let* ((start-column (save-excursion (goto-char start) (current-column)))
-         (indent-line (concat "\n" (make-string start-column ? ))))
-    (replace-regexp-in-string "\n" indent-line formatted)))
+  "Reindent FORMATTED to align with the buffer column of position START.
+Each continuation line is shifted right by START's column, except newlines
+inside string or regex literals, whose contents are left untouched."
+  (let ((start-column (save-excursion (goto-char start) (current-column))))
+    (if (zerop start-column)
+        formatted
+      (with-temp-buffer
+        (set-syntax-table clojure-mode-syntax-table)
+        (insert formatted)
+        (let ((pad (make-string start-column ?\s))
+              (positions nil))
+          ;; Collect the continuation lines that don't start inside a string,
+          ;; in a read-only pass so `syntax-ppss' stays accurate.
+          (goto-char (point-min))
+          (while (zerop (forward-line 1))
+            (unless (or (eobp) (nth 3 (syntax-ppss (point))))
+              (push (point) positions)))
+          ;; Insert bottom-up so earlier positions stay valid.
+          (dolist (pos positions)
+            (goto-char pos)
+            (insert pad)))
+        (buffer-string)))))
 
 
 ;;; Format region
@@ -141,7 +160,9 @@ START and END represent the region's boundaries."
 (defun cider-format-edn-last-sexp ()
   "Format the EDN data of the last sexp."
   (interactive)
-  (apply #'cider-format-edn-region (cider-sexp-at-point 'bounds)))
+  (if-let* ((bounds (cider-sexp-at-point 'bounds)))
+      (apply #'cider-format-edn-region bounds)
+    (user-error "No sexp at point")))
 
 (provide 'cider-format)
 ;;; cider-format.el ends here

--- a/lisp/cider-profile.el
+++ b/lisp/cider-profile.el
@@ -31,18 +31,6 @@
 (require 'cider-inspector)
 (require 'transient)
 
-(defvar cider-profile-map
-  (let ((map (define-prefix-command 'cider-profile-map)))
-    (define-key map (kbd "t") #'cider-profile-toggle)
-    (define-key map (kbd "C-t") #'cider-profile-toggle)
-    (define-key map (kbd "c") #'cider-profile-clear)
-    (define-key map (kbd "C-c") #'cider-profile-clear)
-    (define-key map (kbd "s") #'cider-profile-summary)
-    (define-key map (kbd "C-s") #'cider-profile-summary)
-    (define-key map (kbd "n") #'cider-profile-ns-toggle)
-    (define-key map (kbd "C-n") #'cider-profile-ns-toggle)
-    map)
-  "CIDER profiler keymap.")
 
 (defconst cider-profile-easy-menu
   '("Profile"
@@ -97,24 +85,26 @@ current ns."
           ("unprofiled" (message "Profiling disabled for %s" ns))))))))
 
 ;;;###autoload
-(defun cider-profile-toggle (_query)
+(defun cider-profile-toggle (query)
   "Toggle profiling for a var.
-Defaults to the symbol at point.
-With prefix arg or no symbol at point, prompts for a var."
+Defaults to the symbol at point.  With a prefix arg QUERY, or when there is
+no symbol at point, prompt for the var."
   (interactive "P")
-  (cider-read-symbol-name
-   "Toggle profiling for var: "
-   (lambda (sym)
-     (let ((ns (cider-current-ns)))
-       (cider-nrepl-send-request
-        `("op" "cider/profile-toggle-var"
-          "ns" ,ns
-          "sym" ,sym)
-        (cider-profile--make-response-handler
-         (lambda (value)
-           (pcase value
-             ("profiled" (message "Profiling enabled for %s/%s" ns sym))
-             ("unprofiled" (message "Profiling disabled for %s/%s" ns sym))))))))))
+  (let ((toggle
+         (lambda (sym)
+           (let ((ns (cider-current-ns)))
+             (cider-nrepl-send-request
+              `("op" "cider/profile-toggle-var"
+                "ns" ,ns
+                "sym" ,sym)
+              (cider-profile--make-response-handler
+               (lambda (value)
+                 (pcase value
+                   ("profiled" (message "Profiling enabled for %s/%s" ns sym))
+                   ("unprofiled" (message "Profiling disabled for %s/%s" ns sym))))))))))
+    (if-let* ((sym (and (not query) (cider-symbol-at-point))))
+        (funcall toggle sym)
+      (cider-read-symbol-name "Toggle profiling for var: " toggle))))
 
 ;;;###autoload
 (defun cider-profile-summary ()

--- a/test/cider-apropos-tests.el
+++ b/test/cider-apropos-tests.el
@@ -41,3 +41,9 @@
   (it "raises user-error when cider is not connected."
     (spy-on 'cider-connected-p :and-return-value nil)
     (expect (cider-apropos-documentation) :to-throw 'user-error)))
+
+(describe "cider-apropos-request"
+  (it "raises a user-error in a ClojureScript context"
+    (spy-on 'cider-connected-p :and-return-value t)
+    (spy-on 'cider-runtime-clojure-p :and-return-value nil)
+    (expect (cider-apropos-request "test") :to-throw 'user-error)))

--- a/test/cider-format-tests.el
+++ b/test/cider-format-tests.el
@@ -1,0 +1,59 @@
+;;; cider-format-tests.el  -*- lexical-binding: t; -*-
+
+;; Copyright © 2012-2026 Tim King, Bozhidar Batsov
+
+;; Author: Tim King <kingtim@gmail.com>
+;;         Bozhidar Batsov <bozhidar@batsov.dev>
+;;         Artur Malabarba <bruce.connor.am@gmail.com>
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; This file is part of CIDER
+
+;;; Code:
+
+(require 'buttercup)
+(require 'cider-format)
+
+;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
+
+(describe "cider--format-reindent"
+  (it "is a no-op when the region starts at column 0"
+    (with-temp-buffer
+      (expect (cider--format-reindent "(a\n b)" (point)) :to-equal "(a\n b)")))
+
+  (it "shifts continuation lines by the start column"
+    (with-temp-buffer
+      (insert "    ") ; point is now at column 4
+      (expect (cider--format-reindent "(let [x 1]\n  (+ x 2))" (point))
+              :to-equal "(let [x 1]\n      (+ x 2))")))
+
+  (it "leaves newlines inside string literals untouched"
+    (with-temp-buffer
+      (insert "    ")
+      (expect (cider--format-reindent "(def s \"a\nb\")" (point))
+              :to-equal "(def s \"a\nb\")"))))
+
+(describe "cider-format-edn-last-sexp"
+  (it "signals a user-error when there is no sexp at point"
+    (spy-on 'cider-sexp-at-point :and-return-value nil)
+    (expect (cider-format-edn-last-sexp) :to-throw 'user-error)))
+
+(provide 'cider-format-tests)
+
+;;; cider-format-tests.el ends here

--- a/test/cider-profile-tests.el
+++ b/test/cider-profile-tests.el
@@ -1,0 +1,59 @@
+;;; cider-profile-tests.el  -*- lexical-binding: t; -*-
+
+;; Copyright © 2012-2026 Tim King, Bozhidar Batsov
+
+;; Author: Tim King <kingtim@gmail.com>
+;;         Bozhidar Batsov <bozhidar@batsov.dev>
+;;         Artur Malabarba <bruce.connor.am@gmail.com>
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; This file is part of CIDER
+
+;;; Code:
+
+(require 'buttercup)
+(require 'cider-profile)
+
+;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
+
+(describe "cider-profile-toggle"
+  (before-each
+    (spy-on 'cider-current-ns :and-return-value "my.ns")
+    (spy-on 'cider-nrepl-send-request)
+    (spy-on 'cider-read-symbol-name))
+
+  (it "uses the symbol at point without prompting when there is no prefix arg"
+    (spy-on 'cider-symbol-at-point :and-return-value "my-fn")
+    (cider-profile-toggle nil)
+    (expect 'cider-read-symbol-name :not :to-have-been-called)
+    (expect 'cider-nrepl-send-request :to-have-been-called))
+
+  (it "prompts when given a prefix arg"
+    (spy-on 'cider-symbol-at-point :and-return-value "my-fn")
+    (cider-profile-toggle t)
+    (expect 'cider-read-symbol-name :to-have-been-called))
+
+  (it "prompts when there is no symbol at point"
+    (spy-on 'cider-symbol-at-point :and-return-value nil)
+    (cider-profile-toggle nil)
+    (expect 'cider-read-symbol-name :to-have-been-called)))
+
+(provide 'cider-profile-tests)
+
+;;; cider-profile-tests.el ends here


### PR DESCRIPTION
The audit + verified-bug-fix pass over the least-touched modules ahead of 2.0. One focused commit per concern; no risky behavior changes.

**Bug fixes**
- **classpath:** `cider-fallback-eval:classpath` split `java.class.path` on a hardcoded `:`, shredding entries on Windows (separator is `;`, and `:` appears in `C:\...`). Now uses the JVM `path.separator`.
- **format:** `cider-format-edn-last-sexp` crashed (`wrong-number-of-arguments`) with no sexp at point → clean `user-error`. `cider--format-reindent` injected indentation into newlines *inside* string/regex literals when a region started off-column, corrupting their contents → now reindents only real code lines (verified via a string-aware pass).
- **profile:** `cider-profile-toggle` ignored its prefix arg and always prompted, contradicting its docstring → now honors the symbol at point unless prefixed, mirroring `cider-profile-ns-toggle`.
- **apropos:** guarded against a ClojureScript context (orchard's apropos is JVM-only, so it returned misleading results silently) with a clear `user-error`; and stopped the result's type-label reusing Emacs's own `apropos-*` button types.

**Cleanup / docs**
- Removed the dead `cider-profile-map` (profiling moved to a transient) and its stale doc reference.
- Documented that formatting honors the project's cljfmt config as of cider-nrepl 0.61 (verified live: a project `.cljfmt.edn` is picked up automatically).

**Tests:** new `cider-format-tests.el` and `cider-profile-tests.el`, plus apropos coverage. Full compile (`--warnings-as-errors`) + lint clean; 72 relevant specs pass.

Note: the apropos ClojureScript limitation is ultimately server-side (orchard has no cljs apropos) - this is the client-side guard; the authoritative fix belongs in cider-nrepl/orchard (worth a separate upstream issue).