### PR TITLE
Detect running lein trampoline REPLs in cider-connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### Bugs fixed
 
 - [#4158](https://github.com/clojure-emacs/cider/pull/4158): Detect running `lein trampoline` REPLs in `cider-connect`'s port suggestions (the trampolined JVM has no "leiningen" marker for the process scan to find), and don't miss REPLs running without a controlling terminal.
+- [#4158](https://github.com/clojure-emacs/cider/pull/4158): Stop discarding `.nrepl-port` files on systems without `lsof` (absence of the tool is not evidence the port is dead), and only treat listening sockets as proof of a live server.
 - [#4152](https://github.com/clojure-emacs/cider/pull/4152): Stop the dynamic font-lock locals scanner from treating the default expressions in an `:or` destructuring clause (e.g. `{:keys [x] :or {x (some-default)}}`) as local variables, so references there keep their normal highlighting.
 - [#4150](https://github.com/clojure-emacs/cider/pull/4150): Stop dropping stray output from long-lived background processes (e.g. a `core.async` go-loop still printing under a finished eval's id): once that id is evicted from the completed-requests cache, its `out`/`err` is now routed to the REPL instead of being discarded with a "No response handler with id N found" warning.
 - [#4140](https://github.com/clojure-emacs/cider/pull/4140): Fix `cider-eval-dwim` (and defun evaluation) not descending into a `(comment ...)` form in `clojure-ts-mode` buffers: it now binds `clojure-ts-toplevel-inside-comment-form` alongside the `clojure-mode` variable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Bugs fixed
 
+- [#4158](https://github.com/clojure-emacs/cider/pull/4158): Detect running `lein trampoline` REPLs in `cider-connect`'s port suggestions (the trampolined JVM has no "leiningen" marker for the process scan to find), and don't miss REPLs running without a controlling terminal.
 - [#4152](https://github.com/clojure-emacs/cider/pull/4152): Stop the dynamic font-lock locals scanner from treating the default expressions in an `:or` destructuring clause (e.g. `{:keys [x] :or {x (some-default)}}`) as local variables, so references there keep their normal highlighting.
 - [#4150](https://github.com/clojure-emacs/cider/pull/4150): Stop dropping stray output from long-lived background processes (e.g. a `core.async` go-loop still printing under a finished eval's id): once that id is evicted from the completed-requests cache, its `out`/`err` is now routed to the REPL instead of being discarded with a "No response handler with id N found" warning.
 - [#4140](https://github.com/clojure-emacs/cider/pull/4140): Fix `cider-eval-dwim` (and defun evaluation) not descending into a `(comment ...)` form in `clojure-ts-mode` buffers: it now binds `clojure-ts-toplevel-inside-comment-form` alongside the `clojure-mode` variable.

--- a/lisp/cider-endpoint.el
+++ b/lisp/cider-endpoint.el
@@ -279,16 +279,22 @@ is what the form-init pattern below matches."
                                    bb-indicator
                                    bb-indicator))
                           "\n")
+                         ;; whitespace-split (not single-space): ps pads
+                         ;; columns, and a short pid would otherwise yield ""
                          (mapcar (lambda (s)
-                                   (nth 1 (split-string s " "))))
+                                   (nth 1 (split-string s))))
                          (seq-filter #'identity))))
       (when non-lein-nrepl-pids
         (thread-last non-lein-nrepl-pids
                      (mapcar (lambda (pid)
                                (let* ((directory (cider--lsof-fn-field
                                                   (list "-a" "-d" "cwd" "-n" "-Fn" "-p" pid)))
+                                      ;; -sTCP:LISTEN: only listening sockets.
+                                      ;; Without it the first socket may be an
+                                      ;; outbound connection, whose *remote*
+                                      ;; port we'd then extract.
                                       (port-line (cider--lsof-fn-field
-                                                  (list "-n" "-P" "-Fn" "-i" "-a" "-p" pid)))
+                                                  (list "-n" "-P" "-Fn" "-i" "-sTCP:LISTEN" "-a" "-p" pid)))
                                       (port (when port-line
                                               (replace-regexp-in-string ".*:" "" port-line)))
                                       (port (when (and port

--- a/lisp/cider-endpoint.el
+++ b/lisp/cider-endpoint.el
@@ -56,8 +56,10 @@ This variable is used by `cider-connect'."
                        (string :tag "port")))
   :group 'cider)
 
-(defvar cider-ps-running-lein-nrepls-command "ps u | grep leiningen"
-  "Process snapshot command used in `cider-locate-running-nrepl-ports'.")
+(defvar cider-ps-running-lein-nrepls-command "ps ux | grep leiningen"
+  "Process snapshot command used in `cider-locate-running-nrepl-ports'.
+The `x' flag includes processes without a controlling terminal, so REPLs
+started by IDEs or services are found too.")
 
 (defvar cider-ps-running-lein-nrepl-path-regexp-list
   '("\\(?:leiningen.original.pwd=\\)\\(.+?\\) -D"
@@ -259,16 +261,21 @@ Use `cider-ps-running-lein-nrepls-command' and
                   paths))))
 
 (defun cider--running-non-lein-nrepl-paths ()
-  "Retrieve (directory, port) pairs of running nREPL servers other than Lein ones."
+  "Retrieve (directory, port) pairs of running nREPL servers other than Lein ones.
+This also covers `lein trampoline' REPLs: the trampolined JVM carries no
+\"leiningen\" marker at all in its command line (so the Lein scan can't
+see it), but it does run `clojure.main -i /tmp/form-init<...>.clj', which
+is what the form-init pattern below matches."
   (unless (eq system-type 'windows-nt)
     (let* ((bb-indicator "--nrepl-server")
            (non-lein-nrepl-pids
             (thread-last (split-string
                           (cider--shell-command-to-string
-                           ;; some of the `ps u` lines we intend to catch:
+                           ;; some of the `ps ux` lines we intend to catch:
                            ;; <username> 15411 0.0  0.0 37915744  16084 s000  S+ 3:02PM 0:00.02 bb --nrepl-server
                            ;; <username> 13835 0.1 11.2 37159036 7528432 s009 S+ 2:47PM 6:41.29 java -cp src -m nrepl.cmdline
-                           (format "ps u | grep -E 'java|%s' | grep -E 'nrepl.cmdline|%s' | grep -v -E 'leiningen|grep'"
+                           ;; <username> 49859 0.0  0.4 443188240 105040  ??  SN 3:13PM 0:00.89 java -classpath ... clojure.main -i /tmp/form-init123.clj
+                           (format "ps ux | grep -E 'java|%s' | grep -E 'nrepl.cmdline|%s|form-init' | grep -v -E 'leiningen|grep'"
                                    bb-indicator
                                    bb-indicator))
                           "\n")

--- a/lisp/nrepl-client.el
+++ b/lisp/nrepl-client.el
@@ -268,7 +268,10 @@ Discards it if it can be determined that the port is not active."
   (when (file-exists-p file)
     (when-let* ((port-string (with-temp-buffer
                                (insert-file-contents file)
-                               (buffer-string)))
+                               ;; trim: some tools write a trailing newline,
+                               ;; which pollutes completion candidates and
+                               ;; breaks dedup against lsof-sourced ports
+                               (string-trim (buffer-string))))
                 ;; extract the number, most of all for not passing garbage to `lsof' (which might even be a security risk):
                 (port-number (nrepl--port-string-to-number port-string)))
       (if (eq system-type 'windows-nt)
@@ -1459,10 +1462,10 @@ it; the log then fills as nREPL traffic flows."
       (1 (pop-to-buffer (car buffers)))
       (0 (cond
           (nrepl-log-messages
-           (user-error "nREPL message logging is on, but nothing has been logged yet"))
-          ((y-or-n-p "nREPL message logging is disabled; enable it? ")
+           (user-error "No nREPL messages have been logged yet (logging is on)"))
+          ((y-or-n-p "Message logging is disabled; enable it? ")
            (setq nrepl-log-messages t)
-           (message "nREPL message logging enabled; the log will fill as traffic flows"))))
+           (message "Enabled nREPL message logging; the log will fill as traffic flows"))))
       (_ (pop-to-buffer
           (get-buffer
            (completing-read "nREPL messages buffer: "

--- a/lisp/nrepl-client.el
+++ b/lisp/nrepl-client.el
@@ -274,14 +274,20 @@ Discards it if it can be determined that the port is not active."
                                (string-trim (buffer-string))))
                 ;; extract the number, most of all for not passing garbage to `lsof' (which might even be a security risk):
                 (port-number (nrepl--port-string-to-number port-string)))
-      (if (eq system-type 'windows-nt)
+      (if (or (eq system-type 'windows-nt)
+              ;; No lsof means we can't DETERMINE the port is dead, so
+              ;; keep it (minimal systems often lack lsof; discarding
+              ;; every port file there broke detection entirely).
+              (not (executable-find "lsof" (file-remote-p default-directory))))
           port-string
         ;; `process-file-shell-command' honors `default-directory' and so
         ;; runs lsof on the remote host when FILE lives on TRAMP.
+        ;; -sTCP:LISTEN: only a listening socket proves a live server; a
+        ;; mere established connection involving the port does not.
         (unless (equal ""
                        (with-temp-buffer
                          (process-file-shell-command
-                          (format "lsof -i:%s" port-number) nil t)
+                          (format "lsof -i:%s -sTCP:LISTEN" port-number) nil t)
                          (buffer-string)))
           port-string)))))
 

--- a/test/cider-endpoint-tests.el
+++ b/test/cider-endpoint-tests.el
@@ -87,6 +87,29 @@
     (expect (cider--running-non-lein-nrepl-paths)
             :to-equal '(("/tmp/proj" "63213"))))
 
+  (it "extracts the pid despite ps column padding (short pids)"
+    ;; ps pads columns; a naive single-space split yields "" for the pid
+    (spy-on 'cider--shell-command-to-string :and-return-value
+            "bbatsov   549   0.0 0.4 443188240 105040 ?? SN 3:13PM 0:00.89 java -classpath /tmp/proj/src clojure.main -i /tmp/form-init123.clj\n")
+    (spy-on 'cider--lsof-fn-field :and-call-fake
+            (lambda (args)
+              (expect (car (last args)) :to-equal "549")
+              (if (member "cwd" args) "/tmp/proj" "127.0.0.1:63213")))
+    (expect (cider--running-non-lein-nrepl-paths)
+            :to-equal '(("/tmp/proj" "63213"))))
+
+  (it "only considers listening sockets when extracting the port"
+    (spy-on 'cider--shell-command-to-string :and-return-value
+            "bbatsov 49859 0.0 0.4 1 2 ?? SN 3:13PM 0:00.89 java -cp src -m nrepl.cmdline\n")
+    (spy-on 'cider--lsof-fn-field :and-call-fake
+            (lambda (args)
+              (if (member "cwd" args)
+                  "/tmp/proj"
+                (progn (expect args :to-contain "-sTCP:LISTEN")
+                       "127.0.0.1:63213"))))
+    (cider--running-non-lein-nrepl-paths)
+    (expect 'cider--lsof-fn-field :to-have-been-called))
+
   (it "finds a babashka nREPL server"
     (spy-on 'cider--shell-command-to-string :and-return-value
             "bbatsov 15411 0.0 0.0 37915744 16084 s000 S+ 3:02PM 0:00.02 bb --nrepl-server

--- a/test/cider-endpoint-tests.el
+++ b/test/cider-endpoint-tests.el
@@ -73,6 +73,40 @@
       (let ((default-directory "/tmp/b/")) (cider--running-nrepl-paths))
       (expect 'cider--running-nrepl-paths-uncached :to-have-been-called-times 2))))
 
+(describe "cider--running-non-lein-nrepl-paths"
+  ;; A `lein trampoline repl :headless' JVM has no "leiningen" marker in
+  ;; its command line at all (the Lein ps scan can't see it), but it runs
+  ;; the lein-generated init file: clojure.main -i /tmp/form-init<N>.clj.
+  (it "finds a trampolined lein REPL via its form-init fingerprint"
+    (spy-on 'cider--shell-command-to-string :and-return-value
+            "bbatsov 49859 0.0 0.4 443188240 105040 ?? SN 3:13PM 0:00.89 java -classpath /tmp/proj/src clojure.main -i /tmp/form-init123.clj
+")
+    (spy-on 'cider--lsof-fn-field :and-call-fake
+            (lambda (args)
+              (if (member "cwd" args) "/tmp/proj" "127.0.0.1:63213")))
+    (expect (cider--running-non-lein-nrepl-paths)
+            :to-equal '(("/tmp/proj" "63213"))))
+
+  (it "finds a babashka nREPL server"
+    (spy-on 'cider--shell-command-to-string :and-return-value
+            "bbatsov 15411 0.0 0.0 37915744 16084 s000 S+ 3:02PM 0:00.02 bb --nrepl-server
+")
+    (spy-on 'cider--lsof-fn-field :and-call-fake
+            (lambda (args)
+              (if (member "cwd" args) "/tmp/bb-proj" "127.0.0.1:1667")))
+    (expect (cider--running-non-lein-nrepl-paths)
+            :to-equal '(("/tmp/bb-proj" "1667"))))
+
+  (it "keeps the guard that excludes the parent leiningen JVM"
+    ;; the parent lein process is the Lein scan's job; the shell pipeline
+    ;; here must keep filtering it out
+    (spy-on 'cider--shell-command-to-string :and-return-value "")
+    (cider--running-non-lein-nrepl-paths)
+    (let ((cmd (car (spy-calls-args-for 'cider--shell-command-to-string 0))))
+      (expect cmd :to-match "grep -v -E 'leiningen|grep'")
+      (expect cmd :to-match "form-init")
+      (expect cmd :to-match "ps ux"))))
+
 (describe "cider--lsof-fn-field"
   (it "returns the name field with the leading \"n\" stripped"
     (spy-on 'cider--process-file-to-string

--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -634,3 +634,26 @@
         (spy-on 'message)
         (nrepl--dispatch-response (nrepl-dict "id" "999"))
         (expect 'message :to-have-been-called)))))
+
+(describe "nrepl--port-from-file"
+  (it "trims whitespace from the port file contents"
+    ;; lein and friends write a trailing newline; it must not leak into
+    ;; the returned port string (pollutes completion, breaks dedup)
+    (let ((f (make-temp-file "nrepl-port-test")))
+      (unwind-protect
+          (progn
+            (with-temp-file f (insert "63213\n"))
+            ;; pretend something is listening on the port
+            (spy-on 'process-file-shell-command :and-call-fake
+                    (lambda (&rest _) (insert "java 49859 bbatsov")))
+            (expect (nrepl--port-from-file f) :to-equal "63213"))
+        (delete-file f))))
+
+  (it "discards the port when nothing is listening on it"
+    (let ((f (make-temp-file "nrepl-port-test")))
+      (unwind-protect
+          (progn
+            (with-temp-file f (insert "63213\n"))
+            (spy-on 'process-file-shell-command) ;; no output = no listener
+            (expect (nrepl--port-from-file f) :to-be nil))
+        (delete-file f)))))

--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -643,7 +643,8 @@
       (unwind-protect
           (progn
             (with-temp-file f (insert "63213\n"))
-            ;; pretend something is listening on the port
+            ;; pretend lsof exists and something is listening on the port
+            (spy-on 'executable-find :and-return-value "/usr/bin/lsof")
             (spy-on 'process-file-shell-command :and-call-fake
                     (lambda (&rest _) (insert "java 49859 bbatsov")))
             (expect (nrepl--port-from-file f) :to-equal "63213"))
@@ -654,6 +655,19 @@
       (unwind-protect
           (progn
             (with-temp-file f (insert "63213\n"))
+            (spy-on 'executable-find :and-return-value "/usr/bin/lsof")
             (spy-on 'process-file-shell-command) ;; no output = no listener
             (expect (nrepl--port-from-file f) :to-be nil))
+        (delete-file f))))
+
+  (it "keeps the port when lsof is unavailable"
+    ;; without lsof we cannot DETERMINE the port is dead - keep it
+    (let ((f (make-temp-file "nrepl-port-test")))
+      (unwind-protect
+          (progn
+            (with-temp-file f (insert "63213\n"))
+            (spy-on 'executable-find :and-return-value nil)
+            (spy-on 'process-file-shell-command)
+            (expect (nrepl--port-from-file f) :to-equal "63213")
+            (expect 'process-file-shell-command :not :to-have-been-called))
         (delete-file f)))))


### PR DESCRIPTION
`cider-connect` port discovery couldn't see a `lein trampoline` REPL: the trampolined JVM has no "leiningen" marker anywhere in its command line (lein execs a bare `java -classpath ... clojure.main -i /tmp/form-init<N>.clj`), so `ps u | grep leiningen` finds nothing. The `.nrepl-port` fallback only kicks in when connecting from inside the project, so from anywhere else the port simply wasn't offered - while a regular `lein repl` kept working because its parent JVM does match the grep.

The lein-generated `form-init` init file is a reliable fingerprint, so the non-lein process scan now matches it and pulls the working directory and port from lsof, same as it does for `nrepl.cmdline` servers. Both scans also move from `ps u` to `ps ux`, since without `x` they miss REPLs that have no controlling terminal (started by IDEs, services, etc.).

While touching the area: the port string read from `.nrepl-port` kept its trailing newline, which polluted the connect completion candidates and broke dedup against lsof-sourced ports.