### PR TITLE
Improve clojure-ts-mode support (phase 0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Bugs fixed
 
+- [#4140](https://github.com/clojure-emacs/cider/pull/4140): Fix `cider-eval-dwim` (and defun evaluation) not descending into a `(comment ...)` form in `clojure-ts-mode` buffers: it now binds `clojure-ts-toplevel-inside-comment-form` alongside the `clojure-mode` variable.
 - [#4139](https://github.com/clojure-emacs/cider/pull/4139): Fix source-based find-usages (`M-?`) missing alias- and namespace-qualified references (e.g. `m/foo`), so a var used through its alias from other namespaces is now found, not just the bare occurrences in its defining namespace.
 - [#4136](https://github.com/clojure-emacs/cider/pull/4136): Fix a custom ClojureScript REPL init form being sent unwrapped when it starts with a call like `(dorun ...)` or `(doseq ...)`, which the previous `(do` prefix check mistook for an existing `do` block.
 

--- a/lisp/cider-client.el
+++ b/lisp/cider-client.el
@@ -31,7 +31,6 @@
 (require 'subr-x)
 (require 'parseedn)
 
-(require 'clojure-mode)
 (require 'spinner)
 
 (require 'cider-session)

--- a/lisp/cider-cljs.el
+++ b/lisp/cider-cljs.el
@@ -39,7 +39,6 @@
 (require 'subr-x)
 
 (require 'parseedn)
-(require 'clojure-mode)
 
 (require 'cider-client)
 (require 'nrepl-dict)

--- a/lisp/cider-endpoint.el
+++ b/lisp/cider-endpoint.el
@@ -40,7 +40,6 @@
 (require 'tramp)
 (require 'tramp-sh)
 
-(require 'clojure-mode)
 (require 'nrepl-client)
 
 (require 'cider-common)

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -75,6 +75,10 @@
 (declare-function cider-repl--ns-form-changed-p "cider-repl")
 (declare-function cider-repl--cache-ns-form "cider-repl")
 
+;; Defined in clojure-ts-mode; declared here so we can bind it even when only
+;; clojure-mode is loaded.  clojure-mode uses `clojure-toplevel-inside-comment-form'.
+(defvar clojure-ts-toplevel-inside-comment-form)
+
 (defconst cider-read-eval-buffer "*cider-read-eval*")
 (defconst cider-result-buffer "*cider-result*")
 
@@ -1260,9 +1264,12 @@ buffer, else display in a popup buffer."
   "If no region is active, call `cider-eval-defun-at-point' with DEBUG-IT.
 If a region is active, run `cider-eval-region'.
 
-Always binds `clojure-toplevel-inside-comment-form' to t."
+Always binds `clojure-toplevel-inside-comment-form' (and its clojure-ts-mode
+counterpart `clojure-ts-toplevel-inside-comment-form') to t, so evaluating
+inside a `comment' form picks up the enclosed form."
   (interactive "P")
-  (let ((clojure-toplevel-inside-comment-form t))
+  (let ((clojure-toplevel-inside-comment-form t)
+        (clojure-ts-toplevel-inside-comment-form t))
     (if (use-region-p)
         (cider-eval-region (region-beginning) (region-end))
       (cider-eval-defun-at-point debug-it))))

--- a/lisp/cider-jack-in.el
+++ b/lisp/cider-jack-in.el
@@ -43,7 +43,6 @@
 (require 'seq)
 (require 'subr-x)
 
-(require 'clojure-mode)
 (require 'nrepl-client)
 
 (require 'cider-util)

--- a/lisp/cider-xref.el
+++ b/lisp/cider-xref.el
@@ -38,7 +38,6 @@
 (require 'cider-xref-source)
 (require 'nrepl-dict)
 
-(require 'clojure-mode)
 (require 'apropos)
 (require 'button)
 (require 'xref)

--- a/test/cider-eval-tests.el
+++ b/test/cider-eval-tests.el
@@ -30,6 +30,11 @@
 (require 'cider-test-utils "test/utils/cider-test-utils")
 (require 'cider-connection-test-utils "test/utils/cider-connection-test-utils")
 
+;; Defined by clojure-ts-mode, which isn't loaded in the main test suite.
+;; Declare it special here so the `cider-eval-dwim' binding test observes a
+;; dynamic (not lexical) binding.
+(defvar clojure-ts-toplevel-inside-comment-form nil)
+
 ;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
 
 (describe "cider-eval-pprint-with-multiline-comment-handler"
@@ -648,3 +653,19 @@
           (clojure-mode)
           (setq buffer-file-name (make-temp-name "tmp.clj"))
           (expect (let ((inhibit-message t)) (cider-load-buffer)) :not :to-throw))))))
+
+(describe "cider-eval-dwim"
+  (it "binds both comment-form toplevel vars around the eval"
+    ;; So evaluating inside a `comment' form picks up the enclosed form under
+    ;; both clojure-mode and clojure-ts-mode.
+    (let ((clojure-toplevel-inside-comment-form nil)
+          (clojure-ts-toplevel-inside-comment-form nil)
+          seen-clj seen-ts)
+      (spy-on 'use-region-p :and-return-value nil)
+      (spy-on 'cider-eval-defun-at-point :and-call-fake
+              (lambda (&rest _)
+                (setq seen-clj clojure-toplevel-inside-comment-form
+                      seen-ts clojure-ts-toplevel-inside-comment-form)))
+      (cider-eval-dwim)
+      (expect seen-clj :to-be t)
+      (expect seen-ts :to-be t))))

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -229,7 +229,17 @@
         (with-clojure-buffer--go-to-point)
         (delay-mode-hooks ;; we just want to mark the mode as cider-nrepl, without running other code.
           (cider-repl-mode))
-        (expect (cider-defun-at-point) :to-equal "(. \"\")")))))
+        (expect (cider-defun-at-point) :to-equal "(. \"\")"))))
+
+  (describe "inside a comment form"
+    (it "returns the whole comment form by default"
+      (with-clojure-buffer "(comment (+ 1| 2))"
+        (let ((clojure-toplevel-inside-comment-form nil))
+          (expect (cider-defun-at-point) :to-equal "(comment (+ 1 2))"))))
+    (it "returns the enclosed form when clojure-toplevel-inside-comment-form is set"
+      (with-clojure-buffer "(comment (+ 1| 2))"
+        (let ((clojure-toplevel-inside-comment-form t))
+          (expect (cider-defun-at-point) :to-equal "(+ 1 2)"))))))
 
 (describe "cider-repl-prompt-function"
   (it "returns repl prompts"

--- a/test/clojure-ts-mode/cider-util-ts-tests.el
+++ b/test/clojure-ts-mode/cider-util-ts-tests.el
@@ -90,4 +90,14 @@ buffer."
       (expect (cider-keyword-at-point-p) :not :to-be-truthy)
       (expect (cider-keyword-at-point-p (point)) :not :to-be-truthy))))
 
+(describe "cider-defun-at-point inside a comment form"
+  (it "returns the whole comment form by default"
+    (with-clojure-ts-buffer "(comment (+ 1| 2))"
+      (let ((clojure-ts-toplevel-inside-comment-form nil))
+        (expect (cider-defun-at-point) :to-equal "(comment (+ 1 2))"))))
+  (it "returns the enclosed form when clojure-ts-toplevel-inside-comment-form is set"
+    (with-clojure-ts-buffer "(comment (+ 1| 2))"
+      (let ((clojure-ts-toplevel-inside-comment-form t))
+        (expect (cider-defun-at-point) :to-equal "(+ 1 2)")))))
+
 (provide 'cider-ts-util-tests)


### PR DESCRIPTION
First, low-risk batch of clojure-ts-mode parity work, from a deeper audit of how much CIDER leans on clojure-mode.

- `cider-eval-dwim` bound `clojure-toplevel-inside-comment-form` (clojure-mode) so eval inside a `(comment ...)` grabs the enclosed form, but clojure-ts-mode gates that on its own `clojure-ts-toplevel-inside-comment-form`, which CIDER never set. So a clojure-ts-mode user evaluating inside a rich comment got the whole `(comment ...)` instead of the inner form. Now both are bound.
- Dropped five `(require 'clojure-mode)` that referenced no clojure-mode symbol.

On the testing side, I mirrored the `cider-defun-at-point` comment-form specs under both clojure-mode and clojure-ts-mode, which is the start of tracking behavior parity between the two so differences don't sneak in.