### PR TITLE
Fill in a couple of test-coverage gaps

### DIFF
--- a/test/cider-inspiration-tests.el
+++ b/test/cider-inspiration-tests.el
@@ -1,0 +1,64 @@
+;;; cider-inspiration-tests.el  -*- lexical-binding: t; -*-
+
+;; Copyright © 2026 Bozhidar Batsov and CIDER contributors
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; This file is part of CIDER
+
+;;; Code:
+
+(require 'buttercup)
+(require 'cl-lib)
+(require 'cider-inspiration)
+
+;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
+
+(describe "cider-user-first-name"
+  (it "returns the capitalized first word of the user's full name"
+    (cl-letf (((symbol-function 'user-full-name) (lambda (&rest _) "Ada Lovelace")))
+      (expect (cider-user-first-name) :to-equal "Ada")))
+  (it "capitalizes a lower-case name"
+    (cl-letf (((symbol-function 'user-full-name) (lambda (&rest _) "ada lovelace")))
+      (expect (cider-user-first-name) :to-equal "Ada")))
+  (it "falls back to the login name when the full name is empty"
+    (cl-letf (((symbol-function 'user-full-name) (lambda (&rest _) ""))
+              ((symbol-function 'user-login-name) (lambda (&rest _) "ada")))
+      (expect (cider-user-first-name) :to-equal "Ada"))))
+
+(describe "cider-random-words-of-inspiration"
+  (it "returns an entry from `cider-words-of-inspiration'"
+    (expect (member (cider-random-words-of-inspiration) cider-words-of-inspiration)
+            :to-be-truthy))
+  (it "indexes into the list with `random'"
+    (spy-on 'random :and-return-value 0)
+    (expect (cider-random-words-of-inspiration)
+            :to-equal (car cider-words-of-inspiration))))
+
+(describe "cider-random-tip"
+  (it "returns a non-empty string"
+    (expect (cider-random-tip) :to-be-truthy)
+    (expect (length (cider-random-tip)) :to-be-greater-than 0))
+  (it "substitutes command keys in the selected tip"
+    (spy-on 'random :and-return-value 0)
+    (expect (cider-random-tip)
+            :to-equal (substitute-command-keys (car cider-tips)))))
+
+(provide 'cider-inspiration-tests)
+
+;;; cider-inspiration-tests.el ends here

--- a/test/cider-jack-in-tests.el
+++ b/test/cider-jack-in-tests.el
@@ -199,6 +199,44 @@
       (expect (cider-shadow-cljs-jack-in-dependencies "watch" nil)
               :to-equal "-d nrepl/nrepl:1.7.0 -d cider/cider-nrepl:0.60.0 watch"))))
 
+(describe "cider-gradle-jack-in-dependencies"
+  (it "builds a -P nrepl property from the required deps, then params and middleware"
+    (let ((cider-injected-nrepl-version "1.7.0")
+          (cider-injected-middleware-version "0.60.0")
+          (cider-enable-nrepl-jvmti-agent nil))
+      (expect (cider-gradle-jack-in-dependencies
+               "clojureRepl" nil '("cider.nrepl/cider-middleware"))
+              :to-equal
+              (concat (shell-quote-argument
+                       "-Pdev.clojurephant.jack-in.nrepl=nrepl:nrepl:1.7.0,cider:cider-nrepl:0.60.0")
+                      " clojureRepl "
+                      (shell-quote-argument "--middleware=cider.nrepl/cider-middleware")))))
+  (it "appends extra dependencies to the required ones"
+    (let ((cider-injected-nrepl-version "1.7.0")
+          (cider-injected-middleware-version "0.60.0")
+          (cider-enable-nrepl-jvmti-agent nil))
+      (expect (cider-gradle-jack-in-dependencies
+               "clojureRepl" '(("abc/def" "1.2.3")) nil)
+              :to-equal
+              (concat (shell-quote-argument
+                       "-Pdev.clojurephant.jack-in.nrepl=nrepl:nrepl:1.7.0,cider:cider-nrepl:0.60.0,abc:def:1.2.3")
+                      " clojureRepl "))))
+  (it "prepends the JVMTI attach flag when the agent is enabled"
+    (let ((cider-injected-nrepl-version "1.7.0")
+          (cider-injected-middleware-version "0.60.0")
+          (cider-enable-nrepl-jvmti-agent t))
+      (expect (cider-gradle-jack-in-dependencies "clojureRepl" nil nil)
+              :to-match "\\`-Pjdk\\.attach\\.allowAttachSelf ")))
+  (it "handles empty params without a stray separator"
+    (let ((cider-injected-nrepl-version "1.7.0")
+          (cider-injected-middleware-version "0.60.0")
+          (cider-enable-nrepl-jvmti-agent nil))
+      (expect (cider-gradle-jack-in-dependencies "" nil nil)
+              :to-equal
+              (concat (shell-quote-argument
+                       "-Pdev.clojurephant.jack-in.nrepl=nrepl:nrepl:1.7.0,cider:cider-nrepl:0.60.0")
+                      " ")))))
+
 (describe "cider-lein-jack-in-dependencies"
   (it "builds update-in clauses for deps, plugins and middlewares, ending with params"
     (let ((cider-enable-nrepl-jvmti-agent nil))


### PR DESCRIPTION
Two small test additions ahead of the jack-in cleanup work.

The Gradle jack-in builder was the only per-build-tool dependency builder
without an end-to-end spec (just its sub-helpers were covered), so I added one
before touching that code. And `cider-inspiration.el` was the last module with
no tests at all, so it gets a small smoke suite.