### PR TITLE
Rename cider--ancillary-buffer-repl to cider--pinned-repl-buffer

### DIFF
--- a/lisp/cider-common.el
+++ b/lisp/cider-common.el
@@ -164,13 +164,13 @@ On failure, read a symbol name using PROMPT and call CALLBACK with that."
 
 (declare-function cider-mode "cider-mode")
 (declare-function cider-current-repl "cider-session")
-(defvar cider--ancillary-buffer-repl)
+(defvar cider--pinned-repl-buffer)
 
 (defun cider--pin-repl-if-out-of-project (repl)
   "Pin REPL onto the current buffer if its file is outside REPL's project.
 When jumping to a definition or resource that lives outside the
 originating session's project directory (typically a dependency's
-source), associate the buffer with REPL via `cider--ancillary-buffer-repl'
+source), associate the buffer with REPL via `cider--pinned-repl-buffer'
 so that CIDER commands invoked there target the session the buffer was
 navigated from.  Buffers inside the project directory are left untouched
 so they keep tracking the current session."
@@ -180,7 +180,7 @@ so they keep tracking the current session."
       (when (or (null proj-dir)
                 (not (string-prefix-p (file-name-as-directory (file-truename proj-dir))
                                       (file-truename file))))
-        (setq-local cider--ancillary-buffer-repl repl)))))
+        (setq-local cider--pinned-repl-buffer repl)))))
 
 (defcustom cider-jump-to-pop-to-buffer-actions
   '((display-buffer-reuse-window display-buffer-same-window))

--- a/lisp/cider-compilation.el
+++ b/lisp/cider-compilation.el
@@ -267,7 +267,7 @@ REPL connection can be provided to set it as the connection for the created
            (error-buffer (cider-new-error-buffer #'cider-stacktrace-mode
                                                  error-types is-compilation)))
       (with-current-buffer error-buffer
-        (setq cider--ancillary-buffer-repl repl))
+        (setq cider--pinned-repl-buffer repl))
       (cider-stacktrace-render error-buffer causes error-types))))
 
 (defconst cider-clojure-compilation-error-phases-default-value

--- a/lisp/cider-popup.el
+++ b/lisp/cider-popup.el
@@ -28,7 +28,7 @@
 (require 'subr-x)
 
 (declare-function cider-current-repl "cider-session")
-(defvar cider--ancillary-buffer-repl)
+(defvar cider--pinned-repl-buffer)
 
 (define-minor-mode cider-popup-buffer-mode
   "Mode for CIDER popup buffers."
@@ -119,7 +119,7 @@ If ANCILLARY is non-nil, the buffer is added to `cider-ancillary-buffers'
 and automatically removed when killed.
 
 The buffer is pinned to the REPL of the session it is created from (via
-`cider--ancillary-buffer-repl') and adopts that session's project
+`cider--pinned-repl-buffer') and adopts that session's project
 `default-directory', so its evaluations and project-aware commands target
 the originating session rather than relying on sesman re-resolution."
   ;; Resolve the originating REPL in the *calling* buffer's context (typically
@@ -141,7 +141,7 @@ the originating session rather than relying on sesman re-resolution."
       ;; `cider-current-repl' (see its definition) and makes project-aware
       ;; commands (project.el, magit) operate on the session's project.
       (when (buffer-live-p repl)
-        (setq-local cider--ancillary-buffer-repl repl)
+        (setq-local cider--pinned-repl-buffer repl)
         (setq-local default-directory
                     (buffer-local-value 'default-directory repl)))
       (when ancillary

--- a/lisp/cider-repl.el
+++ b/lisp/cider-repl.el
@@ -2185,7 +2185,7 @@ under the session's project directory.  The checking is done as follows:
   directory.
 
 Buffers associated with their originating session explicitly through
-`cider--ancillary-buffer-repl' (e.g. popups, or a dependency's source
+`cider--pinned-repl-buffer' (e.g. popups, or a dependency's source
 jumped to via `cider-find-var') resolve via that pin and don't rely on
 this matcher.
 

--- a/lisp/cider-scratch.el
+++ b/lisp/cider-scratch.el
@@ -136,12 +136,12 @@ before point, and prints its value into the buffer, advancing point.
 (defun cider-scratch--attach (repl)
   "Associate the current scratch buffer with REPL's session.
 When REPL is a live buffer, pin the scratch to it (via
-`cider--ancillary-buffer-repl') and adopt its project directory, so that
+`cider--pinned-repl-buffer') and adopt its project directory, so that
 evaluations and project-aware commands target REPL's session.  The eval
 destination defaults to `cider-clojurec-eval-destination', unless one has
 already been chosen for this buffer."
   (when (buffer-live-p repl)
-    (setq-local cider--ancillary-buffer-repl repl)
+    (setq-local cider--pinned-repl-buffer repl)
     ;; Adopt the session's project dir so project-aware commands behave.
     (setq-local default-directory (buffer-local-value 'default-directory repl)))
   (unless cider-repl-type-override

--- a/lisp/cider-session.el
+++ b/lisp/cider-session.el
@@ -100,20 +100,22 @@ Set interactively with `cider-set-default-session'.")
   "Return t if CIDER is currently connected, nil otherwise."
   (process-live-p (get-buffer-process (cider-current-repl))))
 
-(defvar-local cider--ancillary-buffer-repl nil
-  "Special buffer-local variable that contains reference to the REPL connection.
-This should be set in ancillary CIDER buffers that originate from some
-event (e.g. *cider-inspector*, *cider-error*) and which never change the
-REPL (connection) which produced them.  It is also set on source buffers
-visited outside the project directory (e.g. a dependency's source jumped
-to via `cider-find-var'), pinning them to the session they were navigated
-from.")
+(defvar-local cider--pinned-repl-buffer nil
+  "The REPL buffer the current buffer is pinned to, or nil.
+Pinning ties a buffer to a specific REPL so that CIDER commands invoked
+there target that session regardless of sesman and `default-directory'.
+It is set on ancillary buffers that originate from a session and must never
+switch away from it (e.g. *cider-inspector*, *cider-error*, popups), and on
+source buffers visited outside the project directory (e.g. a dependency's
+source jumped to via `cider-find-var'), pinning them to the session they
+were navigated from.  Consult it through `cider--pinned-repl' and
+`cider--pinned-session' rather than directly.")
 
 (defun cider--pinned-repl ()
   "Return the REPL the current buffer is pinned to, or nil.
-The pin lives in `cider--ancillary-buffer-repl'; a dead pin yields nil."
-  (and (buffer-live-p cider--ancillary-buffer-repl)
-       cider--ancillary-buffer-repl))
+The pin lives in `cider--pinned-repl-buffer'; a dead pin yields nil."
+  (and (buffer-live-p cider--pinned-repl-buffer)
+       cider--pinned-repl-buffer))
 
 (defun cider--pinned-session ()
   "Return the sesman session of the REPL the current buffer is pinned to.
@@ -618,7 +620,7 @@ return only REPLs of type contained in the list.  If ENSURE is non-nil,
 throw an error if no linked session exists.  If REQUIRED-OPS is non-nil,
 filters out all the REPLs that do not support the designated ops.
 
-If the buffer is pinned to a REPL via `cider--ancillary-buffer-repl', that
+If the buffer is pinned to a REPL via `cider--pinned-repl-buffer', that
 REPL's session is used instead of the current one (taking precedence over
 `cider-default-session'); a stale pin falls through to normal resolution."
   (let* ((type (cond

--- a/lisp/cider-tap.el
+++ b/lisp/cider-tap.el
@@ -27,7 +27,7 @@
 ;;; Code:
 
 (require 'cider-client)
-(require 'cider-session) ; for `cider-current-repl' and `cider--ancillary-buffer-repl'
+(require 'cider-session) ; for `cider-current-repl' and `cider--pinned-repl-buffer'
 (require 'cider-inspector) ; for rendering an inspected tap value
 (require 'cider-util) ; for `cider-font-lock-as-clojure'
 (require 'nrepl-dict)
@@ -182,7 +182,7 @@ inspect it.  Killing the buffer stops the streaming."
       (setq cider-tap--repl connection)
       ;; Pin the buffer to its REPL so the inspector opened from here resolves
       ;; to the same connection.
-      (setq-local cider--ancillary-buffer-repl connection)
+      (setq-local cider--pinned-repl-buffer connection)
       (unless cider-tap--subscription
         (cider-nrepl-send-request
          '("op" "cider/tap-subscribe")

--- a/test/cider-common-tests.el
+++ b/test/cider-common-tests.el
@@ -205,25 +205,25 @@
       (with-temp-buffer
         (setq buffer-file-name (expand-file-name "/some/dep/src/ns.clj"))
         (cider--pin-repl-if-out-of-project repl-buf)
-        (expect cider--ancillary-buffer-repl :to-be repl-buf)))
+        (expect cider--pinned-repl-buffer :to-be repl-buf)))
 
   (it "leaves the buffer untouched when its file is inside the project dir"
       (with-temp-buffer
         (setq buffer-file-name (concat proj-root "src/ns.clj"))
         (cider--pin-repl-if-out-of-project repl-buf)
-        (expect cider--ancillary-buffer-repl :to-be nil)))
+        (expect cider--pinned-repl-buffer :to-be nil)))
 
   (it "does nothing for a dead REPL buffer"
       (kill-buffer repl-buf)
       (with-temp-buffer
         (setq buffer-file-name (expand-file-name "/some/dep/src/ns.clj"))
         (cider--pin-repl-if-out-of-project repl-buf)
-        (expect cider--ancillary-buffer-repl :to-be nil)))
+        (expect cider--pinned-repl-buffer :to-be nil)))
 
   (it "does nothing for a non-file buffer"
       (with-temp-buffer
         (cider--pin-repl-if-out-of-project repl-buf)
-        (expect cider--ancillary-buffer-repl :to-be nil))))
+        (expect cider--pinned-repl-buffer :to-be nil))))
 
 (describe "cider-auto-select-buffer-p"
   (it "follows cider-auto-select-buffer when the legacy option is `default'"

--- a/test/cider-connection-tests.el
+++ b/test/cider-connection-tests.el
@@ -67,7 +67,7 @@
       (with-temp-buffer
         ;; Sanity check: without a pin there is no session reachable here.
         (expect (cider-ensure-session) :to-throw 'user-error)
-        (setq-local cider--ancillary-buffer-repl b)
+        (setq-local cider--pinned-repl-buffer b)
         (expect (cider-ensure-session) :to-equal
                 (list "cider-ensure-session" b)))))
 
@@ -89,7 +89,7 @@
     (let ((repl (get-buffer-create "*cider--pinned-repl-test*")))
       (unwind-protect
           (with-temp-buffer
-            (setq-local cider--ancillary-buffer-repl repl)
+            (setq-local cider--pinned-repl-buffer repl)
             (expect (cider--pinned-repl) :to-be repl))
         (kill-buffer repl))))
 
@@ -101,7 +101,7 @@
     (let ((repl (get-buffer-create "*cider--pinned-repl-test*")))
       (kill-buffer repl)
       (with-temp-buffer
-        (setq-local cider--ancillary-buffer-repl repl)
+        (setq-local cider--pinned-repl-buffer repl)
         (expect (cider--pinned-repl) :to-be nil)))))
 
 (describe "cider--pinned-session"
@@ -114,7 +114,7 @@
   (it "returns the session of the REPL the buffer is pinned to"
     (with-repl-buffer "cider--pinned-session" 'clj b
       (with-temp-buffer
-        (setq-local cider--ancillary-buffer-repl b)
+        (setq-local cider--pinned-repl-buffer b)
         (expect (cider--pinned-session) :to-equal
                 (list "cider--pinned-session" b)))))
 
@@ -122,7 +122,7 @@
     (let ((repl (get-buffer-create "*cider--pinned-session-test*")))
       (unwind-protect
           (with-temp-buffer
-            (setq-local cider--ancillary-buffer-repl repl)
+            (setq-local cider--pinned-repl-buffer repl)
             (expect (cider--pinned-session) :to-be nil))
         (kill-buffer repl)))))
 

--- a/test/cider-popup-tests.el
+++ b/test/cider-popup-tests.el
@@ -51,7 +51,7 @@
                   ;; (1) project-awareness: default-directory follows the session
                   (expect default-directory :to-equal (expand-file-name "/tmp/proj/"))
                   ;; (2) explicit session pin
-                  (expect cider--ancillary-buffer-repl :to-equal repl)
+                  (expect cider--pinned-repl-buffer :to-equal repl)
                   ;; (3) resolution uses the pin even with a bogus default-directory,
                   ;; i.e. it no longer depends on sesman re-resolution at all
                   (setq-local default-directory (expand-file-name "/tmp/elsewhere/"))
@@ -63,7 +63,7 @@
       (let ((popup (cider-make-popup-buffer "*cider-proto-test-2*" nil 'ancillary)))
         (unwind-protect
             (with-current-buffer popup
-              (expect cider--ancillary-buffer-repl :to-be nil))
+              (expect cider--pinned-repl-buffer :to-be nil))
           (kill-buffer popup)))))
 
   ;; The pin identifies a *session*, not a lone REPL: `cider-repls' must still
@@ -77,7 +77,7 @@
               (unwind-protect
                   (with-current-buffer popup
                     ;; pinned to the clj REPL...
-                    (expect cider--ancillary-buffer-repl :to-equal clj-repl)
+                    (expect cider--pinned-repl-buffer :to-equal clj-repl)
                     ;; ...yet the cljs sibling in the same session is still reachable
                     (expect (cider-repls 'clj) :to-equal (list clj-repl))
                     (expect (cider-repls 'cljs) :to-equal (list cljs-repl))

--- a/test/cider-scratch-tests.el
+++ b/test/cider-scratch-tests.el
@@ -50,7 +50,7 @@
           (unwind-protect
               (with-current-buffer buf
                 (expect (buffer-name) :to-equal "*cider-scratch: scratch-ses*")
-                (expect cider--ancillary-buffer-repl :to-equal repl)
+                (expect cider--pinned-repl-buffer :to-equal repl)
                 (expect cider-repl-type-override :to-equal 'multi))
             (kill-buffer buf)))))))
 

--- a/test/cider-xref-backend-tests.el
+++ b/test/cider-xref-backend-tests.el
@@ -112,7 +112,7 @@
   (it "pins the originating REPL onto an out-of-project dependency buffer"
     (cider--var-to-xref-location "dep/foo")
     (with-current-buffer "*cider-xref-pin-test-dep*"
-      (expect cider--ancillary-buffer-repl :to-be repl-buf))))
+      (expect cider--pinned-repl-buffer :to-be repl-buf))))
 
 (provide 'cider-xref-backend-tests)
 


### PR DESCRIPTION
The "ancillary" name dated from when the variable only tracked the REPL of popup/inspector buffers, but it's now the general per-buffer REPL pin (also used for dependency sources jumped to via `cider-find-var`). The new name matches the `cider--pinned-repl`/`cider--pinned-session` accessors.

Follow-up to #4122.