### PR TITLE
Fix a garbled sentence in cider-interrupt's docstring

### DIFF
--- a/lisp/cider-client.el
+++ b/lisp/cider-client.el
@@ -624,7 +624,7 @@ itself is present."
 
 (defun cider-interrupt ()
   "Interrupt any pending evaluations.
-In a `.cljc' buffer this interrupts every REPL evaluations are
+In a `.cljc' buffer this interrupts every REPL that evaluations are
 dispatched to (both Clojure and ClojureScript), mirroring `cider-map-repls'."
   (interactive)
   (cider-map-repls :auto #'cider-interrupt-repl))


### PR DESCRIPTION
Trivial docstring fix found during the 2.0 review: "every REPL evaluations are dispatched to" was missing a word - now "every REPL that evaluations are dispatched to".