### PR TITLE
Highlight #break/#dbg/#light in clojure-ts-mode buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### New features
 
 - [#4142](https://github.com/clojure-emacs/cider/pull/4142): Bring CIDER's dynamic font-locking (highlighting REPL-defined macros, functions, vars and deprecated/instrumented/traced symbols) to `clojure-ts-mode` buffers via tree-sitter; previously it only worked under `clojure-mode`.
+- [#4143](https://github.com/clojure-emacs/cider/pull/4143): Highlight the `#break`/`#dbg`/`#light` debugging reader tags in `clojure-ts-mode` buffers too.
 - [#4117](https://github.com/clojure-emacs/cider/pull/4117): Add `cider-use-completing-read-for-symbol` (off by default): when enabled, symbol prompts (e.g. `cider-doc`, `cider-find-var`) read through `completing-read` over a lazy, runtime-backed collection, so they work with `completing-read` UIs (Vertico, Ivy, Helm) and annotate candidates with their type and namespace.
 - [#4129](https://github.com/clojure-emacs/cider/pull/4129): Render completion annotations as an aligned type/namespace column (via an `affixation-function`) in UIs that support it, such as the built-in `*Completions*`, Corfu and Vertico.
 

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -1062,6 +1062,29 @@ its nREPL metadata dict, as returned by `cider-resolve-ns-symbols'."
 (defconst cider--treesit-font-lock-feature 'cider-dynamic
   "Feature name for CIDER's tree-sitter dynamic font-lock rules.")
 
+(defconst cider--treesit-static-font-lock-feature 'cider-static
+  "Feature name for CIDER's fixed tree-sitter font-lock rules.")
+
+(defun cider--treesit-install-font-lock (feature rules)
+  "Install RULES under FEATURE in the current buffer's treesit settings.
+Replace any prior settings for FEATURE.  RULES are appended so they run
+after (and thus override) clojure-ts-mode's own fontification; FEATURE is
+enabled by adding it to the first, always-active feature level, without
+shifting the existing levels or mutating the shared literal.  When RULES is
+nil, FEATURE is simply removed."
+  (setq-local treesit-font-lock-settings
+              (seq-remove (lambda (s) (eq (nth 2 s) feature))
+                          treesit-font-lock-settings))
+  (when rules
+    (setq-local treesit-font-lock-settings
+                (append treesit-font-lock-settings rules))
+    (unless (memq feature (apply #'append treesit-font-lock-feature-list))
+      (setq-local treesit-font-lock-feature-list
+                  (cons (cons feature (car treesit-font-lock-feature-list))
+                        (cdr treesit-font-lock-feature-list)))))
+  (treesit-font-lock-recompute-features)
+  (font-lock-flush))
+
 (defun cider--treesit-symbol-regexp (names)
   "Return a regexp matching any of NAMES as a whole symbol name."
   (concat "\\`" (regexp-opt names) "\\'"))
@@ -1106,12 +1129,33 @@ there is nothing to highlight."
        :override t
        queries))))
 
+(defun cider--treesit-static-font-lock-rules ()
+  "Return tree-sitter rules for CIDER's fixed reader-tag highlighting.
+Highlights the `#break', `#dbg' and `#light' debugging reader tags, the
+tree-sitter counterpart of `cider--static-font-lock-keywords'."
+  (treesit-font-lock-rules
+   :language 'clojure
+   :feature cider--treesit-static-font-lock-feature
+   :override t
+   '(((tagged_or_ctor_lit
+       marker: "#" @font-lock-warning-face
+       tag: (sym_lit (sym_name) @font-lock-warning-face @cider--ts-reader-tag))
+      (:match "\\`\\(?:break\\|dbg\\|light\\)\\'" @cider--ts-reader-tag)))))
+
+(defun cider--treesit-install-static-font-lock ()
+  "Install CIDER's fixed reader-tag highlighting for the current ts buffer."
+  (cider--treesit-install-font-lock
+   cider--treesit-static-font-lock-feature
+   (cider--treesit-static-font-lock-rules)))
+
 (defun cider--treesit-font-lock-teardown ()
-  "Remove CIDER's dynamic font-lock rules from the current ts buffer."
+  "Remove CIDER's font-lock rules from the current ts buffer."
   (when (boundp 'treesit-font-lock-settings)
     (setq-local treesit-font-lock-settings
                 (seq-remove (lambda (s)
-                              (eq (nth 2 s) cider--treesit-font-lock-feature))
+                              (memq (nth 2 s)
+                                    (list cider--treesit-font-lock-feature
+                                          cider--treesit-static-font-lock-feature)))
                             treesit-font-lock-settings))
     (treesit-font-lock-recompute-features)
     (font-lock-flush)))
@@ -1119,25 +1163,9 @@ there is nothing to highlight."
 (defun cider--treesit-refresh-dynamic-font-lock (symbols-plist core-plist)
   "Install CIDER's tree-sitter dynamic font-lock from resolved symbols.
 SYMBOLS-PLIST and CORE-PLIST are as in `cider--treesit-font-lock-rules'."
-  ;; Drop our previous rules, then append the fresh ones so they run after
-  ;; (and thus override) clojure-ts-mode's own fontification.
-  (setq-local treesit-font-lock-settings
-              (seq-remove (lambda (s)
-                            (eq (nth 2 s) cider--treesit-font-lock-feature))
-                          treesit-font-lock-settings))
-  (when-let* ((rules (cider--treesit-font-lock-rules symbols-plist core-plist)))
-    (setq-local treesit-font-lock-settings
-                (append treesit-font-lock-settings rules))
-    ;; Enable our feature by adding it to the first (always-active) level,
-    ;; without shifting the existing levels or mutating the shared literal.
-    (unless (memq cider--treesit-font-lock-feature
-                  (apply #'append treesit-font-lock-feature-list))
-      (setq-local treesit-font-lock-feature-list
-                  (cons (cons cider--treesit-font-lock-feature
-                              (car treesit-font-lock-feature-list))
-                        (cdr treesit-font-lock-feature-list)))))
-  (treesit-font-lock-recompute-features)
-  (font-lock-flush))
+  (cider--treesit-install-font-lock
+   cider--treesit-font-lock-feature
+   (cider--treesit-font-lock-rules symbols-plist core-plist)))
 
 (defun cider-refresh-dynamic-font-lock (&optional ns)
   "Ensure that the current buffer has up-to-date font-lock rules.
@@ -1391,7 +1419,11 @@ property."
         (cider-eldoc-setup)
         (cider-ns-state-setup)
         (add-hook 'completion-at-point-functions #'cider-complete-at-point nil t)
-        (font-lock-add-keywords nil cider--static-font-lock-keywords)
+        ;; clojure-mode's regexp keywords are a no-op under clojure-ts-mode's
+        ;; tree-sitter fontifier, so install the tree-sitter equivalent there.
+        (if (cider-clojure-ts-mode-p)
+            (cider--treesit-install-static-font-lock)
+          (font-lock-add-keywords nil cider--static-font-lock-keywords))
         (cider-refresh-dynamic-font-lock)
         (font-lock-add-keywords nil cider--reader-conditionals-font-lock-keywords)
         ;; `font-lock-mode' might get enabled after `cider-mode'.

--- a/test/clojure-ts-mode/cider-mode-ts-tests.el
+++ b/test/clojure-ts-mode/cider-mode-ts-tests.el
@@ -74,9 +74,26 @@
             (cider-font-lock-dynamically t))
         (cider--treesit-refresh-dynamic-font-lock
          (list "my-fn" (nrepl-dict "fn" "true")) nil)
+        (cider--treesit-install-static-font-lock)
         (expect (length treesit-font-lock-settings) :to-be-greater-than base)
         (cider--treesit-font-lock-teardown)
         (expect (length treesit-font-lock-settings) :to-equal base)))))
+
+(describe "static tree-sitter font-lock"
+  (it "highlights the #break/#dbg/#light debugging reader tags"
+    (with-clojure-ts-buffer "#break (+ 1 2)\n"
+      (font-lock-mode 1)
+      (cider--treesit-install-static-font-lock)
+      (font-lock-ensure)
+      (expect (cider-mode-ts-tests--face-at "break")
+              :to-equal 'font-lock-warning-face)))
+  (it "leaves ordinary reader tags alone"
+    (with-clojure-ts-buffer "#uuid \"x\"\n"
+      (font-lock-mode 1)
+      (cider--treesit-install-static-font-lock)
+      (font-lock-ensure)
+      (expect (cider-mode-ts-tests--face-at "uuid")
+              :not :to-equal 'font-lock-warning-face))))
 
 (provide 'cider-mode-ts-tests)
 


### PR DESCRIPTION
Follow-up to #4142. The static debugging reader-tag highlighting (`#break`/`#dbg`/`#light`) was regexp-based, so it did nothing under clojure-ts-mode's tree-sitter fontifier.

Adds a tree-sitter counterpart, installed as a fixed `cider-static` feature at `cider-mode` enable and independent of `cider-font-lock-dynamically` (matching the clojure-mode side). The settings install/teardown is now shared with the dynamic path.