### PR TITLE
Clean up and document nREPL port discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Changes
 
+- [#4159](https://github.com/clojure-emacs/cider/pull/4159): Make `cider-default-nrepl-port` customizable, keep `cider-connect` usable when Tramp's ssh-config completion errors, and document how port suggestions are computed in a new "How CIDER Finds Ports" manual section.
 - [#4149](https://github.com/clojure-emacs/cider/pull/4149): Make the nREPL message log easier to reach: add "Show nREPL messages" to the nREPL menu, reflect the logging toggle's on/off state there, and have `nrepl-show-messages` offer to enable logging when it's off instead of erroring.
 
 ### Bugs fixed

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -433,6 +433,36 @@ project.
 
 TIP: In Clojure(Script) buffers the command `cider-connect` is bound to kbd:[C-c C-x c s].
 
+=== How CIDER Finds Ports
+
+The port prompt is not a blank slate - CIDER suggests the ports of nREPL
+servers it can discover, combining a few sources:
+
+* *Port files* in the current project: `.nrepl-port`, `repl-port`,
+  `target/repl-port` and `.shadow-cljs/nrepl.port`. This is how a server
+  started with `lein repl :headless` or `clj` in your project directory is
+  found.
+* *A process scan* for running nREPL servers - Leiningen REPLs (including
+  `lein trampoline` ones), babashka's `--nrepl-server`, and servers started
+  via `nrepl.cmdline`. The scan uses `ps` and `lsof`, so it's skipped on
+  Windows.
+* *Open CIDER REPL buffers*, so sibling connections to an already-connected
+  server are easy.
+
+Ports read from port files are verified with `lsof` - a stale file whose
+port nobody is listening on is not suggested. When `lsof` isn't available
+the port is suggested as-is.
+
+The process scan is cached for a few seconds (see
+`cider-running-nrepl-paths-cache-ttl`); if you've just started or killed a
+server and the suggestions look stale, `M-x
+cider-clear-running-nrepl-paths-cache` discards the cache.
+
+For remote hosts no scanning happens by default; see
+xref:basics/remote.adoc[Remote Development] and
+`cider-infer-remote-nrepl-ports` if you want CIDER to look for ports over
+SSH.
+
 If you frequently connect to the same hosts and ports, you can tell
 CIDER about them and it will use the information to do completing
 reads for the host and port prompts when you invoke

--- a/lisp/cider-endpoint.el
+++ b/lisp/cider-endpoint.el
@@ -62,8 +62,7 @@ The `x' flag includes processes without a controlling terminal, so REPLs
 started by IDEs or services are found too.")
 
 (defvar cider-ps-running-lein-nrepl-path-regexp-list
-  '("\\(?:leiningen.original.pwd=\\)\\(.+?\\) -D"
-    "\\(?:-classpath +:?\\(.+?\\)/self-installs\\)")
+  '("\\(?:leiningen.original.pwd=\\)\\(.+?\\) -D")
   "Regexp list to get project paths.
 Extract project paths from output of `cider-ps-running-lein-nrepls-command'.
 Sub-match 1 must be the project path.")
@@ -71,9 +70,12 @@ Sub-match 1 must be the project path.")
 (defvar cider-host-history nil
   "Completion history for connection hosts.")
 
-(defconst cider-default-nrepl-port "7888"
+(defcustom cider-default-nrepl-port "7888"
   "Use this port number when we couldn't infer a port.
-See also https://github.com/nrepl/nREPL/issues/6.")
+See also https://github.com/nrepl/nREPL/issues/6."
+  :type 'string
+  :group 'cider
+  :package-version '(cider . "2.1.0"))
 
 ;;; Endpoint selection
 
@@ -109,10 +111,13 @@ See also https://github.com/nrepl/nREPL/issues/6.")
     (cons host port)))
 
 (defun cider--ssh-hosts ()
-  "Retrieve all ssh host from local configuration files."
-  (seq-map (lambda (s) (list (replace-regexp-in-string ":$" "" s)))
-           (let ((non-essential t))
-             (tramp-completion-handle-file-name-all-completions "" "/ssh:"))))
+  "Retrieve all ssh host from local configuration files.
+Never signals: a Tramp hiccup here would otherwise abort the whole
+`cider-connect' flow before the first prompt."
+  (ignore-errors
+    (seq-map (lambda (s) (list (replace-regexp-in-string ":$" "" s)))
+             (let ((non-essential t))
+               (tramp-completion-handle-file-name-all-completions "" "/ssh:")))))
 
 (defun cider--completing-read-host (hosts)
   "Interactively select host from HOSTS.
@@ -208,29 +213,28 @@ called from a TRAMP buffer."
     (buffer-string)))
 
 (defun cider--invoke-running-nrepl-path (f)
-  "Invoke F safely.
+  "Invoke F safely, returning only pairs whose directory still exists.
 
 Necessary since we run some OS-specific commands that may fail."
   (condition-case nil
-      (let* ((x (funcall f)))
-        (mapcar (lambda (v)
-                  (if (and (listp v)
-                           (not (file-exists-p (car v))))
-                      nil
-                    v))
-                x))
+      (seq-filter (lambda (v)
+                    (or (not (listp v))
+                        (file-exists-p (car v))))
+                  (funcall f))
     (error nil)))
 
 (defun cider-locate-running-nrepl-ports (&optional dir)
   "Locate ports of running nREPL servers.
-When DIR is non-nil also look for nREPL port files in DIR.  Return a list
-of list of the form (project-dir port)."
+Combines three sources: a process scan for Leiningen servers, the open
+CIDER REPL buffers, and a process scan for other nREPL servers (bare
+`nrepl.cmdline', babashka, `lein trampoline').  When DIR is non-nil,
+nREPL port files in DIR's project are consulted too.  Return a list of
+lists of the form (project-dir port)."
   (let* ((pairs (cider--running-nrepl-paths))
          (pairs (if-let* ((c (and dir (cider-project-dir dir))))
                     (append (cider--path->path-port-pairs c) pairs)
                   pairs)))
     (thread-last pairs
-                 (delq nil)
                  (mapcar (lambda (x)
                            (list (file-name-nondirectory (directory-file-name (car x)))
                                  (nth 1 x))))

--- a/test/cider-endpoint-tests.el
+++ b/test/cider-endpoint-tests.el
@@ -73,6 +73,51 @@
       (let ((default-directory "/tmp/b/")) (cider--running-nrepl-paths))
       (expect 'cider--running-nrepl-paths-uncached :to-have-been-called-times 2))))
 
+(describe "cider--running-lein-nrepl-paths"
+  (it "extracts the project path from the leiningen.original.pwd property"
+    (spy-on 'cider--shell-command-to-string :and-return-value
+            "bbatsov 51642 0.0 0.4 443192976 93200 ?? SN 3:17PM 0:00.58 java -Dleiningen.original.pwd=/tmp/proj -Dfile.encoding=UTF-8 -Xbootclasspath/a:/home/me/.lein/self-installs/leiningen-2.11.2-standalone.jar clojure.main -m leiningen.core.main repl :headless\n")
+    (spy-on 'cider--path->path-port-pairs :and-call-fake
+            (lambda (path) (list (list path "63261"))))
+    (expect (cider--running-lein-nrepl-paths)
+            :to-equal '(("/tmp/proj" "63261"))))
+
+  (it "returns nil when no lein process is running"
+    (spy-on 'cider--shell-command-to-string :and-return-value "")
+    (expect (cider--running-lein-nrepl-paths) :to-be nil)))
+
+(describe "cider--path->path-port-pairs"
+  (it "pairs the path with each port found in it"
+    (spy-on 'cider--file-path :and-call-fake #'identity)
+    (spy-on 'nrepl-extract-ports :and-return-value '("63213" "63214"))
+    (expect (cider--path->path-port-pairs "/tmp/proj")
+            :to-equal '(("/tmp/proj" "63213") ("/tmp/proj" "63214")))))
+
+(describe "cider--infer-ports"
+  (it "consults the current directory's project for a local host"
+    (spy-on 'cider-locate-running-nrepl-ports :and-return-value '(("proj" "1234")))
+    (let ((default-directory "/tmp/proj/"))
+      (expect (cider--infer-ports "localhost" nil) :to-equal '(("proj" "1234")))
+      (expect 'cider-locate-running-nrepl-ports
+              :to-have-been-called-with "/tmp/proj/")))
+
+  (it "does not scan remote hosts unless cider-infer-remote-nrepl-ports is on"
+    (spy-on 'cider-locate-running-nrepl-ports)
+    (let ((cider-infer-remote-nrepl-ports nil))
+      (expect (cider--infer-ports "some-remote" '(("some-remote"))) :to-be nil)
+      (expect 'cider-locate-running-nrepl-ports :not :to-have-been-called))))
+
+(describe "cider--completing-read-port"
+  (it "resolves a (name port) candidate to its port number"
+    (spy-on 'completing-read :and-return-value "proj:63213")
+    (expect (cider--completing-read-port "localhost" '(("proj" "63213")))
+            :to-equal 63213))
+
+  (it "accepts a port typed directly"
+    (spy-on 'completing-read :and-return-value "7888")
+    (expect (cider--completing-read-port "localhost" '())
+            :to-equal 7888)))
+
 (describe "cider--running-non-lein-nrepl-paths"
   ;; A `lein trampoline repl :headless' JVM has no "leiningen" marker in
   ;; its command line at all (the Lein ps scan can't see it), but it runs
@@ -146,10 +191,10 @@
     (expect (cider--invoke-running-nrepl-path (lambda () '(("/p" "1"))))
             :to-equal '(("/p" "1"))))
 
-  (it "blanks out pairs whose path is gone (left for the caller to drop)"
+  (it "drops pairs whose path is gone"
     (spy-on 'file-exists-p :and-return-value nil)
     (expect (cider--invoke-running-nrepl-path (lambda () '(("/p" "1"))))
-            :to-equal '(nil)))
+            :to-equal nil))
 
   (it "swallows errors from the OS-specific probe and returns nil"
     (expect (cider--invoke-running-nrepl-path (lambda () (error "boom")))

--- a/test/cider-endpoint-tests.el
+++ b/test/cider-endpoint-tests.el
@@ -74,17 +74,22 @@
       (expect 'cider--running-nrepl-paths-uncached :to-have-been-called-times 2))))
 
 (describe "cider--running-lein-nrepl-paths"
+  ;; The scans no-op on windows-nt before reaching the spied helpers, so
+  ;; bind system-type: these specs exercise the scan logic itself, which
+  ;; is platform-independent.
   (it "extracts the project path from the leiningen.original.pwd property"
-    (spy-on 'cider--shell-command-to-string :and-return-value
-            "bbatsov 51642 0.0 0.4 443192976 93200 ?? SN 3:17PM 0:00.58 java -Dleiningen.original.pwd=/tmp/proj -Dfile.encoding=UTF-8 -Xbootclasspath/a:/home/me/.lein/self-installs/leiningen-2.11.2-standalone.jar clojure.main -m leiningen.core.main repl :headless\n")
-    (spy-on 'cider--path->path-port-pairs :and-call-fake
-            (lambda (path) (list (list path "63261"))))
-    (expect (cider--running-lein-nrepl-paths)
-            :to-equal '(("/tmp/proj" "63261"))))
+    (let ((system-type 'gnu/linux))
+      (spy-on 'cider--shell-command-to-string :and-return-value
+              "bbatsov 51642 0.0 0.4 443192976 93200 ?? SN 3:17PM 0:00.58 java -Dleiningen.original.pwd=/tmp/proj -Dfile.encoding=UTF-8 -Xbootclasspath/a:/home/me/.lein/self-installs/leiningen-2.11.2-standalone.jar clojure.main -m leiningen.core.main repl :headless\n")
+      (spy-on 'cider--path->path-port-pairs :and-call-fake
+              (lambda (path) (list (list path "63261"))))
+      (expect (cider--running-lein-nrepl-paths)
+              :to-equal '(("/tmp/proj" "63261")))))
 
   (it "returns nil when no lein process is running"
-    (spy-on 'cider--shell-command-to-string :and-return-value "")
-    (expect (cider--running-lein-nrepl-paths) :to-be nil)))
+    (let ((system-type 'gnu/linux))
+      (spy-on 'cider--shell-command-to-string :and-return-value "")
+      (expect (cider--running-lein-nrepl-paths) :to-be nil))))
 
 (describe "cider--path->path-port-pairs"
   (it "pairs the path with each port found in it"
@@ -122,58 +127,68 @@
   ;; A `lein trampoline repl :headless' JVM has no "leiningen" marker in
   ;; its command line at all (the Lein ps scan can't see it), but it runs
   ;; the lein-generated init file: clojure.main -i /tmp/form-init<N>.clj.
+  ;; system-type is bound because the scan no-ops on windows-nt.
   (it "finds a trampolined lein REPL via its form-init fingerprint"
-    (spy-on 'cider--shell-command-to-string :and-return-value
-            "bbatsov 49859 0.0 0.4 443188240 105040 ?? SN 3:13PM 0:00.89 java -classpath /tmp/proj/src clojure.main -i /tmp/form-init123.clj
-")
-    (spy-on 'cider--lsof-fn-field :and-call-fake
-            (lambda (args)
-              (if (member "cwd" args) "/tmp/proj" "127.0.0.1:63213")))
-    (expect (cider--running-non-lein-nrepl-paths)
-            :to-equal '(("/tmp/proj" "63213"))))
+    (let ((system-type 'gnu/linux))
+      (spy-on 'cider--shell-command-to-string :and-return-value
+              "bbatsov 49859 0.0 0.4 443188240 105040 ?? SN 3:13PM 0:00.89 java -classpath /tmp/proj/src clojure.main -i /tmp/form-init123.clj\n")
+      (spy-on 'cider--lsof-fn-field :and-call-fake
+              (lambda (args)
+                (if (member "cwd" args) "/tmp/proj" "127.0.0.1:63213")))
+      (expect (cider--running-non-lein-nrepl-paths)
+              :to-equal '(("/tmp/proj" "63213")))))
 
   (it "extracts the pid despite ps column padding (short pids)"
     ;; ps pads columns; a naive single-space split yields "" for the pid
-    (spy-on 'cider--shell-command-to-string :and-return-value
-            "bbatsov   549   0.0 0.4 443188240 105040 ?? SN 3:13PM 0:00.89 java -classpath /tmp/proj/src clojure.main -i /tmp/form-init123.clj\n")
-    (spy-on 'cider--lsof-fn-field :and-call-fake
-            (lambda (args)
-              (expect (car (last args)) :to-equal "549")
-              (if (member "cwd" args) "/tmp/proj" "127.0.0.1:63213")))
-    (expect (cider--running-non-lein-nrepl-paths)
-            :to-equal '(("/tmp/proj" "63213"))))
+    (let ((system-type 'gnu/linux))
+      (spy-on 'cider--shell-command-to-string :and-return-value
+              "bbatsov   549   0.0 0.4 443188240 105040 ?? SN 3:13PM 0:00.89 java -classpath /tmp/proj/src clojure.main -i /tmp/form-init123.clj\n")
+      (spy-on 'cider--lsof-fn-field :and-call-fake
+              (lambda (args)
+                (expect (car (last args)) :to-equal "549")
+                (if (member "cwd" args) "/tmp/proj" "127.0.0.1:63213")))
+      (expect (cider--running-non-lein-nrepl-paths)
+              :to-equal '(("/tmp/proj" "63213")))))
 
   (it "only considers listening sockets when extracting the port"
-    (spy-on 'cider--shell-command-to-string :and-return-value
-            "bbatsov 49859 0.0 0.4 1 2 ?? SN 3:13PM 0:00.89 java -cp src -m nrepl.cmdline\n")
-    (spy-on 'cider--lsof-fn-field :and-call-fake
-            (lambda (args)
-              (if (member "cwd" args)
-                  "/tmp/proj"
-                (progn (expect args :to-contain "-sTCP:LISTEN")
-                       "127.0.0.1:63213"))))
-    (cider--running-non-lein-nrepl-paths)
-    (expect 'cider--lsof-fn-field :to-have-been-called))
+    (let ((system-type 'gnu/linux))
+      (spy-on 'cider--shell-command-to-string :and-return-value
+              "bbatsov 49859 0.0 0.4 1 2 ?? SN 3:13PM 0:00.89 java -cp src -m nrepl.cmdline\n")
+      (spy-on 'cider--lsof-fn-field :and-call-fake
+              (lambda (args)
+                (if (member "cwd" args)
+                    "/tmp/proj"
+                  (progn (expect args :to-contain "-sTCP:LISTEN")
+                         "127.0.0.1:63213"))))
+      (cider--running-non-lein-nrepl-paths)
+      (expect 'cider--lsof-fn-field :to-have-been-called)))
 
   (it "finds a babashka nREPL server"
-    (spy-on 'cider--shell-command-to-string :and-return-value
-            "bbatsov 15411 0.0 0.0 37915744 16084 s000 S+ 3:02PM 0:00.02 bb --nrepl-server
-")
-    (spy-on 'cider--lsof-fn-field :and-call-fake
-            (lambda (args)
-              (if (member "cwd" args) "/tmp/bb-proj" "127.0.0.1:1667")))
-    (expect (cider--running-non-lein-nrepl-paths)
-            :to-equal '(("/tmp/bb-proj" "1667"))))
+    (let ((system-type 'gnu/linux))
+      (spy-on 'cider--shell-command-to-string :and-return-value
+              "bbatsov 15411 0.0 0.0 37915744 16084 s000 S+ 3:02PM 0:00.02 bb --nrepl-server\n")
+      (spy-on 'cider--lsof-fn-field :and-call-fake
+              (lambda (args)
+                (if (member "cwd" args) "/tmp/bb-proj" "127.0.0.1:1667")))
+      (expect (cider--running-non-lein-nrepl-paths)
+              :to-equal '(("/tmp/bb-proj" "1667")))))
 
   (it "keeps the guard that excludes the parent leiningen JVM"
     ;; the parent lein process is the Lein scan's job; the shell pipeline
     ;; here must keep filtering it out
-    (spy-on 'cider--shell-command-to-string :and-return-value "")
-    (cider--running-non-lein-nrepl-paths)
-    (let ((cmd (car (spy-calls-args-for 'cider--shell-command-to-string 0))))
-      (expect cmd :to-match "grep -v -E 'leiningen|grep'")
-      (expect cmd :to-match "form-init")
-      (expect cmd :to-match "ps ux"))))
+    (let ((system-type 'gnu/linux))
+      (spy-on 'cider--shell-command-to-string :and-return-value "")
+      (cider--running-non-lein-nrepl-paths)
+      (let ((cmd (car (spy-calls-args-for 'cider--shell-command-to-string 0))))
+        (expect cmd :to-match "grep -v -E 'leiningen|grep'")
+        (expect cmd :to-match "form-init")
+        (expect cmd :to-match "ps ux"))))
+
+  (it "returns nil on Windows (ps/lsof are not available)"
+    (let ((system-type 'windows-nt))
+      (spy-on 'cider--shell-command-to-string)
+      (expect (cider--running-non-lein-nrepl-paths) :to-be nil)
+      (expect 'cider--shell-command-to-string :not :to-have-been-called))))
 
 (describe "cider--lsof-fn-field"
   (it "returns the name field with the leading \"n\" stripped"

--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -671,3 +671,36 @@
             (expect (nrepl--port-from-file f) :to-equal "63213")
             (expect 'process-file-shell-command :not :to-have-been-called))
         (delete-file f)))))
+
+(describe "nrepl--port-string-to-number"
+  (it "extracts a leading port number"
+    (expect (nrepl--port-string-to-number "63213") :to-equal 63213)
+    (expect (nrepl--port-string-to-number "63213 extra") :to-equal 63213))
+
+  (it "rejects garbage (guards the lsof shell command)"
+    (expect (nrepl--port-string-to-number "; rm -rf /") :to-be nil)
+    (expect (nrepl--port-string-to-number "") :to-be nil)))
+
+(describe "nrepl-extract-ports"
+  (it "reads all four port file locations"
+    (let ((dir (make-temp-file "nrepl-ports-test" 'dir)))
+      (unwind-protect
+          (progn
+            (make-directory (expand-file-name "target" dir))
+            (make-directory (expand-file-name ".shadow-cljs" dir))
+            (with-temp-file (expand-file-name "repl-port" dir) (insert "1001"))
+            (with-temp-file (expand-file-name ".nrepl-port" dir) (insert "1002"))
+            (with-temp-file (expand-file-name "target/repl-port" dir) (insert "1003"))
+            (with-temp-file (expand-file-name ".shadow-cljs/nrepl.port" dir) (insert "1004"))
+            (spy-on 'executable-find :and-return-value "/usr/bin/lsof")
+            (spy-on 'process-file-shell-command :and-call-fake
+                    (lambda (&rest _) (insert "listening")))
+            (expect (nrepl-extract-ports dir)
+                    :to-equal '("1001" "1002" "1003" "1004")))
+        (delete-directory dir t))))
+
+  (it "returns nil for a directory without port files"
+    (let ((dir (make-temp-file "nrepl-ports-test" 'dir)))
+      (unwind-protect
+          (expect (nrepl-extract-ports dir) :to-be nil)
+        (delete-directory dir t)))))

--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -651,7 +651,9 @@
         (delete-file f))))
 
   (it "discards the port when nothing is listening on it"
-    (let ((f (make-temp-file "nrepl-port-test")))
+    (let ((f (make-temp-file "nrepl-port-test"))
+          ;; bind system-type: on windows-nt the liveness check is skipped
+          (system-type 'gnu/linux))
       (unwind-protect
           (progn
             (with-temp-file f (insert "63213\n"))


### PR DESCRIPTION
Follow-up to #4158, from an audit of the port-discovery code:

- `cider--ssh-hosts` no longer lets a Tramp hiccup abort the whole `cider-connect` flow before the first prompt.
- `cider-default-nrepl-port` is a defcustom now; as a defconst the fallback port couldn't be customized.
- Dropped the `self-installs` regexp from the lein process scan - it extracted `~/.lein` as a "project path", where port files are never written.
- The manual gets a "How CIDER Finds Ports" section; previously the connect docs implied you always type the port by hand, and the discovery machinery (port files, process scans, the lsof liveness check, the scan cache) was documented nowhere - the report that led to #4158 came from someone reverse-engineering it from the source.
- Test coverage for the lein scan regexp, port-file reading, port-string sanitizing, `cider--infer-ports` and `cider--completing-read-port`, none of which had any.