### PR TITLE
Fix cider-macroexpand-undo in the read-only macroexpansion buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 ### Bugs fixed
 
+- [#4089](https://github.com/clojure-emacs/cider/issues/4089): Fix `cider-macroexpand-undo` failing with a read-only error in the macroexpansion buffer.
 - [#4090](https://github.com/clojure-emacs/cider/pull/4090): Don't place evaluation fringe indicators in the REPL buffer (e.g. after `C-x C-e` there); they only make sense in Clojure source buffers.
 - [#4085](https://github.com/clojure-emacs/cider/pull/4085): Resolve unqualified ClojureScript core vars (e.g. their indentation metadata) against `cljs.core` in a cljs REPL, instead of always falling back to `clojure.core`.
 - [#4085](https://github.com/clojure-emacs/cider/pull/4085): Make a prefix argument to `cider-find-keyword` invert `cider-prompt-for-symbol` (matching the sibling find commands), instead of forcing the prompt on.

--- a/lisp/cider-macroexpansion.el
+++ b/lisp/cider-macroexpansion.el
@@ -92,7 +92,10 @@ The default for DISPLAY-NAMESPACES is taken from
 (defun cider-macroexpand-undo (&optional arg)
   "Undo the last macroexpansion, using `undo-only'.
 ARG is passed along to `undo-only'."
-  (interactive "*P")
+  ;; No `*' in the spec: the macroexpansion buffer is read-only, and a leading
+  ;; `*' would signal `buffer-read-only' before the body could bind
+  ;; `inhibit-read-only' around the undo (clojure-emacs/cider#4089).
+  (interactive "P")
   (let ((inhibit-read-only t))
     (undo-only arg)))
 

--- a/test/cider-macroexpansion-tests.el
+++ b/test/cider-macroexpansion-tests.el
@@ -168,6 +168,23 @@
                                        cider-macroexpansion-print-metadata))))
       (expect captured :to-equal '(tidy nil)))))
 
+(describe "cider-macroexpand-undo"
+  ;; Regression: the command used `(interactive "*P")', whose leading `*'
+  ;; signals `buffer-read-only' before the body can bind `inhibit-read-only',
+  ;; so undo failed in the read-only macroexpansion buffer (#4089).
+  (it "undoes in a read-only buffer without a `buffer-read-only' error"
+    (with-temp-buffer
+      (buffer-enable-undo)
+      (insert "(foo)")
+      (undo-boundary)
+      (let ((inhibit-read-only t)) (insert " (bar)"))
+      (setq buffer-read-only t)
+      ;; Invoked interactively, so the `*' check would fire if it were present.
+      (expect (call-interactively #'cider-macroexpand-undo)
+              :not :to-throw 'buffer-read-only)
+      ;; The undo actually took effect (the last change is gone).
+      (expect (buffer-string) :not :to-match "bar"))))
+
 (provide 'cider-macroexpansion-tests)
 
 ;;; cider-macroexpansion-tests.el ends here


### PR DESCRIPTION
Fixes #4089.

`cider-macroexpand-undo` (bound to `u` in `cider-macroexpansion-mode`) already binds `inhibit-read-only` around the undo, but its interactive spec was `(interactive "*P")`. The leading `*` makes Emacs signal `buffer-read-only` *before the command body runs*, so the `inhibit-read-only` binding never gets a chance - which is exactly why toggling read-only off with `C-x C-q` made it work.

Dropping the `*` lets the body run; the existing `inhibit-read-only` binding handles the actual mutation. Regression test invokes it via `call-interactively` (so the `*` check would fire if present) in a read-only buffer and asserts no `buffer-read-only` error and that the undo took effect.