### PR TITLE
Bump the injected cider-nrepl to 0.62.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+- [#4116](https://github.com/clojure-emacs/cider/pull/4116): Bump the injected `cider-nrepl` to [0.62.2](https://github.com/clojure-emacs/cider-nrepl/blob/v0.62.2/CHANGELOG.md#0622-2026-07-18), so a dead trace/tap subscriber no longer breaks every traced evaluation, and the debugger no longer shadows the enlighten middleware's evaluator.
+
 ### Bugs fixed
 
 - [#4115](https://github.com/clojure-emacs/cider/pull/4115): Fix inline macro stepping (`cider-macrostep`): pressing `e`/`RET` right after `n`/`p` now expands the operator you jumped to, instead of erroring with "No sexp before point to expand".

--- a/lisp/cider-jack-in.el
+++ b/lisp/cider-jack-in.el
@@ -341,7 +341,7 @@ the artifact.")
 
 Used when `cider-jack-in-auto-inject-clojure' is set to `latest'.")
 
-(defconst cider-required-middleware-version "0.62.1"
+(defconst cider-required-middleware-version "0.62.2"
   "The CIDER nREPL version that's known to work properly with CIDER.")
 
 (defcustom cider-injected-middleware-version cider-required-middleware-version


### PR DESCRIPTION
0.62.2 carries two fixes we want: a dead trace/tap subscriber no longer breaks every traced evaluation ([cider-nrepl#1037](https://github.com/clojure-emacs/cider-nrepl/pull/1037)), and the debugger no longer shadows the enlighten middleware's evaluator ([cider-nrepl#1038](https://github.com/clojure-emacs/cider-nrepl/pull/1038)). The enlighten fix also needs the client-side #4114 to be fully live.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)