### PR TITLE
Name the pinned session in "no REPL" errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Bugs fixed
 
 - [#4124](https://github.com/clojure-emacs/cider/pull/4124): Fix evaluation failing with "No linked CIDER sessions" after jumping to a dependency's source via `xref-find-references` (`M-?`): out-of-project reference buffers are now pinned to the originating REPL, like `xref-find-definitions` already was.
+- [#4126](https://github.com/clojure-emacs/cider/pull/4126): Fix the "No REPLs in current session" errors showing an empty session name when raised in a buffer pinned to a session (e.g. a dependency's source).
 - [#4120](https://github.com/clojure-emacs/cider/issues/4120): Fix evaluation, debugging and inspecting in a dependency's source buffer still erroring with "No linked CIDER sessions": `cider-ensure-session` now honors the pinned REPL (and `cider-default-session`) like the rest of the REPL resolution does, instead of only checking sesman's linked sessions.
 - [#4118](https://github.com/clojure-emacs/cider/issues/4118): Fix `xref-find-definitions` (`M-.`) onto a dependency's source breaking session linking: the opened buffer is now pinned to the REPL it was navigated from, so evaluation there no longer errors with "No linked CIDER sessions".
 - [#4115](https://github.com/clojure-emacs/cider/pull/4115): Fix inline macro stepping (`cider-macrostep`): pressing `e`/`RET` right after `n`/`p` now expands the operator you jumped to, instead of erroring with "No sexp before point to expand".

--- a/lisp/cider-repl.el
+++ b/lisp/cider-repl.el
@@ -1491,7 +1491,7 @@ Closes all open parentheses or bracketed expressions."
     (if other-repl
         (switch-to-buffer other-repl)
       (user-error "No other REPL in current session (%s)"
-                  (car (sesman-current-session 'CIDER))))))
+                  (cider--current-session-name)))))
 
 (defvar cider-repl-clear-buffer-hook)
 

--- a/lisp/cider-session.el
+++ b/lisp/cider-session.el
@@ -134,6 +134,17 @@ dead or its session has been quit."
   (when-let* ((repl (cider--pinned-repl)))
     (sesman-session-for-object 'CIDER repl 'no-error)))
 
+(defun cider--current-session-name ()
+  "Return the name of the session the current buffer resolves to, or nil.
+Follow the same precedence as REPL resolution - pinned session, then
+`cider-default-session', then sesman's current session - so error messages
+name the session evaluation would actually target, even in a buffer that is
+only pinned (e.g. a dependency's source) and thus has no linked sesman
+session of its own."
+  (car (or (cider--pinned-session)
+           (cider--default-session)
+           (sesman-current-session 'CIDER))))
+
 (defun cider-ensure-session ()
   "Signal a `user-error' unless CIDER has a session available here.
 The CIDER-level nREPL senders (e.g. `cider-nrepl-send-request',
@@ -556,7 +567,7 @@ Reverts to normal project-based session association."
                 (mapconcat #'identity type " or "))
                (type))))
     (user-error "No %s REPLs in current session \"%s\""
-                type (car (sesman-current-session 'CIDER)))))
+                type (cider--current-session-name))))
 
 (defun cider-current-repl (&optional type ensure)
   "Get the most recent REPL of TYPE from the current session.

--- a/test/cider-connection-tests.el
+++ b/test/cider-connection-tests.el
@@ -126,6 +126,38 @@
             (expect (cider--pinned-session) :to-be nil))
         (kill-buffer repl)))))
 
+(describe "cider--current-session-name"
+  :var (sesman-sessions-hashmap sesman-links-alist)
+
+  (before-each
+    (setq sesman-sessions-hashmap (make-hash-table :test #'equal)
+          sesman-links-alist nil
+          cider-default-session nil)
+    ;; make "no linked session" deterministic, independent of sesman's
+    ;; environment-sensitive directory/project linking
+    (spy-on 'sesman-current-session :and-return-value nil))
+
+  (after-each
+    (setq cider-default-session nil))
+
+  (it "returns nil when nothing resolves"
+    (with-temp-buffer
+      (expect (cider--current-session-name) :to-be nil)))
+
+  (it "names the pinned session even with no linked session"
+    (with-repl-buffer "cider--current-session-name" 'clj b
+      (with-temp-buffer
+        (setq-local cider--pinned-repl-buffer b)
+        (expect (cider--current-session-name)
+                :to-equal "cider--current-session-name"))))
+
+  (it "names the default session when one is set"
+    (with-repl-buffer "cider--current-session-name" 'clj b
+      (with-temp-buffer
+        (setq cider-default-session "cider--current-session-name")
+        (expect (cider--current-session-name)
+                :to-equal "cider--current-session-name")))))
+
 (describe "cider-current-repl"
 
   :var (sesman-sessions-hashmap sesman-links-alist ses-name ses-name2)


### PR DESCRIPTION
`cider--no-repls-user-error` and `cider-repl-switch-to-other` named the current session with `(car (sesman-current-session 'CIDER))`, which is nil in a buffer that only has a pin (e.g. a dependency's source), so the error read `... in current session ""`. Resolve the name through the same precedence as REPL dispatch (pin, then default, then linked) via a new `cider--current-session-name` helper.

Last of the pinned-session cleanup items following #4121.