### PR TITLE
Pin the REPL when jumping to a dependency via xref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Bugs fixed
 
+- [#4118](https://github.com/clojure-emacs/cider/issues/4118): Fix `xref-find-definitions` (`M-.`) onto a dependency's source breaking session linking: the opened buffer is now pinned to the REPL it was navigated from, so evaluation there no longer errors with "No linked CIDER sessions".
 - [#4115](https://github.com/clojure-emacs/cider/pull/4115): Fix inline macro stepping (`cider-macrostep`): pressing `e`/`RET` right after `n`/`p` now expands the operator you jumped to, instead of erroring with "No sexp before point to expand".
 - [#4114](https://github.com/clojure-emacs/cider/pull/4114): Fix `cider-enlighten-mode` never lighting anything up: the `enlighten` flag was dropped from eval requests built in source buffers (a 1.22 regression), and the value overlays were discarded because enlighten events carry no source text to verify against.
 - [#4111](https://github.com/clojure-emacs/cider/issues/4111): Fix the macroexpansion commands refusing to expand `let`, `fn`, `loop` and `letfn` (macros that double as special forms), restore the no-op expansion of non-macro forms (useful for normalizing reader syntax like `::auto/kw` and `#(...)`), and stop gating `cider-macroexpand-all` on the top-level operator (a fully-recursive expansion can reach macros in nested sub-forms).

--- a/lisp/cider-xref-backend.el
+++ b/lisp/cider-xref-backend.el
@@ -80,18 +80,27 @@ These are used for presentation purposes."
 
 (defun cider--var-to-xref-location (var)
   "Get location of definition of VAR."
-  (when-let* ((info (cider-var-info var))
-              (line (nrepl-dict-get info "line"))
-              (file (cider--xref-extract-file info))
-              (buf (cider--find-buffer-for-file file)))
-    (xref-make-buffer-location
-     buf
-     (with-current-buffer buf
-       (save-excursion
-         (goto-char 0)
-         (forward-line (1- line))
-         (back-to-indentation)
-         (point))))))
+  ;; Capture the originating session before opening the target buffer, so that
+  ;; a dependency's source (which lives outside the project) stays pinned to the
+  ;; REPL it was navigated from.  xref drives the navigation itself (via
+  ;; `switch-to-buffer'), bypassing `cider-jump-to', so we do the pinning here -
+  ;; otherwise evaluation in the opened buffer fails with "No linked CIDER
+  ;; sessions" (see https://github.com/clojure-emacs/cider/issues/4118).
+  (let ((origin-repl (ignore-errors (cider-current-repl))))
+    (when-let* ((info (cider-var-info var))
+                (line (nrepl-dict-get info "line"))
+                (file (cider--xref-extract-file info))
+                (buf (cider--find-buffer-for-file file)))
+      (with-current-buffer buf
+        (cider--pin-repl-if-out-of-project origin-repl))
+      (xref-make-buffer-location
+       buf
+       (with-current-buffer buf
+         (save-excursion
+           (goto-char 0)
+           (forward-line (1- line))
+           (back-to-indentation)
+           (point)))))))
 
 (cl-defmethod xref-backend-definitions ((_backend (eql cider)) var)
   "Find definitions of VAR."

--- a/test/cider-xref-backend-tests.el
+++ b/test/cider-xref-backend-tests.el
@@ -82,6 +82,38 @@
         (expect 'cider-xref--var-source-references :to-have-been-called)
         (expect 'cider--fn-refs-xrefs :not :to-have-been-called)))))
 
+(describe "cider--var-to-xref-location"
+  :var (proj-root repl-buf dep-file)
+
+  (before-each
+    (setq proj-root (file-name-as-directory
+                     (file-truename (make-temp-file "cider-xref-pin-test-" t)))
+          repl-buf (get-buffer-create "*cider-xref-pin-test-repl*")
+          dep-file (expand-file-name "/some/dep/src/dep/ns.clj"))
+    (with-current-buffer repl-buf
+      (setq-local nrepl-project-dir proj-root))
+    (spy-on 'cider-current-repl :and-return-value repl-buf)
+    (spy-on 'cider-var-info :and-return-value
+            (nrepl-dict "line" 1 "file" dep-file))
+    ;; return a fresh buffer visiting the dependency file
+    (spy-on 'cider--find-buffer-for-file :and-call-fake
+            (lambda (_file)
+              (with-current-buffer (get-buffer-create "*cider-xref-pin-test-dep*")
+                (setq buffer-file-name dep-file)
+                (current-buffer)))))
+
+  (after-each
+    (dolist (name '("*cider-xref-pin-test-repl*" "*cider-xref-pin-test-dep*"))
+      (when-let* ((buf (get-buffer name)))
+        (kill-buffer buf)))
+    (when (and proj-root (file-directory-p proj-root))
+      (delete-directory proj-root t)))
+
+  (it "pins the originating REPL onto an out-of-project dependency buffer"
+    (cider--var-to-xref-location "dep/foo")
+    (with-current-buffer "*cider-xref-pin-test-dep*"
+      (expect cider--ancillary-buffer-repl :to-be repl-buf))))
+
 (provide 'cider-xref-backend-tests)
 
 ;;; cider-xref-backend-tests.el ends here


### PR DESCRIPTION
`xref-find-definitions` (`M-.`) onto a dependency's source drives navigation through Emacs' own xref machinery (`switch-to-buffer`), which never goes through `cider-jump-to`. So the opened buffer, living outside the project root, was never pinned to the session it was navigated from, and evaluation there failed with "No linked CIDER sessions".

This pins the origin REPL when building the xref location, the same way `cider-find-var` already does via `cider-jump-to`. Covers both `M-.` and apropos, which share the same helper.

Fixes #4118.