### PR TITLE
Assorted internal cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - [#4117](https://github.com/clojure-emacs/cider/pull/4117): Add `cider-use-completing-read-for-symbol` (off by default): when enabled, symbol prompts (e.g. `cider-doc`, `cider-find-var`) read through `completing-read` over a lazy, runtime-backed collection, so they work with `completing-read` UIs (Vertico, Ivy, Helm) and annotate candidates with their type and namespace.
 - [#4129](https://github.com/clojure-emacs/cider/pull/4129): Render completion annotations as an aligned type/namespace column (via an `affixation-function`) in UIs that support it, such as the built-in `*Completions*`, Corfu and Vertico.
 
+### Bugs fixed
+
+- [#4136](https://github.com/clojure-emacs/cider/pull/4136): Fix a custom ClojureScript REPL init form being sent unwrapped when it starts with a call like `(dorun ...)` or `(doseq ...)`, which the previous `(do` prefix check mistook for an existing `do` block.
+
 ## 2.0.1 (2026-07-23)
 
 ### Changes

--- a/lisp/cider-client.el
+++ b/lisp/cider-client.el
@@ -1129,41 +1129,35 @@ The result entries are relative to the classpath."
                                        (nrepl-dict-get "resources-list"))))
     (seq-map (lambda (resource) (nrepl-dict-get resource "relpath")) resources)))
 
-(defun cider-sync-request:fn-refs (ns sym)
-  "Return a list of functions that reference the function identified by NS and SYM."
-  (thread-first `("op" "cider/fn-refs"
+(defun cider--sync-request-ns-sym (op ns sym)
+  "Send the ns/sym request OP for NS and SYM and return its like-named result.
+OP is the bare op name (without the \"cider/\" prefix), which is also the key
+the result is stored under."
+  (thread-first `("op" ,(concat "cider/" op)
                   "ns" ,ns
                   "sym" ,sym)
                 (cider-nrepl-sync-request)
-                (nrepl-dict-get "fn-refs")))
+                (nrepl-dict-get op)))
+
+(defun cider-sync-request:fn-refs (ns sym)
+  "Return a list of functions that reference the function identified by NS and SYM."
+  (cider--sync-request-ns-sym "fn-refs" ns sym))
 
 (defun cider-sync-request:fn-deps (ns sym)
   "Return a list of function deps for the function identified by NS and SYM."
-  (thread-first `("op" "cider/fn-deps"
-                  "ns" ,ns
-                  "sym" ,sym)
-                (cider-nrepl-sync-request)
-                (nrepl-dict-get "fn-deps")))
+  (cider--sync-request-ns-sym "fn-deps" ns sym))
 
 (defun cider-sync-request:who-implements (ns sym)
   "Return the implementations of the protocol or multimethod NS and SYM.
 The result is a dict with a \"kind\" of \"protocol\", \"multimethod\" or
 \"other\"; for a protocol an \"impls\" list, for a multimethod a
 \"dispatch-values\" list."
-  (thread-first `("op" "cider/who-implements"
-                  "ns" ,ns
-                  "sym" ,sym)
-                (cider-nrepl-sync-request)
-                (nrepl-dict-get "who-implements")))
+  (cider--sync-request-ns-sym "who-implements" ns sym))
 
 (defun cider-sync-request:type-protocols (ns sym)
   "Return the protocols implemented by the type NS and SYM.
 Each is a dict with a \"name\" and source location."
-  (thread-first `("op" "cider/type-protocols"
-                  "ns" ,ns
-                  "sym" ,sym)
-                (cider-nrepl-sync-request)
-                (nrepl-dict-get "type-protocols")))
+  (cider--sync-request-ns-sym "type-protocols" ns sym))
 
 (defun cider-sync-request:protocols-with-method (method)
   "Return the protocols declaring a method named METHOD.

--- a/lisp/cider-cljs.el
+++ b/lisp/cider-cljs.el
@@ -245,9 +245,9 @@ The supplied string will be wrapped in a do form if needed."
   (or
    cider-custom-cljs-repl-init-form
    (let ((form (read-from-minibuffer "Please, provide a form to start a ClojureScript REPL: ")))
-     ;; TODO: We should probably make this more robust (e.g. by using a regexp or
-     ;; parsing the form).
-     (if (string-prefix-p "(do" form)
+     ;; Only skip the wrapping when the form is already a `do' block; a bare
+     ;; prefix check would also match calls like `(dorun ...)' or `(doseq ...)'.
+     (if (string-match-p "\\`(do[[:space:])]" form)
          form
        (format "(do %s)" form)))))
 

--- a/lisp/cider-clojuredocs.el
+++ b/lisp/cider-clojuredocs.el
@@ -154,27 +154,27 @@ opposite of what that option dictates."
     (insert "Not available\n"))
   (newline))
 
-(defun cider-clojuredocs--insert-examples (dict)
-  "Insert \"Examples\" section based on data from DICT."
-  (insert "== Examples\n")
+(defun cider-clojuredocs--insert-section (header key render-item dict)
+  "Insert a divider-delimited section of DICT under HEADER.
+Render each item found under KEY with RENDER-ITEM, or note that the section
+is unavailable when there are none."
+  (insert header "\n")
   (newline)
-  (if-let* ((examples (nrepl-dict-get dict "examples")))
-      (dolist (example examples)
-        (insert (cider-font-lock-as-clojure example) "\n")
+  (if-let* ((items (nrepl-dict-get dict key)))
+      (dolist (item items)
+        (insert (funcall render-item item) "\n")
         (insert "-------------------------------------------------\n"))
     (insert "Not available\n"))
   (newline))
 
+(defun cider-clojuredocs--insert-examples (dict)
+  "Insert \"Examples\" section based on data from DICT."
+  (cider-clojuredocs--insert-section
+   "== Examples" "examples" #'cider-font-lock-as-clojure dict))
+
 (defun cider-clojuredocs--insert-notes (dict)
   "Insert \"Notes\" section based on data from DICT."
-  (insert "== Notes\n")
-  (newline)
-  (if-let* ((notes (nrepl-dict-get dict "notes")))
-      (dolist (note notes)
-        (insert note "\n")
-        (insert "-------------------------------------------------\n"))
-    (insert "Not available\n"))
-  (newline))
+  (cider-clojuredocs--insert-section "== Notes" "notes" #'identity dict))
 
 (defun cider-clojuredocs--content (dict)
   "Generate a nice string from DICT."

--- a/lisp/cider-inspector.el
+++ b/lisp/cider-inspector.el
@@ -351,12 +351,17 @@ In particular, it does not read `cider-sexp-at-point'."
     (cider-inspect-expr (cider-read-from-minibuffer prompt nil 'skip-colon)
                         ns)))
 
+(defun cider-inspector--send-op (op &optional point-action)
+  "Send the argument-less inspector OP and re-render the returned value, if any.
+POINT-ACTION is forwarded to `cider-inspector--render-value' to place point."
+  (let ((result (cider-nrepl-sync-request `("op" ,op))))
+    (when (nrepl-dict-get result "value")
+      (cider-inspector--render-value result point-action))))
+
 (defun cider-inspector-pop ()
   "Pop the last value off the inspector stack and render it."
   (interactive)
-  (let ((result (cider-nrepl-sync-request `("op" "cider/inspect-pop"))))
-    (when (nrepl-dict-get result "value")
-      (cider-inspector--render-value result :pop))))
+  (cider-inspector--send-op "cider/inspect-pop" :pop))
 
 (defun cider-inspector-push (idx)
   "Inspect the value at IDX in the inspector stack and render it."
@@ -382,16 +387,12 @@ If EX-DATA is true, inspect ex-data of the exception instead."
 (defun cider-inspector-previous-sibling ()
   "Inspect the previous sibling value within a sequential parent."
   (interactive)
-  (let ((result (cider-nrepl-sync-request `("op" "cider/inspect-previous-sibling"))))
-    (when (nrepl-dict-get result "value")
-      (cider-inspector--render-value result))))
+  (cider-inspector--send-op "cider/inspect-previous-sibling"))
 
 (defun cider-inspector-next-sibling ()
   "Inspect the next sibling value within a sequential parent."
   (interactive)
-  (let ((result (cider-nrepl-sync-request `("op" "cider/inspect-next-sibling"))))
-    (when (nrepl-dict-get result "value")
-      (cider-inspector--render-value result))))
+  (cider-inspector--send-op "cider/inspect-next-sibling"))
 
 (defun cider-inspector--refresh-with-opts (&rest opts)
   "Invokes `inspect-refresh' op with supplied extra OPTS.
@@ -410,18 +411,14 @@ Re-renders the currently inspected value."
 
 Does nothing if already on the last page."
   (interactive)
-  (let ((result (cider-nrepl-sync-request '("op" "cider/inspect-next-page"))))
-    (when (nrepl-dict-get result "value")
-      (cider-inspector--render-value result))))
+  (cider-inspector--send-op "cider/inspect-next-page"))
 
 (defun cider-inspector-prev-page ()
   "Jump to the previous page when inspecting a paginated sequence/map.
 
 Does nothing if already on the first page."
   (interactive)
-  (let ((result (cider-nrepl-sync-request '("op" "cider/inspect-prev-page"))))
-    (when (nrepl-dict-get result "value")
-      (cider-inspector--render-value result))))
+  (cider-inspector--send-op "cider/inspect-prev-page"))
 
 (defun cider-inspector-set-page-size (page-size)
   "Set the page size in pagination mode to the specified PAGE-SIZE.
@@ -450,9 +447,7 @@ MAX-NESTED-DEPTH is the new value."
 (defun cider-inspector-display-analytics ()
   "Toggle the display of analytics for the inspected object."
   (interactive)
-  (let ((result (cider-nrepl-sync-request `("op" "cider/inspect-display-analytics"))))
-    (when (nrepl-dict-get result "value")
-      (cider-inspector--render-value result :next-inspectable))))
+  (cider-inspector--send-op "cider/inspect-display-analytics" :next-inspectable))
 
 (defun cider-inspector-toggle-display-help ()
   "Toggle the display of help message in the inspector window."
@@ -484,9 +479,7 @@ MAX-NESTED-DEPTH is the new value."
 (defun cider-inspector-toggle-view-mode ()
   "Toggle the view mode of the inspector between normal and object view mode."
   (interactive)
-  (let ((result (cider-nrepl-sync-request `("op" "cider/inspect-toggle-view-mode"))))
-    (when (nrepl-dict-get result "value")
-      (cider-inspector--render-value result :next-inspectable))))
+  (cider-inspector--send-op "cider/inspect-toggle-view-mode" :next-inspectable))
 
 (defcustom cider-inspector-preferred-var-names nil
   "The preferred var names to be suggested by `cider-inspector-def-current-val'.

--- a/lisp/cider-log.el
+++ b/lisp/cider-log.el
@@ -357,15 +357,6 @@ The KEYS are used to lookup the values and are joined by SEPARATOR."
              (propertize (format " - %s" (cider-log--strip-whitespace annotation))
                          'face 'font-lock-comment-face)))))))
 
-(defun cider-log--read-appender-id (prompt initial-input history)
-  "Read a appender from the minibuffer using PROMPT, INITIAL-INPUT and HISTORY."
-  (let ((table (when cider-log-framework
-                 (when-let* ((framework (cider-log-framework-reload cider-log-framework)))
-                   (seq-map #'cider-log-appender-id (cider-log-framework-appenders framework))))))
-    (completing-read (or prompt "Log appender: ") table nil nil
-                     (or initial-input cider-log-appender-id)
-                     history cider-log-appender-id)))
-
 (defun cider-log--read-buffer (&optional prompt initial-input history)
   "Read the log buffer name using PROMPT, INITIAL-INPUT and HISTORY."
   (let ((table (seq-map #'buffer-name (cider-log--buffers-in-major-mode 'cider-log-mode))))

--- a/lisp/cider-xref.el
+++ b/lisp/cider-xref.el
@@ -122,16 +122,26 @@ namespace is a likelier cause than a var that genuinely has none."
       (message "No %s found for %S in currently loaded namespaces" noun symbol)
     (user-error "%s" (cider-resolution-failure-message symbol))))
 
+(defun cider-xref--show-fn-relation (ns symbol request-fn summary-fmt noun)
+  "Show the functions related to the var matching NS and SYMBOL via REQUEST-FN.
+NS and SYMBOL default to the current namespace and the symbol at point.
+Display the results with a summary built from SUMMARY-FMT (given the result
+count and the symbol).  NOUN names the relation for the no-results report."
+  (let ((ns (or ns (cider-current-ns)))
+        (symbol (or symbol (cider-symbol-at-point))))
+    (unless symbol (user-error "No symbol at point"))
+    (if-let* ((results (funcall request-fn ns symbol)))
+        (cider-show-xref (format summary-fmt (length results) symbol) results)
+      (cider-xref--report-no-results symbol noun))))
+
 ;;;###autoload
 (defun cider-xref-fn-refs (&optional ns symbol)
   "Show all functions that reference the var matching NS and SYMBOL."
   (interactive)
-  (let ((ns (or ns (cider-current-ns)))
-        (symbol (or symbol (cider-symbol-at-point))))
-    (unless symbol (user-error "No symbol at point"))
-    (if-let* ((results (cider-sync-request:fn-refs ns symbol)))
-        (cider-show-xref (format "Showing %d functions that reference %s in currently loaded namespaces" (length results) symbol) results)
-      (cider-xref--report-no-results symbol "references"))))
+  (cider-xref--show-fn-relation
+   ns symbol #'cider-sync-request:fn-refs
+   "Showing %d functions that reference %s in currently loaded namespaces"
+   "references"))
 
 ;;;###autoload
 (defun cider-xref-fn-refs-in-source (&optional symbol)
@@ -177,12 +187,10 @@ function `cider-who-calls' is usually the better tool."
 (defun cider-xref-fn-deps (&optional ns symbol)
   "Show all functions referenced by the var matching NS and SYMBOL."
   (interactive)
-  (let ((ns (or ns (cider-current-ns)))
-        (symbol (or symbol (cider-symbol-at-point))))
-    (unless symbol (user-error "No symbol at point"))
-    (if-let* ((results (cider-sync-request:fn-deps ns symbol)))
-        (cider-show-xref (format "Showing %d function dependencies for %s" (length results) symbol) results)
-      (cider-xref--report-no-results symbol "dependencies"))))
+  (cider-xref--show-fn-relation
+   ns symbol #'cider-sync-request:fn-deps
+   "Showing %d function dependencies for %s"
+   "dependencies"))
 
 (defun cider-xref-act-on-symbol (symbol)
   "Apply selected action on SYMBOL."
@@ -197,29 +205,33 @@ function `cider-who-calls' is usually the better tool."
         (funcall action-fn symbol)
       (user-error "Unknown action `%s`" action-key))))
 
+(defun cider-xref--select-fn-relation (ns symbol request-fn summary-prefix noun)
+  "Pick a function related to the var matching NS and SYMBOL and act on it.
+NS and SYMBOL default to the current namespace and the symbol at point.
+Prompt with `completing-read' over the names REQUEST-FN returns, using
+SUMMARY-PREFIX in the prompt, and run the selected xref action on the choice.
+NOUN names the relation for the no-results report."
+  (let ((ns (or ns (cider-current-ns)))
+        (symbol (or symbol (cider-symbol-at-point))))
+    (unless symbol (user-error "No symbol at point"))
+    (if-let* ((results (mapcar (lambda (d) (nrepl-dict-get d "name")) (funcall request-fn ns symbol)))
+              (summary (format "%s %s" summary-prefix symbol)))
+        (cider-xref-act-on-symbol (completing-read (concat summary ": ") results))
+      (cider-xref--report-no-results symbol noun))))
+
 ;;;###autoload
 (defun cider-xref-fn-refs-select (&optional ns symbol)
   "Display the references for NS and SYMBOL using completing read."
   (interactive)
-  (let ((ns (or ns (cider-current-ns)))
-        (symbol (or symbol (cider-symbol-at-point))))
-    (unless symbol (user-error "No symbol at point"))
-    (if-let* ((results (mapcar (lambda (d) (nrepl-dict-get d "name")) (cider-sync-request:fn-refs ns symbol)))
-              (summary (format "References for %s" symbol)))
-        (cider-xref-act-on-symbol (completing-read (concat summary ": ") results))
-      (cider-xref--report-no-results symbol "references"))))
+  (cider-xref--select-fn-relation
+   ns symbol #'cider-sync-request:fn-refs "References for" "references"))
 
 ;;;###autoload
 (defun cider-xref-fn-deps-select (&optional ns symbol)
   "Display the function dependencies for NS and SYMBOL using completing read."
   (interactive)
-  (let ((ns (or ns (cider-current-ns)))
-        (symbol (or symbol (cider-symbol-at-point))))
-    (unless symbol (user-error "No symbol at point"))
-    (if-let* ((results (mapcar (lambda (d) (nrepl-dict-get d "name")) (cider-sync-request:fn-deps ns symbol)))
-              (summary (format "Dependencies for %s" symbol)))
-        (cider-xref-act-on-symbol (completing-read (concat summary ": ") results))
-      (cider-xref--report-no-results symbol "dependencies"))))
+  (cider-xref--select-fn-relation
+   ns symbol #'cider-sync-request:fn-deps "Dependencies for" "dependencies"))
 
 (provide 'cider-xref)
 

--- a/lisp/nrepl-client.el
+++ b/lisp/nrepl-client.el
@@ -139,7 +139,6 @@ log warnings."
 ;;; Buffer Local Declarations
 
 ;; These variables are used to track the state of nREPL connections
-(defvar-local nrepl-connection-buffer nil)
 (defvar-local nrepl-server-buffer nil)
 (defvar-local nrepl-messages-buffer nil)
 (defvar-local nrepl-endpoint nil)
@@ -167,12 +166,6 @@ To be used for tooling calls (i.e. completion, eldoc, etc)")
 (defvar-local nrepl--completed-requests-order nil
   "FIFO of ids in `nrepl-completed-requests', used for bounded eviction.
 See `nrepl-completed-requests-max-size'.")
-
-(defvar-local nrepl-last-sync-response nil
-  "Result of the last sync request.")
-
-(defvar-local nrepl-last-sync-request-timestamp nil
-  "The time when the last sync request was initiated.")
 
 (defvar-local nrepl-ops nil
   "Available nREPL server ops (from describe).")


### PR DESCRIPTION
A handful of low-risk cleanups I found while looking for genuinely leaner
code (as opposed to churn):

- Drop a few dead symbols: three nrepl-client buffer-locals that were never read or written, and an unused cider-log reader.
- Collapse the duplicated bodies behind the xref fn-refs/fn-deps commands, the inspector send-op-and-render commands, the two ClojureDocs section inserters, and four ns/sym cider-nrepl request wrappers.
- Fix the custom cljs REPL init-form check so it only skips do-wrapping for a real `do` block, not for anything starting with `(do` (e.g. `(dorun ...)`).

No behavior change except the cljs fix.