### PR TITLE
Test Emacs 30.2 in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         # Test all Emacs versions on Ubuntu.
         os: [ubuntu-latest]
-        emacs_version: ['28.2', '29.3', '30.1']
+        emacs_version: ['28.2', '29.3', '30.1', '30.2']
         java_version: ['21']
         include:
           # For other OSes, test only the latest stable Emacs version.


### PR DESCRIPTION
Add current stable Emacs 30.2 to the Ubuntu test matrix. Keeping 30.1 too, since it's the minimum `clojure-ts-mode` supports and is where 30.1-only tree-sitter bugs surface (like the macrostep/indent-region one in #4147, which 30.2 masks).