### PR TITLE
Honor pinned REPL in cider-ensure-session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Bugs fixed
 
+- [#4120](https://github.com/clojure-emacs/cider/issues/4120): Fix evaluation, debugging and inspecting in a dependency's source buffer still erroring with "No linked CIDER sessions": `cider-ensure-session` now honors the pinned REPL (and `cider-default-session`) like the rest of the REPL resolution does, instead of only checking sesman's linked sessions.
 - [#4118](https://github.com/clojure-emacs/cider/issues/4118): Fix `xref-find-definitions` (`M-.`) onto a dependency's source breaking session linking: the opened buffer is now pinned to the REPL it was navigated from, so evaluation there no longer errors with "No linked CIDER sessions".
 - [#4115](https://github.com/clojure-emacs/cider/pull/4115): Fix inline macro stepping (`cider-macrostep`): pressing `e`/`RET` right after `n`/`p` now expands the operator you jumped to, instead of erroring with "No sexp before point to expand".
 - [#4114](https://github.com/clojure-emacs/cider/pull/4114): Fix `cider-enlighten-mode` never lighting anything up: the `enlighten` flag was dropped from eval requests built in source buffers (a 1.22 regression), and the value overlays were discarded because enlighten events carry no source text to verify against.

--- a/lisp/cider-session.el
+++ b/lisp/cider-session.el
@@ -100,14 +100,30 @@ Set interactively with `cider-set-default-session'.")
   "Return t if CIDER is currently connected, nil otherwise."
   (process-live-p (get-buffer-process (cider-current-repl))))
 
+;; Forward declaration; the real definition is the `defvar-local' further down.
+(defvar cider--ancillary-buffer-repl)
+
 (defun cider-ensure-session ()
-  "Signal a `user-error' unless there is a linked CIDER session.
+  "Signal a `user-error' unless CIDER has a session available here.
 The CIDER-level nREPL senders (e.g. `cider-nrepl-send-request',
 `cider-nrepl-sync-request') already ensure a connection - they resolve the
 REPL with `cider-current-repl' ENSURE - so commands don't need this for
 correctness.  Use it only to fail fast, before doing interactive or
-side-effecting work, rather than at the point of the first request."
-  (sesman-ensure-session 'CIDER))
+side-effecting work, rather than at the point of the first request.
+
+Mirror the resolution precedence of `cider-current-repl' and `cider-repls':
+honor a buffer pinned to a REPL via `cider--ancillary-buffer-repl' and a
+`cider-default-session' before falling back to sesman's linked sessions.
+Otherwise this guard would reject buffers where evaluation actually works,
+such as a dependency's source jumped to via `cider-find-var' (which lives
+outside the project and so has no linked session, only a pin - see
+https://github.com/clojure-emacs/cider/issues/4120)."
+  (or (and (buffer-live-p cider--ancillary-buffer-repl)
+           (sesman-session-for-object
+            'CIDER cider--ancillary-buffer-repl 'no-error))
+      (and cider-default-session
+           (sesman-session 'CIDER cider-default-session))
+      (sesman-ensure-session 'CIDER)))
 
 (define-obsolete-function-alias 'cider-ensure-connected #'cider-ensure-session "2.0.0")
 

--- a/test/cider-connection-tests.el
+++ b/test/cider-connection-tests.el
@@ -53,7 +53,36 @@
                 (list "cider-ensure-session" b)))))
 
   (it "raises a user-error in the absence of a connection"
-    (expect (cider-ensure-session) :to-throw 'user-error)))
+    (expect (cider-ensure-session) :to-throw 'user-error))
+
+  (it "resolves a REPL the buffer is pinned to, even with no linked session"
+    ;; A dependency's source buffer lives outside the session's project, so it
+    ;; has no linked session of its own - only a pin to the REPL it was
+    ;; navigated from (see #4120).  The guard must honor that pin instead of
+    ;; erroring with "No linked CIDER sessions".  Force "no linked session" by
+    ;; stubbing the sesman lookup, so the test doesn't depend on sesman's
+    ;; environment-sensitive directory/project linking.
+    (spy-on 'sesman-current-session :and-return-value nil)
+    (with-repl-buffer "cider-ensure-session" 'clj b
+      (with-temp-buffer
+        ;; Sanity check: without a pin there is no session reachable here.
+        (expect (cider-ensure-session) :to-throw 'user-error)
+        (setq-local cider--ancillary-buffer-repl b)
+        (expect (cider-ensure-session) :to-equal
+                (list "cider-ensure-session" b)))))
+
+  (it "resolves the default session even with no linked session"
+    ;; With `cider-default-session' set, evaluation targets that session
+    ;; regardless of project context (see `cider-repls'), so the guard has to
+    ;; accept it rather than only looking at sesman's linked sessions.
+    (spy-on 'sesman-current-session :and-return-value nil)
+    (let ((cider-default-session nil))
+      (with-repl-buffer "cider-ensure-session" 'clj b
+        (with-temp-buffer
+          (expect (cider-ensure-session) :to-throw 'user-error)
+          (setq cider-default-session "cider-ensure-session")
+          (expect (cider-ensure-session) :to-equal
+                  (list "cider-ensure-session" b)))))))
 
 (describe "cider-current-repl"
 


### PR DESCRIPTION
`cider-ensure-session` guarded interactive commands by calling `sesman-ensure-session` directly, which only sees sesman's linked sessions. The actual dispatch (`cider-current-repl`/`cider-repls`) first consults the pinned REPL and `cider-default-session`, so in a dependency's source buffer (pinned via `cider-find-var`/xref but living outside the project, hence unlinked) the guard errored with "No linked CIDER sessions" before evaluation could run. This broke eval, the debugger and the inspector there. The guard now resolves through the same precedence.

Fixes #4120