### PR TITLE
Tier-2 cleanup: cljs var resolution and find-keyword prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@
 
 ### Bugs fixed
 
+- [#4085](https://github.com/clojure-emacs/cider/pull/4085): Resolve unqualified ClojureScript core vars (e.g. their indentation metadata) against `cljs.core` in a cljs REPL, instead of always falling back to `clojure.core`.
+- [#4085](https://github.com/clojure-emacs/cider/pull/4085): Make a prefix argument to `cider-find-keyword` invert `cider-prompt-for-symbol` (matching the sibling find commands), instead of forcing the prompt on.
 - [#4084](https://github.com/clojure-emacs/cider/pull/4084): Fix `nrepl-dict-merge` mutating a shared literal when its first argument is nil, which leaked state (e.g. the REPL ns cache) between unrelated merges.
 - [#4084](https://github.com/clojure-emacs/cider/pull/4084): Don't treat a server notification's text as a format string in `nrepl-notify` (a stray `%` could error).
 - [#4084](https://github.com/clojure-emacs/cider/pull/4084): Reap the sync-request callback on `abort-on-input`/timeout exits, fixing a slow per-lookup memory leak on the eldoc/completion path.

--- a/lisp/cider-find.el
+++ b/lisp/cider-find.el
@@ -272,7 +272,7 @@ thing at point."
   (interactive "P")
   (cider-ensure-session)
   (let* ((kw (let ((kw-at-point (cider-symbol-at-point 'look-back)))
-               (if (or cider-prompt-for-symbol arg)
+               (if (cider--prompt-for-symbol-p arg)
                    (read-string
                     (format "Keyword (default %s): " kw-at-point)
                     nil nil kw-at-point)

--- a/lisp/cider-resolve.el
+++ b/lisp/cider-resolve.el
@@ -90,10 +90,21 @@ If it doesn't point anywhere, returns ALIAS."
 
 (defconst cider-resolve--prefix-regexp "\\`\\(?:#'\\)?\\([^/]+\\)/")
 
-(defun cider-resolve--var (cache ns var)
+(defun cider-resolve--core-ns-name ()
+  "Return the core namespace name for the current connection.
+Either \"cljs.core\" or \"clojure.core\", depending on the value of
+`cider-repl-type' in the connected REPL."
+  (if-let* ((repl (cider-current-repl)))
+      (with-current-buffer repl
+        (if (eq cider-repl-type 'cljs) "cljs.core" "clojure.core"))
+    "clojure.core"))
+
+(defun cider-resolve--var (cache ns var core-ns)
   "Resolve VAR in namespace NS against the namespace CACHE dict.
-Helper for `cider-resolve-var'; recurses on CACHE instead of re-resolving
-the connection on every lookup.  See `cider-resolve-var' for the contract."
+CORE-NS is the core namespace (\"clojure.core\" or \"cljs.core\") that an
+unqualified, non-referred VAR falls back to.  Helper for `cider-resolve-var';
+recurses on CACHE instead of re-resolving the connection on every lookup.
+See `cider-resolve-var' for the contract."
   (let* ((var-ns (when (string-match cider-resolve--prefix-regexp var)
                    (let ((alias (match-string 1 var)))
                      (or (nrepl-dict-get-in cache (list ns "aliases" alias))
@@ -104,17 +115,17 @@ the connection on every lookup.  See `cider-resolve-var' for the contract."
      (unless var-ns
        ;; If the var had no prefix, it might be referred.
        (if-let* ((referral (nrepl-dict-get-in cache (list ns "refers" name))))
-           (cider-resolve--var cache ns referral)
+           (cider-resolve--var cache ns referral core-ns)
          ;; Or it might be from core.
-         (unless (equal ns "clojure.core")
-           (cider-resolve--var cache "clojure.core" name)))))))
+         (unless (equal ns core-ns)
+           (cider-resolve--var cache core-ns name core-ns)))))))
 
 (defun cider-resolve-var (ns var)
   "Return a dict of the metadata of a clojure var VAR in namespace NS.
 VAR is a string.
 Return nil only if VAR cannot be resolved."
   (when-let* ((cache (cider-resolve--ns-cache)))
-    (cider-resolve--var cache ns var)))
+    (cider-resolve--var cache ns var (cider-resolve--core-ns-name))))
 
 (defun cider-resolve-core-ns ()
   "Return a dict of the core namespace for current connection.

--- a/test/cider-find-tests.el
+++ b/test/cider-find-tests.el
@@ -77,7 +77,22 @@
     (spy-on 'cider-ensure-session :and-return-value t)
     (spy-on 'cider-symbol-at-point :and-return-value nil)
     (let ((cider-prompt-for-symbol nil))
-      (expect (cider-find-keyword nil) :to-throw 'user-error))))
+      (expect (cider-find-keyword nil) :to-throw 'user-error)))
+
+  ;; Regression: a prefix arg must invert `cider-prompt-for-symbol', not be
+  ;; OR-ed with it (which made the prompt unconditional when the option was t).
+  (it "inverts cider-prompt-for-symbol with a prefix arg"
+    (spy-on 'cider-ensure-session :and-return-value t)
+    (spy-on 'cider-symbol-at-point :and-return-value ":foo")
+    (spy-on 'read-string :and-return-value ":foo")
+    (spy-on 'cider--find-keyword-loc :and-return-value
+            (nrepl-dict "dest" (current-buffer) "dest-point" 1))
+    (spy-on 'cider-jump-to)
+    (let ((cider-prompt-for-symbol t))
+      (cider-find-keyword '(4))         ; prefix inverts t -> no prompt
+      (expect 'read-string :not :to-have-been-called)
+      (cider-find-keyword nil)          ; no prefix -> prompt
+      (expect 'read-string :to-have-been-called))))
 
 (describe "cider--find-keyword-loc"
   (it "finds the given keyword, discarding false positives"

--- a/test/cider-resolve-tests.el
+++ b/test/cider-resolve-tests.el
@@ -58,6 +58,12 @@
           "interns"
           (dict "map" (dict "arglists" "([f] [f coll])")
                 "filter" (dict "arglists" "([pred] [pred coll])"))
+          "refers" (dict))
+    "cljs.core"
+    (dict "aliases" (dict)
+          "interns"
+          (dict "map" (dict "arglists" "([f] [f coll])")
+                "js-obj" (dict "arglists" "([& keyvals])"))
           "refers" (dict))))
 
 (defmacro with-mock-ns-cache (&rest body)
@@ -142,7 +148,20 @@
   (it "returns nil for completely unknown vars"
     (with-mock-ns-cache
       (expect (cider-resolve-var "myapp.core" "totally-unknown")
-              :to-be nil))))
+              :to-be nil)))
+
+  (it "falls back to cljs.core in a ClojureScript REPL"
+    (with-mock-ns-cache
+      (with-current-buffer repl-buf (setq-local cider-repl-type 'cljs))
+      ;; A cljs.core-only var resolves in a cljs REPL...
+      (let ((meta (cider-resolve-var "myapp.core" "js-obj")))
+        (expect meta :to-be-truthy)
+        (expect (nrepl-dict-get meta "arglists") :to-equal "([& keyvals])"))))
+
+  (it "does not resolve cljs.core vars in a Clojure REPL"
+    (with-mock-ns-cache
+      ;; ...but not in a clj REPL, where the fallback is clojure.core.
+      (expect (cider-resolve-var "myapp.core" "js-obj") :to-be nil))))
 
 (describe "cider-resolve-core-ns"
   (it "returns clojure.core for Clojure REPLs"


### PR DESCRIPTION
Follow-up to #4084 with the lower-severity items from the stale-module audit.

- **`cider-resolve--var` cljs fallback:** unqualified, non-referred vars fell back to a hardcoded `clojure.core`, so ClojureScript core vars (their indentation metadata) never resolved in a cljs buffer. Fall back to the connection's actual core namespace instead.
- **`cider-find-keyword` prefix inversion:** the prefix arg was OR-ed with `cider-prompt-for-symbol` rather than inverting it, so with the option enabled the prompt was unconditional. Now uses `cider--prompt-for-symbol-p`, matching the sibling find commands and the docstring.

Both have regression tests.

Deliberately left out: the three `cider-log` async/state smells from the audit. On a closer look they need a live logging framework to verify and fix safely (and the "kill in the wrong buffer" one looks gated by an `:inapt-if-not` predicate, so its real-world reachability is doubtful). Better handled separately with the framework running than patched blind.