### PR TITLE
Relax the overzealous macroexpansion guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+- [#4111](https://github.com/clojure-emacs/cider/issues/4111): Fix the macroexpansion commands refusing to expand `let`, `fn`, `loop` and `letfn` (macros that double as special forms), restore the no-op expansion of non-macro forms (useful for normalizing reader syntax like `::auto/kw` and `#(...)`), and stop gating `cider-macroexpand-all` on the top-level operator (a fully-recursive expansion can reach macros in nested sub-forms).
+
 ## 2.0.0 (2026-07-15)
 
 ### New features

--- a/lisp/cider-client.el
+++ b/lisp/cider-client.el
@@ -772,19 +772,24 @@ last one being the out-of-sync case where the namespace is loaded but stale."
   "Signal a helpful `user-error' unless OPERATOR names a resolvable macro.
 This turns the silent \"nothing happens\" case (e.g. the namespace hasn't
 been evaluated yet) into an actionable message, distinguishing an unresolved
-symbol from a special form or an ordinary (non-macro) var."
-  (cond
-   ((not (cider--symbol-operator-p operator))
-    (user-error "`%s' is not a macro" (or operator "form")))
-   (t
+symbol from a special form or an ordinary (non-macro) var.
+
+A nil or non-symbol OPERATOR (a literal, reader syntax like \\=`::kw\\=` or
+\\=`#(...)\\=`, and so on) passes the check: expanding it is a no-op on the
+runtime side, but the reader may still normalize the form usefully."
+  (when (cider--symbol-operator-p operator)
     (let ((info (cider-var-info operator)))
       (cond
        ((null info)
         (user-error "%s" (cider-resolution-failure-message operator)))
+       ;; `let', `fn', `loop' and `letfn' carry both `:macro' and
+       ;; `:special-form' metadata - they are real macros delegating to the
+       ;; `*'-suffixed special forms - so the macro check must come first.
+       ((nrepl-dict-get info "macro") nil)
        ((nrepl-dict-get info "special-form")
         (user-error "`%s' is a special form; there's nothing to macroexpand" operator))
-       ((not (nrepl-dict-get info "macro"))
-        (user-error "`%s' is not a macro" operator)))))))
+       (t
+        (user-error "`%s' is not a macro" operator))))))
 
 
 ;;; Requests

--- a/lisp/cider-macroexpansion.el
+++ b/lisp/cider-macroexpansion.el
@@ -136,7 +136,10 @@ required, so it is not meant to be called interactively."
   (pcase-let ((`(,beg . ,end) (or (cider-macroexpansion--form-bounds)
                                   (user-error "No sexp before point to expand"))))
     (let ((code (buffer-substring-no-properties beg end)))
-      (cider-ensure-macro (cider-macroexpansion--operator code))
+      ;; A fully-recursive expansion can reach macros in nested sub-forms, so
+      ;; it is useful even when the form's head is not a macro itself.
+      (unless (equal expander "macroexpand-all")
+        (cider-ensure-macro (cider-macroexpansion--operator code)))
       (cider-redraw-macroexpansion-buffer
        (cider-sync-request:macroexpand expander code)
        (current-buffer) beg end))))
@@ -173,11 +176,11 @@ If invoked with a PREFIX argument, use \\=`macroexpand\\=` instead of
 
 ;;;###autoload
 (defun cider-macroexpand-all ()
-  "Invoke \\=`macroexpand-all\\=` on the expression preceding point."
+  "Invoke \\=`macroexpand-all\\=` on the expression preceding point.
+The form's head needn't be a macro itself, since a fully-recursive
+expansion can reach macros in nested sub-forms."
   (interactive)
-  (let ((form (cider-last-sexp)))
-    (cider-ensure-macro (cider-macroexpansion--operator form))
-    (cider-macroexpand-expr "macroexpand-all" form)))
+  (cider-macroexpand-expr "macroexpand-all" (cider-last-sexp)))
 
 (defun cider-macroexpand-all-inplace ()
   "Perform inplace \\=`macroexpand-all\\=` on the form before point."

--- a/test/cider-client-tests.el
+++ b/test/cider-client-tests.el
@@ -172,15 +172,23 @@
     (spy-on 'cider-var-info :and-return-value nil)
     (spy-on 'cider-resolution-failure-message :and-return-value "nope")
     (expect (cider-ensure-macro "my.ns/foo") :to-throw 'user-error))
+  (it "passes for macros that double as special forms (let, fn, loop, letfn)"
+    ;; #4111: these carry both `:macro' and `:special-form' metadata.
+    (spy-on 'cider-var-info :and-return-value (nrepl-dict "macro" "true"
+                                                          "special-form" "true"))
+    (expect (cider-ensure-macro "let") :not :to-throw))
   (it "rejects special forms"
     (spy-on 'cider-var-info :and-return-value (nrepl-dict "special-form" "true"))
     (expect (cider-ensure-macro "if") :to-throw 'user-error))
   (it "rejects ordinary (non-macro) vars"
     (spy-on 'cider-var-info :and-return-value (nrepl-dict "arglists" "([coll])"))
     (expect (cider-ensure-macro "map") :to-throw 'user-error))
-  (it "rejects non-symbol operators without consulting the runtime"
+  (it "passes non-symbol operators through without consulting the runtime"
+    ;; #4111: reader syntax (::kw, #(...), literals) is expanded as a no-op
+    ;; server-side, but the reader still normalizes it usefully.
     (spy-on 'cider-var-info)
-    (expect (cider-ensure-macro ":kw") :to-throw 'user-error)
+    (expect (cider-ensure-macro ":kw") :not :to-throw)
+    (expect (cider-ensure-macro nil) :not :to-throw)
     (expect 'cider-var-info :not :to-have-been-called)))
 
 (describe "cider-classpath-entries"

--- a/test/cider-macroexpansion-tests.el
+++ b/test/cider-macroexpansion-tests.el
@@ -143,6 +143,37 @@
     (expect (cider-macroexpansion--operator "(defn- f [])") :to-equal "defn-")
     (expect (cider-macroexpansion--operator "(-> x f)") :to-equal "->")))
 
+(describe "cider-macroexpand-all"
+  (it "doesn't require the form's head to be a macro"
+    ;; #4111: a fully-recursive expansion can reach macros in nested
+    ;; sub-forms, so the operator must not be gated.
+    (spy-on 'cider-last-sexp :and-return-value "(inc (when x 1))")
+    (spy-on 'cider-ensure-macro)
+    (spy-on 'cider-macroexpand-expr)
+    (cider-macroexpand-all)
+    (expect 'cider-ensure-macro :not :to-have-been-called)
+    (expect 'cider-macroexpand-expr
+            :to-have-been-called-with "macroexpand-all" "(inc (when x 1))")))
+
+(describe "cider-macroexpand-expr-inplace"
+  (it "guards single-step expansion on the operator"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(inc 1)")
+      (spy-on 'cider-var-info :and-return-value (nrepl-dict "arglists" "([x])"))
+      (expect (cider-macroexpand-expr-inplace "macroexpand-1")
+              :to-throw 'user-error)))
+  (it "skips the operator guard for macroexpand-all"
+    (with-temp-buffer
+      (clojure-mode)
+      (insert "(inc (when x 1))")
+      (spy-on 'cider-ensure-macro)
+      (spy-on 'cider-sync-request:macroexpand
+              :and-return-value "(inc (if x (do 1)))")
+      (cider-macroexpand-expr-inplace "macroexpand-all")
+      (expect 'cider-ensure-macro :not :to-have-been-called)
+      (expect (string-trim (buffer-string)) :to-equal "(inc (if x (do 1)))"))))
+
 (describe "cider-macroexpand-menu--apply-args"
   (it "binds the namespace display style from --ns="
     (let (captured)


### PR DESCRIPTION
The 2.0 macroexpansion diagnostics (da0e416f) were stricter than intended in three ways:

- `let`, `fn`, `loop` and `letfn` were rejected as special forms, although they're real macros that merely carry `:special-form` documentation metadata (they delegate to the `*`-suffixed true specials). The macro check now comes before the special-form check.
- Non-symbol forms (auto-resolved keywords, `#()` and other reader syntax, literals) errored with "'form' is not a macro". They now pass through again - expansion is a no-op server-side, but the reader still normalizes them usefully.
- `cider-macroexpand-all` gated on the top-level operator even though a fully-recursive expansion can reach macros in nested sub-forms, e.g. `(inc (when x 1))`. The `-all` commands no longer consult the guard (matching what `cider-macrostep-expand-all` already did).

The useful parts of the diagnostics are unchanged: an unresolved operator still points at loading the namespace, a true special form (`if`, `do`, ...) still explains there's nothing to expand, and a plain function still gets "not a macro" on single-step expansion.

Fixes #4111

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)