### PR TITLE
Fix Tier-1 bugs found auditing the stale modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@
 
 ### Bugs fixed
 
+- [#4084](https://github.com/clojure-emacs/cider/pull/4084): Fix `nrepl-dict-merge` mutating a shared literal when its first argument is nil, which leaked state (e.g. the REPL ns cache) between unrelated merges.
+- [#4084](https://github.com/clojure-emacs/cider/pull/4084): Don't treat a server notification's text as a format string in `nrepl-notify` (a stray `%` could error).
+- [#4084](https://github.com/clojure-emacs/cider/pull/4084): Reap the sync-request callback on `abort-on-input`/timeout exits, fixing a slow per-lookup memory leak on the eldoc/completion path.
+- [#4084](https://github.com/clojure-emacs/cider/pull/4084): Signal a clean error from `cider-find-keyword` when there is no keyword at point, instead of a raw type error.
+- [#4084](https://github.com/clojure-emacs/cider/pull/4084): Recreate the log appender when it is missing server-side (after an appender kill or a REPL restart), which a stuck once-per-session flag used to prevent.
 - [#4083](https://github.com/clojure-emacs/cider/pull/4083): Split the classpath on the platform path separator, fixing `cider-classpath`/`cider-open-classpath-entry` on Windows.
 - [#4083](https://github.com/clojure-emacs/cider/pull/4083): Stop `cider-format-region`/`cider-format-defun` from corrupting multi-line string and regex literals when the region starts at a non-zero column, and give `cider-format-edn-last-sexp` a clean error when there is no sexp at point.
 - [#4083](https://github.com/clojure-emacs/cider/pull/4083): Make `cider-profile-toggle` honor its prefix argument (use the symbol at point unless prefixed), instead of always prompting.

--- a/lisp/cider-find.el
+++ b/lisp/cider-find.el
@@ -278,7 +278,9 @@ thing at point."
                     nil nil kw-at-point)
                  kw-at-point)))
          (before (buffer-list))
-         (result (cider--find-keyword-loc kw)))
+         (result (if kw
+                     (cider--find-keyword-loc kw)
+                   (user-error "No keyword at point"))))
     (nrepl-dbind-response result (dest dest-point)
       (if dest-point
           (cider-jump-to dest dest-point (cider--open-other-window-p arg))

--- a/lisp/cider-log.el
+++ b/lisp/cider-log.el
@@ -129,9 +129,6 @@ It will not be used if the package hasn't been installed."
 (declare-function logview-initialized-p "logview" () t)
 (declare-function logview-mode "logview" () t)
 
-(defvar cider-log--initialized-once-p nil
-  "Set to t if log framework and appender have been initialized once.")
-
 (defvar cider-log-framework nil
   "The current log framework to use.")
 
@@ -719,10 +716,12 @@ The KEYS are used to lookup the values and are joined by SEPARATOR."
   (when consumer
     (setq cider-log-consumer consumer)
     (cider-log--set-filters (cider-log-consumer-filters consumer)))
-  (when (and appender (not cider-log--initialized-once-p))
+  ;; Recreate the appender whenever it's missing server-side (after it was
+  ;; killed, or on a fresh REPL session).  `cider-log-appender-reload' is the
+  ;; authoritative existence check.
+  (when appender
     (unless (cider-log-appender-reload framework appender)
-      (setq cider-log-appender (cider-sync-request:log-add-appender framework appender))
-      (setq cider-log--initialized-once-p t))))
+      (setq cider-log-appender (cider-sync-request:log-add-appender framework appender)))))
 
 (defun cider-log-kill-buffer-hook-handler ()
   "Called from `kill-buffer-hook' to remove the consumer."

--- a/lisp/cider-log.el
+++ b/lisp/cider-log.el
@@ -645,7 +645,7 @@ The KEYS are used to lookup the values and are joined by SEPARATOR."
   "Format the log EVENT of FRAMEWORK and APPENDER."
   (when-let* ((event (cider-sync-request:log-format-event framework appender event)))
     (cider-popup-buffer cider-log-event-buffer
-                        (cider-auto-select-buffer-p 'error cider-auto-select-error-buffer)
+                        (cider-auto-select-buffer-p 'error 'default)
                         'clojure-mode 'ancillary)
     (with-current-buffer cider-log-event-buffer
       (let ((inhibit-read-only t))
@@ -680,7 +680,7 @@ The KEYS are used to lookup the values and are joined by SEPARATOR."
     (when-let* ((framework cider-log-framework)
                 (appender cider-log-appender)
                 (event (cider-log-event-at-point)))
-      (let ((cider-auto-select-error-buffer nil))
+      (let ((cider-auto-select-buffer nil))
         (save-window-excursion
           (when (get-buffer-window cider-inspector-buffer)
             (cider-log-event--inspect framework appender event))

--- a/lisp/nrepl-client.el
+++ b/lisp/nrepl-client.el
@@ -773,7 +773,9 @@ Displays the notification via `message'."
          (msg (if face
                   (propertize msg 'face face)
                 (format "%s: %s" (upcase type) msg))))
-    (message msg)))
+    ;; MSG is server-provided, so pass it as an argument rather than as the
+    ;; format string - a stray `%' would otherwise misparse or error.
+    (message "%s" msg)))
 
 (cl-defun nrepl-make-eval-handler (&key on-value on-stdout on-stderr on-done
                                         on-ns on-status

--- a/lisp/nrepl-client.el
+++ b/lisp/nrepl-client.el
@@ -964,42 +964,46 @@ positional shim retained for backward compatibility."
                (when callback
                  (funcall callback resp))
                (nrepl--merge response resp)))
-         status)
-    (nrepl-send-request request cb connection tooling)
-    (while (and (not (member "done" status))
-                (not (and abort-on-input
-                          (input-pending-p))))
-      (setq status (nrepl-dict-get response "status"))
-      ;; If we get a need-input message then the repl probably isn't going
-      ;; anywhere, and we'll just timeout.  So we forward it to the user.
-      (if (and (member "need-input" status)
-               nrepl-need-input-handler-function)
-          (progn (funcall nrepl-need-input-handler-function (current-buffer))
-                 ;; If the user took a few seconds to respond, we might
-                 ;; unnecessarily timeout, so let's reset the timer.
-                 (setq time0 (current-time)))
-        ;; break out in case we don't receive a response for a while
-        (when (and nrepl-sync-request-timeout
-                   (time-less-p
-                    nrepl-sync-request-timeout
-                    (time-subtract nil time0)))
-          (error "Sync nREPL request timed out %s after %s secs" request nrepl-sync-request-timeout)))
-      ;; Clean up the response, otherwise we might repeatedly ask for input.
-      (nrepl-dict-put response "status" (remove "need-input" status))
-      (accept-process-output nil 0.01))
-    ;; If we couldn't finish, return nil.
-    (when (member "done" status)
-      (nrepl-dbind-response response (ex err eval-error id)
-        (when (and ex err eval-error nrepl-err-handler-function)
-          (funcall nrepl-err-handler-function connection))
-        (when id
-          (with-current-buffer connection
-            (nrepl--mark-id-completed id)))
-        ;; The op was declined because a ClojureScript REPL is active; abort
-        ;; the calling command with a clear message (clojure-emacs/cider#2198).
-        (when-let* ((msg (nrepl--clojure-only-error response)))
-          (user-error "%s" msg))
-        response))))
+         status
+         (id (nrepl-send-request request cb connection tooling)))
+    (unwind-protect
+        (progn
+          (while (and (not (member "done" status))
+                      (not (and abort-on-input
+                                (input-pending-p))))
+            (setq status (nrepl-dict-get response "status"))
+            ;; If we get a need-input message then the repl probably isn't going
+            ;; anywhere, and we'll just timeout.  So we forward it to the user.
+            (if (and (member "need-input" status)
+                     nrepl-need-input-handler-function)
+                (progn (funcall nrepl-need-input-handler-function (current-buffer))
+                       ;; If the user took a few seconds to respond, we might
+                       ;; unnecessarily timeout, so let's reset the timer.
+                       (setq time0 (current-time)))
+              ;; break out in case we don't receive a response for a while
+              (when (and nrepl-sync-request-timeout
+                         (time-less-p
+                          nrepl-sync-request-timeout
+                          (time-subtract nil time0)))
+                (error "Sync nREPL request timed out %s after %s secs" request nrepl-sync-request-timeout)))
+            ;; Clean up the response, otherwise we might repeatedly ask for input.
+            (nrepl-dict-put response "status" (remove "need-input" status))
+            (accept-process-output nil 0.01))
+          ;; If we couldn't finish, return nil.
+          (when (member "done" status)
+            (nrepl-dbind-response response (ex err eval-error)
+              (when (and ex err eval-error nrepl-err-handler-function)
+                (funcall nrepl-err-handler-function connection))
+              ;; The op was declined because a ClojureScript REPL is active; abort
+              ;; the calling command with a clear message (clojure-emacs/cider#2198).
+              (when-let* ((msg (nrepl--clojure-only-error response)))
+                (user-error "%s" msg))
+              response)))
+      ;; Always reap the pending callback -- even on an abort-on-input or
+      ;; timeout exit -- so it isn't leaked for the life of the connection.
+      (when (buffer-live-p connection)
+        (with-current-buffer connection
+          (nrepl--mark-id-completed id))))))
 
 (defun nrepl-send-sync-request (request connection &optional abort-on-input
                                         tooling callback)

--- a/lisp/nrepl-dict.el
+++ b/lisp/nrepl-dict.el
@@ -130,10 +130,13 @@ FN must accept two arguments key and value."
 (defun nrepl-dict-merge (dict1 dict2)
   "Destructively merge DICT2 into DICT1.
 Keys in DICT2 override those in DICT1."
-  (let ((base (or dict1 '(dict))))
+  ;; Allocate a fresh dict when DICT1 is nil.  Using the quoted literal
+  ;; `\='(dict)' here would be mutated in place by `nrepl-dict-put', polluting
+  ;; the shared constant for every later nil-seeded merge in the session.
+  (let ((base (or dict1 (nrepl-dict))))
     (nrepl-dict-map (lambda (k v)
                       (nrepl-dict-put base k v))
-                    (or dict2 '(dict)))
+                    (or dict2 (nrepl-dict)))
     base))
 
 (defun nrepl-dict-get-in (dict keys)

--- a/test/cider-find-tests.el
+++ b/test/cider-find-tests.el
@@ -69,7 +69,15 @@
     (expect (nth 2 (spy-context-args (spy-calls-most-recent 'cider-jump-to))) :to-be-truthy)
     (spy-calls-reset 'cider-jump-to)
     (cider-find-keyword '-)             ; negative -> other window
-    (expect (nth 2 (spy-context-args (spy-calls-most-recent 'cider-jump-to))) :to-be-truthy)))
+    (expect (nth 2 (spy-context-args (spy-calls-most-recent 'cider-jump-to))) :to-be-truthy))
+
+  ;; Regression test: with the default config and no keyword at point, `kw' is
+  ;; nil and used to reach `string-match', crashing with a raw type error.
+  (it "signals a user-error when there is no keyword at point"
+    (spy-on 'cider-ensure-session :and-return-value t)
+    (spy-on 'cider-symbol-at-point :and-return-value nil)
+    (let ((cider-prompt-for-symbol nil))
+      (expect (cider-find-keyword nil) :to-throw 'user-error))))
 
 (describe "cider--find-keyword-loc"
   (it "finds the given keyword, discarding false positives"

--- a/test/cider-log-tests.el
+++ b/test/cider-log-tests.el
@@ -39,20 +39,25 @@
       (spy-on 'cider-connected-p :and-return-value nil)
       (expect (cider-log framework appender) :to-throw 'user-error))
 
-    (it "doesn't add an appender when initialized."
-      (let ((cider-log--initialized-once-p t))
-        (spy-on 'cider-sync-request:log-frameworks :and-return-value (list framework))
-        (spy-on 'transient-setup)
-        (cider-log framework appender)
-        (expect 'transient-setup :to-have-been-called-with 'cider-log)))
+    (it "doesn't add an appender when it already exists server-side."
+      (spy-on 'cider-sync-request:log-frameworks :and-return-value (list framework))
+      (spy-on 'cider-log-appender-reload :and-return-value appender) ; exists
+      (spy-on 'cider-sync-request:log-add-appender)
+      (spy-on 'transient-setup)
+      (cider-log framework appender)
+      (expect 'cider-sync-request:log-add-appender :not :to-have-been-called)
+      (expect 'transient-setup :to-have-been-called-with 'cider-log))
 
-    (it "does add an appender when not initialized."
-      (let ((cider-log--initialized-once-p nil))
-        (spy-on 'cider-sync-request:log-frameworks :and-return-value (list framework))
-        (spy-on 'cider-sync-request:log-add-appender :and-return-value appender)
-        (spy-on 'transient-setup)
-        (cider-log framework appender)
-        (expect 'transient-setup :to-have-been-called-with 'cider-log)))
+    (it "adds an appender when it is missing server-side."
+      ;; Regression: this must keep working across an appender kill or a REPL
+      ;; restart, which a stuck once-per-session flag used to prevent.
+      (spy-on 'cider-sync-request:log-frameworks :and-return-value (list framework))
+      (spy-on 'cider-log-appender-reload :and-return-value nil) ; missing
+      (spy-on 'cider-sync-request:log-add-appender :and-return-value appender)
+      (spy-on 'transient-setup)
+      (cider-log framework appender)
+      (expect 'cider-sync-request:log-add-appender :to-have-been-called)
+      (expect 'transient-setup :to-have-been-called-with 'cider-log))
 
     (it "applies the consumer's own filters when initializing, not the appender's."
       ;; Regression: the consumer branch of `cider-log--ensure-initialized'
@@ -60,8 +65,8 @@
       (let* ((appender-filters (nrepl-dict "pattern" "appender-pattern"))
              (consumer-filters (nrepl-dict "pattern" "consumer-pattern"))
              (appender (nrepl-dict "id" "cider-log" "filters" appender-filters))
-             (consumer (nrepl-dict "id" "consumer" "filters" consumer-filters))
-             (cider-log--initialized-once-p t)) ; skip the add-appender network path
+             (consumer (nrepl-dict "id" "consumer" "filters" consumer-filters)))
+        (spy-on 'cider-log-appender-reload :and-return-value appender) ; skip add path
         (spy-on 'cider-log--set-filters)
         (with-temp-buffer
           (cider-log--ensure-initialized framework appender consumer))

--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -547,3 +547,10 @@
         (funcall (nrepl-make-response-handler 'shim-buf nil nil nil nil)
                  '(dict "id" "1" "status" ("eval-error"))))
       (expect seen :to-be 'shim-buf))))
+
+(describe "nrepl-notify"
+  ;; The server controls the message text, so a `%' in it must not be treated
+  ;; as a format directive (which used to signal or misparse).
+  (it "does not treat a server message as a format string"
+    (expect (nrepl-notify "test %s and 100%" "warning") :not :to-throw)
+    (expect (nrepl-notify "raw 50% done" nil) :not :to-throw)))

--- a/test/nrepl-dict-tests.el
+++ b/test/nrepl-dict-tests.el
@@ -43,7 +43,14 @@
 
   (it "handles nil values"
     (expect (nrepl-dict-merge nil '(dict 1 3 "10" me)) :to-equal '(dict 1 3 "10" me))
-    (expect (nrepl-dict-merge '(dict 1 3 "10" me) nil) :to-equal '(dict 1 3 "10" me))))
+    (expect (nrepl-dict-merge '(dict 1 3 "10" me) nil) :to-equal '(dict 1 3 "10" me)))
+
+  (it "does not leak state between nil-seeded merges"
+    ;; A nil DICT1 must yield a fresh dict, not a shared literal that later
+    ;; merges keep mutating.
+    (nrepl-dict-merge nil '(dict "x" 1))
+    (expect (nrepl-dict-merge nil nil) :to-equal '(dict))
+    (expect (nrepl-dict-merge nil '(dict "y" 2)) :to-equal '(dict "y" 2))))
 
 (describe "nrepl-dict-contains"
   :var (input)


### PR DESCRIPTION
Second pass over the least-touched modules (nrepl protocol, log, find). Each fix is its own commit with a regression test where feasible; all verified against the code.

- **`nrepl-dict-merge` cross-contamination:** with a nil first arg it mutated a shared quoted literal, so every later nil-seeded merge inherited the previous one's contents. Real callers seed from nil (REPL ns cache, eldoc), so state leaked between them. Proven live. Now allocates a fresh dict.
- **`nrepl-notify` format-string bug:** server notification text was passed to `message` as the format string, so a stray `%` ("100% resolved") misparsed or errored. Now `(message "%s" msg)`.
- **sync-request callback leak:** `nrepl-sync-request` only reaped its request id on a "done" reply; `abort-on-input` (the hot eldoc/completion path) and timeout exits leaked the callback for the connection's life. Now reaped via `unwind-protect`.
- **`cider-find-keyword` crash:** with the default config and no keyword at point it hit `string-match` on nil and crashed with a raw type error. Now a clean `user-error`.
- **`cider-log` appender never recreated:** a global once-per-session flag gated appender creation and was never reset, so after an appender kill or a REPL restart the appender wasn't re-added (and consumer registration then failed). Dropped the flag; `cider-log-appender-reload` already does the real existence check.
- **`cider-log` byte-compile fix:** it still referenced the obsolete `cider-auto-select-error-buffer` (consolidated into `cider-auto-select-buffer` earlier this cycle), which broke the byte-compile since a file may only use its own obsolete vars warning-free. This was already failing on master.

Tier-2 items (cljs indent fallback, find-keyword prefix inversion, more log state cleanup) will follow in a second PR.