### PR TITLE
Fix circular load in the Embark integration

### DIFF
--- a/lisp/cider-embark.el
+++ b/lisp/cider-embark.el
@@ -37,7 +37,21 @@
 
 ;;; Code:
 
-(require 'cider)
+(require 'subr-x)  ; for `when-let*' (a macro; needed at compile time)
+
+;; No `require' of CIDER here on purpose.  CIDER only loads this file once it is
+;; itself loaded (via the `with-eval-after-load' hook in cider.el), so the
+;; functions below are defined by the time an action runs.  Requiring `cider'
+;; back would create a circular load - and force all of CIDER to load whenever
+;; Embark does.  Declare what we call instead, to keep the byte-compiler happy.
+(declare-function cider-doc-lookup "cider-doc" (symbol))
+(declare-function cider-find-var "cider-find" (&optional arg var line))
+(declare-function cider-xref-fn-refs "cider-xref-backend" (&optional ns symbol))
+(declare-function cider-inspect-expr "cider-inspector" (expr ns))
+(declare-function cider-clojuredocs-lookup "cider-clojuredocs" (sym))
+(declare-function cider-apropos "cider-apropos" (query &optional ns docs-p privates-p case-sensitive-p))
+(declare-function cider-current-ns "cider-client" (&optional no-default no-repl-check))
+(declare-function cider-symbol-at-point "cider-common" (&optional look-back))
 
 ;; These belong to Embark.  This file only touches them inside the
 ;; `with-eval-after-load' below, i.e. when Embark is loaded and they are bound;
@@ -102,7 +116,7 @@ The target has type `cider-clojure-symbol', mapped to
                         'clojure-ts-mode 'cider-repl-mode)
     (when-let* ((bounds (bounds-of-thing-at-point 'symbol))
                 (sym (cider-symbol-at-point)))
-      (unless (string-empty-p sym)
+      (unless (string= sym "")
         `(cider-clojure-symbol ,sym . ,bounds)))))
 
 ;;; Registration (only once Embark is loaded)

--- a/lisp/cider.el
+++ b/lisp/cider.el
@@ -657,10 +657,11 @@ alternative to the default is `cider-random-tip'."
      clojure-ts-mode-map)
    'clojure-ts-mode-hook))
 
-;; Optional Embark integration: load it once Embark is available, so
-;; `embark-act' on a Clojure symbol offers CIDER actions.  No hard dependency -
-;; nothing happens for users who don't have Embark.
-;;;###autoload
+;; Optional Embark integration: once CIDER is loaded, wire up the actions as
+;; soon as Embark is available, so `embark-act' on a Clojure symbol offers CIDER
+;; actions.  Deliberately NOT autoloaded: the hook must register only when CIDER
+;; itself is loaded, otherwise merely loading Embark would pull all of CIDER in
+;; (and, since `cider-embark' resolves against CIDER, risk a circular load).
 (with-eval-after-load 'embark
   (require 'cider-embark))
 


### PR DESCRIPTION
The Embark integration (#4132, unreleased) had a load problem: the `with-eval-after-load 'embark` hook was `;;;###autoload`d, so it lived in `cider-autoloads.el` and fired whenever Embark loaded - pulling in `cider-embark`, which `(require 'cider)`'d back. Loading Embark alone thus force-loaded all of CIDER, and when that happened mid-load it re-entered CIDER's load (a circular dependency that errors on stricter Emacsen; on Emacs 30 it "merely" force-loads CIDER).

Two changes:

- Drop the `;;;###autoload` cookie so the hook registers only when CIDER is actually loaded. Loading Embark on its own no longer drags CIDER in.
- Remove `(require 'cider)` from `cider-embark.el` (declare-function the handful of functions it calls). It's only ever loaded after CIDER, so there's no need - and it removes the back-edge that closed the cycle.

Verified in a clean `emacs -Q` across all three load orders: Embark alone (CIDER not pulled in), cider-then-embark, and embark-then-cider (no recursion). Existing tests still pass.