### PR TITLE
Stop relying on private sesman--linked-sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changes
 
 - [#4116](https://github.com/clojure-emacs/cider/pull/4116): Bump the injected `cider-nrepl` to [0.62.2](https://github.com/clojure-emacs/cider-nrepl/blob/v0.62.2/CHANGELOG.md#0622-2026-07-18), so a dead trace/tap subscriber no longer breaks every traced evaluation, and the debugger no longer shadows the enlighten middleware's evaluator.
+- [#4037](https://github.com/clojure-emacs/cider/issues/4037): Stop calling the private `sesman--linked-sessions`, using the public `sesman-sessions` API instead, so REPL font-locking doesn't break if that internal changes across `sesman` versions.
 
 ### Bugs fixed
 

--- a/lisp/cider-repl.el
+++ b/lisp/cider-repl.el
@@ -261,8 +261,9 @@ This cache is stored in the connection buffer.")
                   ;; for Clojure buffers directly related to this repl
                   ;; (specifically, we omit 'friendly' sessions because a given buffer may be friendly to multiple repls,
                   ;;  so we don't want a buffer to mix up font locking rules from different repls).
-                  ;; Note that `sesman--linked-sessions' only queries for the directly linked sessions.
-                  (when (member this-repl (car (sesman--linked-sessions 'CIDER)))
+                  ;; Note that we query only the directly linked sessions
+                  ;; (`sesman-sessions' with the `linked' type), not friendly ones.
+                  (when (member this-repl (car (sesman-sessions 'CIDER nil 'linked)))
                     ;; Metadata changed, so signatures may have changed too.
                     (setq cider-eldoc-last-symbol nil)
                     (when-let* ((ns-dict (or (nrepl-dict-get changed-namespaces (cider-current-ns))


### PR DESCRIPTION
`cider-refresh-dynamic-font-lock` used the private `sesman--linked-sessions` to limit font-lock updates to directly-linked (non-friendly) sessions. Private sesman internals can shift between versions, so switch to the public `sesman-sessions` with the `linked` type, which resolves the same list.

Fixes #4037