### PR TITLE
Share one implementation of the preceding-sexp bounds

### DIFF
--- a/lisp/cider-macroexpansion.el
+++ b/lisp/cider-macroexpansion.el
@@ -112,18 +112,6 @@ ARG is passed along to `undo-only'."
           cider-last-macroexpand-expander expander)
     (cider-initialize-macroexpansion-buffer expansion (cider-current-ns))))
 
-(defun cider-macroexpansion--form-bounds ()
-  "Return the bounds (BEG . END) of the sexp before point, or nil.
-This follows CIDER's usual convention (like `\\[cider-eval-last-sexp]'): place
-point right after the form.  To drill into a nested macro call in an
-expansion, put point after that form and expand again."
-  (save-excursion
-    (ignore-errors
-      (let ((beg (progn (clojure-backward-logical-sexp 1) (point)))
-            (end (progn (clojure-forward-logical-sexp 1) (point))))
-        (when (< beg end)
-          (cons beg end))))))
-
 (defun cider-macroexpansion--operator (form)
   "Return the operator (leading symbol) of the Clojure FORM string, or nil."
   (when (and form (string-match "\\`(\\s-*\\([^][(){} \t\n]+\\)" form))
@@ -133,7 +121,7 @@ expansion, put point after that form and expand again."
   "Substitute the form before point with its macroexpansion using EXPANDER.
 This is a helper invoked by the in-place expansion commands; EXPANDER is
 required, so it is not meant to be called interactively."
-  (pcase-let ((`(,beg . ,end) (or (cider-macroexpansion--form-bounds)
+  (pcase-let ((`(,beg . ,end) (or (cider--last-sexp-bounds)
                                   (user-error "No sexp before point to expand"))))
     (let ((code (buffer-substring-no-properties beg end)))
       ;; A fully-recursive expansion can reach macros in nested sub-forms, so

--- a/lisp/cider-macrostep.el
+++ b/lisp/cider-macrostep.el
@@ -217,18 +217,6 @@ EXPANDER is a `cider/macroexpand' expander name, such as \"macroexpand-1\"
                      (< (overlay-end ov) end)))
               cider-macrostep--overlays))
 
-(defun cider-macrostep--form-bounds ()
-  "Return the bounds (BEG . END) of the sexp before point, or nil.
-This follows CIDER's usual convention (like `\\[cider-eval-last-sexp]'): you
-place point right after the form you want to expand.  When stepping inside an
-expansion, put point after the nested form to drill into it."
-  (save-excursion
-    (ignore-errors
-      (let ((beg (progn (clojure-backward-logical-sexp 1) (point)))
-            (end (progn (clojure-forward-logical-sexp 1) (point))))
-        (when (< beg end)
-          (cons beg end))))))
-
 (defun cider-macrostep--operator (beg)
   "Return the operator (a string) of the list form starting at BEG, or nil."
   (save-excursion
@@ -424,7 +412,7 @@ before point, the `\\[cider-eval-last-sexp]' convention that
           (ignore-errors
             (backward-up-list)
             (cons (point) (progn (forward-sexp) (point))))))
-      (cider-macrostep--form-bounds)))
+      (cider--last-sexp-bounds)))
 
 (defvar cider-macrostep-mode-map
   (let ((map (make-sparse-keymap)))
@@ -580,7 +568,7 @@ The session uses the same overlay engine and key bindings as the inline
 flow, except that `q' dismisses the whole popup in one step."
   (interactive)
   (cider-ensure-session)
-  (pcase-let ((`(,beg . ,end) (or (cider-macrostep--form-bounds)
+  (pcase-let ((`(,beg . ,end) (or (cider--last-sexp-bounds)
                                   (user-error "No sexp before point to expand"))))
     (let ((operator (cider-macrostep--operator beg)))
       (cider-ensure-macro operator)

--- a/lisp/cider-util.el
+++ b/lisp/cider-util.el
@@ -338,6 +338,20 @@ instead."
                  (progn (clojure-forward-logical-sexp 1)
                         (point))))))
 
+(defun cider--last-sexp-bounds ()
+  "Return the bounds (BEG . END) of the sexp before point, or nil.
+A forgiving wrapper around `cider-last-sexp': it answers nil where that
+signals (unbalanced code) or where the answer is degenerate, which suits
+callers that want to fall back rather than fail.
+
+Note that sexp motion no-ops at the start of a buffer, so there the
+answer is the *following* form.  That quirk belongs to `cider-last-sexp'
+and is preserved here."
+  (ignore-errors
+    (pcase-let ((`(,beg ,end) (cider-last-sexp 'bounds)))
+      (when (< beg end)
+        (cons beg end)))))
+
 (defun cider-start-of-next-sexp (&optional skip)
   "Move to the start of the next sexp.
 Skip any non-logical sexps like ^metadata or #reader macros.

--- a/test/cider-macroexpansion-tests.el
+++ b/test/cider-macroexpansion-tests.el
@@ -106,17 +106,6 @@
         (cider-macroexpansion-toggle-print-metadata)
         (expect cider-macroexpansion-print-metadata :to-be nil)))))
 
-(describe "cider-macroexpansion--form-bounds"
-  (it "returns the bounds of the sexp before point"
-    (with-temp-buffer
-      (clojure-mode)
-      (insert "(if x (do (println y)))")
-      ;; point right after the nested form
-      (goto-char (point-min))
-      (search-forward "(println y)")
-      (pcase-let ((`(,beg . ,end) (cider-macroexpansion--form-bounds)))
-        (expect (buffer-substring-no-properties beg end) :to-equal "(println y)")))))
-
 (describe "cider-redraw-macroexpansion-buffer"
   (it "replaces the region from START to END with the expansion"
     (with-temp-buffer

--- a/test/cider-macrostep-tests.el
+++ b/test/cider-macrostep-tests.el
@@ -31,23 +31,6 @@
 
 ;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
 
-(describe "cider-macrostep--form-bounds"
-  (it "returns the bounds of the sexp before point"
-    (with-temp-buffer
-      (clojure-mode)
-      (insert "(when x (foo))")
-      ;; point is at the end, right after the whole form
-      (pcase-let ((`(,beg . ,end) (cider-macrostep--form-bounds)))
-        (expect (buffer-substring-no-properties beg end) :to-equal "(when x (foo))"))))
-  (it "targets the nested form when point is right after it"
-    (with-temp-buffer
-      (clojure-mode)
-      (insert "(when x (foo))")
-      (goto-char (point-min))
-      (search-forward "(foo)")           ; point right after the nested form
-      (pcase-let ((`(,beg . ,end) (cider-macrostep--form-bounds)))
-        (expect (buffer-substring-no-properties beg end) :to-equal "(foo)")))))
-
 (describe "cider-macrostep--operator"
   (it "returns the operator symbol of a list form"
     (with-temp-buffer

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -239,6 +239,41 @@
       (with-clojure-buffer "^:foo (bar|)"
         (expect (cider-sexp-at-point) :to-equal "^:foo (bar)")))))
 
+(describe "cider--last-sexp-bounds"
+  (it "returns the bounds of the sexp before point"
+    (with-clojure-buffer "a\n\n(defn ...)|\n\nb"
+      (expect (cider--last-sexp-bounds) :to-equal '(4 . 14))))
+
+  (it "targets the nested form when point is right after it"
+    (with-clojure-buffer "(when x (foo)|)"
+      (pcase-let ((`(,beg . ,end) (cider--last-sexp-bounds)))
+        (expect (buffer-substring-no-properties beg end) :to-equal "(foo)"))))
+
+  (it "targets the whole form from the end of it"
+    (with-clojure-buffer "(when x (foo))|"
+      (pcase-let ((`(,beg . ,end) (cider--last-sexp-bounds)))
+        (expect (buffer-substring-no-properties beg end) :to-equal "(when x (foo))"))))
+
+  (it "agrees with `cider-last-sexp' where both have an answer"
+    (with-clojure-buffer "(foo (bar 1) baz)|"
+      (expect (cider--last-sexp-bounds)
+              :to-equal (apply #'cons (cider-last-sexp 'bounds)))))
+
+  (it "returns the following form at the start of a buffer"
+    ;; backward sexp motion no-ops at point-min, so the forward motion
+    ;; lands on the next form instead.  Long-standing `cider-last-sexp'
+    ;; behavior; pinned here because callers rely on it
+    (with-clojure-buffer "|(foo)"
+      (expect (cider--last-sexp-bounds) :to-equal '(1 . 6))))
+
+  (it "answers nil rather than signalling when there is no sexp at all"
+    (with-clojure-buffer "|"
+      (expect (cider--last-sexp-bounds) :to-be nil))
+    ;; unbalanced code with nothing complete before point
+    (with-clojure-buffer "(foo (bar"
+      (goto-char (point-min))
+      (expect (cider--last-sexp-bounds) :to-be nil))))
+
 (describe "cider-last-sexp"
   (describe "when the param 'bounds is not given"
     (it "returns the last sexp"


### PR DESCRIPTION
First step of the form-command cleanup. `cider-macroexpansion.el` and `cider-macrostep.el` each carried a private `--form-bounds` that was, line for line, the same backward/forward-logical-sexp walk `cider-last-sexp` already does, just wrapped so it answers nil instead of signalling. Now there's one wrapper in `cider-util.el` and both call it, so the in-place expansion commands can't quietly drift away from the primitive everything else uses.

No behavior change: I compared all three form primitives at every cursor position across a handful of representative forms, before and after, and the output is identical.

While reviewing this I turned up two pre-existing bugs that I've deliberately left alone, since neither is caused by the refactor. `cider-last-sexp` only rejects an empty range, so with point at the end of a trailing comment it hands back the last word of that comment; `cider-macroexpand-all-inplace` skips the macro check, so it will send that text off and overwrite the comment with whatever comes back. And the reader-prefix narrowing in `cider-sexp-at-point`/`cider-list-at-point` covers `'`, `,` and `@`, which is the Emacs Lisp set: `,` is whitespace in Clojure so it never matters, while syntax-quote and `#(...)` aren't handled. Both get their own PRs.
