### PR TITLE
Don't offer stale ports from the connect host history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Changes
 
+- [#4160](https://github.com/clojure-emacs/cider/pull/4160): Stop offering the previous session's port as the `cider-connect` default when nothing is listening on it anymore; the host is still offered and port inference takes over.
 - [#4159](https://github.com/clojure-emacs/cider/pull/4159): Make `cider-default-nrepl-port` customizable, keep `cider-connect` usable when Tramp's ssh-config completion errors, and document how port suggestions are computed in a new "How CIDER Finds Ports" manual section.
 - [#4149](https://github.com/clojure-emacs/cider/pull/4149): Make the nREPL message log easier to reach: add "Show nREPL messages" to the nREPL menu, reflect the logging toggle's on/off state there, and have `nrepl-show-messages` offer to enable logging when it's off instead of erroring.
 

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -448,6 +448,9 @@ servers it can discover, combining a few sources:
   Windows.
 * *Open CIDER REPL buffers*, so sibling connections to an already-connected
   server are easy.
+* *The most recent endpoint you connected to*, so reconnecting is a single
+  kbd:[RET] - unless its port is no longer listening, in which case only the
+  host is suggested.
 
 Ports read from port files are verified with `lsof` - a stale file whose
 port nobody is listening on is not suggested. When `lsof` isn't available

--- a/lisp/cider-endpoint.el
+++ b/lisp/cider-endpoint.el
@@ -94,8 +94,8 @@ See also https://github.com/nrepl/nREPL/issues/6."
                   (nth 0 endpoint))))
   (let* ((ssh-hosts (cider--ssh-hosts))
          (hosts (seq-uniq (append (when cider-host-history
-                                    ;; history elements are strings of the form "host:port"
-                                    (list (split-string (car cider-host-history) ":")))
+                                    (list (cider--host-history-candidate
+                                           (car cider-host-history))))
                                   (list (list (cider-current-host)))
                                   cider-known-endpoints
                                   ssh-hosts
@@ -109,6 +109,23 @@ See also https://github.com/nrepl/nREPL/issues/6."
                        (cider--completing-read-socket-file)
                      (cider--completing-read-port host (cider--infer-ports host ssh-hosts))))))
     (cons host port)))
+
+(defun cider--host-history-candidate (entry)
+  "Return a (HOST PORT) or (HOST) candidate from the history ENTRY.
+ENTRY is a \"host:port\" string from `cider-host-history'.  The port
+makes reconnecting to the same server a single RET - but it comes from
+a previous session, so when the host is local and nothing is listening
+on the port anymore, offer just the host and let port inference take
+over instead of defaulting to a stale endpoint."
+  (let* ((parts (split-string entry ":"))
+         (host (car parts))
+         (port (cadr parts))
+         (port-number (and port (nrepl--port-string-to-number port))))
+    (cond ((null port-number) (list host))
+          ((and (nrepl-local-host-p host)
+                (not (nrepl--port-alive-p port-number)))
+           (list host))
+          (t (list host port)))))
 
 (defun cider--ssh-hosts ()
   "Retrieve all ssh host from local configuration files.

--- a/lisp/nrepl-client.el
+++ b/lisp/nrepl-client.el
@@ -261,6 +261,24 @@ PARAMS is as in `nrepl-make-buffer-name'."
   (when (string-match "^\\([0-9]+\\)" s)
     (string-to-number (match-string 0 s))))
 
+(defun nrepl--port-alive-p (port-number)
+  "Return non-nil unless PORT-NUMBER can be shown to have no listener.
+Checks for a listening TCP socket with lsof; errs on the side of
+liveness when that cannot be determined (Windows, or no lsof - minimal
+systems often lack it, and absence of the tool is not evidence the
+port is dead).  `process-file-shell-command' honors `default-directory'
+and so runs lsof on the remote host in TRAMP contexts."
+  (if (or (eq system-type 'windows-nt)
+          (not (executable-find "lsof" (file-remote-p default-directory))))
+      t
+    ;; -sTCP:LISTEN: only a listening socket proves a live server; a
+    ;; mere established connection involving the port does not.
+    (not (equal ""
+                (with-temp-buffer
+                  (process-file-shell-command
+                   (format "lsof -i:%s -sTCP:LISTEN" port-number) nil t)
+                  (buffer-string))))))
+
 (defun nrepl--port-from-file (file)
   "Attempt to read port from a file named by FILE.
 
@@ -274,22 +292,8 @@ Discards it if it can be determined that the port is not active."
                                (string-trim (buffer-string))))
                 ;; extract the number, most of all for not passing garbage to `lsof' (which might even be a security risk):
                 (port-number (nrepl--port-string-to-number port-string)))
-      (if (or (eq system-type 'windows-nt)
-              ;; No lsof means we can't DETERMINE the port is dead, so
-              ;; keep it (minimal systems often lack lsof; discarding
-              ;; every port file there broke detection entirely).
-              (not (executable-find "lsof" (file-remote-p default-directory))))
-          port-string
-        ;; `process-file-shell-command' honors `default-directory' and so
-        ;; runs lsof on the remote host when FILE lives on TRAMP.
-        ;; -sTCP:LISTEN: only a listening socket proves a live server; a
-        ;; mere established connection involving the port does not.
-        (unless (equal ""
-                       (with-temp-buffer
-                         (process-file-shell-command
-                          (format "lsof -i:%s -sTCP:LISTEN" port-number) nil t)
-                         (buffer-string)))
-          port-string)))))
+      (when (nrepl--port-alive-p port-number)
+        port-string))))
 
 (defun nrepl--ssh-file-name-matches-host-p (file-name host)
   "Return t, if FILE-NAME is a tramp-file-name on HOST via ssh."

--- a/test/cider-endpoint-tests.el
+++ b/test/cider-endpoint-tests.el
@@ -190,6 +190,31 @@
       (expect (cider--running-non-lein-nrepl-paths) :to-be nil)
       (expect 'cider--shell-command-to-string :not :to-have-been-called))))
 
+(describe "cider--host-history-candidate"
+  (it "keeps the port when something is listening on it"
+    (spy-on 'nrepl--port-alive-p :and-return-value t)
+    (expect (cider--host-history-candidate "localhost:63213")
+            :to-equal '("localhost" "63213")))
+
+  (it "drops a stale port from a local host, keeping the host"
+    (spy-on 'nrepl--port-alive-p :and-return-value nil)
+    (expect (cider--host-history-candidate "localhost:63213")
+            :to-equal '("localhost")))
+
+  (it "does not try to check remote hosts"
+    (spy-on 'nrepl--port-alive-p)
+    (expect (cider--host-history-candidate "example.com:7888")
+            :to-equal '("example.com" "7888"))
+    (expect 'nrepl--port-alive-p :not :to-have-been-called))
+
+  (it "drops a non-numeric port"
+    (expect (cider--host-history-candidate "localhost:garbage")
+            :to-equal '("localhost")))
+
+  (it "handles a bare host entry"
+    (expect (cider--host-history-candidate "localhost")
+            :to-equal '("localhost"))))
+
 (describe "cider--lsof-fn-field"
   (it "returns the name field with the leading \"n\" stripped"
     (spy-on 'cider--process-file-to-string

--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -706,3 +706,28 @@
       (unwind-protect
           (expect (nrepl-extract-ports dir) :to-be nil)
         (delete-directory dir t)))))
+
+(describe "nrepl--port-alive-p"
+  (it "is true when a listener is found"
+    (let ((system-type 'gnu/linux))
+      (spy-on 'executable-find :and-return-value "/usr/bin/lsof")
+      (spy-on 'process-file-shell-command :and-call-fake
+              (lambda (&rest _) (insert "java 123")))
+      (expect (nrepl--port-alive-p 63213) :to-be-truthy)))
+
+  (it "is false when lsof finds no listener"
+    (let ((system-type 'gnu/linux))
+      (spy-on 'executable-find :and-return-value "/usr/bin/lsof")
+      (spy-on 'process-file-shell-command)
+      (expect (nrepl--port-alive-p 63213) :to-be nil)))
+
+  (it "errs on the side of liveness without lsof"
+    (let ((system-type 'gnu/linux))
+      (spy-on 'executable-find :and-return-value nil)
+      (expect (nrepl--port-alive-p 63213) :to-be-truthy)))
+
+  (it "errs on the side of liveness on Windows"
+    (let ((system-type 'windows-nt))
+      (spy-on 'process-file-shell-command)
+      (expect (nrepl--port-alive-p 63213) :to-be-truthy)
+      (expect 'process-file-shell-command :not :to-have-been-called))))


### PR DESCRIPTION
The last piece of the port-discovery audit behind #4158/#4159: `cider-select-endpoint` offers the previously used "host:port" as the default, which makes reconnecting a single RET - but that port comes from an earlier session, and it was the only suggestion bypassing the liveness check every other source goes through. A dead server meant the default silently pointed at a stale endpoint.

Now, when the host is local and nothing listens on the remembered port anymore, only the host is offered and port inference takes over. The liveness check moves out of `nrepl--port-from-file` into a reusable `nrepl--port-alive-p` (same errs-on-liveness semantics on Windows and lsof-less systems).