### PR TITLE
Address two small TODO/FIXMEs

### DIFF
--- a/lisp/cider-connection.el
+++ b/lisp/cider-connection.el
@@ -197,13 +197,18 @@ message in the REPL area."
                                  "CIDER %s requires cider-nrepl %s, but you're currently using cider-nrepl %s. The version mismatch might break some functionality!"
                                  cider-version cider-required-middleware-version middleware-version)))))
 
-(declare-function cider-interactive-eval-handler "cider-eval")
 (declare-function cider-nrepl-send-request "cider-client")
-;; TODO: Use some null handler here
+(declare-function cider-emit-interactive-eval-output "cider-eval")
+(declare-function cider-emit-interactive-eval-err-output "cider-eval")
 (defun cider--subscribe-repl-to-server-out ()
   "Subscribe to the nREPL server's *out*."
+  ;; Server *out* only streams stdout/stderr, so use a minimal handler that
+  ;; routes just those, rather than the full interactive-eval handler with its
+  ;; value/done/error machinery.
   (cider-nrepl-send-request '("op" "cider/out-subscribe")
-                            (cider-interactive-eval-handler (current-buffer))))
+                            (nrepl-make-eval-handler
+                             :on-stdout #'cider-emit-interactive-eval-output
+                             :on-stderr #'cider-emit-interactive-eval-err-output)))
 
 (defvar cider-mode)
 (declare-function cider-mode "cider-mode")

--- a/lisp/cider-inspector.el
+++ b/lisp/cider-inspector.el
@@ -133,8 +133,7 @@ override it for this buffer."
 (defvar cider-inspector-uninteresting-regexp
   (concat "nil"                      ; nils are not interesting
           "\\|:" cider--sym-regexp ; nor keywords
-          ;; FIXME: This range also matches ",", is it on purpose?
-          "\\|[+-.0-9]+")            ; nor numbers. Note: BigInts, ratios etc. are interesting
+          "\\|[-+.0-9]+")            ; nor numbers. Note: BigInts, ratios etc. are interesting
   "Regexp of uninteresting and skippable values.")
 
 (defun cider-inspector-open-thing-at-point ()

--- a/test/cider-connection-tests.el
+++ b/test/cider-connection-tests.el
@@ -793,3 +793,10 @@
   (it "raises a user error if cider is not connected"
     (spy-on 'cider-connected-p :and-return-value nil)
     (expect (cider-restart) :to-throw 'user-error)))
+
+(describe "cider--subscribe-repl-to-server-out"
+  (it "sends the out-subscribe op"
+    (spy-on 'cider-nrepl-send-request)
+    (cider--subscribe-repl-to-server-out)
+    (expect (car (spy-calls-args-for 'cider-nrepl-send-request 0))
+            :to-equal '("op" "cider/out-subscribe"))))

--- a/test/cider-inspector-tests.el
+++ b/test/cider-inspector-tests.el
@@ -474,3 +474,10 @@
   (it "errors on an invalid direction"
     (expect (with-temp-buffer (cider-find-inspectable-object 'sideways (point-max)))
             :to-throw 'error)))
+
+(describe "cider-inspector-uninteresting-regexp"
+  (it "matches uninteresting scalar values (nil, keywords, numbers)"
+    (dolist (s '("nil" ":foo" "42" "-3" "1.5" "+7"))
+      (expect (string-match-p cider-inspector-uninteresting-regexp s) :to-be-truthy)))
+  (it "does not treat a comma as an uninteresting value"
+    (expect (string-match-p cider-inspector-uninteresting-regexp ",") :to-be nil)))


### PR DESCRIPTION
Two small, contained cleanups from the inline-TODO sweep:

- `cider--subscribe-repl-to-server-out` used the full `cider-interactive-eval-handler` for the `out-subscribe` op, which only streams stdout/stderr. Route just those via a minimal `nrepl-make-eval-handler` (the "use some null handler here" TODO).
- The inspector's uninteresting-values regexp had `[+-.0-9]`, where `+-.` is a character range that also matches `,` (the FIXME). Made the hyphen literal (`[-+.0-9]`). Inconsequential in practice since `,` is whitespace in Clojure, but it removes the confusion.