### PR TITLE
Remove the source-buffer eval keybindings from the REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,6 @@
 ### Bugs fixed
 
 - [#4089](https://github.com/clojure-emacs/cider/issues/4089): Fix `cider-macroexpand-undo` failing with a read-only error in the macroexpansion buffer.
-- [#4090](https://github.com/clojure-emacs/cider/pull/4090): Don't place evaluation fringe indicators in the REPL buffer (e.g. after `C-x C-e` there); they only make sense in Clojure source buffers.
 - [#4085](https://github.com/clojure-emacs/cider/pull/4085): Resolve unqualified ClojureScript core vars (e.g. their indentation metadata) against `cljs.core` in a cljs REPL, instead of always falling back to `clojure.core`.
 - [#4085](https://github.com/clojure-emacs/cider/pull/4085): Make a prefix argument to `cider-find-keyword` invert `cider-prompt-for-symbol` (matching the sibling find commands), instead of forcing the prompt on.
 - [#4084](https://github.com/clojure-emacs/cider/pull/4084): Fix `nrepl-dict-merge` mutating a shared literal when its first argument is nil, which leaked state (e.g. the REPL ns cache) between unrelated merges.
@@ -83,6 +82,7 @@
 
 ### Changes
 
+- [#4092](https://github.com/clojure-emacs/cider/pull/4092): Stop the `C-x C-e` and `C-c C-v` eval keybindings from running the source-buffer eval path in the REPL (which left fringe indicators and the like there) for a niche use case; evaluate at the prompt instead. `C-x C-e` is now a no-op in the REPL rather than falling through to Emacs's Emacs Lisp `eval-last-sexp`. Macroexpansion (`C-c C-m`/`C-c M-m`) and inspection (`C-c M-i`) stay bound.
 - [#4081](https://github.com/clojure-emacs/cider/pull/4081): Remove the long-obsolete (no-op since 1.18) `cider-stacktrace-analyze-at-point` and `cider-stacktrace-analyze-in-region` commands.
 - Bump the injected `cider-nrepl` to 0.62.0 (and `piggieback` to 0.7.0), which carries the hardened content-type/slurp middleware backing the rich-content revival below (and no longer double-sends `value` alongside content-typed responses).
 - Enable rich content in the REPL by default (`cider-repl-use-content-types` is now t): image results render inline, and results naming external content (files, URLs) render a `[show content]` button that fetches and renders it on demand. The automatic fetching that got the feature disabled back in 0.25 ([#2825](https://github.com/clojure-emacs/cider/issues/2825)) is gone - nothing is transferred until the button is pressed - and the server side is hardened in `cider-nrepl` 0.62 (URL-scheme allowlist, size caps, graceful fetch errors).

--- a/lisp/cider-overlays.el
+++ b/lisp/cider-overlays.el
@@ -255,30 +255,25 @@ END is the position where the sexp ends, and defaults to point."
     (with-current-buffer (if (markerp end)
                              (marker-buffer end)
                            (current-buffer))
-      ;; The fringe indicators track a source form's load/eval state, which is
-      ;; meaningless in the REPL (and other non-source buffers), so only place
-      ;; them in Clojure source buffers.  `cider-eval-last-sexp' is bound in the
-      ;; REPL, so without this guard `C-x C-e' there would leave a marker.
-      (when (derived-mode-p 'clojure-mode 'clojure-ts-mode)
-        (save-excursion
-          (if end
-              (goto-char end)
-            (setq end (point)))
-          (clojure-forward-logical-sexp -1)
-          ;; Drop any prior indicator on this form (e.g. a stale one) so a
-          ;; re-evaluation replaces it with a fresh in-sync indicator.
-          (remove-overlays (point) end 'category 'cider-fringe-indicator)
-          ;; Create the green-circle overlay.
-          (let ((ov (cider--make-overlay (point) end 'cider-fringe-indicator
-                                         'before-string cider--fringe-overlay-good)))
-            (when cider-mark-stale-after-edit
-              ;; `cider--make-overlay' installs a delete-on-edit hook; swap just
-              ;; that one out for mark-stale, leaving any other hooks intact.
-              (overlay-put ov 'modification-hooks
-                           (cons #'cider--fringe-overlay-mark-stale
-                                 (remq #'cider--delete-overlay
-                                       (overlay-get ov 'modification-hooks)))))
-            ov))))))
+      (save-excursion
+        (if end
+            (goto-char end)
+          (setq end (point)))
+        (clojure-forward-logical-sexp -1)
+        ;; Drop any prior indicator on this form (e.g. a stale one) so a
+        ;; re-evaluation replaces it with a fresh in-sync indicator.
+        (remove-overlays (point) end 'category 'cider-fringe-indicator)
+        ;; Create the green-circle overlay.
+        (let ((ov (cider--make-overlay (point) end 'cider-fringe-indicator
+                                       'before-string cider--fringe-overlay-good)))
+          (when cider-mark-stale-after-edit
+            ;; `cider--make-overlay' installs a delete-on-edit hook; swap just
+            ;; that one out for mark-stale, leaving any other hooks intact.
+            (overlay-put ov 'modification-hooks
+                         (cons #'cider--fringe-overlay-mark-stale
+                               (remq #'cider--delete-overlay
+                                     (overlay-get ov 'modification-hooks)))))
+          ov)))))
 
 (cl-defun cider--make-result-overlay (value &rest props &key where duration (type 'result)
                                             (format (concat " " cider-eval-result-prefix "%s "))

--- a/lisp/cider-repl.el
+++ b/lisp/cider-repl.el
@@ -2259,7 +2259,6 @@ in an unexpected place."
 (defvar cider-repl-mode-syntax-table
   (copy-syntax-table clojure-mode-syntax-table))
 
-(declare-function cider-eval-last-sexp "cider-eval")
 (declare-function cider-toggle-trace-ns "cider-tracing")
 (declare-function cider-toggle-trace-var "cider-tracing")
 (declare-function cider-find-resource "cider-find")
@@ -2318,9 +2317,11 @@ in an unexpected place."
     (define-key map (kbd "C-c M-p") #'cider-history)
     (define-key map (kbd "C-c M-t") #'cider-trace-menu)
     (define-key map (kbd "C-c C-x") #'cider-start-menu)
-    (define-key map (kbd "C-x C-e") #'cider-eval-last-sexp)
     (define-key map (kbd "C-c C-r") 'clojure-refactor-map)
-    (define-key map (kbd "C-c C-v") #'cider-eval-menu)
+    ;; Shadow the global `eval-last-sexp' (Emacs Lisp) so `C-x C-e' is an
+    ;; explicit no-op in the REPL rather than evaluating the Clojure text as
+    ;; Emacs Lisp.  Evaluate at the prompt instead.
+    (define-key map (kbd "C-x C-e") #'undefined)
     ;; Deprecated REPL-only aliases; the canonical bindings live in the
     ;; `C-c C-x' start map, shared with `cider-mode'.
     ;; Soft-deprecated since the `C-c C-x' start map landed in 0.18.0; now

--- a/test/cider-overlay-tests.el
+++ b/test/cider-overlay-tests.el
@@ -22,8 +22,6 @@
 (require 'cl-lib)
 
 (require 'cider-overlays)
-(require 'clojure-mode)
-(require 'cider-repl)
 
 ;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
 
@@ -239,31 +237,6 @@ being set that way"
     (let ((cider-fringe-indicators '(eval test)))
       (expect (cider--use-fringe-indicators-p 'eval) :to-be-truthy)
       (expect (cider--use-fringe-indicators-p 'test) :to-be-truthy))))
-
-(describe "cider--make-fringe-overlay"
-  (it "places an eval indicator in a Clojure source buffer"
-    (with-temp-buffer
-      (clojure-mode)
-      (insert "(+ 1 2)")
-      (let ((cider-fringe-indicators t))
-        (cider--make-fringe-overlay (point)))
-      (expect (seq-filter (lambda (o) (eq (overlay-get o 'category) 'cider-fringe-indicator))
-                          (overlays-in (point-min) (point-max)))
-              :not :to-be nil)))
-
-  ;; Regression: `cider-eval-last-sexp' is bound to `C-x C-e' in the REPL, and
-  ;; the fringe indicators track source-form state, so they must not appear
-  ;; there.  `cider-repl-mode' is `fundamental-mode'-derived, so the
-  ;; source-buffer guard excludes it.
-  (it "does not place an indicator in the REPL buffer"
-    (with-temp-buffer
-      (setq major-mode 'cider-repl-mode)
-      (insert "(+ 1 2)")
-      (let ((cider-fringe-indicators t))
-        (cider--make-fringe-overlay (point)))
-      (expect (seq-filter (lambda (o) (eq (overlay-get o 'category) 'cider-fringe-indicator))
-                          (overlays-in (point-min) (point-max)))
-              :to-be nil))))
 
 (describe "cider--eval-result-display"
   (it "passes the canonical values through unchanged"

--- a/test/cider-repl-tests.el
+++ b/test/cider-repl-tests.el
@@ -780,3 +780,17 @@ PROPERTY should be a symbol of either 'text, 'ansi-context or
               "image/svg+xml" "text/html"))
     (dolist (entry cider-repl-content-type-handler-alist)
       (expect (functionp (cdr entry)) :to-be-truthy))))
+
+(describe "cider-repl-mode-map"
+  ;; The plain-eval commands were removed from the REPL keymap: they ran
+  ;; source-buffer eval machinery (fringe indicators and the like) in the REPL
+  ;; for a use case that was niche to begin with.
+  (it "does not bind the source-buffer eval commands"
+    ;; `C-x C-e' is shadowed with `undefined' so it doesn't fall through to the
+    ;; global Emacs Lisp `eval-last-sexp'; `C-c C-v' is simply left unbound.
+    (expect (lookup-key cider-repl-mode-map (kbd "C-x C-e")) :to-be 'undefined)
+    (expect (lookup-key cider-repl-mode-map (kbd "C-c C-v")) :to-be nil))
+
+  (it "keeps the macroexpand and inspect commands"
+    (expect (lookup-key cider-repl-mode-map (kbd "C-c C-m")) :to-be 'cider-macroexpand-1)
+    (expect (lookup-key cider-repl-mode-map (kbd "C-c M-i")) :to-be 'cider-inspect)))


### PR DESCRIPTION
This drops the two plain-eval keys from the REPL and reverts #4090 along with them.

`C-x C-e` and `C-c C-v` ran the source-buffer eval path from inside the REPL, which is how source-only machinery (the fringe indicators from #4090, result overlays, load-state marking) ended up running there. Digging through the history, `C-x C-e` was added to the REPL back in 2014 (`f97acb2f`) mostly so it would not error, and the commit message itself calls it "an odd use case." A decade on, the main thing it buys us is that coupling, so rather than keep guarding the symptom, it is cleaner to not bind it. Evaluate at the prompt.

`C-c C-v` is simply left unbound. `C-x C-e` is shadowed with `undefined` rather than dropped outright, so it is an explicit no-op in the REPL instead of falling through to Emacs Lisp `eval-last-sexp` (which would try to read the Clojure text as elisp).

Kept `C-c C-m`/`C-c M-m` (macroexpand) and `C-c M-i` (inspect) - acting on a form you can see in the scrollback is genuinely useful, unlike plain re-eval. `C-c C-r` is the refactor prefix and untouched.

Since the fringe leak can no longer happen via a REPL binding, the guard #4090 added to `cider--make-fringe-overlay` is dead weight, so this reverts it and its test too.