### PR TITLE
Apply print settings to load-file requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Bugs fixed
 
+- [#4128](https://github.com/clojure-emacs/cider/pull/4128): Fix `cider-load-buffer`/`cider-load-file` potentially freezing Emacs on a huge last-form result, by honoring the print settings (notably `cider-print-quota`) for `load-file` requests, as `eval` requests already do.
 - [#4124](https://github.com/clojure-emacs/cider/pull/4124): Fix evaluation failing with "No linked CIDER sessions" after jumping to a dependency's source via `xref-find-references` (`M-?`): out-of-project reference buffers are now pinned to the originating REPL, like `xref-find-definitions` already was.
 - [#4126](https://github.com/clojure-emacs/cider/pull/4126): Fix the "No REPLs in current session" errors showing an empty session name when raised in a buffer pinned to a session (e.g. a dependency's source).
 - [#4120](https://github.com/clojure-emacs/cider/issues/4120): Fix evaluation, debugging and inspecting in a dependency's source buffer still erroring with "No linked CIDER sessions": `cider-ensure-session` now honors the pinned REPL (and `cider-default-session`) like the rest of the REPL resolution does, instead of only checking sesman's linked sessions.

--- a/lisp/cider-client.el
+++ b/lisp/cider-client.el
@@ -806,7 +806,11 @@ positional shim retained for backward compatibility."
   (cider-nrepl-send-request `("op" "load-file"
                               "file" ,file-contents
                               "file-path" ,file-path
-                              "file-name" ,file-name)
+                              "file-name" ,file-name
+                              ;; Honor the print settings (notably `cider-print-quota')
+                              ;; so a huge value from the last form doesn't flood the
+                              ;; echo area and freeze Emacs, matching `eval' requests.
+                              ,@(cider--nrepl-pr-request-plist))
                             (or callback
                                 (cider-load-file-handler (current-buffer)))
                             connection))

--- a/test/cider-client-tests.el
+++ b/test/cider-client-tests.el
@@ -371,6 +371,23 @@
     (expect 'cider-nrepl-sync-request :to-have-been-called-with
             '("op" "lookup" "ns" "user" "sym" "foo") :connection 'fake-conn)))
 
+(describe "cider-load-file-request"
+  (it "includes the print settings so cider-print-quota is enforced"
+    (let (captured)
+      (spy-on 'cider-nrepl-send-request :and-call-fake
+              (lambda (request &rest _) (setq captured request)))
+      (spy-on 'cider-load-file-handler :and-return-value #'ignore)
+      (let ((cider-print-quota 12345))
+        (cider-load-file-request "contents" "/path" "name" :connection :fake-conn))
+      ;; string-keyed plist, so look up with `member' (`plist-get' compares with `eq')
+      (expect (cadr (member "op" captured)) :to-equal "load-file")
+      ;; the print middleware params (from `cider--nrepl-pr-request-plist') must
+      ;; ride along, otherwise a huge last-form result floods the echo area (#3052)
+      (expect (cadr (member "nrepl.middleware.print/print" captured))
+              :to-equal "cider.nrepl.pprint/pr")
+      (expect (cadr (member "nrepl.middleware.print/quota" captured))
+              :to-equal 12345))))
+
 (describe "cider-request:load-file"
   (it "delegates to cider-load-file-request with positional args mapped to keywords"
     (let (captured)


### PR DESCRIPTION
`cider-load-buffer` / `cider-load-file` echo the last form's value, but the `load-file` op wasn't sending the print middleware params, so `cider-print-quota` didn't apply there. A huge result (deep map, big string) could flood the echo area and freeze Emacs. Send `cider--nrepl-pr-request-plist` with the request, matching `eval`.

Based on #4113 by @mmustafasenoglu (which was closed unmerged). Addresses part of #3052.