### PR TITLE
Add g-to-refresh and menu entries for cider-doctor

### DIFF
--- a/doc/modules/ROOT/pages/troubleshooting.adoc
+++ b/doc/modules/ROOT/pages/troubleshooting.adoc
@@ -26,6 +26,9 @@ nREPL, `cider-nrepl` and Clojure versions and probes the middleware ops
 that back the major features - so a missing feature shows up as a named
 missing op rather than a mystery.
 
+Press kbd:[g] in the report buffer to re-run the checks in place, for
+instance after installing a missing dependency or starting a REPL.
+
 TIP: The report is meant to be copied into a bug report, which usually saves a
 round of back-and-forth about your environment.
 

--- a/lisp/cider-doctor.el
+++ b/lisp/cider-doctor.el
@@ -302,24 +302,44 @@ detail names the affected feature."
   (mapc #'cider-doctor--insert-result results)
   (insert "\n"))
 
+(defun cider-doctor--render ()
+  "Render the diagnostics report into the current buffer.
+Runs the offline environment checks and, when a REPL is connected, the
+connection-health checks."
+  (let ((inhibit-read-only t))
+    (erase-buffer)
+    (insert "CIDER Doctor\n")
+    (insert "============\n\n")
+    (cider-doctor--insert-section "Environment" (cider-doctor--offline-checks))
+    (if (cider-doctor--online-p)
+        (cider-doctor--insert-section "Connection" (cider-doctor--online-checks))
+      (insert "Connection\n\nNo active REPL; connection checks skipped.\n\n"))
+    (goto-char (point-min))))
+
+(defun cider-doctor--revert (&rest _)
+  "Re-run the checks and re-render the report.
+Serves as the `revert-buffer-function', so \\[revert-buffer] refreshes the
+report in place."
+  (cider-doctor--render))
+
+(define-derived-mode cider-doctor-mode special-mode "CIDER Doctor"
+  "Major mode for the CIDER Doctor report.
+Press \\[revert-buffer] to re-run the checks and refresh the report.
+
+\\{cider-doctor-mode-map}"
+  (setq-local revert-buffer-function #'cider-doctor--revert))
+
 ;;;###autoload
 (defun cider-doctor ()
   "Diagnose the current CIDER setup and show a report.
 Runs offline environment checks and, when a REPL is connected, a set of
 connection-health checks.  The resulting buffer is meant to be pasted
-into bug reports."
+into bug reports.  Press \\<cider-doctor-mode-map>\\[revert-buffer] to
+refresh it."
   (interactive)
-  (let ((buffer (cider-popup-buffer "*cider-doctor*" 'select)))
+  (let ((buffer (cider-popup-buffer "*cider-doctor*" 'select #'cider-doctor-mode)))
     (with-current-buffer buffer
-      (let ((inhibit-read-only t))
-        (erase-buffer)
-        (insert "CIDER Doctor\n")
-        (insert "============\n\n")
-        (cider-doctor--insert-section "Environment" (cider-doctor--offline-checks))
-        (if (cider-doctor--online-p)
-            (cider-doctor--insert-section "Connection" (cider-doctor--online-checks))
-          (insert "Connection\n\nNo active REPL; connection checks skipped.\n\n"))
-        (goto-char (point-min))))
+      (cider-doctor--render))
     buffer))
 
 ;;; Helpers

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -334,6 +334,7 @@ If invoked with a prefix ARG eval the expression after inserting it."
     ["A sip of CIDER" cider-drink-a-sip]
     ["View user manual" cider-view-manual]
     ["View quick reference card" cider-view-refcard]
+    ["Diagnose your setup" cider-doctor]
     ["Report a bug" cider-report-bug]
     ["Version info" cider-version]
     "--"
@@ -733,7 +734,8 @@ loaded yet, this will be shown in Clojure buffers next to the Clojure menu."
                     ["Start a Clojure REPL, and a ClojureScript REPL" cider-jack-in-clj&cljs
                      :help "Starts an nREPL server, connects a Clojure REPL to it, and then a ClojureScript REPL."]
                     "--"
-                    ["View user manual" cider-view-manual]))
+                    ["View user manual" cider-view-manual]
+                    ["Diagnose your setup" cider-doctor]))
                 :visible (not cider-mode))))
 
 ;;;###autoload

--- a/lisp/cider-repl.el
+++ b/lisp/cider-repl.el
@@ -2393,6 +2393,7 @@ in an unexpected place."
         ["A sip of CIDER" cider-drink-a-sip]
         ["View user manual" cider-view-manual]
         ["View quick reference card" cider-view-refcard]
+        ["Diagnose your setup" cider-doctor]
         ["Report a bug" cider-report-bug]
         ["Version info" cider-version]))
     map))

--- a/test/cider-doctor-tests.el
+++ b/test/cider-doctor-tests.el
@@ -171,6 +171,25 @@
       (expect (plist-get result :status) :to-be 'warn)
       (expect (plist-get result :detail) :to-match "xref"))))
 
+(describe "cider-doctor"
+  (after-each
+    (when (get-buffer "*cider-doctor*")
+      (kill-buffer "*cider-doctor*")))
+
+  (it "renders into a cider-doctor-mode buffer"
+    (with-current-buffer (cider-doctor)
+      (expect major-mode :to-be 'cider-doctor-mode)
+      (expect (buffer-substring-no-properties (point-min) (min 13 (point-max)))
+              :to-equal "CIDER Doctor")))
+
+  (it "refreshes in place via revert-buffer"
+    (with-current-buffer (cider-doctor)
+      (expect revert-buffer-function :to-be #'cider-doctor--revert)
+      ;; a revert re-runs the checks without erroring and keeps the report
+      (revert-buffer)
+      (expect (buffer-substring-no-properties (point-min) (min 13 (point-max)))
+              :to-equal "CIDER Doctor"))))
+
 (provide 'cider-doctor-tests)
 
 ;;; cider-doctor-tests.el ends here


### PR DESCRIPTION
Two small follow-ups to `cider-doctor` (#4094):

- The report buffer gets its own `cider-doctor-mode` (derived from `special-mode`), so you can re-run the checks in place with `g` after fixing something, instead of typing `M-x cider-doctor` again. Rendering moved into a reusable helper wired up as the buffer's `revert-buffer-function`.
- A "Diagnose your setup" entry now sits next to "Report a bug" in the main CIDER menu, the REPL menu, and the pre-connection Clojure menu, so the diagnostics are actually discoverable - usually right when you need them, before a connection exists.

Since `cider-doctor` itself hasn't shipped in a release yet, there's no separate changelog entry.

- [x] The commits are consistent with our contribution guidelines
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`)
- [x] You've updated the changelog (n/a - cider-doctor is still unreleased)
- [x] You've updated the user manual