### PR TITLE
Make cider-doctor show actual - untruncated - Clojure version

### DIFF
--- a/lisp/cider-doctor.el
+++ b/lisp/cider-doctor.el
@@ -212,8 +212,8 @@ Probed by `cider-doctor--check-ops' to explain why a feature might be dead.")
 (defun cider-doctor--check-clojure-runtime ()
   "Check the connected runtime's Clojure version."
   (if-let* ((ver (cider--clojure-version))
-            (ver (car (split-string ver "-"))))
-      (if (version< ver cider-minimum-clojure-version)
+            (trunc-ver (car (split-string ver "-"))))
+      (if (version< trunc-ver cider-minimum-clojure-version)
           (cider-doctor--result 'error (format "Clojure %s is unsupported" ver)
                                 :detail (format "Minimum supported version is %s."
                                                 cider-minimum-clojure-version)

--- a/test/cider-doctor-tests.el
+++ b/test/cider-doctor-tests.el
@@ -137,7 +137,12 @@
 
   (it "strips qualifiers before comparing"
     (spy-on 'cider--clojure-version :and-return-value "1.12.0-master-SNAPSHOT")
-    (expect (plist-get (cider-doctor--check-clojure-runtime) :status) :to-be 'ok)))
+    (expect (plist-get (cider-doctor--check-clojure-runtime) :status) :to-be 'ok))
+
+  (it "return full version including qualifier"
+    (spy-on 'cider--clojure-version :and-return-value "1.13.0-alpha6")
+    (expect (plist-get (cider-doctor--check-clojure-runtime) :label)
+            :to-equal "Clojure 1.13.0-alpha6")))
 
 (describe "cider-doctor--check-middleware"
   (it "errors when no cider-nrepl version is reported"


### PR DESCRIPTION
`cider-doctor` reported
  ✓  Clojure 1.13.0
instead of
  ✓  Clojure 1.13.0-alpha6

`cider-minimum-clojure-version` is still compared to the truncated version string.

-----------------

- [✓] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [✓] You've added tests (if possible) to cover your change(s)
- [✓] All tests are passing (`eldev test`)