### PR TITLE
Re-subscribe cider-tap after reconnecting to a new REPL

### DIFF
--- a/lisp/cider-tap.el
+++ b/lisp/cider-tap.el
@@ -171,6 +171,14 @@ inspect it.  Killing the buffer stops the streaming."
     (with-current-buffer buffer
       (unless (eq major-mode 'cider-tap-mode)
         (cider-tap-mode))
+      ;; When reopening against a different (e.g. reconnected) REPL, the old
+      ;; subscription belongs to a connection we no longer track.  Drop it -
+      ;; best-effort unsubscribing from the old REPL if it's still live - so a
+      ;; fresh subscription gets established below instead of the buffer going
+      ;; silent.
+      (unless (eq cider-tap--repl connection)
+        (cider-tap--unsubscribe)
+        (setq cider-tap--subscription nil))
       (setq cider-tap--repl connection)
       ;; Pin the buffer to its REPL so the inspector opened from here resolves
       ;; to the same connection.

--- a/test/cider-tap-tests.el
+++ b/test/cider-tap-tests.el
@@ -1,0 +1,79 @@
+;;; cider-tap-tests.el --- Tests for cider-tap       -*- lexical-binding: t; -*-
+
+;; Copyright © 2026 Bozhidar Batsov and CIDER contributors
+
+;; Author: Bozhidar Batsov <bozhidar@batsov.dev>
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; This file is part of CIDER
+
+;;; Code:
+
+(require 'buttercup)
+(require 'cider-tap)
+
+;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
+
+(describe "cider-tap"
+  :var (subscribe-calls)
+
+  (before-each
+    (setq subscribe-calls nil)
+    ;; don't pop a window during the test run
+    (spy-on 'pop-to-buffer)
+    (spy-on 'cider-nrepl-send-request :and-call-fake
+            (lambda (request &rest _)
+              (when (equal request '("op" "cider/tap-subscribe"))
+                (push t subscribe-calls)))))
+
+  (after-each
+    (when (get-buffer cider-tap-buffer)
+      (kill-buffer cider-tap-buffer)))
+
+  (it "subscribes on first open"
+    (spy-on 'cider-current-repl :and-return-value 'conn-a)
+    (cider-tap)
+    (expect (length subscribe-calls) :to-equal 1)
+    (expect (buffer-local-value 'cider-tap--repl (get-buffer cider-tap-buffer))
+            :to-be 'conn-a))
+
+  (it "does not re-subscribe when reopened against the same REPL"
+    (spy-on 'cider-current-repl :and-return-value 'conn-a)
+    (cider-tap)
+    ;; pretend the first subscription was acknowledged
+    (with-current-buffer cider-tap-buffer
+      (setq cider-tap--subscription "sub-a"))
+    (cider-tap)
+    (expect (length subscribe-calls) :to-equal 1))
+
+  (it "re-subscribes when reopened against a different REPL"
+    (spy-on 'cider-current-repl :and-return-value 'conn-a)
+    (cider-tap)
+    (with-current-buffer cider-tap-buffer
+      (setq cider-tap--subscription "sub-a"))
+    ;; now a reconnect hands us a different REPL
+    (spy-on 'cider-current-repl :and-return-value 'conn-b)
+    (cider-tap)
+    (expect (length subscribe-calls) :to-equal 2)
+    (with-current-buffer cider-tap-buffer
+      (expect cider-tap--repl :to-be 'conn-b))))
+
+(provide 'cider-tap-tests)
+
+;;; cider-tap-tests.el ends here


### PR DESCRIPTION
Reopening the `*cider-tap*` buffer against a different REPL (after a reconnect, or once the original connection died) overwrote `cider-tap--repl` with the new connection but left the stale `cider-tap--subscription` set. The `unless cider-tap--subscription` guard then skipped re-subscribing, so the buffer went silent - pinned to the new REPL with a subscription that belonged to the old, dead one.

Now, when the connection has changed, the stale subscription is dropped (best-effort unsubscribing from the old REPL if it's still live) so a fresh one is established. Reopening against the same REPL still doesn't re-subscribe.

Found during the 2.0 review. `cider-tap` is new this cycle, so no changelog entry.