### PR TITLE
Don't place eval fringe indicators in the REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 ### Bugs fixed
 
+- [#4090](https://github.com/clojure-emacs/cider/pull/4090): Don't place evaluation fringe indicators in the REPL buffer (e.g. after `C-x C-e` there); they only make sense in Clojure source buffers.
 - [#4085](https://github.com/clojure-emacs/cider/pull/4085): Resolve unqualified ClojureScript core vars (e.g. their indentation metadata) against `cljs.core` in a cljs REPL, instead of always falling back to `clojure.core`.
 - [#4085](https://github.com/clojure-emacs/cider/pull/4085): Make a prefix argument to `cider-find-keyword` invert `cider-prompt-for-symbol` (matching the sibling find commands), instead of forcing the prompt on.
 - [#4084](https://github.com/clojure-emacs/cider/pull/4084): Fix `nrepl-dict-merge` mutating a shared literal when its first argument is nil, which leaked state (e.g. the REPL ns cache) between unrelated merges.

--- a/lisp/cider-overlays.el
+++ b/lisp/cider-overlays.el
@@ -255,25 +255,30 @@ END is the position where the sexp ends, and defaults to point."
     (with-current-buffer (if (markerp end)
                              (marker-buffer end)
                            (current-buffer))
-      (save-excursion
-        (if end
-            (goto-char end)
-          (setq end (point)))
-        (clojure-forward-logical-sexp -1)
-        ;; Drop any prior indicator on this form (e.g. a stale one) so a
-        ;; re-evaluation replaces it with a fresh in-sync indicator.
-        (remove-overlays (point) end 'category 'cider-fringe-indicator)
-        ;; Create the green-circle overlay.
-        (let ((ov (cider--make-overlay (point) end 'cider-fringe-indicator
-                                       'before-string cider--fringe-overlay-good)))
-          (when cider-mark-stale-after-edit
-            ;; `cider--make-overlay' installs a delete-on-edit hook; swap just
-            ;; that one out for mark-stale, leaving any other hooks intact.
-            (overlay-put ov 'modification-hooks
-                         (cons #'cider--fringe-overlay-mark-stale
-                               (remq #'cider--delete-overlay
-                                     (overlay-get ov 'modification-hooks)))))
-          ov)))))
+      ;; The fringe indicators track a source form's load/eval state, which is
+      ;; meaningless in the REPL (and other non-source buffers), so only place
+      ;; them in Clojure source buffers.  `cider-eval-last-sexp' is bound in the
+      ;; REPL, so without this guard `C-x C-e' there would leave a marker.
+      (when (derived-mode-p 'clojure-mode 'clojure-ts-mode)
+        (save-excursion
+          (if end
+              (goto-char end)
+            (setq end (point)))
+          (clojure-forward-logical-sexp -1)
+          ;; Drop any prior indicator on this form (e.g. a stale one) so a
+          ;; re-evaluation replaces it with a fresh in-sync indicator.
+          (remove-overlays (point) end 'category 'cider-fringe-indicator)
+          ;; Create the green-circle overlay.
+          (let ((ov (cider--make-overlay (point) end 'cider-fringe-indicator
+                                         'before-string cider--fringe-overlay-good)))
+            (when cider-mark-stale-after-edit
+              ;; `cider--make-overlay' installs a delete-on-edit hook; swap just
+              ;; that one out for mark-stale, leaving any other hooks intact.
+              (overlay-put ov 'modification-hooks
+                           (cons #'cider--fringe-overlay-mark-stale
+                                 (remq #'cider--delete-overlay
+                                       (overlay-get ov 'modification-hooks)))))
+            ov))))))
 
 (cl-defun cider--make-result-overlay (value &rest props &key where duration (type 'result)
                                             (format (concat " " cider-eval-result-prefix "%s "))

--- a/test/cider-overlay-tests.el
+++ b/test/cider-overlay-tests.el
@@ -22,6 +22,8 @@
 (require 'cl-lib)
 
 (require 'cider-overlays)
+(require 'clojure-mode)
+(require 'cider-repl)
 
 ;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
 
@@ -237,6 +239,31 @@ being set that way"
     (let ((cider-fringe-indicators '(eval test)))
       (expect (cider--use-fringe-indicators-p 'eval) :to-be-truthy)
       (expect (cider--use-fringe-indicators-p 'test) :to-be-truthy))))
+
+(describe "cider--make-fringe-overlay"
+  (it "places an eval indicator in a Clojure source buffer"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(+ 1 2)")
+      (let ((cider-fringe-indicators t))
+        (cider--make-fringe-overlay (point)))
+      (expect (seq-filter (lambda (o) (eq (overlay-get o 'category) 'cider-fringe-indicator))
+                          (overlays-in (point-min) (point-max)))
+              :not :to-be nil)))
+
+  ;; Regression: `cider-eval-last-sexp' is bound to `C-x C-e' in the REPL, and
+  ;; the fringe indicators track source-form state, so they must not appear
+  ;; there.  `cider-repl-mode' is `fundamental-mode'-derived, so the
+  ;; source-buffer guard excludes it.
+  (it "does not place an indicator in the REPL buffer"
+    (with-temp-buffer
+      (setq major-mode 'cider-repl-mode)
+      (insert "(+ 1 2)")
+      (let ((cider-fringe-indicators t))
+        (cider--make-fringe-overlay (point)))
+      (expect (seq-filter (lambda (o) (eq (overlay-get o 'category) 'cider-fringe-indicator))
+                          (overlays-in (point-min) (point-max)))
+              :to-be nil))))
 
 (describe "cider--eval-result-display"
   (it "passes the canonical values through unchanged"


### PR DESCRIPTION
The green "successful eval / in-sync" fringe indicator (`cider-fringe-indicators`) was showing up in the REPL buffer. `cider-repl-mode-map` binds `C-x C-e` to `cider-eval-last-sexp`, so evaluating at the REPL runs the *interactive* eval path (not the REPL's own input handler), whose `:on-done` places a fringe overlay in whatever buffer the eval came from - and the placement functions had no buffer guard.

These indicators track a *source* form's load/eval state against the REPL, which is meaningless inside the REPL itself. Fixed by guarding `cider--make-fringe-overlay` - the single chokepoint every eval fringe overlay flows through (single-form, region, and `cider--mark-loaded` paths all funnel through it) - to `derived-mode-p 'clojure-mode 'clojure-ts-mode`. That:

- excludes the REPL (`cider-repl-mode` is `fundamental-mode`-derived),
- keeps the scratch buffer working (`cider-clojure-interaction-mode` derives from `clojure-mode`),
- matches the exact guard `cider-ns-state` already uses, so the two source-tracking features stay consistent.

The `cider-ns-state` load-state indicators and the post-reload resync were already guarded, so they were never the source of the leak. Regression test added for both the positive (source buffer) and negative (REPL) cases.