### PR TITLE
Route stray output for unmatched response ids to the REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Bugs fixed
 
+- [#4150](https://github.com/clojure-emacs/cider/pull/4150): Stop dropping stray output from long-lived background processes (e.g. a `core.async` go-loop still printing under a finished eval's id): once that id is evicted from the completed-requests cache, its `out`/`err` is now routed to the REPL instead of being discarded with a "No response handler with id N found" warning.
 - [#4140](https://github.com/clojure-emacs/cider/pull/4140): Fix `cider-eval-dwim` (and defun evaluation) not descending into a `(comment ...)` form in `clojure-ts-mode` buffers: it now binds `clojure-ts-toplevel-inside-comment-form` alongside the `clojure-mode` variable.
 - [#4139](https://github.com/clojure-emacs/cider/pull/4139): Fix source-based find-usages (`M-?`) missing alias- and namespace-qualified references (e.g. `m/foo`), so a var used through its alias from other namespaces is now found, not just the bare occurrences in its defining namespace.
 - [#4136](https://github.com/clojure-emacs/cider/pull/4136): Fix a custom ClojureScript REPL init form being sent unwrapped when it starts with a call like `(dorun ...)` or `(doseq ...)`, which the previous `(do` prefix check mistook for an existing `do` block.

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -339,6 +339,19 @@ REPL buffer.  This is controlled via
 `cider-eval-output-destination'."
   (cider--emit-interactive-eval-output output 'cider-repl-emit-interactive-stderr))
 
+(defun cider--emit-orphaned-output (response)
+  "Emit RESPONSE's stdout/stderr when no handler is registered for its id.
+Return non-nil when RESPONSE carried output.  Installed as
+`nrepl-orphaned-output-function', so prints from a background process (e.g. a
+core.async go-loop still using a completed eval's id) reach the REPL instead
+of being dropped with a \"No response handler\" warning."
+  (nrepl-dbind-response response (out err)
+    (when out (cider-emit-interactive-eval-output out))
+    (when err (cider-emit-interactive-eval-err-output err))
+    (or out err)))
+
+(setq nrepl-orphaned-output-function #'cider--emit-orphaned-output)
+
 (defun cider--make-fringe-overlays-for-region (beg end)
   "Place eval indicators on all sexps between BEG and END."
   (with-current-buffer (if (markerp end)

--- a/lisp/nrepl-client.el
+++ b/lisp/nrepl-client.el
@@ -334,6 +334,14 @@ the server didn't supply one."
     (string-trim (or (nrepl-dict-get response "err")
                      "This operation isn't available in a ClojureScript REPL."))))
 
+(defvar nrepl-orphaned-output-function nil
+  "Function called with a RESPONSE whose id has no registered handler.
+It runs in the connection buffer and should return non-nil when it handled
+the response (e.g. emitted its stdout/stderr somewhere), or nil to let the
+dispatcher log the usual \"No response handler\" message.  Higher layers
+\(CIDER) set this to route stray output - such as prints from a long-lived
+core.async go-loop still using a completed eval's id - to the REPL.")
+
 (defun nrepl--dispatch-response (response)
   "Dispatch the RESPONSE to associated callback.
 First we check the callbacks of pending requests.  If no callback was found,
@@ -353,9 +361,18 @@ later responses sitting in the queue."
       (message "%s" msg))
     (let ((callback (or (gethash id nrepl-pending-requests)
                         (gethash id nrepl-completed-requests))))
-      (if callback
-          (funcall callback response)
-        (message "[nREPL] No response handler with id %s found for %s" id (buffer-name))))))
+      (cond
+       (callback (funcall callback response))
+       ;; No handler: the request finished long ago and was evicted from
+       ;; `nrepl-completed-requests', yet output keeps arriving (e.g. a
+       ;; core.async go-loop still printing under the original eval's id).
+       ;; Let a higher layer route the stray output rather than dropping it.
+       ;; This must never abort the dispatcher (see the #853 history), hence
+       ;; `with-demoted-errors'.
+       ((and nrepl-orphaned-output-function
+             (with-demoted-errors "[nREPL] orphaned-response handler error: %S"
+               (funcall nrepl-orphaned-output-function response))))
+       (t (message "[nREPL] No response handler with id %s found for %s" id (buffer-name)))))))
 
 (defun nrepl-client-sentinel (process message)
   "Handle sentinel events from PROCESS.

--- a/test/cider-eval-tests.el
+++ b/test/cider-eval-tests.el
@@ -654,6 +654,17 @@
           (setq buffer-file-name (make-temp-name "tmp.clj"))
           (expect (let ((inhibit-message t)) (cider-load-buffer)) :not :to-throw))))))
 
+(describe "cider--emit-orphaned-output"
+  (it "emits stray stdout/stderr and reports that it handled the response"
+    (spy-on 'cider-emit-interactive-eval-output)
+    (spy-on 'cider-emit-interactive-eval-err-output)
+    (expect (cider--emit-orphaned-output (nrepl-dict "id" "9" "out" "hi" "err" "oops"))
+            :to-be-truthy)
+    (expect 'cider-emit-interactive-eval-output :to-have-been-called-with "hi")
+    (expect 'cider-emit-interactive-eval-err-output :to-have-been-called-with "oops"))
+  (it "returns nil when the response carries no output"
+    (expect (cider--emit-orphaned-output (nrepl-dict "id" "9")) :to-be nil)))
+
 (describe "cider-eval-dwim"
   (it "binds both comment-form toplevel vars around the eval"
     ;; So evaluating inside a `comment' form picks up the enclosed form under

--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -606,3 +606,31 @@
   (it "errors when logging is on but nothing has been captured yet"
     (let ((nrepl-log-messages t))
       (expect (nrepl-show-messages) :to-throw 'user-error))))
+
+(describe "nrepl--dispatch-response for an orphaned id"
+  (it "routes stray output through nrepl-orphaned-output-function"
+    (with-temp-buffer
+      (setq-local nrepl-pending-requests (make-hash-table :test 'equal)
+                  nrepl-completed-requests (make-hash-table :test 'equal))
+      (let* ((seen nil)
+             (nrepl-orphaned-output-function (lambda (r) (setq seen r) t)))
+        (spy-on 'message)
+        (nrepl--dispatch-response (nrepl-dict "id" "999" "out" "hi"))
+        (expect seen :not :to-be nil)
+        (expect 'message :not :to-have-been-called))))
+  (it "warns when the handler declines to handle the response"
+    (with-temp-buffer
+      (setq-local nrepl-pending-requests (make-hash-table :test 'equal)
+                  nrepl-completed-requests (make-hash-table :test 'equal))
+      (let ((nrepl-orphaned-output-function (lambda (_r) nil)))
+        (spy-on 'message)
+        (nrepl--dispatch-response (nrepl-dict "id" "999"))
+        (expect 'message :to-have-been-called))))
+  (it "warns when there is no orphaned-output handler at all"
+    (with-temp-buffer
+      (setq-local nrepl-pending-requests (make-hash-table :test 'equal)
+                  nrepl-completed-requests (make-hash-table :test 'equal))
+      (let ((nrepl-orphaned-output-function nil))
+        (spy-on 'message)
+        (nrepl--dispatch-response (nrepl-dict "id" "999"))
+        (expect 'message :to-have-been-called)))))


### PR DESCRIPTION
From a Slack report: logging inside a `core.async` go-loop works at first, then starts spamming `[nREPL] No response handler with id N found` and the output vanishes - often right after reloading a buffer.

The go-loop keeps printing under its originating eval's id. That eval finished long ago, so its handler lives in `nrepl-completed-requests` (bounded, FIFO 1000); once ~1000 more requests complete (buffer reloads burn through them fast), the id is evicted and the loop's output is orphaned.

CIDER used to route such output to the REPL via `nrepl--make-default-handler`, removed back in 2014 (#853) because that handler could error the process filter and abort the whole response queue. This brings the behavior back, defensively:

- `nrepl-client` gains an `nrepl-orphaned-output-function` hook and only logs the warning when nothing handles the response; the call is wrapped in `with-demoted-errors` so it can never abort the dispatcher (the #853 failure mode).
- `cider-eval` sets the hook to emit the response's `out`/`err` through the normal interactive-output path (respecting `cider-eval-output-destination`).

Non-output orphaned responses still log as before.