### PR TITLE
Fix macrostep under clojure-ts-mode (marker/indent-region)

### DIFF
--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -1113,7 +1113,9 @@ later insertions (the eval-to-comment handler inserts the result there)."
           (set-marker beg (point))
           (insert trimmed)
           (set-marker end (point))
-          (indent-region (car bounds) block-end))
+          ;; Integer bounds, not the marker: see the `indent-region' note in
+          ;; `cider-macrostep--expand-region' (Emacs 30.1 tree-sitter bug).
+          (indent-region (car bounds) (marker-position block-end)))
       ;; no block yet: create one at the end of the buffer
       (goto-char (point-max))
       (skip-chars-backward " \t\n")

--- a/lisp/cider-macrostep.el
+++ b/lisp/cider-macrostep.el
@@ -480,7 +480,11 @@ Enter `cider-macrostep-mode' when it isn't already active."
           (let ((ins-beg (point-marker))
                 (ins-end (copy-marker (point) t)))
             (insert expansion)
-            (indent-region ins-beg ins-end)
+            ;; Pass integer positions, not the markers: `indent-region'
+            ;; forwards its args to `treesit-indent-region', and Emacs 30.1's
+            ;; tree-sitter chokes on marker bounds (bug in `treesit-query-capture'
+            ;; via the markdown-inline range update clojure-ts-mode installs).
+            (indent-region (marker-position ins-beg) (marker-position ins-end))
             (let ((ov (make-overlay ins-beg ins-end)))
               (overlay-put ov 'cider-macrostep-original-text original)
               (overlay-put ov 'priority (if parent
@@ -549,13 +553,12 @@ sub-forms."
 
 (defun cider-macrostep--popup-buffer (code ns)
   "Pop to the macrostep buffer seeded with CODE, expanded in namespace NS.
-The buffer is a `clojure-mode' popup whose `cider-buffer-ns' is NS so the
-expander resolves vars as it would in the originating buffer.  Point is left
-right after the inserted form, ready for `cider-macrostep-expand'."
+The buffer is a Clojure popup (see `cider-preferred-clojure-mode') whose
+`cider-buffer-ns' is NS so the expander resolves vars as it would in the
+originating buffer.  Point is left right after the inserted form, ready for
+`cider-macrostep-expand'."
   (with-current-buffer
-      ;; Stays clojure-mode: the `macrostep' package's stepping session relies
-      ;; on clojure-mode and breaks under clojure-ts-mode.
-      (cider-popup-buffer cider-macrostep-buffer 'select 'clojure-mode 'ancillary)
+      (cider-popup-buffer cider-macrostep-buffer 'select (cider--preferred-clojure-mode) 'ancillary)
     (setq cider-buffer-ns ns
           cider-macrostep--popup t)
     (let ((inhibit-read-only t))


### PR DESCRIPTION
Follow-up that removes the one special case left by #4146.

When I made CIDER's popups follow the preferred mode, the macrostep popup broke under clojure-ts-mode and I pinned it back to clojure-mode with a comment blaming the (external) `macrostep` package. That diagnosis was wrong - CIDER's macro-stepping is its own overlay-based code.

The real cause: `cider-macrostep--expand-region` passed markers to `indent-region`, which forwards them straight to `treesit-indent-region`; Emacs 30.1's tree-sitter then hits `wrong-type-argument integerp #<marker in no buffer>` in `treesit-query-capture` while updating the markdown-inline ranges clojure-ts-mode installs for docstrings. It's fixed in Emacs 30.2, which is why it only showed up in CI.

The fix is to pass integer positions to `indent-region` (the conventional usage), so the popup can follow `cider-preferred-clojure-mode` like the other display buffers - no special case. I fixed the same latent marker-to-`indent-region` pattern in `cider-insert-in-comment` too.