### PR TITLE
Add aligned completion annotations via affixation-function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### New features
 
 - [#4117](https://github.com/clojure-emacs/cider/pull/4117): Add `cider-use-completing-read-for-symbol` (off by default): when enabled, symbol prompts (e.g. `cider-doc`, `cider-find-var`) read through `completing-read` over a lazy, runtime-backed collection, so they work with `completing-read` UIs (Vertico, Ivy, Helm) and annotate candidates with their type and namespace.
+- [#4129](https://github.com/clojure-emacs/cider/pull/4129): Render completion annotations as an aligned type/namespace column (via an `affixation-function`) in UIs that support it, such as the built-in `*Completions*`, Corfu and Vertico.
 
 ## 2.0.1 (2026-07-23)
 

--- a/lisp/cider-completion.el
+++ b/lisp/cider-completion.el
@@ -22,7 +22,8 @@
 
 ;;; Commentary:
 
-;; Smart REPL-powered code completion and integration with company-mode.
+;; Smart REPL-powered code completion, exposed through `completion-at-point'
+;; so it works with the built-in UI, `corfu' and `company' alike.
 
 ;;; Code:
 
@@ -99,7 +100,8 @@ backend, and ABBREVIATION is a short form of that type."
     ("static-method" interface)
     ("type" parameter)
     ("var" variable))
-  "Icon mapping for company-mode.")
+  "Kind mapping for the `:company-kind' capf property.
+Both company and corfu (via `kind-icon') use it to pick a candidate's icon.")
 
 (defcustom cider-completion-annotations-include-ns 'unqualified
   "Controls passing of namespaces to `cider-annotate-completion-function'.
@@ -179,6 +181,44 @@ performed by `cider-annotate-completion-function'."
            (ns (cider-completion--get-candidate-ns symbol)))
       (funcall cider-annotate-completion-function type ns))))
 
+(defun cider-affixate-symbol (candidates)
+  "Affixate CANDIDATES for display, aligning their annotations into a column.
+Return a list of (CANDIDATE PREFIX SUFFIX) triples, where SUFFIX carries the
+same type/namespace information as `cider-annotate-symbol', left-padded so the
+annotations line up across candidates.  This is the richer successor to
+`annotation-function' (Emacs 28+); completion UIs that support it (the
+built-in `*Completions*', Corfu, Vertico, ...) render aligned annotations,
+while `company' keeps using the `annotation-function' we provide alongside."
+  (let ((width (seq-reduce (lambda (acc cand) (max acc (length cand))) candidates 0)))
+    (mapcar
+     (lambda (cand)
+       (let ((annotation (cider-annotate-symbol cand)))
+         (list cand ""
+               (if (and annotation (not (string-empty-p annotation)))
+                   (concat (make-string (max 1 (- (1+ width) (length cand))) ?\s)
+                           (propertize (string-trim-left annotation)
+                                       'face 'completions-annotations))
+                 ""))))
+     candidates)))
+
+(defun cider--completion-table (candidates-fn &optional metadata-extra)
+  "Return a programmed-completion table over CANDIDATES-FN.
+CANDIDATES-FN is called with the current completion string and returns the
+candidate list, each candidate carrying `type'/`ns' text properties; it owns
+its own caching.  METADATA-EXTRA is spliced into the `metadata' response - use
+it for `completing-read' tables, which (unlike a capf, whose plist carries
+them) must announce their `annotation-function'/`affixation-function' through
+metadata.  See Info node `(elisp) Programmed Completion'."
+  (lambda (string pred action)
+    (cond
+     ((eq action 'metadata)
+      `(metadata
+        (category . cider) ;; our completion category, keyed on by `completion-category-overrides'
+        (display-sort-function . identity) ;; keep the backend's ranking
+        ,@metadata-extra))
+     ((eq (car-safe action) 'boundaries) nil)
+     (t (complete-with-action action (funcall candidates-fn string) string pred)))))
+
 (defun cider-complete-at-point ()
   "Complete the symbol at point."
   (when-let* ((bounds (or (bounds-of-thing-at-point 'symbol)
@@ -189,11 +229,10 @@ performed by `cider-annotate-completion-function'."
       (let* (last-bounds-string
              last-result
              (complete
-              (lambda ()
-                ;; We are Not using the prefix extracted within the (prefix pred action)
-                ;; lambda.  In certain completion styles, the prefix might be an empty
-                ;; string, which is unreliable. A more dependable method is to use the
-                ;; string defined by the bounds of the symbol at point.
+              (lambda (_string)
+                ;; We do NOT use the string the completion table is called with:
+                ;; under some completion styles it can be an empty string, which is
+                ;; unreliable.  The bounds of the symbol at point are dependable.
                 ;;
                 ;; Caching just within the function is sufficient. Keeping it local
                 ;; ensures that it will not extend across different CIDER sessions.
@@ -202,23 +241,9 @@ performed by `cider-annotate-completion-function'."
                   (setq last-result (cider-complete bounds-string)))
                 last-result)))
         (list (car bounds) (cdr bounds)
-              (lambda (prefix pred action)
-                ;; When the 'action is 'metadata, this lambda returns metadata about this
-                ;; capf, when action is (boundaries . suffix), it returns nil. With every
-                ;; other value of 'action (t, nil, or lambda), 'action is forwarded to
-                ;; (complete-with-action), together with (cider-complete), prefix and pred.
-                ;; And that function performs the completion based on those arguments.
-                ;;
-                ;; This api is better described in the section
-                ;; '21.6.7 Programmed Completion' of the elisp manual.
-                (cond ((eq action 'metadata)
-                       `(metadata
-                         (category . cider) ;; defines a completion category named 'cider, used later in our `completion-category-overrides` logic.
-                         (display-sort-function . identity))) ;; don't override sorting done by backend
-                      ((eq (car-safe action) 'boundaries) nil)
-                      (t (with-current-buffer (current-buffer)
-                           (complete-with-action action (funcall complete) prefix pred)))))
+              (cider--completion-table complete)
               :annotation-function #'cider-annotate-symbol
+              :affixation-function #'cider-affixate-symbol
               :company-kind #'cider-company-symbol-kind
               :company-doc-buffer #'cider-create-compact-doc-buffer
               :company-location #'cider-company-location
@@ -249,21 +274,18 @@ properties so `cider-annotate-symbol' can annotate them.  Querying only
 starts once the input reaches `cider-completion-symbol-prompt-min-length'
 characters, which keeps an empty prompt from asking for every symbol."
   (let ((cache-key 'none) cache-val)
-    (lambda (string pred action)
-      (cond
-       ((eq action 'metadata)
-        `(metadata
-          (category . cider)
-          (display-sort-function . identity)
-          (annotation-function . ,#'cider-annotate-symbol)))
-       ((eq (car-safe action) 'boundaries) nil)
-       (t
-        (unless (equal string cache-key)
-          (setq cache-key string
-                cache-val (when (>= (length string)
-                                    cider-completion-symbol-prompt-min-length)
-                            (cider-complete string))))
-        (complete-with-action action cache-val string pred))))))
+    (cider--completion-table
+     (lambda (string)
+       (unless (equal string cache-key)
+         (setq cache-key string
+               cache-val (when (>= (length string)
+                                   cider-completion-symbol-prompt-min-length)
+                           (cider-complete string))))
+       cache-val)
+     ;; `completing-read' has no capf plist, so the annotation/affixation
+     ;; functions must ride along in the metadata.
+     `((annotation-function . ,#'cider-annotate-symbol)
+       (affixation-function . ,#'cider-affixate-symbol)))))
 
 (defun cider-company-location (var)
   "Open VAR's definition in a buffer.

--- a/test/cider-completion-tests.el
+++ b/test/cider-completion-tests.el
@@ -66,12 +66,38 @@
                 :to-equal '((cider (styles basic flex)
                                    (cycle t))))))))
 
+(describe "cider-affixate-symbol"
+  (it "returns (candidate prefix suffix) triples carrying type/ns"
+    (let* ((cand (propertize "map" 'type "function" 'ns "clojure.core"))
+           (triple (car (cider-affixate-symbol (list cand)))))
+      (expect (nth 0 triple) :to-equal "map")
+      (expect (nth 1 triple) :to-equal "")
+      (expect (nth 2 triple) :to-match "clojure.core")
+      (expect (nth 2 triple) :to-match "<f>")))
+
+  (it "left-pads suffixes so annotations align across candidates"
+    (let* ((short (propertize "map" 'type "function" 'ns "clojure.core"))
+           (long (propertize "reductions" 'type "function" 'ns "clojure.core"))
+           (result (cider-affixate-symbol (list short long)))
+           (col (lambda (triple)
+                  (let ((cand (nth 0 triple))
+                        (suffix (nth 2 triple)))
+                    (+ (length cand)
+                       (- (length suffix) (length (string-trim-left suffix))))))))
+      (expect (funcall col (nth 0 result)) :to-equal (funcall col (nth 1 result)))))
+
+  (it "produces empty affixes when annotations are disabled"
+    (let ((cider-annotate-completion-candidates nil)
+          (cand (propertize "map" 'type "function" 'ns "clojure.core")))
+      (expect (cider-affixate-symbol (list cand)) :to-equal '(("map" "" ""))))))
+
 (describe "cider--symbol-completion-table"
-  (it "reports the `cider' category and an annotation function"
+  (it "reports the `cider' category with annotation and affixation functions"
     (let* ((table (cider--symbol-completion-table))
            (md (cdr (funcall table "" nil 'metadata))))
       (expect (cdr (assq 'category md)) :to-equal 'cider)
-      (expect (assq 'annotation-function md) :to-be-truthy)))
+      (expect (assq 'annotation-function md) :to-be-truthy)
+      (expect (assq 'affixation-function md) :to-be-truthy)))
 
   (it "does not query the runtime until the input reaches the min length"
     (spy-on 'cider-complete :and-return-value '("reduce" "reductions"))


### PR DESCRIPTION
Modernization pass on `cider-completion.el`:

- Add an `affixation-function` (`cider-affixate-symbol`) next to the existing `annotation-function`. UIs that support it (built-in `*Completions*`, Corfu, Vertico) now render the type/namespace as an aligned column rather than a ragged suffix; company keeps using the annotation function.
- Fold the capf table and the `completing-read` symbol table onto a shared `cider--completion-table` builder — they had duplicated the metadata / `complete-with-action` skeleton (the second was added in #4117).
- Drop a no-op `with-current-buffer`, and refresh comments that called the capf company-only (corfu consumes the same `:company-*` properties).

No behavior change to matching or candidate sourcing. First slice of a broader completion modernization.