### PR TITLE
Stop reaching into clojure-mode private internals

### DIFF
--- a/lisp/cider-debug.el
+++ b/lisp/cider-debug.el
@@ -650,10 +650,14 @@ REASON is a keyword describing why this buffer was necessary."
     (search-forward-regexp (concat "\\_<" (regexp-quote key) "\\_>")
                            limit 'noerror)))
 
+(defvar cider-debug--comment-macro-regexp
+  (rx (seq (+ (seq "#_" (* " ")))) (group-n 1 (not (any " "))))
+  "Regexp matching the start of a #_ reader-macro comment sexp.
+The beginning of match-group 1 is before the discarded sexp.")
+
 (defun cider--debug-skip-discarded-forms ()
   "Skip past all forms discarded with the #_ reader macro."
-  ;; Logic taken from `clojure--search-comment-macro-internal'
-  (while (looking-at (concat "[ ,\r\t\n]*" clojure--comment-macro-regexp))
+  (while (looking-at (concat "[ ,\r\t\n]*" cider-debug--comment-macro-regexp))
     (let ((md (match-data))
           (start (match-beginning 1)))
       (goto-char start)
@@ -684,7 +688,7 @@ key of a map, and it means \"go to the value associated with this key\"."
       ;; Navigate through sexps inside the sexp.
       (let ((in-syntax-quote nil))
         (while coordinates
-          (while (clojure--looking-at-non-logical-sexp)
+          (while (cider--looking-at-non-logical-sexp)
             (forward-sexp))
           ;; An `@x` is read as (deref x), so we pop coordinates once to account
           ;; for the extra depth, and move past the @ char.

--- a/lisp/cider-inspector.el
+++ b/lisp/cider-inspector.el
@@ -33,6 +33,7 @@
 (require 'transient)
 (require 'cider-client)
 (require 'cider-eval)
+(require 'cider-util)
 
 ;; ===================================
 ;; Inspector Key Map and Derived Mode
@@ -131,7 +132,7 @@ override it for this buffer."
 
 (defvar cider-inspector-uninteresting-regexp
   (concat "nil"                      ; nils are not interesting
-          "\\|:" clojure--sym-regexp ; nor keywords
+          "\\|:" cider--sym-regexp ; nor keywords
           ;; FIXME: This range also matches ",", is it on purpose?
           "\\|[+-.0-9]+")            ; nor numbers. Note: BigInts, ratios etc. are interesting
   "Regexp of uninteresting and skippable values.")

--- a/lisp/cider-repl.el
+++ b/lisp/cider-repl.el
@@ -2164,6 +2164,10 @@ the history file is rewritten if `cider-repl-history-file' is set."
 (defvar cider-repl-mode-syntax-table
   (copy-syntax-table clojure-mode-syntax-table))
 
+(defconst cider-repl--prettify-symbols-alist
+  '(("fn" . ?λ))
+  "Alist used to seed `prettify-symbols-alist' in the REPL buffer.")
+
 (declare-function cider-toggle-trace-ns "cider-tracing")
 (declare-function cider-toggle-trace-var "cider-tracing")
 (declare-function cider-find-resource "cider-find")
@@ -2353,7 +2357,7 @@ the history file is rewritten if `cider-repl-history-file' is set."
   ;; Notice the interplay with `cider-repl-beginning-of-defun'.
   (setq-local beginning-of-defun-function #'cider-repl-mode-beginning-of-defun)
   (setq-local end-of-defun-function #'cider-repl-mode-end-of-defun)
-  (setq-local prettify-symbols-alist clojure--prettify-symbols-alist)
+  (setq-local prettify-symbols-alist cider-repl--prettify-symbols-alist)
   ;; apply dir-local variables to REPL buffers
   (hack-dir-local-variables-non-file-buffer)
   (cider-repl-history-load)

--- a/lisp/cider-util.el
+++ b/lisp/cider-util.el
@@ -46,6 +46,27 @@
 
 (defalias 'cider-pop-back #'pop-tag-mark)
 
+;;; Clojure syntax helpers
+;; CIDER-owned copies of a few small clojure-mode internals, so we don't
+;; reach into its private (`clojure--…') API - which is unstable across
+;; versions and absent from clojure-ts-mode.
+
+(eval-and-compile
+  (defconst cider--sym-forbidden-rest-chars "][\";@\\^`~\(\)\{\}\\,\s\t\n\r"
+    "Chars that a Clojure symbol or namespace alias cannot contain.")
+  (defconst cider--sym-forbidden-1st-chars (concat cider--sym-forbidden-rest-chars "0-9:'")
+    "Chars that a Clojure symbol or namespace alias cannot start with.")
+  (defconst cider--sym-regexp
+    (concat "[^" cider--sym-forbidden-1st-chars "][^" cider--sym-forbidden-rest-chars "]*")
+    "A regexp matching a Clojure symbol or namespace alias."))
+
+(defun cider--looking-at-non-logical-sexp ()
+  "Return non-nil if text after point is a \"non-logical\" sexp.
+\"Non-logical\" sexps are ^metadata and #reader.macros."
+  (comment-normalize-vars t) ;; `t': avoid prompts
+  (comment-forward (point-max))
+  (looking-at-p "\\(?:#?\\^\\)\\|#:?:?[[:alpha:]]"))
+
 (defcustom cider-font-lock-max-length 10000
   "The max length of strings to fontify in `cider-font-lock-as'.
 
@@ -278,7 +299,7 @@ instead."
 Skip any non-logical sexps like ^metadata or #reader macros.
 If SKIP is an integer, also skip that many logical sexps first.
 Can only error if SKIP is non-nil."
-  (while (clojure--looking-at-non-logical-sexp)
+  (while (cider--looking-at-non-logical-sexp)
     (forward-sexp 1))
   (when (and skip (> skip 0))
     (dotimes (_ skip)
@@ -685,7 +706,7 @@ restore it properly when going back."
     (rx-to-string
      `(or (: "`" (group-n 1 (+ (not space))) "`")  ; `var`
           (: "[[" (group-n 1 (+ (not space))) "]]") ; [[var]]
-          (group-n 1 (regexp ,clojure--sym-regexp) "/" (regexp ,clojure--sym-regexp))))) ;; Fully qualified
+          (group-n 1 (regexp ,cider--sym-regexp) "/" (regexp ,cider--sym-regexp))))) ;; Fully qualified
   "The regexp used to search Clojure vars in doc buffers."
   :type 'regexp
   :safe #'stringp


### PR DESCRIPTION
Phase 1 of the clojure-ts-mode parity work: de-fragilize the clojure-mode coupling.

CIDER reached into four private `clojure--*` symbols. Those are unstable across clojure-mode versions and don't exist in clojure-ts-mode, so owning local copies removes a needless dependency on someone else's internals:

- `cider--sym-regexp` (plus the two forbidden-chars constants) - verified byte-identical to `clojure--sym-regexp`
- `cider--looking-at-non-logical-sexp`
- `cider-debug--comment-macro-regexp`
- `cider-repl--prettify-symbols-alist`

No behavior change; the public `clojure-*` navigation API CIDER still uses is left as-is.