### PR TITLE
Bump the injected cider-nrepl to 0.62.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@
 
 ### Changes
 
+- Bump the injected `cider-nrepl` to [0.62.1](https://github.com/clojure-emacs/cider-nrepl/blob/v0.62.1/CHANGELOG.md#0621-2026-07-15), which carries a batch of debugger and enlighten fixes (record literals survive instrumentation, clear errors for forms too large to instrument, and several `STATE__` crashes are gone).
 - [#4093](https://github.com/clojure-emacs/cider/pull/4093): In the REPL, `C-c M-m` now opens the macroexpand menu (matching `cider-mode`) instead of running `cider-macroexpand-all` directly, and `C-c C-r` no longer injects clojure-mode's source-editing refactor map.
 - [#4092](https://github.com/clojure-emacs/cider/pull/4092): Stop the `C-x C-e` and `C-c C-v` eval keybindings from running the source-buffer eval path in the REPL (which left fringe indicators and the like there) for a niche use case; evaluate at the prompt instead. `C-x C-e` is now a no-op in the REPL rather than falling through to Emacs's Emacs Lisp `eval-last-sexp`. Macroexpansion (`C-c C-m`/`C-c M-m`) and inspection (`C-c M-i`) stay bound.
 - [#4081](https://github.com/clojure-emacs/cider/pull/4081): Remove the long-obsolete (no-op since 1.18) `cider-stacktrace-analyze-at-point` and `cider-stacktrace-analyze-in-region` commands.

--- a/lisp/cider-jack-in.el
+++ b/lisp/cider-jack-in.el
@@ -341,7 +341,7 @@ the artifact.")
 
 Used when `cider-jack-in-auto-inject-clojure' is set to `latest'.")
 
-(defconst cider-required-middleware-version "0.62.0"
+(defconst cider-required-middleware-version "0.62.1"
   "The CIDER nREPL version that's known to work properly with CIDER.")
 
 (defcustom cider-injected-middleware-version cider-required-middleware-version


### PR DESCRIPTION
0.62.1 was released today with a batch of debugger and enlighten fixes (record literals survive instrumentation, clear errors for forms too large to instrument, and several `STATE__` crashes are gone).

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)