### PR TITLE
Tidy up a few oddities in cider-repl.el

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 ### Bugs fixed
 
+- [#4093](https://github.com/clojure-emacs/cider/pull/4093): Fix a crash (`wrong-type-argument stringp nil`) when a REPL result is truncated by the print middleware.
 - [#4089](https://github.com/clojure-emacs/cider/issues/4089): Fix `cider-macroexpand-undo` failing with a read-only error in the macroexpansion buffer.
 - [#4085](https://github.com/clojure-emacs/cider/pull/4085): Resolve unqualified ClojureScript core vars (e.g. their indentation metadata) against `cljs.core` in a cljs REPL, instead of always falling back to `clojure.core`.
 - [#4085](https://github.com/clojure-emacs/cider/pull/4085): Make a prefix argument to `cider-find-keyword` invert `cider-prompt-for-symbol` (matching the sibling find commands), instead of forcing the prompt on.
@@ -82,6 +83,7 @@
 
 ### Changes
 
+- [#4093](https://github.com/clojure-emacs/cider/pull/4093): In the REPL, `C-c M-m` now opens the macroexpand menu (matching `cider-mode`) instead of running `cider-macroexpand-all` directly, and `C-c C-r` no longer injects clojure-mode's source-editing refactor map.
 - [#4092](https://github.com/clojure-emacs/cider/pull/4092): Stop the `C-x C-e` and `C-c C-v` eval keybindings from running the source-buffer eval path in the REPL (which left fringe indicators and the like there) for a niche use case; evaluate at the prompt instead. `C-x C-e` is now a no-op in the REPL rather than falling through to Emacs's Emacs Lisp `eval-last-sexp`. Macroexpansion (`C-c C-m`/`C-c M-m`) and inspection (`C-c M-i`) stay bound.
 - [#4081](https://github.com/clojure-emacs/cider/pull/4081): Remove the long-obsolete (no-op since 1.18) `cider-stacktrace-analyze-at-point` and `cider-stacktrace-analyze-in-region` commands.
 - Bump the injected `cider-nrepl` to 0.62.0 (and `piggieback` to 0.7.0), which carries the hardened content-type/slurp middleware backing the rich-content revival below (and no longer double-sends `value` alongside content-typed responses).

--- a/lisp/cider-repl.el
+++ b/lisp/cider-repl.el
@@ -1354,9 +1354,7 @@ REPL BUFFER rather than popping to the inspector (#3636)."
                             (setq show-prompt (funcall handler content-type buffer value nil t))
                           (cider-repl-emit-result buffer value t t)))
      :on-truncated (lambda ()
-                     ;; Preserve the (incidentally nil) warning the legacy
-                     ;; truncated-handler form passed through.
-                     (cider-repl-emit-stderr buffer nil)))))
+                     (cider-repl-emit-stderr buffer "\n... output truncated ...\n")))))
 
 (defun cider--repl-request-plist ()
   "Plist to be merged into REPL eval requests."

--- a/lisp/cider-repl.el
+++ b/lisp/cider-repl.el
@@ -2072,7 +2072,6 @@ the history file is rewritten if `cider-repl-history-file' is set."
   "Add a REPL shortcut command, defined by NAME and HANDLER."
   (puthash name handler cider-repl-shortcuts))
 
-(declare-function cider-toggle-trace-ns "cider-tracing")
 (declare-function cider-undef "cider-eval")
 (declare-function cider-browse-ns "cider-browse-ns")
 (declare-function cider-classpath "cider-classpath")
@@ -2080,7 +2079,6 @@ the history file is rewritten if `cider-repl-history-file' is set."
 (declare-function cider-run "cider-mode")
 (declare-function cider-ns-refresh "cider-ns")
 (declare-function cider-ns-reload "cider-ns")
-(declare-function cider-find-var "cider-find")
 (declare-function cider-version "cider")
 (declare-function cider-test-run-loaded-tests "cider-test")
 (declare-function cider-test-run-project-tests "cider-test")

--- a/lisp/cider-repl.el
+++ b/lisp/cider-repl.el
@@ -2268,6 +2268,7 @@ in an unexpected place."
 (declare-function cider-switch-to-last-clojure-buffer "cider-mode")
 (declare-function cider-macroexpand-1 "cider-macroexpansion")
 (declare-function cider-macroexpand-all "cider-macroexpansion")
+(declare-function cider-macroexpand-menu "cider-macroexpansion")
 (declare-function cider-selector "cider-selector")
 (declare-function cider-jack-in-clj "cider")
 (declare-function cider-jack-in-cljs "cider")
@@ -2305,7 +2306,7 @@ in an unexpected place."
     (define-key map (kbd "C-c C-b") #'cider-interrupt)
     (define-key map (kbd "C-c C-c") #'cider-interrupt)
     (define-key map (kbd "C-c C-m") #'cider-macroexpand-1)
-    (define-key map (kbd "C-c M-m") #'cider-macroexpand-all)
+    (define-key map (kbd "C-c M-m") #'cider-macroexpand-menu)
     (define-key map (kbd "C-c C-s") #'sesman-map)
     (define-key map (kbd "C-c C-z") #'cider-switch-to-last-clojure-buffer)
     (define-key map (kbd "C-c M-o") #'cider-repl-switch-to-other)
@@ -2317,7 +2318,6 @@ in an unexpected place."
     (define-key map (kbd "C-c M-p") #'cider-history)
     (define-key map (kbd "C-c M-t") #'cider-trace-menu)
     (define-key map (kbd "C-c C-x") #'cider-start-menu)
-    (define-key map (kbd "C-c C-r") 'clojure-refactor-map)
     ;; Shadow the global `eval-last-sexp' (Emacs Lisp) so `C-x C-e' is an
     ;; explicit no-op in the REPL rather than evaluating the Clojure text as
     ;; Emacs Lisp.  Evaluate at the prompt instead.

--- a/test/cider-repl-tests.el
+++ b/test/cider-repl-tests.el
@@ -791,6 +791,12 @@ PROPERTY should be a symbol of either 'text, 'ansi-context or
     (expect (lookup-key cider-repl-mode-map (kbd "C-x C-e")) :to-be 'undefined)
     (expect (lookup-key cider-repl-mode-map (kbd "C-c C-v")) :to-be nil))
 
+  (it "does not inject clojure-mode's source-editing refactor map"
+    (expect (lookup-key cider-repl-mode-map (kbd "C-c C-r")) :to-be nil))
+
   (it "keeps the macroexpand and inspect commands"
     (expect (lookup-key cider-repl-mode-map (kbd "C-c C-m")) :to-be 'cider-macroexpand-1)
-    (expect (lookup-key cider-repl-mode-map (kbd "C-c M-i")) :to-be 'cider-inspect)))
+    (expect (lookup-key cider-repl-mode-map (kbd "C-c M-i")) :to-be 'cider-inspect))
+
+  (it "binds C-c M-m to the macroexpand menu, matching cider-mode"
+    (expect (lookup-key cider-repl-mode-map (kbd "C-c M-m")) :to-be 'cider-macroexpand-menu)))


### PR DESCRIPTION
A careful pass over the REPL keymap and code turned up three things worth fixing (follow-up to #4092, which removed the `C-x C-e`/`C-c C-v` leaks).

`C-c M-m` had drifted: the REPL still ran `cider-macroexpand-all` directly, while `cider-mode` moved that key to the `cider-macroexpand-menu` transient a while back. So the same keystroke did different things depending on whether you were in a source buffer or the REPL. The REPL now points at the menu too.

`C-c C-r` bound clojure-mode's source-editing refactor map (`sort-ns`, `insert-ns-form`, `introduce-let`, and friends). Those act on file/ns structure and make no sense at a prompt, and - like the eval keys - it was injected only in the REPL, not in `cider-mode`. Dropped it.

And a latent crash: the REPL's `:on-truncated` handler passed `nil` to `cider-repl-emit-stderr`, which propertizes it and throws `wrong-type-argument stringp nil`. So a result the print middleware flagged as truncated would error instead of being reported. It now emits an actual truncation notice, like the interactive-eval path does.

Plus a trivial cleanup of two duplicated `declare-function`s. Keymap assertions added for the two binding changes.