### PR TITLE
Don't treat :or destructuring defaults as locals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Bugs fixed
 
+- [#4152](https://github.com/clojure-emacs/cider/pull/4152): Stop the dynamic font-lock locals scanner from treating the default expressions in an `:or` destructuring clause (e.g. `{:keys [x] :or {x (some-default)}}`) as local variables, so references there keep their normal highlighting.
 - [#4150](https://github.com/clojure-emacs/cider/pull/4150): Stop dropping stray output from long-lived background processes (e.g. a `core.async` go-loop still printing under a finished eval's id): once that id is evicted from the completed-requests cache, its `out`/`err` is now routed to the REPL instead of being discarded with a "No response handler with id N found" warning.
 - [#4140](https://github.com/clojure-emacs/cider/pull/4140): Fix `cider-eval-dwim` (and defun evaluation) not descending into a `(comment ...)` form in `clojure-ts-mode` buffers: it now binds `clojure-ts-toplevel-inside-comment-form` alongside the `clojure-mode` variable.
 - [#4139](https://github.com/clojure-emacs/cider/pull/4139): Fix source-based find-usages (`M-?`) missing alias- and namespace-qualified references (e.g. `m/foo`), so a var used through its alias from other namespaces is now found, not just the bare occurrences in its defining namespace.

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -1214,12 +1214,28 @@ namespace itself."
     (ignore-errors
       (clojure-forward-logical-sexp 1)
       (let ((out nil)
-            (end (point)))
+            (end (point))
+            (or-regions nil))
         (forward-sexp -1)
-        ;; FIXME: This returns locals found inside the :or clause of a
-        ;; destructuring map.
+        ;; Record the bounds of any `:or' default maps.  Their contents are
+        ;; default *expressions* (references, not locals); the bound names
+        ;; come from the `:keys'/`:syms'/... side of the same destructuring
+        ;; form, so we skip anything found inside these regions below.
+        (save-excursion
+          (while (search-forward-regexp "\\_<:or\\_>" end 'noerror)
+            (ignore-errors
+              (let ((start (point)))
+                (forward-sexp 1)
+                (push (cons start (point)) or-regions)))))
         (while (search-forward-regexp "\\_<[^:&]\\(\\sw\\|\\s_\\)*\\_>" end 'noerror)
-          (push (match-string-no-properties 0) out))
+          (let ((beg (match-beginning 0))
+                (fin (match-end 0))
+                (in-or-map nil))
+            (dolist (region or-regions)
+              (when (and (>= beg (car region)) (<= fin (cdr region)))
+                (setq in-or-map t)))
+            (unless in-or-map
+              (push (match-string-no-properties 0) out))))
         out))))
 
 (defun cider--read-locals-from-bindings-vector ()

--- a/test/cider-locals-tests.el
+++ b/test/cider-locals-tests.el
@@ -74,6 +74,11 @@
     (cider--test-with-content ("[a |^ints {:keys [my nombre]} c]"
                                "[a |^:type-hint #macro {:keys [my nombre]} c]")
         ("my" "nombre")
+      (cider--read-locals-from-next-sexp)))
+
+  (it "skips the default expressions in an :or destructuring clause"
+    (cider--test-with-content ("|{:keys [a b] :or {a (default-a) b some-ref}}")
+        ("a" "b")
       (cider--read-locals-from-next-sexp))))
 
 


### PR DESCRIPTION
From the inline-FIXME sweep. The dynamic font-lock locals scanner (`cider--read-locals-from-next-sexp`) collected every symbol in a destructuring form, so the *default expressions* in an `:or` clause were mistaken for locals - e.g. in `{:keys [x] :or {x (some-default)}}`, `some-default` was treated as a local and lost its dynamic highlighting.

Now the scanner records the bounds of `:or` default maps and skips symbols inside them; the bound names still come from the `:keys`/`:syms`/... side of the form. No-op when there's no `:or`.