### PR TITLE
Add cider-form-targeting for cursor-position-forgiving commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### New features
 
+- [#4156](https://github.com/clojure-emacs/cider/pull/4156): Add `cider-form-targeting`: when set to `smart`, the `last-sexp` commands (`cider-eval-last-sexp`, `cider-macroexpand-1`, `cider-inspect-last-sexp`, etc.) resolve their target form from the cursor position (on a delimiter, inside a form) instead of requiring point to sit right after it; the default `preceding` keeps the classic behavior.
 - [#4142](https://github.com/clojure-emacs/cider/pull/4142): Bring CIDER's dynamic font-locking (highlighting REPL-defined macros, functions, vars and deprecated/instrumented/traced symbols) to `clojure-ts-mode` buffers via tree-sitter; previously it only worked under `clojure-mode`.
 - [#4145](https://github.com/clojure-emacs/cider/pull/4145): Add `cider-preferred-clojure-mode` (default `auto`) controlling which Clojure major mode CIDER uses to font-lock the code it renders (REPL input/results, doc examples, overlays, xref labels, etc.); when set to (or auto-detecting) `clojure-ts-mode`, those snippets get tree-sitter highlighting instead of `clojure-mode`'s.
 - [#4146](https://github.com/clojure-emacs/cider/pull/4146): Have CIDER's own Clojure display buffers (macroexpansion, evaluation results, tracing) honor `cider-preferred-clojure-mode` too, so they open in `clojure-ts-mode` when that's your preference instead of always `clojure-mode`.

--- a/doc/modules/ROOT/pages/usage/code_evaluation.adoc
+++ b/doc/modules/ROOT/pages/usage/code_evaluation.adoc
@@ -19,6 +19,35 @@ confusing to people not familiar with it. Let's take a look at it:
 * `region` - the selected part of a buffer
 * `load` - a synonym for "evaluate"; most often used in the context of buffers/files
 
+== Form Targeting
+
+By default the `last-sexp` family of commands (`cider-eval-last-sexp`,
+`cider-macroexpand-1`, `cider-inspect-last-sexp`, etc) operates on the form
+preceding the cursor, so you have to place the cursor right after the form
+you're interested in. That's the classic behavior shared with Emacs Lisp's
+`eval-last-sexp`, SLIME and inf-clojure, but it can be unforgiving when the
+cursor sits on one of the form's delimiters, or inside it.
+
+You can make those commands resolve the target form from the cursor position
+instead:
+
+[source,lisp]
+----
+(setq cider-form-targeting 'smart)
+----
+
+With `smart` targeting: on an opening delimiter the target is the form it
+opens; on (or right after) a closing delimiter the form it closes; inside a
+symbol, keyword or string that atom; and in whitespace between forms the
+preceding form, as before. In other words - smart targeting agrees with the
+classic behavior at every position where "the form preceding the cursor" makes
+sense, and does something more useful everywhere else. (that's also how most
+non-Emacs Clojure editors handle evaluation targeting)
+
+Commands that can only operate on compound forms (e.g. the macroexpansion
+ones) never target a bare symbol - with smart targeting they widen to the
+enclosing form instead.
+
 == Basic Evaluation
 
 As CIDER derives almost all of its functionality by inspecting the runtime (REPL) state

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -898,6 +898,7 @@ arguments and only proceed with evaluation if it returns nil."
 
 (defun cider-eval-last-sexp (&optional output-to-current-buffer)
   "Evaluate the expression preceding point.
+How the expression is located is controlled by `cider-form-targeting'.
 If invoked with OUTPUT-TO-CURRENT-BUFFER, print the result in the current
 buffer."
   (interactive "P")
@@ -907,15 +908,15 @@ buffer."
                           (cider--nrepl-pr-request-plist)))
 
 (defun cider-eval-last-sexp-and-replace ()
-  "Evaluate the expression preceding point and replace it with its result."
+  "Evaluate the expression preceding point and replace it with its result.
+How the expression is located is controlled by `cider-form-targeting'."
   (interactive)
-  (let ((last-sexp (cider-last-sexp)))
+  (let* ((bounds (cider-form-bounds))
+         (last-sexp (apply #'buffer-substring-no-properties bounds)))
     ;; we have to be sure the evaluation won't result in an error
     (cider-nrepl-sync-request:eval last-sexp)
     ;; seems like the sexp is valid, so we can safely kill it
-    (let ((opoint (point)))
-      (clojure-backward-logical-sexp)
-      (kill-region (point) opoint))
+    (apply #'kill-region bounds)
     (cider-interactive-eval last-sexp
                             (cider-eval-print-handler)
                             nil
@@ -941,6 +942,7 @@ If invoked with OUTPUT-TO-CURRENT-BUFFER, output the result to current buffer."
 
 (defun cider-tap-last-sexp (&optional output-to-current-buffer)
   "Evaluate and tap the expression preceding point.
+How the expression is located is controlled by `cider-form-targeting'.
 If invoked with OUTPUT-TO-CURRENT-BUFFER, print the result in the current
 buffer."
   (interactive "P")
@@ -1214,6 +1216,7 @@ honoring SWITCH-TO-REPL, REQUEST-MAP."
 
 (defun cider-eval-last-sexp-to-repl (&optional prefix)
   "Evaluate the expression preceding point and insert its result in the REPL.
+How the expression is located is controlled by `cider-form-targeting'.
 If invoked with a PREFIX argument, switch to the REPL buffer."
   (interactive "P")
   (cider--eval-last-sexp-to-repl prefix (cider--nrepl-pr-request-plist)))
@@ -1227,6 +1230,7 @@ If invoked with a PREFIX argument, switch to the REPL buffer."
 (defun cider-eval-print-last-sexp (&optional pretty-print)
   "Evaluate the expression preceding point.
 Print its value into the current buffer.
+How the expression is located is controlled by `cider-form-targeting'.
 With an optional PRETTY-PRINT prefix it pretty-prints the result."
   (interactive "P")
   (cider-interactive-eval nil
@@ -1249,6 +1253,7 @@ With an optional PRETTY-PRINT prefix it pretty-prints the result."
 
 (defun cider-pprint-eval-last-sexp (&optional output-to-current-buffer)
   "Evaluate the sexp preceding point and pprint its value.
+How the sexp is located is controlled by `cider-form-targeting'.
 If invoked with OUTPUT-TO-CURRENT-BUFFER, insert as comment in the current
 buffer, else display in a popup buffer."
   (interactive "P")

--- a/lisp/cider-format.el
+++ b/lisp/cider-format.el
@@ -158,7 +158,8 @@ START and END represent the region's boundaries."
 
 ;;;###autoload
 (defun cider-format-edn-last-sexp ()
-  "Format the EDN data of the sexp preceding point."
+  "Format the EDN data of the sexp preceding point.
+How the sexp is located is controlled by `cider-form-targeting'."
   (interactive)
   (if-let* ((bounds (ignore-errors (cider-last-sexp 'bounds))))
       (apply #'cider-format-edn-region bounds)

--- a/lisp/cider-inspector.el
+++ b/lisp/cider-inspector.el
@@ -290,6 +290,7 @@ This lets the inspector act on the tagged class directly, the way
 
 (defun cider-inspect-last-sexp ()
   "Inspect the result of the expression preceding point.
+How the expression is located is controlled by `cider-form-targeting'.
 When point is on a type tag (e.g. `^String'), inspect the tagged class
 itself rather than the form it applies to."
   (interactive)

--- a/lisp/cider-macroexpansion.el
+++ b/lisp/cider-macroexpansion.el
@@ -113,16 +113,17 @@ ARG is passed along to `undo-only'."
     (cider-initialize-macroexpansion-buffer expansion (cider-current-ns))))
 
 (defun cider-macroexpansion--form-bounds ()
-  "Return the bounds (BEG . END) of the sexp before point, or nil.
-This follows CIDER's usual convention (like `\\[cider-eval-last-sexp]'): place
-point right after the form.  To drill into a nested macro call in an
-expansion, put point after that form and expand again."
-  (save-excursion
-    (ignore-errors
-      (let ((beg (progn (clojure-backward-logical-sexp 1) (point)))
-            (end (progn (clojure-forward-logical-sexp 1) (point))))
-        (when (< beg end)
-          (cons beg end))))))
+  "Return the bounds (BEG . END) of the sexp to expand, or nil.
+The sexp is located per `cider-form-targeting' (by default the sexp
+before point, like `\\[cider-eval-last-sexp]').  With `smart' targeting
+the target is never narrower than a compound form, since a bare symbol
+is not expandable."
+  (ignore-errors
+    ;; `compound' because a bare symbol is not expandable - with smart
+    ;; targeting, point mid-symbol targets the enclosing call instead.
+    (let ((b (cider-form-bounds 'compound)))
+      (when (< (car b) (cadr b))
+        (cons (car b) (cadr b))))))
 
 (defun cider-macroexpansion--operator (form)
   "Return the operator (leading symbol) of the Clojure FORM string, or nil."
@@ -158,10 +159,14 @@ display options (see `cider-macroexpansion-display-namespaces' and
 ;;;###autoload
 (defun cider-macroexpand-1 (&optional prefix)
   "Invoke \\=`macroexpand-1\\=` on the expression preceding point.
+The expression is located per `cider-form-targeting'; with `smart'
+targeting it is never narrower than a compound form.
 If invoked with a PREFIX argument, use \\=`macroexpand\\=` instead of
 \\=`macroexpand-1\\=`."
   (interactive "P")
-  (let ((form (cider-last-sexp))
+  ;; `compound' because a bare symbol is not expandable - with smart
+  ;; targeting, point mid-symbol targets the enclosing call instead.
+  (let ((form (cider-form-string 'compound))
         (expander (if prefix "macroexpand" "macroexpand-1")))
     (cider-ensure-macro (cider-macroexpansion--operator form))
     (cider-macroexpand-expr expander form)))
@@ -177,10 +182,12 @@ If invoked with a PREFIX argument, use \\=`macroexpand\\=` instead of
 ;;;###autoload
 (defun cider-macroexpand-all ()
   "Invoke \\=`macroexpand-all\\=` on the expression preceding point.
+The expression is located per `cider-form-targeting'.
 The form's head needn't be a macro itself, since a fully-recursive
 expansion can reach macros in nested sub-forms."
   (interactive)
-  (cider-macroexpand-expr "macroexpand-all" (cider-last-sexp)))
+  ;; `compound' for the same reason as in `cider-macroexpand-1'
+  (cider-macroexpand-expr "macroexpand-all" (cider-form-string 'compound)))
 
 (defun cider-macroexpand-all-inplace ()
   "Perform inplace \\=`macroexpand-all\\=` on the form before point."

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -287,6 +287,7 @@ If EVAL is non-nil the form will also be evaluated.  Use
 
 (defun cider-insert-last-sexp-in-repl (&optional arg)
   "Insert the expression preceding point in the REPL buffer.
+How the expression is located is controlled by `cider-form-targeting'.
 If invoked with a prefix ARG eval the expression after inserting it."
   (interactive "P")
   (cider-insert-in-repl (cider-last-sexp) arg))

--- a/lisp/cider-util.el
+++ b/lisp/cider-util.el
@@ -316,16 +316,107 @@ instead."
     (funcall (if bounds #'list #'buffer-substring-no-properties)
              (car b) (cdr b))))
 
+(defcustom cider-form-targeting 'preceding
+  "How commands locate the form they operate on.
+
+`preceding' is the classic behavior: the target is the sexp before
+point, so point must sit right after the form (like `eval-last-sexp'
+in Emacs Lisp).
+
+`smart' resolves the intended form from the cursor position: on an
+opening delimiter it targets the form it opens, on a closing delimiter
+the form it closes, inside an atom or string that atom, and otherwise
+the sexp preceding point.  It agrees with `preceding' at every position
+where the preceding sexp is well-defined, and only differs where the
+classic answer was surprising (e.g. point sitting on a delimiter).
+
+Consulted by `cider-eval-last-sexp', `cider-macroexpand-1' and the rest
+of the commands that operate on the preceding sexp."
+  :group 'cider
+  :type '(choice (const :tag "Classic: the sexp preceding point" preceding)
+                 (const :tag "Smart: infer the form from the cursor position" smart))
+  :package-version '(cider . "2.0.0"))
+
+(defun cider--preceding-form-bounds ()
+  "Return the bounds (START . END) of the logical sexp preceding point."
+  (save-excursion
+    (clojure-backward-logical-sexp 1)
+    (cons (point)
+          (progn (clojure-forward-logical-sexp 1)
+                 (point)))))
+
+(defun cider--smart-form-bounds (&optional min)
+  "Return the bounds (START . END) of the form point targets, resolved smartly.
+See `cider-form-targeting' for the resolution rules.  When MIN is the
+symbol `compound' and the resolved target is an atom or a string, widen
+to the enclosing compound form, if there is one."
+  (let* ((ppss (syntax-ppss))
+         (b (cond
+             ;; inside a string: the string literal is the form
+             ((nth 3 ppss)
+              (let ((start (nth 8 ppss)))
+                (cons start (save-excursion
+                              (goto-char start)
+                              (forward-sexp 1)
+                              (point)))))
+             ;; right after a closing delimiter: the form just closed
+             ((eq (char-syntax (or (char-before) ?\s)) ?\))
+              (cider--preceding-form-bounds))
+             ;; on an opening delimiter: the form it opens
+             ((eq (char-syntax (or (char-after) ?\s)) ?\()
+              (cons (point) (save-excursion (forward-sexp 1) (point))))
+             ;; on a closing delimiter: the form it closes
+             ((eq (char-syntax (or (char-after) ?\s)) ?\))
+              (save-excursion
+                (up-list 1)
+                (let ((end (point)))
+                  (backward-sexp 1)
+                  (cons (point) end))))
+             ;; inside or right next to an atom: the atom
+             ((bounds-of-thing-at-point 'sexp))
+             ;; in whitespace between forms: the preceding sexp
+             (t (cider--preceding-form-bounds)))))
+    ;; A compound form (list, vector, map, set...) always ends in a
+    ;; closing delimiter, regardless of any reader-macro prefix; anything
+    ;; else is an atom-ish target that widens to its enclosing form when
+    ;; the caller asked for a compound one.
+    (if (and (eq min 'compound)
+             (not (eq (char-syntax (char-before (cdr b))) ?\)))
+             (nth 1 ppss))
+        (save-excursion
+          (goto-char (nth 1 ppss))
+          (cons (point) (progn (forward-sexp 1) (point))))
+      b)))
+
+(defun cider-form-bounds (&optional min)
+  "Return the list (START END) of the form point targets.
+Honors `cider-form-targeting'; with the default `preceding' targeting
+this is exactly the bounds of the sexp preceding point.
+MIN expresses a constraint of the operation itself, not a user
+preference: the symbol `compound' means the target should be no
+narrower than a compound form, since some operations (macroexpansion,
+notably) can only consume a call form, never a bare symbol.  It is
+only consulted by `smart' targeting; `preceding' targeting always
+returns the classic preceding sexp, atoms included."
+  (let ((b (if (eq cider-form-targeting 'smart)
+               (cider--smart-form-bounds min)
+             (cider--preceding-form-bounds))))
+    (list (car b) (cdr b))))
+
+(defun cider-form-string (&optional min)
+  "Return the text of the form point targets, per `cider-form-bounds'.
+MIN is passed to `cider-form-bounds'."
+  (apply #'buffer-substring-no-properties (cider-form-bounds min)))
+
 (defun cider-last-sexp (&optional bounds)
   "Return the sexp preceding the point.
 If BOUNDS is non-nil, return a list of its starting and ending position
-instead."
-  (apply (if bounds #'list #'buffer-substring-no-properties)
-         (save-excursion
-           (clojure-backward-logical-sexp 1)
-           (list (point)
-                 (progn (clojure-forward-logical-sexp 1)
-                        (point))))))
+instead.
+How the sexp is located is controlled by `cider-form-targeting': the
+default matches the classic behavior exactly, while `smart' also
+resolves the form when point sits on its delimiters or inside it."
+  (let ((b (cider-form-bounds)))
+    (if bounds b (apply #'buffer-substring-no-properties b))))
 
 (defun cider-start-of-next-sexp (&optional skip)
   "Move to the start of the next sexp.

--- a/test/cider-eval-tests.el
+++ b/test/cider-eval-tests.el
@@ -709,3 +709,34 @@
       (let ((bounds (nth 2 (spy-calls-args-for 'cider-interactive-eval 0))))
         (expect (apply #'buffer-substring-no-properties bounds)
                 :to-equal "(+ 1 2)")))))
+
+(describe "cider-eval-last-sexp under smart targeting"
+  (it "evaluates the form point sits on, not just the one behind it"
+    (spy-on 'cider-interactive-eval)
+    (with-clojure-buffer "(foo |(bar 1) baz)"
+      (let ((cider-form-targeting 'smart))
+        (cider-eval-last-sexp))
+      (let ((bounds (nth 2 (spy-calls-args-for 'cider-interactive-eval 0))))
+        (expect (apply #'buffer-substring-no-properties bounds)
+                :to-equal "(bar 1)"))))
+
+  (it "behaves classically by default"
+    (spy-on 'cider-interactive-eval)
+    (with-clojure-buffer "(foo |(bar 1) baz)"
+      (cider-eval-last-sexp)
+      (let ((bounds (nth 2 (spy-calls-args-for 'cider-interactive-eval 0))))
+        (expect (apply #'buffer-substring-no-properties bounds)
+                :to-equal "foo")))))
+
+(describe "cider-eval-last-sexp-and-replace"
+  (it "replaces the resolved form, not the region behind point"
+    (spy-on 'cider-nrepl-sync-request:eval)
+    (spy-on 'cider-interactive-eval)
+    (with-clojure-buffer "(+ 1 2|)"
+      (let ((cider-form-targeting 'smart))
+        (cider-eval-last-sexp-and-replace))
+      ;; under smart targeting, point on the closing paren targets the
+      ;; whole form, so the whole form is killed
+      (expect (buffer-string) :to-equal "")
+      (expect (nth 0 (spy-calls-args-for 'cider-interactive-eval 0))
+              :to-equal "(+ 1 2)"))))

--- a/test/cider-macroexpansion-tests.el
+++ b/test/cider-macroexpansion-tests.el
@@ -28,8 +28,27 @@
 (require 'clojure-mode)
 (require 'nrepl-dict)
 (require 'cider-macroexpansion)
+(require 'cider-test-utils)
 
 ;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
+
+(describe "cider-macroexpand-1's form targeting"
+  (it "expands the sexp preceding point by default"
+    (spy-on 'cider-ensure-macro)
+    (spy-on 'cider-macroexpand-expr)
+    (with-clojure-buffer "(when t 1)|"
+      (cider-macroexpand-1)
+      (expect 'cider-macroexpand-expr
+              :to-have-been-called-with "macroexpand-1" "(when t 1)")))
+
+  (it "expands the enclosing form from inside an atom under smart targeting"
+    (spy-on 'cider-ensure-macro)
+    (spy-on 'cider-macroexpand-expr)
+    (with-clojure-buffer "(when t| 1)"
+      (let ((cider-form-targeting 'smart))
+        (cider-macroexpand-1))
+      (expect 'cider-macroexpand-expr
+              :to-have-been-called-with "macroexpand-1" "(when t 1)"))))
 
 (describe "cider-sync-request:macroexpand"
   (it "sends the expander, code and namespace and returns the expansion"
@@ -147,7 +166,7 @@
   (it "doesn't require the form's head to be a macro"
     ;; #4111: a fully-recursive expansion can reach macros in nested
     ;; sub-forms, so the operator must not be gated.
-    (spy-on 'cider-last-sexp :and-return-value "(inc (when x 1))")
+    (spy-on 'cider-form-string :and-return-value "(inc (when x 1))")
     (spy-on 'cider-ensure-macro)
     (spy-on 'cider-macroexpand-expr)
     (cider-macroexpand-all)

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -267,7 +267,79 @@
       ;; backward motion no-ops at (point-min), so the \"preceding\" sexp
       ;; is the one ahead -- forgiving, and relied upon by callers
       (with-clojure-buffer "|(foo 1)"
-        (expect (cider-last-sexp) :to-equal "(foo 1)")))))
+        (expect (cider-last-sexp) :to-equal "(foo 1)")))
+
+    (it "returns the previous sibling when on an opening paren (classic)"
+      (with-clojure-buffer "(foo |(bar 1) baz)"
+        (expect (cider-last-sexp) :to-equal "foo")))))
+
+(describe "cider-form-targeting smart"
+  ;; positions where smart agrees with the classic preceding behavior
+  (it "matches classic targeting right after a form"
+    (with-clojure-buffer "(foo (bar 1)| baz)"
+      (let ((cider-form-targeting 'smart))
+        (expect (cider-last-sexp) :to-equal "(bar 1)"))))
+
+  (it "matches classic targeting in whitespace after a form"
+    (with-clojure-buffer "(foo bar |  baz)"
+      (let ((cider-form-targeting 'smart))
+        (expect (cider-last-sexp) :to-equal "bar"))))
+
+  (it "matches classic targeting for metadata"
+    (with-clojure-buffer "^:foo (bar)|"
+      (let ((cider-form-targeting 'smart))
+        (expect (cider-last-sexp) :to-equal "^:foo (bar)"))))
+
+  ;; positions where the classic answer was surprising
+  (it "targets the opened form when on an opening paren"
+    (with-clojure-buffer "(foo |(bar 1) baz)"
+      (let ((cider-form-targeting 'smart))
+        (expect (cider-last-sexp) :to-equal "(bar 1)"))))
+
+  (it "targets the closed form when on a closing paren"
+    (with-clojure-buffer "(foo (bar 1|) baz)"
+      (let ((cider-form-targeting 'smart))
+        (expect (cider-last-sexp) :to-equal "(bar 1)"))))
+
+  (it "targets the atom at point when inside one"
+    (with-clojure-buffer "(foo (b|ar 1) baz)"
+      (let ((cider-form-targeting 'smart))
+        (expect (cider-last-sexp) :to-equal "bar"))))
+
+  (it "targets the string literal when inside a string"
+    (with-clojure-buffer "(foo \"ba|r\" baz)"
+      (let ((cider-form-targeting 'smart))
+        (expect (cider-last-sexp) :to-equal "\"bar\""))))
+
+  (it "targets the adjacent form when right before one"
+    (with-clojure-buffer "(foo |bar baz)"
+      (let ((cider-form-targeting 'smart))
+        (expect (cider-last-sexp) :to-equal "bar")))))
+
+(describe "cider-form-string with the compound granularity"
+  (it "widens an atom target to the enclosing form under smart targeting"
+    (with-clojure-buffer "(when t| 1)"
+      (let ((cider-form-targeting 'smart))
+        (expect (cider-form-string 'compound) :to-equal "(when t 1)"))))
+
+  (it "widens a string target to the enclosing form under smart targeting"
+    (with-clojure-buffer "(foo \"ba|r\")"
+      (let ((cider-form-targeting 'smart))
+        (expect (cider-form-string 'compound) :to-equal "(foo \"bar\")"))))
+
+  (it "keeps a top-level atom that has no enclosing form"
+    (with-clojure-buffer "xy|z"
+      (let ((cider-form-targeting 'smart))
+        (expect (cider-form-string 'compound) :to-equal "xyz"))))
+
+  (it "does not widen an already-compound target"
+    (with-clojure-buffer "(foo (bar 1|) baz)"
+      (let ((cider-form-targeting 'smart))
+        (expect (cider-form-string 'compound) :to-equal "(bar 1)"))))
+
+  (it "is ignored under classic targeting"
+    (with-clojure-buffer "(when t| 1)"
+      (expect (cider-form-string 'compound) :to-equal "t"))))
 
 (describe "cider-defun-at-point"
   (describe "when the param 'bounds is not given"


### PR DESCRIPTION
The `last-sexp` commands require point to sit right after the form, and the classic answers at other cursor positions are never what anyone wants (previous sibling on an opening paren, last atom inside on a closing paren). Calva, Conjure, Tutkain and vim-fireplace all resolve the form from the cursor position; Emacs heritage is the odd one out here.

This adds a `cider-form-targeting` option consulted by the whole family (eval, macroexpand, inspect, tap, pprint, insert-in-repl, format-edn, etc). The default `preceding` is exactly the current behavior; `smart` resolves the form from delimiters and insides, and deliberately agrees with `preceding` at every position where "the sexp before point" is well-defined - it only differs where the classic answer was useless. No commands were renamed and none of the muscle-memory keys change behavior unless you opt in.

Macroexpansion asks the resolver for a `compound` target since a bare symbol isn't expandable - mid-symbol it widens to the enclosing call.

Builds on #4155; the manual's evaluation page has a new Form Targeting section. Flipping the default to `smart` is deliberately left for a later discussion once the option has seen some real use.