### PR TITLE
Fix cursor-position warts in the form-targeting commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,9 @@
 
 ### Bugs fixed
 
+- [#4155](https://github.com/clojure-emacs/cider/pull/4155): `cider-format-edn-last-sexp` now formats the sexp preceding point, as its name says, instead of the (possibly partial) sexp at point.
+- [#4155](https://github.com/clojure-emacs/cider/pull/4155): `cider-sexp-at-point` treats a closing delimiter as part of the form it closes and keeps leading metadata; this fixes `cider-eval-sexp-at-point` and `cider-tap-sexp-at-point` evaluating a lone trailing atom when invoked on a closing paren.
+- [#4155](https://github.com/clojure-emacs/cider/pull/4155): The point-based eval commands (`cider-eval-sexp-at-point`, `cider-eval-list-at-point` and friends) signal a proper `user-error` instead of crashing when there's no form at point.
 - [#4107](https://github.com/clojure-emacs/cider/pull/4107): Route stdin input (and a cancel's interrupt) to the exact connection that requested it, so reads no longer misroute when several connections are active.
 - [#4106](https://github.com/clojure-emacs/cider/pull/4106): Cancelling a stdin prompt now interrupts the evaluation, instead of sending a value nREPL treated as EOF and letting the evaluation continue.
 - [#4093](https://github.com/clojure-emacs/cider/pull/4093): Fix a crash (`wrong-type-argument stringp nil`) when a REPL result is truncated by the print middleware.
@@ -120,6 +123,7 @@
 
 ### Changes
 
+- [#4155](https://github.com/clojure-emacs/cider/pull/4155): `cider-eval-defun-at-point` (`C-c C-c`/`C-M-x`) now evaluates the enclosed form when invoked inside a `comment` block, matching `cider-eval-dwim` and other Clojure editors.
 - [#4002](https://github.com/clojure-emacs/cider/pull/4002), [#4050](https://github.com/clojure-emacs/cider/pull/4050): Bump the injected `cider-nrepl` from 0.59.0 to [0.62.1](https://github.com/clojure-emacs/cider-nrepl/blob/v0.62.1/CHANGELOG.md#0621-2026-07-15) (and `piggieback` to 0.7.0); besides backing many of the features above, the new middleware honors the project's cljfmt configuration when formatting and carries a batch of debugger fixes.
 - Enable rich content in the REPL by default (`cider-repl-use-content-types` is now `t`): image results render inline, and external content (files, URLs) renders a `[show content]` button that fetches only on demand - the automatic fetching that got the feature disabled back in 0.25 ([#2825](https://github.com/clojure-emacs/cider/issues/2825)) is gone, and the server side is hardened in `cider-nrepl` 0.62.
 - [#4092](https://github.com/clojure-emacs/cider/pull/4092), [#4093](https://github.com/clojure-emacs/cider/pull/4093): Clean up the REPL's keybindings: the source-buffer eval keys no longer run the source-buffer eval path there (`C-x C-e` is a no-op at the REPL; evaluate at the prompt instead), `C-c M-m` now opens the macroexpand menu (matching `cider-mode`), and `C-c C-r` no longer injects clojure-mode's source-editing refactor map.

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -926,7 +926,8 @@ buffer."
 If invoked with OUTPUT-TO-CURRENT-BUFFER, output the result to current buffer."
   (interactive "P")
   (save-excursion
-    (goto-char (cadr (cider-list-at-point 'bounds)))
+    (goto-char (cadr (or (cider-list-at-point 'bounds)
+                         (user-error "No list at point"))))
     (cider-eval-last-sexp output-to-current-buffer)))
 
 (defun cider-eval-sexp-at-point (&optional output-to-current-buffer)
@@ -934,7 +935,8 @@ If invoked with OUTPUT-TO-CURRENT-BUFFER, output the result to current buffer."
 If invoked with OUTPUT-TO-CURRENT-BUFFER, output the result to current buffer."
   (interactive "P")
   (save-excursion
-    (goto-char (cadr (cider-sexp-at-point 'bounds)))
+    (goto-char (cadr (or (cider-sexp-at-point 'bounds)
+                         (user-error "No sexp at point"))))
     (cider-eval-last-sexp output-to-current-buffer)))
 
 (defun cider-tap-last-sexp (&optional output-to-current-buffer)
@@ -953,7 +955,8 @@ buffer."
 If invoked with OUTPUT-TO-CURRENT-BUFFER, output the result to current buffer."
   (interactive "P")
   (save-excursion
-    (goto-char (cadr (cider-sexp-at-point 'bounds)))
+    (goto-char (cadr (or (cider-sexp-at-point 'bounds)
+                         (user-error "No sexp at point"))))
     (cider-tap-last-sexp output-to-current-buffer)))
 
 (defvar-local cider-previous-eval-context nil
@@ -1016,7 +1019,9 @@ The context is remembered between command invocations.
 When GUESS is non-nil, or called interactively with \\[universal-argument],
 attempt to extract the context from parent let-bindings."
   (interactive "P")
-  (cider--eval-in-context (cider-sexp-at-point 'bounds) guess))
+  (cider--eval-in-context (or (cider-sexp-at-point 'bounds)
+                              (user-error "No sexp at point"))
+                          guess))
 
 (defun cider-eval-defun-to-comment (&optional insert-before)
   "Evaluate the \"top-level\" form and insert result as comment.

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -1296,6 +1296,8 @@ inside a `comment' form picks up the enclosed form."
 
 (defun cider-eval-defun-at-point (&optional debug-it)
   "Evaluate the current toplevel form, and print result in the minibuffer.
+Inside a `comment' form the enclosed form is treated as the toplevel one,
+matching `cider-eval-dwim'.
 With DEBUG-IT prefix argument, also debug the entire form as with the
 command `cider-debug-defun-at-point'."
   (interactive "P")
@@ -1307,11 +1309,13 @@ command `cider-debug-defun-at-point'."
         (user-error "The debugger does not support ClojureScript"))
       (when inline-debug
         (cider--prompt-and-insert-inline-dbg)))
-    (cider-interactive-eval (when (and debug-it (not inline-debug))
-                              (concat "#dbg\n" (cider-defun-at-point)))
-                            nil
-                            (cider-defun-at-point 'bounds)
-                            (cider--nrepl-pr-request-plist))))
+    (let ((clojure-toplevel-inside-comment-form t)
+          (clojure-ts-toplevel-inside-comment-form t))
+      (cider-interactive-eval (when (and debug-it (not inline-debug))
+                                (concat "#dbg\n" (cider-defun-at-point)))
+                              nil
+                              (cider-defun-at-point 'bounds)
+                              (cider--nrepl-pr-request-plist)))))
 
 (defun cider--insert-closing-delimiters (code)
   "Closes all open parenthesized or bracketed expressions of CODE."

--- a/lisp/cider-format.el
+++ b/lisp/cider-format.el
@@ -158,11 +158,11 @@ START and END represent the region's boundaries."
 
 ;;;###autoload
 (defun cider-format-edn-last-sexp ()
-  "Format the EDN data of the last sexp."
+  "Format the EDN data of the sexp preceding point."
   (interactive)
-  (if-let* ((bounds (cider-sexp-at-point 'bounds)))
+  (if-let* ((bounds (ignore-errors (cider-last-sexp 'bounds))))
       (apply #'cider-format-edn-region bounds)
-    (user-error "No sexp at point")))
+    (user-error "No sexp preceding point")))
 
 (provide 'cider-format)
 ;;; cider-format.el ends here

--- a/lisp/cider-util.el
+++ b/lisp/cider-util.el
@@ -261,19 +261,46 @@ keywords."
 
 
 ;;; sexp navigation
+(defun cider--include-leading-metadata (b)
+  "Extend the bounds cons B backwards over leading ^metadata, if any.
+The `thing-at-point' machinery doesn't know Clojure metadata belongs to
+the form it annotates; `clojure-backward-logical-sexp' does."
+  (let ((logical-start (ignore-errors
+                         (save-excursion
+                           (goto-char (cdr b))
+                           (clojure-backward-logical-sexp 1)
+                           (point)))))
+    (if (and logical-start
+             (< logical-start (car b))
+             (eq (char-after logical-start) ?^))
+        (cons logical-start (cdr b))
+      b)))
+
 (defun cider-sexp-at-point (&optional bounds)
   "Return the sexp at point as a string, otherwise nil.
+When point is on a closing delimiter, this is the sexp it closes; leading
+metadata is considered part of the sexp.
 If BOUNDS is non-nil, return a list of its starting and ending position
 instead."
-  (when-let* ((b (or (and (equal (char-after) ?\()
-                          (member (char-before) '(?\' ?\, ?\@))
-                          ;; hide stuff before ( to avoid quirks with '( etc.
-                          (save-restriction
-                            (narrow-to-region (point) (point-max))
-                            (bounds-of-thing-at-point 'sexp)))
-                     (bounds-of-thing-at-point 'sexp))))
-    (funcall (if bounds #'list #'buffer-substring-no-properties)
-             (car b) (cdr b))))
+  (when-let* ((b (cond
+                  ;; on a closing delimiter: the form it closes
+                  ((eq (char-syntax (or (char-after) ?\s)) ?\))
+                   (ignore-errors
+                     (save-excursion
+                       (up-list 1)
+                       (let ((end (point)))
+                         (backward-sexp 1)
+                         (cons (point) end)))))
+                  ;; hide stuff before ( to avoid quirks with '( etc.
+                  ((and (equal (char-after) ?\()
+                        (member (char-before) '(?\' ?\, ?\@)))
+                   (save-restriction
+                     (narrow-to-region (point) (point-max))
+                     (bounds-of-thing-at-point 'sexp)))
+                  (t (bounds-of-thing-at-point 'sexp)))))
+    (let ((b (cider--include-leading-metadata b)))
+      (funcall (if bounds #'list #'buffer-substring-no-properties)
+               (car b) (cdr b)))))
 
 (defun cider-list-at-point (&optional bounds)
   "Return the list (compound form) at point as a string, otherwise nil.

--- a/test/cider-eval-tests.el
+++ b/test/cider-eval-tests.el
@@ -700,3 +700,12 @@
       (cider-eval-dwim)
       (expect seen-clj :to-be t)
       (expect seen-ts :to-be t))))
+
+(describe "cider-eval-defun-at-point"
+  (it "targets the enclosed form inside a comment form, like cider-eval-dwim"
+    (spy-on 'cider-interactive-eval)
+    (with-clojure-buffer "(comment (+ 1| 2))"
+      (cider-eval-defun-at-point)
+      (let ((bounds (nth 2 (spy-calls-args-for 'cider-interactive-eval 0))))
+        (expect (apply #'buffer-substring-no-properties bounds)
+                :to-equal "(+ 1 2)")))))

--- a/test/cider-eval-tests.el
+++ b/test/cider-eval-tests.el
@@ -193,6 +193,26 @@
           (clojure-mode)
           (expect (cider-interactive-eval "(+ 1)") :not :to-throw))))))
 
+(describe "the point-based eval commands with no form at point"
+  ;; These used to crash with (wrong-type-argument integer-or-marker-p nil)
+  ;; when the respective primitive found nothing (e.g. an empty buffer, or
+  ;; right after a top-level form for `cider-eval-list-at-point').
+  (it "cider-eval-sexp-at-point signals a user-error"
+    (with-clojure-buffer ""
+      (expect (cider-eval-sexp-at-point) :to-throw 'user-error)))
+
+  (it "cider-tap-sexp-at-point signals a user-error"
+    (with-clojure-buffer ""
+      (expect (cider-tap-sexp-at-point) :to-throw 'user-error)))
+
+  (it "cider-eval-sexp-at-point-in-context signals a user-error"
+    (with-clojure-buffer ""
+      (expect (cider-eval-sexp-at-point-in-context nil) :to-throw 'user-error)))
+
+  (it "cider-eval-list-at-point signals a user-error right after a top-level form"
+    (with-clojure-buffer "(foo 1)|"
+      (expect (cider-eval-list-at-point) :to-throw 'user-error))))
+
 (describe "cider--comment-format"
   (it "returns the configured prefixes for the `line' style"
     (let ((cider-comment-style 'line)

--- a/test/cider-format-tests.el
+++ b/test/cider-format-tests.el
@@ -29,6 +29,7 @@
 
 (require 'buttercup)
 (require 'cider-format)
+(require 'cider-test-utils)
 
 ;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
 
@@ -50,9 +51,27 @@
               :to-equal "(def s \"a\nb\")"))))
 
 (describe "cider-format-edn-last-sexp"
-  (it "signals a user-error when there is no sexp at point"
-    (spy-on 'cider-sexp-at-point :and-return-value nil)
-    (expect (cider-format-edn-last-sexp) :to-throw 'user-error)))
+  (it "formats the sexp preceding point"
+    (spy-on 'cider-format-edn-region)
+    (with-clojure-buffer "{:a 1}|"
+      (cider-format-edn-last-sexp)
+      (expect 'cider-format-edn-region :to-have-been-called-with 1 7)))
+
+  (it "targets the preceding sexp, not the one ahead"
+    (spy-on 'cider-format-edn-region)
+    (with-clojure-buffer "{:a 1} |{:b 2}"
+      (cider-format-edn-last-sexp)
+      (expect 'cider-format-edn-region :to-have-been-called-with 1 7)))
+
+  (it "keeps leading metadata"
+    (spy-on 'cider-format-edn-region)
+    (with-clojure-buffer "^:foo {:a 1}|"
+      (cider-format-edn-last-sexp)
+      (expect 'cider-format-edn-region :to-have-been-called-with 1 13)))
+
+  (it "signals a user-error in an empty buffer"
+    (with-clojure-buffer ""
+      (expect (cider-format-edn-last-sexp) :to-throw 'user-error))))
 
 (provide 'cider-format-tests)
 

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -221,14 +221,21 @@
       (with-clojure-buffer ""
         (expect (cider-sexp-at-point) :to-equal nil)))
 
-    ;; Pinned warts, fixed later in this PR:
-    (it "returns the last atom inside when on a closing paren"
+    (it "returns the closed form when on a closing paren"
       (with-clojure-buffer "(foo (bar 1|) baz)"
-        (expect (cider-sexp-at-point) :to-equal "1")))
+        (expect (cider-sexp-at-point) :to-equal "(bar 1)")))
 
-    (it "drops leading metadata"
+    (it "returns the closed form when on the closing delimiter of a map"
+      (with-clojure-buffer "{:a 1|}"
+        (expect (cider-sexp-at-point) :to-equal "{:a 1}")))
+
+    (it "keeps leading metadata"
       (with-clojure-buffer "^:foo (bar)|"
-        (expect (cider-sexp-at-point) :to-equal "(bar)")))))
+        (expect (cider-sexp-at-point) :to-equal "^:foo (bar)")))
+
+    (it "keeps leading metadata when on the closing paren"
+      (with-clojure-buffer "^:foo (bar|)"
+        (expect (cider-sexp-at-point) :to-equal "^:foo (bar)")))))
 
 (describe "cider-last-sexp"
   (describe "when the param 'bounds is not given"

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -171,7 +171,20 @@
       (with-clojure-buffer "(1 2 3|)"
         (delete-char -1)
         (insert "'")
-        (expect (cider-list-at-point 'bounds) :to-equal '(1 8))))))
+        (expect (cider-list-at-point 'bounds) :to-equal '(1 8)))))
+
+  (describe "across cursor positions"
+    (it "returns the enclosing list from inside an atom"
+      (with-clojure-buffer "(foo (b|ar 1) baz)"
+        (expect (cider-list-at-point) :to-equal "(bar 1)")))
+
+    (it "returns the enclosing list right after a nested closing paren"
+      (with-clojure-buffer "(foo (bar 1)| baz)"
+        (expect (cider-list-at-point) :to-equal "(foo (bar 1) baz)")))
+
+    (it "returns nil right after a top-level form"
+      (with-clojure-buffer "(foo 1)|"
+        (expect (cider-list-at-point) :to-equal nil)))))
 
 (describe "cider-sexp-at-point"
   (describe "when the param 'bounds is not given"
@@ -189,7 +202,33 @@
       (with-clojure-buffer "a\n\n,|(defn ...)\n\nb"
         (delete-char -1)
         (insert "'")
-        (expect (cider-sexp-at-point 'bounds) :to-equal '(5 15))))))
+        (expect (cider-sexp-at-point 'bounds) :to-equal '(5 15)))))
+
+  (describe "across cursor positions"
+    (it "returns the form ahead when on its opening paren"
+      (with-clojure-buffer "(foo |(bar 1) baz)"
+        (expect (cider-sexp-at-point) :to-equal "(bar 1)")))
+
+    (it "returns the atom at point when inside one"
+      (with-clojure-buffer "(foo (b|ar 1) baz)"
+        (expect (cider-sexp-at-point) :to-equal "bar")))
+
+    (it "returns the preceding form right after its closing paren"
+      (with-clojure-buffer "(foo (bar 1)| baz)"
+        (expect (cider-sexp-at-point) :to-equal "(bar 1)")))
+
+    (it "returns nil in an empty buffer"
+      (with-clojure-buffer ""
+        (expect (cider-sexp-at-point) :to-equal nil)))
+
+    ;; Pinned warts, fixed later in this PR:
+    (it "returns the last atom inside when on a closing paren"
+      (with-clojure-buffer "(foo (bar 1|) baz)"
+        (expect (cider-sexp-at-point) :to-equal "1")))
+
+    (it "drops leading metadata"
+      (with-clojure-buffer "^:foo (bar)|"
+        (expect (cider-sexp-at-point) :to-equal "(bar)")))))
 
 (describe "cider-last-sexp"
   (describe "when the param 'bounds is not given"
@@ -206,7 +245,22 @@
         (expect (cider-last-sexp 'bounds) :to-equal '(4 14))))
     (it "returns the bounds of last sexp event when there are whitespaces"
       (with-clojure-buffer "a\n\n(defn ...) ,\n|\nb"
-        (expect (cider-last-sexp 'bounds) :to-equal '(4 14))))))
+        (expect (cider-last-sexp 'bounds) :to-equal '(4 14)))))
+
+  (describe "across cursor positions"
+    (it "keeps leading metadata, unlike `cider-sexp-at-point'"
+      (with-clojure-buffer "^:foo (bar)|"
+        (expect (cider-last-sexp) :to-equal "^:foo (bar)")))
+
+    (it "keeps a leading quote"
+      (with-clojure-buffer "'(1 2 3)|"
+        (expect (cider-last-sexp) :to-equal "'(1 2 3)")))
+
+    (it "returns the following form at the beginning of the buffer"
+      ;; backward motion no-ops at (point-min), so the \"preceding\" sexp
+      ;; is the one ahead -- forgiving, and relied upon by callers
+      (with-clojure-buffer "|(foo 1)"
+        (expect (cider-last-sexp) :to-equal "(foo 1)")))))
 
 (describe "cider-defun-at-point"
   (describe "when the param 'bounds is not given"


### PR DESCRIPTION
A sweep of how commands pick the form they operate on turned up a few outright bugs, fixed here (the broader targeting-consistency work will build on these):

- `cider-format-edn-last-sexp` said "last sexp" but used the sexp at point, so inside a data structure it formatted a lone atom.
- The point-based eval commands crashed with a raw `wrong-type-argument` when no form was found - trivially reachable for `cider-eval-list-at-point` right after a top-level form.
- `cider-sexp-at-point` on a closing paren grabbed the last atom inside the form instead of the form itself, and silently dropped leading `^metadata`.
- `C-c C-c` inside a `(comment ...)` block evaluated the whole block to nil, while `cider-eval-dwim` picked up the enclosed form; the two now agree (and match Calva/Cursive/Tutkain).

The first commit pins the primitives' behavior across cursor positions, so the fixes show up as explicit diffs against that baseline.