### PR TITLE
Font-lock rendered Clojure snippets with the preferred mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### New features
 
 - [#4142](https://github.com/clojure-emacs/cider/pull/4142): Bring CIDER's dynamic font-locking (highlighting REPL-defined macros, functions, vars and deprecated/instrumented/traced symbols) to `clojure-ts-mode` buffers via tree-sitter; previously it only worked under `clojure-mode`.
+- [#4145](https://github.com/clojure-emacs/cider/pull/4145): Add `cider-clojure-font-lock-mode` (default `auto`) controlling which Clojure major mode CIDER uses to font-lock the code it renders (REPL input/results, doc examples, overlays, xref labels, etc.); when set to (or auto-detecting) `clojure-ts-mode`, those snippets get tree-sitter highlighting instead of `clojure-mode`'s.
 - [#4143](https://github.com/clojure-emacs/cider/pull/4143): Highlight the `#break`/`#dbg`/`#light` debugging reader tags in `clojure-ts-mode` buffers too.
 - [#4117](https://github.com/clojure-emacs/cider/pull/4117): Add `cider-use-completing-read-for-symbol` (off by default): when enabled, symbol prompts (e.g. `cider-doc`, `cider-find-var`) read through `completing-read` over a lazy, runtime-backed collection, so they work with `completing-read` UIs (Vertico, Ivy, Helm) and annotate candidates with their type and namespace.
 - [#4129](https://github.com/clojure-emacs/cider/pull/4129): Render completion annotations as an aligned type/namespace column (via an `affixation-function`) in UIs that support it, such as the built-in `*Completions*`, Corfu and Vertico.

--- a/lisp/cider-util.el
+++ b/lisp/cider-util.el
@@ -44,6 +44,12 @@
 (require 'clojure-mode)
 (require 'nrepl-dict)
 
+;; Optional clojure-ts-mode / tree-sitter support (Emacs 29+); guarded at
+;; runtime by `cider--clojure-ts-mode-available-p'.
+(declare-function treesit-ready-p "treesit")
+(declare-function major-mode-remap "subr")
+(defvar major-mode-remap-alist)
+
 (defalias 'cider-pop-back #'pop-tag-mark)
 
 ;;; Clojure syntax helpers
@@ -436,12 +442,62 @@ Unless you specify a BUFFER it will default to the current one."
       (goto-char beg)
       (insert (cider-font-lock-as mode text)))))
 
+(defcustom cider-clojure-font-lock-mode 'auto
+  "Which Clojure major mode to use when font-locking Clojure snippets.
+CIDER renders Clojure code (REPL input and results, doc examples, debug
+and enlighten overlays, xref labels, and so on) by font-locking it in a
+hidden buffer.  This controls which major mode does that fontification:
+
+  `auto' (the default): use `clojure-ts-mode' when Clojure source files
+  open in it and its tree-sitter grammar is ready, otherwise `clojure-mode'.
+  `clojure-mode': always use `clojure-mode'.
+  `clojure-ts-mode': use `clojure-ts-mode' when available, else fall back
+  to `clojure-mode'."
+  :type '(choice (const :tag "Auto-detect" auto)
+                 (const :tag "clojure-mode" clojure-mode)
+                 (const :tag "clojure-ts-mode" clojure-ts-mode))
+  :group 'cider
+  :package-version '(cider . "2.1.0"))
+
+(defun cider--clojure-ts-mode-available-p ()
+  "Return non-nil if `clojure-ts-mode' and the Clojure grammar are usable."
+  (and (fboundp 'clojure-ts-mode)
+       (featurep 'treesit)
+       (treesit-ready-p 'clojure t)))
+
+(defun cider--clojure-ts-mode-preferred-p ()
+  "Return non-nil when Clojure source files open in `clojure-ts-mode'.
+Handles both mechanisms clojure-ts-mode registers with: remapping
+`clojure-mode' and a direct `auto-mode-alist' entry for Clojure files."
+  (or (eq 'clojure-ts-mode
+          (if (fboundp 'major-mode-remap)
+              (major-mode-remap 'clojure-mode)
+            (and (boundp 'major-mode-remap-alist)
+                 (alist-get 'clojure-mode major-mode-remap-alist))))
+      (eq 'clojure-ts-mode
+          (assoc-default "a.clj" auto-mode-alist #'string-match-p))))
+
+(defun cider--clojure-font-lock-mode ()
+  "Return the major mode to use for font-locking Clojure snippets.
+Resolves `cider-clojure-font-lock-mode', falling back to `clojure-mode'
+whenever `clojure-ts-mode' or its grammar is unavailable."
+  (pcase cider-clojure-font-lock-mode
+    ('clojure-mode 'clojure-mode)
+    ('clojure-ts-mode (if (cider--clojure-ts-mode-available-p)
+                          'clojure-ts-mode
+                        'clojure-mode))
+    (_ (if (and (cider--clojure-ts-mode-available-p)
+                (cider--clojure-ts-mode-preferred-p))
+           'clojure-ts-mode
+         'clojure-mode))))
+
 (defun cider-font-lock-as-clojure (string)
-  "Font-lock STRING as Clojure code."
+  "Font-lock STRING as Clojure code.
+The major mode used is chosen by `cider-clojure-font-lock-mode'."
   ;; If something goes wrong (e.g. the code is not balanced)
   ;; we simply return the string.
   (condition-case nil
-      (cider-font-lock-as 'clojure-mode string)
+      (cider-font-lock-as (cider--clojure-font-lock-mode) string)
     (error string)))
 
 ;; Button allowing use of `font-lock-face', ignoring any inherited `face'

--- a/test/cider-repl-tests.el
+++ b/test/cider-repl-tests.el
@@ -286,7 +286,11 @@
 
   (it "leaves a value that is unbalanced as a whole untouched, without error"
     (with-temp-buffer
+      ;; This exercises clojure-mode's bail-on-unbalanced path; clojure-ts-mode
+      ;; fontifies partial code instead (tree-sitter is error-tolerant), so pin
+      ;; the mode for a deterministic assertion.
       (let ((cider-repl-use-clojure-font-lock t)
+            (cider-clojure-font-lock-mode 'clojure-mode)
             (cider-repl-result-prefix ""))
         (cider-repl-reset-markers)
         (cider-repl-emit-result (current-buffer) "((" t)

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -639,3 +639,29 @@ and some other vars (like clojure.core/filter).
       (expect (string-match-p blocked "http://example.com/pixel.png") :to-be-truthy)
       (expect (string-match-p blocked "https://example.com/x.png") :to-be-truthy)
       (expect (string-match-p blocked "data:image/png;base64,AAAA") :to-be nil))))
+
+(describe "cider--clojure-font-lock-mode"
+  (it "always uses clojure-mode when configured to"
+    (let ((cider-clojure-font-lock-mode 'clojure-mode))
+      (spy-on 'cider--clojure-ts-mode-available-p :and-return-value t)
+      (spy-on 'cider--clojure-ts-mode-preferred-p :and-return-value t)
+      (expect (cider--clojure-font-lock-mode) :to-equal 'clojure-mode)))
+  (it "uses clojure-ts-mode when configured to and it is available"
+    (let ((cider-clojure-font-lock-mode 'clojure-ts-mode))
+      (spy-on 'cider--clojure-ts-mode-available-p :and-return-value t)
+      (expect (cider--clojure-font-lock-mode) :to-equal 'clojure-ts-mode)))
+  (it "falls back to clojure-mode when clojure-ts-mode is unavailable"
+    (let ((cider-clojure-font-lock-mode 'clojure-ts-mode))
+      (spy-on 'cider--clojure-ts-mode-available-p :and-return-value nil)
+      (expect (cider--clojure-font-lock-mode) :to-equal 'clojure-mode)))
+  (describe "auto"
+    (it "uses clojure-ts-mode when available and preferred"
+      (let ((cider-clojure-font-lock-mode 'auto))
+        (spy-on 'cider--clojure-ts-mode-available-p :and-return-value t)
+        (spy-on 'cider--clojure-ts-mode-preferred-p :and-return-value t)
+        (expect (cider--clojure-font-lock-mode) :to-equal 'clojure-ts-mode)))
+    (it "uses clojure-mode when clojure-ts-mode is not the preferred mode"
+      (let ((cider-clojure-font-lock-mode 'auto))
+        (spy-on 'cider--clojure-ts-mode-available-p :and-return-value t)
+        (spy-on 'cider--clojure-ts-mode-preferred-p :and-return-value nil)
+        (expect (cider--clojure-font-lock-mode) :to-equal 'clojure-mode)))))

--- a/test/clojure-ts-mode/cider-util-ts-tests.el
+++ b/test/clojure-ts-mode/cider-util-ts-tests.el
@@ -90,6 +90,15 @@ buffer."
       (expect (cider-keyword-at-point-p) :not :to-be-truthy)
       (expect (cider-keyword-at-point-p (point)) :not :to-be-truthy))))
 
+(describe "cider-font-lock-as-clojure with clojure-ts-mode"
+  (it "fontifies a snippet via tree-sitter when so configured"
+    (let ((cider-clojure-font-lock-mode 'clojure-ts-mode))
+      (let ((s (cider-font-lock-as-clojure "(defn foo [x] :kw)")))
+        (expect (get-text-property (string-search "defn" s) 'face s)
+                :to-equal 'font-lock-keyword-face)
+        (expect (get-text-property (string-search ":kw" s) 'face s)
+                :to-equal 'clojure-ts-keyword-face)))))
+
 (describe "cider-defun-at-point inside a comment form"
   (it "returns the whole comment form by default"
     (with-clojure-ts-buffer "(comment (+ 1| 2))"


### PR DESCRIPTION
Follow-up in the clojure-ts-mode line of work, addressing REPL-input (and more) fontification.

CIDER renders Clojure code - REPL input and results, doc examples, tracing/enlighten overlays, xref labels, and so on - by font-locking it in a hidden buffer through `cider-font-lock-as-clojure`, which hardcoded `clojure-mode`. So a clojure-ts-mode user got clojure-mode's regexp highlighting in all those places, never tree-sitter.

Adds `cider-clojure-font-lock-mode` (default `auto`): auto-detect clojure-ts-mode when your Clojure files open in it and the grammar is ready, otherwise clojure-mode; you can also pin it to either mode. `cider-font-lock-as-clojure` routes through it, so everything CIDER renders as Clojure follows your preferred mode at once.

Verified in a real clojure-ts-mode buffer that snippets pick up tree-sitter faces (`defn` -> keyword, `:kw` -> `clojure-ts-keyword-face`).