### PR TITLE
Unbreak CircleCI's silently-no-op lint step

### DIFF
--- a/Eldev
+++ b/Eldev
@@ -73,4 +73,8 @@
 
 ;; package-lint is disabled because nrepl-*.el files intentionally use
 ;; the `nrepl-' prefix instead of the `cider-' package prefix.
-(setf eldev-lint-default '(checkdoc))
+;; `doc' is the linter's canonical name; `checkdoc' is only a command-line
+;; alias, and the default-linter matching doesn't resolve aliases - with
+;; `(checkdoc)' here, a bare `eldev lint' (which is what CI runs) silently
+;; lints nothing.
+(setf eldev-lint-default '(doc))


### PR DESCRIPTION
CircleCI's lint step (`eldev lint -c`) has been green without linting anything: `eldev-lint-default` named the linter by its command-line alias (`checkdoc`), and the default-linter matching doesn't resolve aliases - the canonical name is `doc`. Verified with `eldev lint --list-linters`, which shows no linter marked as default under the old config.

One-line fix in the Eldev file, so both a bare `eldev lint` and CI's invocation actually run checkdoc now. The codebase is already checkdoc-clean, so re-arming the step doesn't break anything.