### PR TITLE
Signal an error when running tests without a connection

### DIFF
--- a/lisp/cider-test.el
+++ b/lisp/cider-test.el
@@ -846,6 +846,10 @@ If SILENT is non-nil, suppress all messages other then test results.
 If PROMPT-FOR-FILTERS is non-nil, prompt the user for a test selector filters.
 The include/exclude selectors will be used to filter the tests before
 running them."
+  ;; `cider-map-repls' with `:auto' does not ensure a connection (it maps over
+  ;; zero REPLs when disconnected), so guard here to fail fast with a clear
+  ;; error instead of silently doing nothing.
+  (cider-ensure-session)
   (cider-test-clear-highlights)
   (let ((include-selectors
          (if prompt-for-filters

--- a/test/cider-test-tests.el
+++ b/test/cider-test-tests.el
@@ -189,3 +189,12 @@
        (lambda () (setq captured (list cider-test-default-include-selectors
                                        cider-test-default-exclude-selectors))))
       (expect captured :to-equal '(("keep") ("skip"))))))
+
+(describe "cider-test-execute"
+  (it "fails fast without a session, before dispatching to any REPL"
+    (spy-on 'cider-ensure-session :and-call-fake
+            (lambda () (user-error "No linked CIDER sessions")))
+    (spy-on 'cider-map-repls)
+    (expect (cider-test-execute :loaded) :to-throw 'user-error)
+    ;; the guard must fire before any REPL dispatch / side effect
+    (expect 'cider-map-repls :not :to-have-been-called)))


### PR DESCRIPTION
Switching `cider-test-execute` to `cider-map-repls :auto` (for the new ClojureScript test support) silently dropped the connection guard. With `:auto`, `cider-map-repls` maps over zero REPLs when disconnected, so running tests with no REPL just did nothing instead of raising the usual "no REPL" error. None of the public test commands guard upstream, so pressing a test key while disconnected was a silent no-op.

Add `cider-ensure-session` at the top of `cider-test-execute` to fail fast with a clear message.

Found during the 2.0 review. The `:auto` switch is new this cycle, so no changelog entry.