### PR TITLE
Restore the cider-profile-map prefix keymap

### DIFF
--- a/lisp/cider-profile.el
+++ b/lisp/cider-profile.el
@@ -41,6 +41,22 @@
     ["Clear data" cider-profile-clear])
   "CIDER profiling submenu (for the menu bar).")
 
+;;;###autoload (autoload 'cider-profile-map "cider-profile" "CIDER profiling keymap." nil 'keymap)
+(defvar cider-profile-map
+  (let ((map (define-prefix-command 'cider-profile-map)))
+    (define-key map (kbd "t") #'cider-profile-toggle)
+    (define-key map (kbd "C-t") #'cider-profile-toggle)
+    (define-key map (kbd "c") #'cider-profile-clear)
+    (define-key map (kbd "C-c") #'cider-profile-clear)
+    (define-key map (kbd "s") #'cider-profile-summary)
+    (define-key map (kbd "C-s") #'cider-profile-summary)
+    (define-key map (kbd "n") #'cider-profile-ns-toggle)
+    (define-key map (kbd "C-n") #'cider-profile-ns-toggle)
+    map)
+  "CIDER profiler keymap, grouping the profiling commands.
+No longer bound by default - `C-c C-=' opens `cider-profile-menu' instead - but
+retained so existing user bindings into this prefix keep working.")
+
 ;;;###autoload (autoload 'cider-profile-menu "cider-profile" "Menu for CIDER's profiling commands." t)
 (transient-define-prefix cider-profile-menu ()
   "Transient menu for CIDER's profiling commands."


### PR DESCRIPTION
The profiling commands moved to the `cider-profile-menu` transient on `C-c C-=` this cycle, but unlike every other transient migration (`cider-ns-map`, `cider-eval-commands-map`, `cider-doc-map`, `cider-macroexpand-map`, `cider-insert-commands-map` are all still defvar'd), `cider-profile-map` was deleted outright. That silently broke configs that bound the prefix or added keys into it (void-variable).

Restore the map - defined but not bound into `cider-mode-map`, since the transient owns `C-c C-=` now - to match its retained siblings.

Found during the 2.0 review. Restores something removed within the same unreleased cycle, so no changelog entry.