### PR TITLE
Skip local vars in clojure-ts-mode dynamic font-lock

### DIFF
--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -56,6 +56,8 @@
 ;; compiler happy there.
 (declare-function treesit-font-lock-rules "treesit")
 (declare-function treesit-font-lock-recompute-features "treesit")
+(declare-function treesit-node-start "treesit")
+(declare-function treesit-node-text "treesit")
 (defvar treesit-font-lock-settings)
 (defvar treesit-font-lock-feature-list)
 
@@ -1089,6 +1091,16 @@ nil, FEATURE is simply removed."
   "Return a regexp matching any of NAMES as a whole symbol name."
   (concat "\\`" (regexp-opt names) "\\'"))
 
+(defun cider--treesit-not-local-p (node)
+  "Return non-nil unless NODE is a local var or in a blocked region.
+Tree-sitter counterpart of `cider--unless-local-match': a symbol shadowed
+by a local binding (per the `cider-locals' text property) should keep its
+own face rather than the dynamic one."
+  (let ((start (treesit-node-start node)))
+    (not (or (get-text-property start 'cider-block-dynamic-font-lock)
+             (member (treesit-node-text node)
+                     (get-text-property start 'cider-locals))))))
+
 (defun cider--treesit-font-lock-rules (symbols-plist core-plist)
   "Return tree-sitter font-lock settings for SYMBOLS-PLIST and CORE-PLIST.
 The Clojure counterpart to `cider--compile-font-lock-keywords', producing
@@ -1116,9 +1128,11 @@ there is nothing to highlight."
                          ;; Macros only in call position, like the clojure-mode
                          ;; rule that requires a preceding \"(\".
                          `((list_lit :anchor (sym_lit (sym_name) ,cap))
-                           (:match ,re ,cap))
+                           (:match ,re ,cap)
+                           (:pred cider--treesit-not-local-p ,cap))
                        `((sym_lit (sym_name) ,cap)
-                         (:match ,re ,cap)))))))
+                         (:match ,re ,cap)
+                         (:pred cider--treesit-not-local-p ,cap)))))))
     (when queries
       ;; Pass all pattern/predicate groups as a single query (like
       ;; clojure-ts-mode's own multi-pattern features), not as separate query

--- a/test/clojure-ts-mode/cider-mode-ts-tests.el
+++ b/test/clojure-ts-mode/cider-mode-ts-tests.el
@@ -67,6 +67,18 @@
       (expect (cider-mode-ts-tests--face-at "my-fn")
               :to-equal 'font-lock-function-name-face)))
 
+  (it "does not highlight a local that shadows a resolved symbol"
+    (with-clojure-ts-buffer "(let [my-fn 1] my-fn)\n"
+      (font-lock-mode 1)
+      (let ((cider-font-lock-dynamically t))
+        (cider--treesit-refresh-dynamic-font-lock
+         (list "my-fn" (nrepl-dict "fn" "true")) nil))
+      ;; Simulate CIDER's locals detection marking `my-fn' as a local.
+      (put-text-property (point-min) (point-max) 'cider-locals '("my-fn"))
+      (font-lock-ensure)
+      (expect (cider-mode-ts-tests--face-at "my-fn")
+              :not :to-equal 'font-lock-function-name-face)))
+
   (it "tears down its rules, leaving clojure-ts-mode's own settings intact"
     (with-clojure-ts-buffer "(my-fn 1)\n"
       (font-lock-mode 1)


### PR DESCRIPTION
Follow-up to #4142. The clojure-mode dynamic font-lock skips symbols shadowed by a local binding (`cider--unless-local-match`, keyed on the `cider-locals` text property). The tree-sitter path didn't, so a `let` binding named like a resolved var/function/macro - `(let [map ...])` and friends - got the dynamic face.

Adds a `cider--treesit-not-local-p` query predicate (`:pred`) that mirrors the clojure-mode check, so locals keep their own face on the tree-sitter path too.