### PR TITLE
Make cider-enlighten-mode light things up again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs fixed
 
 - [#4115](https://github.com/clojure-emacs/cider/pull/4115): Fix inline macro stepping (`cider-macrostep`): pressing `e`/`RET` right after `n`/`p` now expands the operator you jumped to, instead of erroring with "No sexp before point to expand".
+- [#4114](https://github.com/clojure-emacs/cider/pull/4114): Fix `cider-enlighten-mode` never lighting anything up: the `enlighten` flag was dropped from eval requests built in source buffers (a 1.22 regression), and the value overlays were discarded because enlighten events carry no source text to verify against.
 - [#4111](https://github.com/clojure-emacs/cider/issues/4111): Fix the macroexpansion commands refusing to expand `let`, `fn`, `loop` and `letfn` (macros that double as special forms), restore the no-op expansion of non-macro forms (useful for normalizing reader syntax like `::auto/kw` and `#(...)`), and stop gating `cider-macroexpand-all` on the top-level operator (a fully-recursive expansion can reach macros in nested sub-forms).
 
 ## 2.0.0 (2026-07-15)

--- a/lisp/cider-debug.el
+++ b/lisp/cider-debug.el
@@ -745,8 +745,13 @@ key of a map, and it means \"go to the value associated with this key\"."
 
 (defun cider--debug-position-for-code (code)
   "Return non-nil if point is roughly before CODE.
-This might move point one line above."
-  (or (looking-at-p (regexp-quote code))
+This might move point one line above.
+
+A nil CODE counts as a match: enlighten events carry only the form's
+line/column (not its source text), so there is nothing to verify against
+and the position must be trusted as-is."
+  (or (null code)
+      (looking-at-p (regexp-quote code))
       (let ((trimmed (regexp-quote (cider--debug-trim-code code))))
         (or (looking-at-p trimmed)
             ;; If this is a fake #dbg injected by `C-u

--- a/lisp/nrepl-client.el
+++ b/lisp/nrepl-client.el
@@ -1062,13 +1062,21 @@ If LINE and COLUMN are non-nil and current buffer is a file buffer, \"line\",
   `("op" "eval"
     "code" ,(substring-no-properties input)
     ,@(when ns `("ns" ,ns))
-    ,@(when nrepl-extra-eval-params-function
-        (funcall nrepl-extra-eval-params-function))
     ,@(let ((file (or (buffer-file-name) (buffer-name))))
         (when (and line column file)
           `("file" ,file
             "line" ,line
             "column" ,column)))))
+
+(defun nrepl--connection-eval-params (connection)
+  "Extra eval-request params contributed by CONNECTION's client.
+`nrepl-extra-eval-params-function' is local to the connection buffer, while
+eval requests are assembled in the originating source buffer (whose file and
+position they carry), so the lookup must target CONNECTION explicitly."
+  (when-let* ((buffer (cond ((buffer-live-p connection) connection)
+                            ((stringp connection) (get-buffer connection))))
+              (f (buffer-local-value 'nrepl-extra-eval-params-function buffer)))
+    (funcall f)))
 
 (cl-defun nrepl-send-eval-request (input callback connection
                                          &key ns line column additional-params tooling)
@@ -1082,7 +1090,9 @@ ADDITIONAL-PARAMS is a plist to be appended to the request message.
 
 This is the keyword-argument form; `nrepl-request:eval' is the legacy
 positional shim retained for backward compatibility."
-  (nrepl-send-request (append (nrepl--eval-request input ns line column) additional-params)
+  (nrepl-send-request (append (nrepl--eval-request input ns line column)
+                              (nrepl--connection-eval-params connection)
+                              additional-params)
                       callback
                       connection
                       tooling))
@@ -1147,7 +1157,8 @@ If NS is non-nil, include it in the request
 If TOOLING is non-nil the evaluation is done using the tooling nREPL
 session."
   (nrepl-sync-request
-   (nrepl--eval-request input ns)
+   (append (nrepl--eval-request input ns)
+           (nrepl--connection-eval-params connection))
    connection
    :tooling tooling))
 

--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -554,3 +554,36 @@
   (it "does not treat a server message as a format string"
     (expect (nrepl-notify "test %s and 100%" "warning") :not :to-throw)
     (expect (nrepl-notify "raw 50% done" nil) :not :to-throw)))
+
+(describe "nrepl--connection-eval-params"
+  ;; `nrepl-extra-eval-params-function' lives in the connection buffer, but
+  ;; eval requests are assembled in the source buffer (for their file/line
+  ;; context), so the params must be looked up against the connection - this
+  ;; is how `cider-enlighten-mode' gets its `enlighten' flag onto requests.
+  (it "contributes the connection's extra params from any buffer"
+    (let ((conn (generate-new-buffer " *fake-conn*")))
+      (unwind-protect
+          (progn
+            (with-current-buffer conn
+              (setq-local nrepl-extra-eval-params-function
+                          (lambda () '("enlighten" "true"))))
+            (with-temp-buffer ;; an unrelated source buffer
+              (spy-on 'nrepl-send-request)
+              (nrepl-send-eval-request "(inc 1)" #'ignore conn)
+              (let ((request (car (spy-calls-args-for 'nrepl-send-request 0))))
+                (expect (member "enlighten" request) :to-be-truthy))
+              (spy-on 'nrepl-sync-request)
+              (nrepl-sync-request:eval "(inc 1)" conn)
+              (let ((request (car (spy-calls-args-for 'nrepl-sync-request 0))))
+                (expect (member "enlighten" request) :to-be-truthy))))
+        (kill-buffer conn))))
+
+  (it "contributes nothing when the connection sets no params function"
+    (let ((conn (generate-new-buffer " *fake-conn*")))
+      (unwind-protect
+          (with-temp-buffer
+            (spy-on 'nrepl-send-request)
+            (nrepl-send-eval-request "(inc 1)" #'ignore conn)
+            (let ((request (car (spy-calls-args-for 'nrepl-send-request 0))))
+              (expect (member "enlighten" request) :not :to-be-truthy)))
+        (kill-buffer conn)))))


### PR DESCRIPTION
Enlighten has been completely dark for a while, thanks to independent regressions on both sides of the wire. The server-side ones are fixed in clojure-emacs/cider-nrepl#1038; this PR fixes the two client-side ones:

- The `enlighten` flag moved to the connection-buffer-local `nrepl-extra-eval-params-function` during the 1.22 nREPL/UI decoupling, but eval requests are assembled in the *source* buffer (they need its file/line), so the params function was never consulted and the flag never left Emacs. The senders now look it up against the connection explicitly.
- Enlighten events carry the form's line/column but no source text, and `cider--debug-position-for-code` errored on the missing `code` entry (silently, since the response dispatcher tolerates callback errors), so no overlay was ever placed. A nil `code` now counts as nothing-to-verify.

With this plus the cider-nrepl fix, enlighten works end-to-end again (verified against a live REPL - values render inline for every sub-expression). Found while capturing enlighten screenshots for the docs.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)