### PR TITLE
Fix source xref missing alias- and namespace-qualified references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Bugs fixed
 
+- [#4139](https://github.com/clojure-emacs/cider/pull/4139): Fix source-based find-usages (`M-?`) missing alias- and namespace-qualified references (e.g. `m/foo`), so a var used through its alias from other namespaces is now found, not just the bare occurrences in its defining namespace.
 - [#4136](https://github.com/clojure-emacs/cider/pull/4136): Fix a custom ClojureScript REPL init form being sent unwrapped when it starts with a call like `(dorun ...)` or `(doseq ...)`, which the previous `(do` prefix check mistook for an existing `do` block.
 
 ## 2.0.1 (2026-07-23)

--- a/lisp/cider-xref-source.el
+++ b/lisp/cider-xref-source.el
@@ -70,6 +70,14 @@ Wrap in \"[...]\" to match one, or \"[^...]\" to match a boundary.  Used to guar
 the edges of a match so that, e.g., searching for `foo' does not match inside
 `foobar' or `other/foo'.")
 
+(defconst cider-xref--symbol-chars-no-slash
+  (replace-regexp-in-string "/" "" cider-xref--symbol-chars)
+  "Like `cider-xref--symbol-chars' but without the `/' namespace separator.
+Used only for the left edge of the candidate-narrowing search: a reference
+like `alias/foo' or `some.ns/foo' has a `/' right before the bare name, so
+treating `/' as a boundary (rather than a symbol constituent) is what lets a
+qualified reference still mark its file as a candidate for the precise scan.")
+
 (defun cider-xref--source-file-p (file)
   "Return non-nil when FILE has a Clojure source extension."
   (when-let* ((ext (file-name-extension file)))
@@ -88,7 +96,10 @@ search program, say) all of FILES are returned as candidates."
   (if (null files)
       nil
     (condition-case nil
-        (let ((regexp (concat "[^" cider-xref--symbol-chars "]"
+        ;; The left edge treats `/' as a boundary (via -no-slash) so that
+        ;; qualified references like `alias/foo' aren't filtered out here before
+        ;; the precise per-file scan - which knows how to match them - ever runs.
+        (let ((regexp (concat "[^" cider-xref--symbol-chars-no-slash "]"
                               (regexp-quote name)
                               "[^" cider-xref--symbol-chars "]")))
           (delete-dups

--- a/test/cider-xref-source-tests.el
+++ b/test/cider-xref-source-tests.el
@@ -141,6 +141,41 @@ context, and scanned - exercising the whole non-REPL half of the engine."
                     "my.ns" "foo")))
       (expect (length matches) :to-equal 2))))
 
+(defun cider-xref-source-tests--candidates (files-by-name name)
+  "Return the basenames selected by `cider-xref--candidate-files' for NAME.
+FILES-BY-NAME is an alist of (BASENAME . CONTENT); each entry is written to a
+throwaway directory on disk, since the narrowing pass shells out to grep."
+  (let ((dir (make-temp-file "cider-xref-cand" t)))
+    (unwind-protect
+        (let ((paths (mapcar (lambda (entry)
+                               (let ((path (expand-file-name (car entry) dir)))
+                                 (with-temp-file path (insert (cdr entry)))
+                                 path))
+                             files-by-name)))
+          (sort (mapcar #'file-name-nondirectory
+                        (cider-xref--candidate-files name paths))
+                #'string<))
+      (delete-directory dir t))))
+
+(describe "cider-xref--candidate-files"
+  (it "selects files that reference the name via an alias or namespace qualifier"
+    ;; Regression test: a qualified reference such as `m/foo' has a `/' right
+    ;; before the bare name, and `/' is a Clojure symbol constituent, so a
+    ;; naive boundary would filter these files out before the precise scan.
+    (expect (cider-xref-source-tests--candidates
+             '(("aliased.clj"   . "(ns a (:require [my.ns :as m]))\n(m/foo)\n")
+               ("qualified.clj" . "(ns b)\n(my.ns/foo)\n")
+               ("bare.clj"      . "(ns my.ns)\n(defn foo [])\n(bar foo)\n")
+               ("unrelated.clj" . "(ns c)\n(baz)\n"))
+             "foo")
+            :to-equal '("aliased.clj" "bare.clj" "qualified.clj")))
+
+  (it "does not select files that only mention a longer symbol"
+    (expect (cider-xref-source-tests--candidates
+             '(("longer.clj" . "(ns a (:require [my.ns :as m]))\n(m/foobar)\n(foo-bar)\n"))
+             "foo")
+            :to-equal nil)))
+
 (describe "cider-xref--short-name"
   (it "drops a namespace or alias qualifier"
     (expect (cider-xref--short-name "my.ns/foo") :to-equal "foo")


### PR DESCRIPTION
Source-based find-usages was only turning up references written with the bare name. A var used through its alias from another namespace (`m/foo`, the common case) was invisible.

The candidate-narrowing pass filters files by the bare name bounded by non-symbol characters. `/` is a Clojure symbol constituent, so `m/foo` has a `/` right before the name and failed the left boundary - the file got dropped before the precise per-file scan (which does handle qualified forms) ever ran. The fix treats `/` as a boundary on the left edge of that narrowing regexp only.

Added a couple of tests for `cider-xref--candidate-files`, which had none - that's how the gap slipped through.