### PR TITLE
Treat comment contents as top level in the whole defun family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Changes
 
+- [#4166](https://github.com/clojure-emacs/cider/pull/4166): Treat the contents of a `comment` form as top level in the whole defun command family (pretty-printing, eval-to-comment, inspect, format, debug, etc.), not just `cider-eval-defun-at-point` and `cider-eval-dwim`; CIDER's commands no longer depend on `clojure-toplevel-inside-comment-form`.
 - [#4160](https://github.com/clojure-emacs/cider/pull/4160): Stop offering the previous session's port as the `cider-connect` default when nothing is listening on it anymore; the host is still offered and port inference takes over.
 - [#4159](https://github.com/clojure-emacs/cider/pull/4159): Make `cider-default-nrepl-port` customizable, keep `cider-connect` usable when Tramp's ssh-config completion errors, and document how port suggestions are computed in a new "How CIDER Finds Ports" manual section.
 - [#4149](https://github.com/clojure-emacs/cider/pull/4149): Make the nREPL message log easier to reach: add "Show nREPL messages" to the nREPL menu, reflect the logging toggle's on/off state there, and have `nrepl-show-messages` offer to enable logging when it's off instead of erroring.

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -75,10 +75,6 @@
 (declare-function cider-repl--ns-form-changed-p "cider-repl")
 (declare-function cider-repl--cache-ns-form "cider-repl")
 
-;; Defined in clojure-ts-mode; declared here so we can bind it even when only
-;; clojure-mode is loaded.  clojure-mode uses `clojure-toplevel-inside-comment-form'.
-(defvar clojure-ts-toplevel-inside-comment-form)
-
 (defconst cider-read-eval-buffer "*cider-read-eval*")
 (defconst cider-result-buffer "*cider-result*")
 
@@ -1288,21 +1284,17 @@ buffer, else display in a popup buffer."
 (defun cider-eval-dwim (&optional debug-it)
   "If no region is active, call `cider-eval-defun-at-point' with DEBUG-IT.
 If a region is active, run `cider-eval-region'.
-
-Always binds `clojure-toplevel-inside-comment-form' (and its clojure-ts-mode
-counterpart `clojure-ts-toplevel-inside-comment-form') to t, so evaluating
-inside a `comment' form picks up the enclosed form."
+Inside a `comment' form the enclosed form is evaluated - a property of
+`cider-defun-at-point', shared by the whole defun-operating family."
   (interactive "P")
-  (let ((clojure-toplevel-inside-comment-form t)
-        (clojure-ts-toplevel-inside-comment-form t))
-    (if (use-region-p)
-        (cider-eval-region (region-beginning) (region-end))
-      (cider-eval-defun-at-point debug-it))))
+  (if (use-region-p)
+      (cider-eval-region (region-beginning) (region-end))
+    (cider-eval-defun-at-point debug-it)))
 
 (defun cider-eval-defun-at-point (&optional debug-it)
   "Evaluate the current toplevel form, and print result in the minibuffer.
-Inside a `comment' form the enclosed form is treated as the toplevel one,
-matching `cider-eval-dwim'.
+Inside a `comment' form the enclosed form is treated as the toplevel
+one; see `cider-defun-at-point'.
 With DEBUG-IT prefix argument, also debug the entire form as with the
 command `cider-debug-defun-at-point'."
   (interactive "P")
@@ -1314,13 +1306,11 @@ command `cider-debug-defun-at-point'."
         (user-error "The debugger does not support ClojureScript"))
       (when inline-debug
         (cider--prompt-and-insert-inline-dbg)))
-    (let ((clojure-toplevel-inside-comment-form t)
-          (clojure-ts-toplevel-inside-comment-form t))
-      (cider-interactive-eval (when (and debug-it (not inline-debug))
-                                (concat "#dbg\n" (cider-defun-at-point)))
-                              nil
-                              (cider-defun-at-point 'bounds)
-                              (cider--nrepl-pr-request-plist)))))
+    (cider-interactive-eval (when (and debug-it (not inline-debug))
+                              (concat "#dbg\n" (cider-defun-at-point)))
+                            nil
+                            (cider-defun-at-point 'bounds)
+                            (cider--nrepl-pr-request-plist))))
 
 (defun cider--insert-closing-delimiters (code)
   "Closes all open parenthesized or bracketed expressions of CODE."

--- a/lisp/cider-util.el
+++ b/lisp/cider-util.el
@@ -199,18 +199,29 @@ positions.  Else returns the substring from START to END."
   (funcall (if bounds #'list #'buffer-substring-no-properties)
            start end))
 
+;; The clojure-mode var is a defcustom that comes with the required
+;; clojure-mode; the clojure-ts-mode one is declared so we can bind it
+;; even when only clojure-mode is loaded.
+(defvar clojure-ts-toplevel-inside-comment-form)
+
 (defun cider-defun-at-point (&optional bounds)
   "Return the text of the top level sexp at point.
+Inside a `comment' form the enclosed form is treated as the top level
+one, so the whole CIDER command family (eval, pprint, inspect, debug,
+format...) behaves consistently in rich-comment blocks - evaluating a
+whole `(comment ...)' yields nil, which is never what anyone wants.
 If BOUNDS is non-nil, return a list of its starting and ending position
 instead."
   (save-excursion
     (save-match-data
-      (if (derived-mode-p 'cider-repl-mode)
-          (goto-char (point-max)) ;; in repls, end-of-defun won't work, so we perform the closest reasonable thing
-        (end-of-defun))
-      (let ((end (point)))
-        (clojure-backward-logical-sexp 1)
-        (cider--text-or-limits bounds (point) end)))))
+      (let ((clojure-toplevel-inside-comment-form t)
+            (clojure-ts-toplevel-inside-comment-form t))
+        (if (derived-mode-p 'cider-repl-mode)
+            (goto-char (point-max)) ;; in repls, end-of-defun won't work, so we perform the closest reasonable thing
+          (end-of-defun))
+        (let ((end (point)))
+          (clojure-backward-logical-sexp 1)
+          (cider--text-or-limits bounds (point) end))))))
 
 (defun cider-get-ns-name ()
   "Return the current namespace in the buffer, suppressing any errors.

--- a/test/cider-eval-tests.el
+++ b/test/cider-eval-tests.el
@@ -685,21 +685,33 @@
   (it "returns nil when the response carries no output"
     (expect (cider--emit-orphaned-output (nrepl-dict "id" "9")) :to-be nil)))
 
-(describe "cider-eval-dwim"
-  (it "binds both comment-form toplevel vars around the eval"
-    ;; So evaluating inside a `comment' form picks up the enclosed form under
-    ;; both clojure-mode and clojure-ts-mode.
-    (let ((clojure-toplevel-inside-comment-form nil)
-          (clojure-ts-toplevel-inside-comment-form nil)
-          seen-clj seen-ts)
-      (spy-on 'use-region-p :and-return-value nil)
-      (spy-on 'cider-eval-defun-at-point :and-call-fake
-              (lambda (&rest _)
-                (setq seen-clj clojure-toplevel-inside-comment-form
-                      seen-ts clojure-ts-toplevel-inside-comment-form)))
+(describe "comment-form awareness across the defun family"
+  ;; All defun-operating commands go through `cider-defun-at-point', which
+  ;; treats the enclosed form as top level inside a `comment' block.
+  (it "cider-eval-dwim evaluates the enclosed form"
+    (spy-on 'cider-interactive-eval)
+    (spy-on 'use-region-p :and-return-value nil)
+    (with-clojure-buffer "(comment (+ 1| 2))"
       (cider-eval-dwim)
-      (expect seen-clj :to-be t)
-      (expect seen-ts :to-be t))))
+      (let ((bounds (nth 2 (spy-calls-args-for 'cider-interactive-eval 0))))
+        (expect (apply #'buffer-substring-no-properties bounds)
+                :to-equal "(+ 1 2)"))))
+
+  (it "cider-pprint-eval-defun-at-point pretty-prints the enclosed form"
+    (spy-on 'cider--pprint-eval-form)
+    (with-clojure-buffer "(comment (+ 1| 2))"
+      (cider-pprint-eval-defun-at-point)
+      (let ((bounds (car (spy-calls-args-for 'cider--pprint-eval-form 0))))
+        (expect (apply #'buffer-substring-no-properties bounds)
+                :to-equal "(+ 1 2)"))))
+
+  (it "cider-eval-defun-to-comment targets the enclosed form"
+    (spy-on 'cider-interactive-eval)
+    (with-clojure-buffer "(comment (+ 1| 2))"
+      (cider-eval-defun-to-comment)
+      (let ((bounds (nth 2 (spy-calls-args-for 'cider-interactive-eval 0))))
+        (expect (apply #'buffer-substring-no-properties bounds)
+                :to-equal "(+ 1 2)")))))
 
 (describe "cider-eval-defun-at-point"
   (it "targets the enclosed form inside a comment form, like cider-eval-dwim"

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -371,13 +371,14 @@
         (expect (cider-defun-at-point) :to-equal "(. \"\")"))))
 
   (describe "inside a comment form"
-    (it "returns the whole comment form by default"
+    (it "treats the enclosed form as the top level one"
+      (with-clojure-buffer "(comment (+ 1| 2))"
+        (expect (cider-defun-at-point) :to-equal "(+ 1 2)")))
+    (it "does so regardless of the user's clojure-toplevel-inside-comment-form"
+      ;; the primitive binds the variable itself, so the whole command
+      ;; family behaves the same in rich-comment blocks
       (with-clojure-buffer "(comment (+ 1| 2))"
         (let ((clojure-toplevel-inside-comment-form nil))
-          (expect (cider-defun-at-point) :to-equal "(comment (+ 1 2))"))))
-    (it "returns the enclosed form when clojure-toplevel-inside-comment-form is set"
-      (with-clojure-buffer "(comment (+ 1| 2))"
-        (let ((clojure-toplevel-inside-comment-form t))
           (expect (cider-defun-at-point) :to-equal "(+ 1 2)"))))))
 
 (describe "cider-repl-prompt-function"

--- a/test/clojure-ts-mode/cider-util-ts-tests.el
+++ b/test/clojure-ts-mode/cider-util-ts-tests.el
@@ -100,13 +100,14 @@ buffer."
                 :to-equal 'clojure-ts-keyword-face)))))
 
 (describe "cider-defun-at-point inside a comment form"
-  (it "returns the whole comment form by default"
+  (it "treats the enclosed form as the top level one"
+    (with-clojure-ts-buffer "(comment (+ 1| 2))"
+      (expect (cider-defun-at-point) :to-equal "(+ 1 2)")))
+  (it "does so regardless of the user's clojure-ts-toplevel-inside-comment-form"
+    ;; the primitive binds the variable itself, so the whole command
+    ;; family behaves the same in rich-comment blocks
     (with-clojure-ts-buffer "(comment (+ 1| 2))"
       (let ((clojure-ts-toplevel-inside-comment-form nil))
-        (expect (cider-defun-at-point) :to-equal "(comment (+ 1 2))"))))
-  (it "returns the enclosed form when clojure-ts-toplevel-inside-comment-form is set"
-    (with-clojure-ts-buffer "(comment (+ 1| 2))"
-      (let ((clojure-ts-toplevel-inside-comment-form t))
         (expect (cider-defun-at-point) :to-equal "(+ 1 2)")))))
 
 (provide 'cider-ts-util-tests)


### PR DESCRIPTION
Part of the form-targeting cleanup: `C-c C-c` and `cider-eval-dwim` were comment-aware, but the rest of the defun family (`C-c C-f`, eval-to-comment, insert-in-REPL, inspect, format, debug) still operated on the whole `(comment ...)` - evaluating one always yields nil, which is never what anyone wants. The `clojure-toplevel-inside-comment-form` binding moves into `cider-defun-at-point` itself, so the entire command family behaves identically in rich-comment blocks, and the per-command bindings are gone.

This also means CIDER's commands no longer change behavior based on the clojure-mode variable - it keeps governing defun navigation and other non-CIDER things. The docs section on evaluating inside comments is rewritten accordingly, and the family's behavior is pinned with specs (dwim, pprint, eval-to-comment).