### PR TITLE
Pin out-of-project buffers reached via xref-find-references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Bugs fixed
 
+- [#4124](https://github.com/clojure-emacs/cider/pull/4124): Fix evaluation failing with "No linked CIDER sessions" after jumping to a dependency's source via `xref-find-references` (`M-?`): out-of-project reference buffers are now pinned to the originating REPL, like `xref-find-definitions` already was.
 - [#4120](https://github.com/clojure-emacs/cider/issues/4120): Fix evaluation, debugging and inspecting in a dependency's source buffer still erroring with "No linked CIDER sessions": `cider-ensure-session` now honors the pinned REPL (and `cider-default-session`) like the rest of the REPL resolution does, instead of only checking sesman's linked sessions.
 - [#4118](https://github.com/clojure-emacs/cider/issues/4118): Fix `xref-find-definitions` (`M-.`) onto a dependency's source breaking session linking: the opened buffer is now pinned to the REPL it was navigated from, so evaluation there no longer errors with "No linked CIDER sessions".
 - [#4115](https://github.com/clojure-emacs/cider/pull/4115): Fix inline macro stepping (`cider-macrostep`): pressing `e`/`RET` right after `n`/`p` now expands the operator you jumped to, instead of erroring with "No sexp before point to expand".

--- a/lisp/cider-xref-backend.el
+++ b/lisp/cider-xref-backend.el
@@ -147,42 +147,60 @@ connected, rather than reporting no references."
   "Find references of VAR in NS via runtime introspection (the `fn-refs' op).
 These cover only namespaces already loaded into the REPL."
   (when (cider-nrepl-op-supported-p "cider/fn-refs")
-    (when-let* ((results (cider-sync-request:fn-refs ns var))
-                (previously-existing-buffers (buffer-list)))
-      (thread-last results
-                   (mapcar (lambda (info)
-                             (let* ((filename (cider--xref-extract-file info))
-                                    (column (nrepl-dict-get info "column"))
-                                    (line (nrepl-dict-get info "line"))
-                                    (friendly-name (cider--xref-extract-friendly-file-name info))
-                                    ;; translate .jar urls and such:
-                                    (buf (cider--find-buffer-for-file filename))
-                                    (bfn (and buf (buffer-file-name buf)))
-                                    (loc (when buf
-                                           ;; favor `xref-make-file-location' when possible, since that way, we can close their buffers.
-                                           (if bfn
-                                               (xref-make-file-location bfn line (or column 0))
-                                             (xref-make-buffer-location buf (with-current-buffer buf
-                                                                              (save-excursion
-                                                                                (goto-char 0)
-                                                                                (forward-line (1- line))
-                                                                                (move-to-column (or column 0))
-                                                                                (point)))))))
-                                    (should-be-closed (and
-                                                       buf
-                                                       ;; if a buffer did not exist before,
-                                                       ;; then it is a side-effect of invoking `cider--find-buffer-for-file'.
-                                                       (not (member buf previously-existing-buffers))
-                                                       bfn
-                                                       ;; only buffers with a normally reachable filename are safe to close.
-                                                       ;; buffers not backed by such files may include .jars, TRAMP files, etc.
-                                                       ;; Sadly this means we will still 'leak' some open buffers, but it's what we can do atm.
-                                                       (file-exists-p bfn))))
-                               (when should-be-closed
-                                 (kill-buffer buf))
-                               (when loc
-                                 (xref-make friendly-name loc)))))
-                   (seq-filter #'identity)))))
+    ;; Capture the originating session up front, before opening any target
+    ;; buffer, so out-of-project reference hits (a dependency's source) stay
+    ;; pinned to the REPL they were navigated from.  xref opens the buffer
+    ;; itself (via `switch-to-buffer'), bypassing `cider-jump-to', so we pin
+    ;; here, mirroring `cider--var-to-xref-location' for definitions -
+    ;; otherwise evaluation there fails with "No linked CIDER sessions" (see
+    ;; https://github.com/clojure-emacs/cider/issues/4118).
+    (let ((origin-repl (ignore-errors (cider-current-repl))))
+      (when-let* ((results (cider-sync-request:fn-refs ns var))
+                  (previously-existing-buffers (buffer-list)))
+        (thread-last results
+                     (mapcar (lambda (info)
+                               (let* ((filename (cider--xref-extract-file info))
+                                      (column (nrepl-dict-get info "column"))
+                                      (line (nrepl-dict-get info "line"))
+                                      (friendly-name (cider--xref-extract-friendly-file-name info))
+                                      ;; translate .jar urls and such:
+                                      (buf (cider--find-buffer-for-file filename))
+                                      (bfn (and buf (buffer-file-name buf)))
+                                      ;; Pin an out-of-project hit to the origin REPL so evaluation
+                                      ;; there resolves the right session; a no-op (returns nil) for
+                                      ;; in-project buffers, which resolve via friendly sessions.
+                                      (pinned (when buf
+                                                (with-current-buffer buf
+                                                  (cider--pin-repl-if-out-of-project origin-repl))))
+                                      (loc (when buf
+                                             ;; favor `xref-make-file-location' when possible, since that way, we can close their buffers.
+                                             (if bfn
+                                                 (xref-make-file-location bfn line (or column 0))
+                                               (xref-make-buffer-location buf (with-current-buffer buf
+                                                                                (save-excursion
+                                                                                  (goto-char 0)
+                                                                                  (forward-line (1- line))
+                                                                                  (move-to-column (or column 0))
+                                                                                  (point)))))))
+                                      (should-be-closed (and
+                                                         buf
+                                                         ;; never close a buffer we pinned: it's an out-of-project
+                                                         ;; dependency the user may jump to and evaluate in, and
+                                                         ;; reopening it later would lose the pin (see #4118).
+                                                         (not pinned)
+                                                         ;; if a buffer did not exist before,
+                                                         ;; then it is a side-effect of invoking `cider--find-buffer-for-file'.
+                                                         (not (member buf previously-existing-buffers))
+                                                         bfn
+                                                         ;; only buffers with a normally reachable filename are safe to close.
+                                                         ;; buffers not backed by such files may include .jars, TRAMP files, etc.
+                                                         ;; Sadly this means we will still 'leak' some open buffers, but it's what we can do atm.
+                                                         (file-exists-p bfn))))
+                                 (when should-be-closed
+                                   (kill-buffer buf))
+                                 (when loc
+                                   (xref-make friendly-name loc)))))
+                     (seq-filter #'identity))))))
 
 (defun cider--xref-item-file (item)
   "Return the file backing xref ITEM, or nil for a non-file location."

--- a/test/cider-xref-backend-tests.el
+++ b/test/cider-xref-backend-tests.el
@@ -114,6 +114,66 @@
     (with-current-buffer "*cider-xref-pin-test-dep*"
       (expect cider--pinned-repl-buffer :to-be repl-buf))))
 
+(describe "cider--fn-refs-xrefs"
+  :var (proj-root repl-buf ref-file dep-file proj-file dep-buf-name)
+
+  (before-each
+    (setq proj-root (file-name-as-directory
+                     (file-truename (make-temp-file "cider-xref-refs-test-" t)))
+          repl-buf (get-buffer-create "*cider-xref-refs-test-repl*")
+          ;; a real, existing, OUT-OF-project file (so the pin fires and the
+          ;; `file-exists-p' close-candidate check would otherwise close it)
+          dep-file (make-temp-file "cider-xref-refs-dep-" nil ".clj" "(ns dep)\n")
+          ;; a real, existing IN-project file (pin is a no-op there)
+          proj-file (expand-file-name "in_proj.clj" proj-root)
+          ref-file dep-file
+          dep-buf-name "*cider-xref-refs-test-dep*")
+    (write-region "(ns in.proj)\n" nil proj-file)
+    (with-current-buffer repl-buf
+      (setq-local nrepl-project-dir proj-root))
+    (spy-on 'cider-nrepl-op-supported-p :and-return-value t)
+    (spy-on 'cider-current-repl :and-return-value repl-buf)
+    (spy-on 'cider-sync-request:fn-refs :and-return-value
+            (list (nrepl-dict "file" "dep-ref" "line" 1 "column" 0)))
+    ;; return a fresh buffer visiting the file under test (`ref-file')
+    (spy-on 'cider--find-buffer-for-file :and-call-fake
+            (lambda (_file)
+              (with-current-buffer (get-buffer-create dep-buf-name)
+                (setq buffer-file-name ref-file)
+                (current-buffer)))))
+
+  (after-each
+    (dolist (name (list "*cider-xref-refs-test-repl*" "*cider-xref-refs-test-dep*"))
+      (when-let* ((buf (get-buffer name)))
+        (kill-buffer buf)))
+    (when (and dep-file (file-exists-p dep-file))
+      (delete-file dep-file))
+    (when (and proj-root (file-directory-p proj-root))
+      (delete-directory proj-root t)))
+
+  (it "pins the originating REPL onto an out-of-project reference buffer"
+    (setq ref-file dep-file)
+    (cider--fn-refs-xrefs "dep" "dep/foo")
+    (let ((buf (get-buffer dep-buf-name)))
+      (expect (buffer-live-p buf) :to-be-truthy)
+      (with-current-buffer buf
+        (expect cider--pinned-repl-buffer :to-be repl-buf))))
+
+  (it "keeps the pinned out-of-project buffer open instead of closing it"
+    ;; The buffer is created during the scan and backs a file that exists, so
+    ;; without the pin guard `should-be-closed' would kill it.  The pin must
+    ;; keep it alive so the user can jump to and evaluate in it.
+    (setq ref-file dep-file)
+    (cider--fn-refs-xrefs "dep" "dep/foo")
+    (expect (buffer-live-p (get-buffer dep-buf-name)) :to-be-truthy))
+
+  (it "does not pin an in-project reference buffer"
+    (setq ref-file proj-file)
+    (cider--fn-refs-xrefs "dep" "dep/foo")
+    ;; in-project buffers resolve via friendly sessions, so no pin is set;
+    ;; the buffer is a scan side-effect backing a real file, so it is closed.
+    (expect (get-buffer dep-buf-name) :to-be nil)))
+
 (provide 'cider-xref-backend-tests)
 
 ;;; cider-xref-backend-tests.el ends here


### PR DESCRIPTION
The #4118 fix pinned the buffer `xref-find-definitions` jumps to, but `xref-find-references` (the runtime `fn-refs` path) had the same gap: xref opens the reference buffer itself via `switch-to-buffer`, bypassing `cider-jump-to`, so a hit inside a dependency's source was never pinned and evaluation there failed with "No linked CIDER sessions".

Pin each out-of-project reference buffer to the originating REPL, and stop closing a buffer once it's been pinned (it's a dependency source you may want to jump to and evaluate in).

Found while auditing the pinned-session mechanism after #4121.