### PR TITLE
Optionally read symbol prompts via completing-read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## master (unreleased)
 
+### New features
+
+- [#4117](https://github.com/clojure-emacs/cider/pull/4117): Add `cider-use-completing-read-for-symbol` (off by default): when enabled, symbol prompts (e.g. `cider-doc`, `cider-find-var`) read through `completing-read` over a lazy, runtime-backed collection, so they work with `completing-read` UIs (Vertico, Ivy, Helm) and annotate candidates with their type and namespace.
+
 ## 2.0.1 (2026-07-23)
 
 ### Changes

--- a/doc/modules/ROOT/pages/usage/code_completion.adoc
+++ b/doc/modules/ROOT/pages/usage/code_completion.adoc
@@ -46,6 +46,35 @@ which shows the top completion candidate inline as you type (accept it with
 kbd:[TAB]). It's a lightweight alternative to the popup UIs described below and
 works out-of-the-box with CIDER's completion.
 
+== Completion in minibuffer prompts
+
+Some commands ask you for a Clojure symbol in the minibuffer (for example
+`cider-doc` or `cider-find-var` when there's no symbol at point, or when
+`cider-prompt-for-symbol` is `t`). By default these prompts use a plain
+minibuffer read where kbd:[TAB] completes the symbol against the running REPL.
+
+If you drive completion with a `completing-read` UI such as
+https://github.com/minad/vertico[Vertico], Ivy or Helm, set
+`cider-use-completing-read-for-symbol` to `t`. The symbol prompts then go
+through `completing-read`, so your usual narrowing UI, sorting and annotations
+apply, and candidates are labelled with their type and namespace:
+
+[source,lisp]
+----
+(setq cider-use-completing-read-for-symbol t)
+----
+
+Candidates are fetched from the runtime lazily as you type, so nothing is
+transferred up front. Querying only starts once your input reaches
+`cider-completion-symbol-prompt-min-length` characters (2 by default), which
+keeps an empty prompt from asking the runtime for every symbol.
+
+TIP: The prompt also feeds eldoc, so the arglist of the symbol you're typing
+shows in the echo area. With a vertical completion UI the eldoc line and the
+minibuffer can compete for the echo area; if you rarely see the arglist, the
+per-candidate annotations (type and namespace) still give you the essentials,
+and you can widen the echo area with `max-mini-window-height`.
+
 == Auto-completion
 
 While the standard Emacs tooling works just fine, we suggest that CIDER users

--- a/lisp/cider-common.el
+++ b/lisp/cider-common.el
@@ -43,6 +43,20 @@ prompt if that throws an error."
   :group 'cider
   :package-version '(cider . "0.9.0"))
 
+(defcustom cider-use-completing-read-for-symbol nil
+  "Whether symbol prompts read the symbol via `completing-read'.
+
+When non-nil, prompts that ask for a Clojure symbol (e.g. `cider-doc',
+`cider-find-var') use `completing-read' over a dynamic, runtime-backed
+collection, so they compose with `completing-read' UIs such as Vertico,
+Ivy and Helm, and show type/namespace annotations for the candidates.
+
+When nil (the default for now), those prompts use a plain minibuffer read
+with the traditional \\<cider-minibuffer-map>\\[complete-symbol] completion."
+  :type 'boolean
+  :group 'cider
+  :package-version '(cider . "2.1.0"))
+
 (defcustom cider-special-mode-truncate-lines t
   "If non-nil, contents of CIDER's special buffers will be line-truncated.
 Should be set before loading CIDER."
@@ -147,10 +161,39 @@ If SKIP-COLON is non-nil, no \": \" is forced at the end of the prompt."
           value
         input))))
 
+(declare-function cider--symbol-completion-table "cider-completion")
+(defun cider-completing-read-symbol (prompt &optional default)
+  "Read a Clojure symbol with PROMPT via `completing-read'.
+DEFAULT, typically the symbol at point, is offered as the default value.
+Candidates come from the runtime through a dynamic collection, so this works
+with `completing-read'-based UIs (Vertico, Ivy, Helm, ...) without fetching
+every symbol up front, and it honors the user's completion styles and
+annotations."
+  (minibuffer-with-setup-hook
+      (lambda ()
+        (set-syntax-table clojure-mode-syntax-table)
+        (setq-local eldoc-documentation-function #'cider-eldoc)
+        (run-hooks 'eval-expression-minibuffer-setup-hook))
+    (let ((input (completing-read
+                  (if default
+                      (format "%s (default %s): " prompt default)
+                    (format "%s: " prompt))
+                  (cider--symbol-completion-table)
+                  nil nil nil 'cider-minibuffer-history default)))
+      (if (string-empty-p input) (or default input) input))))
+
+(defun cider--read-symbol (prompt &optional default)
+  "Read a Clojure symbol with PROMPT, defaulting to DEFAULT.
+Dispatches on `cider-use-completing-read-for-symbol' between the
+`completing-read' collection and the traditional minibuffer read."
+  (if cider-use-completing-read-for-symbol
+      (cider-completing-read-symbol prompt default)
+    (cider-read-from-minibuffer prompt default)))
+
 (defun cider-read-symbol-name (prompt callback)
   "Read a symbol name using PROMPT with a default of the one at point.
 Use CALLBACK as the completing read var callback."
-  (funcall callback (cider-read-from-minibuffer
+  (funcall callback (cider--read-symbol
                      prompt
                      ;; if the thing at point is a keyword we treat it as symbol
                      (cider--kw-to-symbol (cider-symbol-at-point 'look-back)))))
@@ -160,7 +203,7 @@ Use CALLBACK as the completing read var callback."
 On failure, read a symbol name using PROMPT and call CALLBACK with that."
   (condition-case nil
       (funcall callback (cider--kw-to-symbol (cider-symbol-at-point 'look-back)))
-    (error (funcall callback (cider-read-from-minibuffer prompt)))))
+    (error (funcall callback (cider--read-symbol prompt)))))
 
 (declare-function cider-mode "cider-mode")
 (declare-function cider-current-repl "cider-session")

--- a/lisp/cider-completion.el
+++ b/lisp/cider-completion.el
@@ -232,6 +232,39 @@ has started."
   (interactive)
   (cider-sync-request:complete-flush-caches))
 
+(defcustom cider-completion-symbol-prompt-min-length 2
+  "Minimum input length before a symbol prompt queries the runtime.
+Completing an empty prompt would ask the runtime for every symbol, so
+`cider-completing-read-symbol' only starts querying once you've typed at
+least this many characters."
+  :type 'integer
+  :group 'cider
+  :package-version '(cider . "2.1.0"))
+
+(defun cider--symbol-completion-table ()
+  "Return a `completing-read' collection backed by the `complete' op.
+Candidates for the current input are fetched from the runtime lazily (so
+nothing is dumped up front), cached per input, and carry `type'/`ns' text
+properties so `cider-annotate-symbol' can annotate them.  Querying only
+starts once the input reaches `cider-completion-symbol-prompt-min-length'
+characters, which keeps an empty prompt from asking for every symbol."
+  (let ((cache-key 'none) cache-val)
+    (lambda (string pred action)
+      (cond
+       ((eq action 'metadata)
+        `(metadata
+          (category . cider)
+          (display-sort-function . identity)
+          (annotation-function . ,#'cider-annotate-symbol)))
+       ((eq (car-safe action) 'boundaries) nil)
+       (t
+        (unless (equal string cache-key)
+          (setq cache-key string
+                cache-val (when (>= (length string)
+                                    cider-completion-symbol-prompt-min-length)
+                            (cider-complete string))))
+        (complete-with-action action cache-val string pred))))))
+
 (defun cider-company-location (var)
   "Open VAR's definition in a buffer.
 Returns the cons of the buffer itself and the location of VAR's definition

--- a/test/cider-common-tests.el
+++ b/test/cider-common-tests.el
@@ -243,3 +243,20 @@
       (expect (cider-auto-select-buffer-p 'error nil) :to-be nil))
     (let ((cider-auto-select-buffer nil))
       (expect (cider-auto-select-buffer-p 'error t) :to-be-truthy))))
+
+(describe "cider--read-symbol"
+  (before-each
+    (spy-on 'cider-completing-read-symbol :and-return-value "via-completing-read")
+    (spy-on 'cider-read-from-minibuffer :and-return-value "via-minibuffer"))
+
+  (it "uses completing-read when the option is enabled"
+    (let ((cider-use-completing-read-for-symbol t))
+      (expect (cider--read-symbol "Sym" "map") :to-equal "via-completing-read")
+      (expect 'cider-completing-read-symbol :to-have-been-called-with "Sym" "map")
+      (expect 'cider-read-from-minibuffer :not :to-have-been-called)))
+
+  (it "uses the plain minibuffer read by default"
+    (let ((cider-use-completing-read-for-symbol nil))
+      (expect (cider--read-symbol "Sym" "map") :to-equal "via-minibuffer")
+      (expect 'cider-read-from-minibuffer :to-have-been-called-with "Sym" "map")
+      (expect 'cider-completing-read-symbol :not :to-have-been-called))))

--- a/test/cider-completion-tests.el
+++ b/test/cider-completion-tests.el
@@ -65,3 +65,27 @@
         (expect completion-category-overrides
                 :to-equal '((cider (styles basic flex)
                                    (cycle t))))))))
+
+(describe "cider--symbol-completion-table"
+  (it "reports the `cider' category and an annotation function"
+    (let* ((table (cider--symbol-completion-table))
+           (md (cdr (funcall table "" nil 'metadata))))
+      (expect (cdr (assq 'category md)) :to-equal 'cider)
+      (expect (assq 'annotation-function md) :to-be-truthy)))
+
+  (it "does not query the runtime until the input reaches the min length"
+    (spy-on 'cider-complete :and-return-value '("reduce" "reductions"))
+    (let ((cider-completion-symbol-prompt-min-length 2)
+          (table (cider--symbol-completion-table)))
+      (expect (all-completions "r" table) :to-equal nil)
+      (expect 'cider-complete :not :to-have-been-called)
+      (expect (all-completions "re" table) :to-have-same-items-as '("reduce" "reductions"))
+      (expect 'cider-complete :to-have-been-called-with "re")))
+
+  (it "caches per input, so repeated table calls make one query"
+    (spy-on 'cider-complete :and-return-value '("map" "mapv" "mapcat"))
+    (let ((table (cider--symbol-completion-table)))
+      (all-completions "map" table)
+      (try-completion "map" table)
+      (test-completion "map" table)
+      (expect (spy-calls-count 'cider-complete) :to-equal 1))))


### PR DESCRIPTION
CIDER's symbol prompts (`cider-doc`, `cider-find-var`, and friends when there's no symbol at point) read through `cider-read-from-minibuffer`, which uses `completion-at-point` rather than `completing-read`. So `completing-read` UIs like Vertico, Ivy and Helm don't apply there, and you get the old TAB/`*Completions*` behavior instead of your usual narrowing UI. We couldn't switch to `completing-read` in the past because it wants the whole candidate list up front and we can't dump every symbol.

A dynamic collection gets us there: `cider-completing-read-symbol` reads via `completing-read` over a table that queries the `complete` op lazily per input, caches per input, annotates candidates with their type/namespace, and only starts querying once the input reaches `cider-completion-symbol-prompt-min-length` chars (2), so an empty prompt never asks the runtime for every symbol.

It's gated behind `cider-use-completing-read-for-symbol`, off by default for now. Verified against a live REPL (lazy querying, the min-length guard, namespaced candidates, annotations, per-input caching) and covered by tests. Docs are in the code-completion page, including a note on eldoc-in-the-prompt behavior.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`eldev test`)
- [x] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)