### PR TITLE
Make two implicit module dependencies explicit

### DIFF
--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -41,6 +41,7 @@
 (require 'cider-resolve)
 (require 'cider-doc) ; required only for the menu
 (require 'cider-profile) ; required only for the menu
+(require 'cider-enlighten) ; for the menu entries and `cider-enlightened-face'
 (require 'cider-completion)
 (require 'cider-completion-context)
 (require 'cider-inspector)

--- a/lisp/cider-profile.el
+++ b/lisp/cider-profile.el
@@ -29,6 +29,7 @@
 (require 'cider-popup)
 (require 'cider-eval)
 (require 'cider-inspector)
+(require 'cider-util) ; for `cider-symbol-at-point'
 (require 'transient)
 
 


### PR DESCRIPTION
Two require-hygiene fixes found during the 2.0 review:

- `cider-profile` calls `cider-symbol-at-point` (from `cider-util`) without requiring it.
- `cider-mode` references the enlighten menu commands and `cider-enlightened-face` (which moved to `cider-enlighten` this cycle) without requiring it - it joins the existing "required only for the menu" group next to `cider-test`/`cider-doc`/`cider-profile`.

Both worked only because the module happened to be loaded transitively. `cider-enlighten` adds no new transitive deps (its dependencies are already loaded by that point in `cider-mode`). No behavior change.