### PR TITLE
Make nREPL message logging easier to reach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 - [#4117](https://github.com/clojure-emacs/cider/pull/4117): Add `cider-use-completing-read-for-symbol` (off by default): when enabled, symbol prompts (e.g. `cider-doc`, `cider-find-var`) read through `completing-read` over a lazy, runtime-backed collection, so they work with `completing-read` UIs (Vertico, Ivy, Helm) and annotate candidates with their type and namespace.
 - [#4129](https://github.com/clojure-emacs/cider/pull/4129): Render completion annotations as an aligned type/namespace column (via an `affixation-function`) in UIs that support it, such as the built-in `*Completions*`, Corfu and Vertico.
 
+### Changes
+
+- [#4149](https://github.com/clojure-emacs/cider/pull/4149): Make the nREPL message log easier to reach: add "Show nREPL messages" to the nREPL menu, reflect the logging toggle's on/off state there, and have `nrepl-show-messages` offer to enable logging when it's off instead of erroring.
+
 ### Bugs fixed
 
 - [#4140](https://github.com/clojure-emacs/cider/pull/4140): Fix `cider-eval-dwim` (and defun evaluation) not descending into a `(comment ...)` form in `clojure-ts-mode` buffers: it now binds `clojure-ts-toplevel-inside-comment-form` alongside the `clojure-mode` variable.

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -355,7 +355,9 @@ If invoked with a prefix ARG eval the expression after inserting it."
     ("nREPL" :active (cider-connected-p)
      ["List nREPL middleware" cider-list-nrepl-middleware]
      ["Describe nREPL session" cider-describe-nrepl-session]
-     ["Toggle message logging" nrepl-toggle-message-logging]))
+     ["Log protocol messages" nrepl-toggle-message-logging
+      :style toggle :selected nrepl-log-messages]
+     ["Show nREPL messages" nrepl-show-messages]))
   "Menu for CIDER mode.")
 
 (defconst cider-mode-eval-menu

--- a/lisp/nrepl-client.el
+++ b/lisp/nrepl-client.el
@@ -1431,16 +1431,21 @@ This in effect enables or disables the logging of nREPL messages."
 (defun nrepl-show-messages ()
   "Pop up an nREPL messages buffer.
 With more than one active connection, prompt for which one to show.
-If `nrepl-log-messages' is nil no buffer exists yet, so signal an
-error pointing at `nrepl-toggle-message-logging'."
+When message logging is disabled (`nrepl-log-messages'), offer to enable
+it; the log then fills as nREPL traffic flows."
   (interactive)
   (let ((buffers (seq-filter (lambda (b)
                                (with-current-buffer b
                                  (derived-mode-p 'nrepl-messages-mode)))
                              (buffer-list))))
     (pcase (length buffers)
-      (0 (user-error "No nREPL messages buffer exists; enable logging with `nrepl-toggle-message-logging'"))
       (1 (pop-to-buffer (car buffers)))
+      (0 (cond
+          (nrepl-log-messages
+           (user-error "nREPL message logging is on, but nothing has been logged yet"))
+          ((y-or-n-p "nREPL message logging is disabled; enable it? ")
+           (setq nrepl-log-messages t)
+           (message "nREPL message logging enabled; the log will fill as traffic flows"))))
       (_ (pop-to-buffer
           (get-buffer
            (completing-read "nREPL messages buffer: "

--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -587,3 +587,22 @@
             (let ((request (car (spy-calls-args-for 'nrepl-send-request 0))))
               (expect (member "enlighten" request) :not :to-be-truthy)))
         (kill-buffer conn)))))
+
+(describe "nrepl-show-messages"
+  (before-each
+    ;; No message-log buffers exist, so exercise the "nothing to show" paths.
+    (spy-on 'buffer-list :and-return-value nil))
+  (it "offers to enable logging when it is disabled"
+    (let ((nrepl-log-messages nil))
+      (spy-on 'y-or-n-p :and-return-value t)
+      (nrepl-show-messages)
+      (expect 'y-or-n-p :to-have-been-called)
+      (expect nrepl-log-messages :to-be t)))
+  (it "leaves logging disabled when the user declines"
+    (let ((nrepl-log-messages nil))
+      (spy-on 'y-or-n-p :and-return-value nil)
+      (nrepl-show-messages)
+      (expect nrepl-log-messages :to-be nil)))
+  (it "errors when logging is on but nothing has been captured yet"
+    (let ((nrepl-log-messages t))
+      (expect (nrepl-show-messages) :to-throw 'user-error))))


### PR DESCRIPTION
While reviewing the message-logging feature (`nrepl-log-messages`), the gap was discoverability, not the feature itself: the menu exposed the toggle but not the viewer, and `nrepl-show-messages` was M-x-only and errored when logging was off.

- Add "Show nREPL messages" to the nREPL menu, and render the logging toggle with a checkbox showing its current state.
- When logging is disabled, `nrepl-show-messages` offers to enable it instead of erroring, so it's a single entry point (enable, then the log fills as traffic flows).