### PR TITLE
Stop reading line comments as code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Bugs fixed
 
+- [#4172](https://github.com/clojure-emacs/cider/pull/4172): Stop treating the text of a line comment as code: with point in or after a comment, `cider-eval-last-sexp` and friends now target the form preceding the comment, and the in-place macroexpansion commands no longer overwrite the comment with an expansion.
 - [#4158](https://github.com/clojure-emacs/cider/pull/4158): Detect running `lein trampoline` REPLs in `cider-connect`'s port suggestions (the trampolined JVM has no "leiningen" marker for the process scan to find), and don't miss REPLs running without a controlling terminal.
 - [#4158](https://github.com/clojure-emacs/cider/pull/4158): Stop discarding `.nrepl-port` files on systems without `lsof` (absence of the tool is not evidence the port is dead), and only treat listening sockets as proof of a live server.
 - [#4152](https://github.com/clojure-emacs/cider/pull/4152): Stop the dynamic font-lock locals scanner from treating the default expressions in an `:or` destructuring clause (e.g. `{:keys [x] :or {x (some-default)}}`) as local variables, so references there keep their normal highlighting.

--- a/lisp/cider-util.el
+++ b/lisp/cider-util.el
@@ -327,16 +327,32 @@ instead."
     (funcall (if bounds #'list #'buffer-substring-no-properties)
              (car b) (cdr b))))
 
+(defun cider--skip-back-over-comment ()
+  "Move to the start of the line comment point sits in, if any.
+Sexp motion has no notion of comments once point is inside one: it
+happily walks over the prose as if the words were symbols.  Stepping out
+of the comment first means the search for a form resumes from the code
+that precedes it."
+  (let ((ppss (syntax-ppss)))
+    (when (nth 4 ppss)
+      (goto-char (nth 8 ppss)))))
+
 (defun cider-last-sexp (&optional bounds)
   "Return the sexp preceding the point.
 If BOUNDS is non-nil, return a list of its starting and ending position
-instead."
+instead.
+A line comment before point is skipped over rather than read as code."
   (apply (if bounds #'list #'buffer-substring-no-properties)
          (save-excursion
+           (cider--skip-back-over-comment)
            (clojure-backward-logical-sexp 1)
            (list (point)
-                 (progn (clojure-forward-logical-sexp 1)
-                        (point))))))
+                 (if (looking-at-p "\\s<")
+                     ;; nothing but comments behind us; walking forward from
+                     ;; here would hand back the comment as if it were code
+                     (point)
+                   (progn (clojure-forward-logical-sexp 1)
+                          (point)))))))
 
 (defun cider--last-sexp-bounds ()
   "Return the bounds (BEG . END) of the sexp before point, or nil.

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -239,6 +239,33 @@
       (with-clojure-buffer "^:foo (bar|)"
         (expect (cider-sexp-at-point) :to-equal "^:foo (bar)")))))
 
+(describe "cider-last-sexp with comments"
+  (it "skips a trailing comment on the same line"
+    (with-clojure-buffer "(+ 1 2) ; hey|"
+      (expect (cider-last-sexp) :to-equal "(+ 1 2)")))
+
+  (it "skips a whole comment line"
+    (with-clojure-buffer "(defn foo [])\n;; a comment|"
+      (expect (cider-last-sexp) :to-equal "(defn foo [])")))
+
+  (it "skips several comments in a row"
+    (with-clojure-buffer "(+ 1 2) ;; c1\n;; c2|"
+      (expect (cider-last-sexp) :to-equal "(+ 1 2)")))
+
+  (it "is not fooled by a semicolon inside a string"
+    (with-clojure-buffer "(str \";\")|"
+      (expect (cider-last-sexp) :to-equal "(str \";\")")))
+
+  (it "finds nothing when only comments precede point"
+    (with-clojure-buffer ";; only a comment|"
+      (expect (cider-last-sexp) :to-equal "")
+      (expect (cider--last-sexp-bounds) :to-be nil)))
+
+  (it "still reads a comment form as the code it is"
+    ;; (comment ...) is a list, not a line comment
+    (with-clojure-buffer "(comment (+ 1 2))|"
+      (expect (cider-last-sexp) :to-equal "(comment (+ 1 2))"))))
+
 (describe "cider--last-sexp-bounds"
   (it "returns the bounds of the sexp before point"
     (with-clojure-buffer "a\n\n(defn ...)|\n\nb"


### PR DESCRIPTION
Sexp motion has no notion of comments once point is inside one, so it walks over the prose as if the words were symbols. With point at the end of a comment line following a form, `cider-last-sexp` answered `comment`, and everything built on it followed along.

For evaluation that just produced a puzzling error. The in-place macroexpansion commands are worse, because they replace the region they resolved, and `cider-macroexpand-all-inplace` skips the is-this-a-macro check. Expanding at the end of these buffers currently rewrites the comment:

```
;; only a comment              ->  ;; only a EXPANDED<comment>
(defn foo [])                      (defn foo [])
;; a comment                       ;; a EXPANDED<comment>

(+ 1 2) ; hey                  ->  (+ 1 2)          ; EXPANDED<hey>
```

`cider-last-sexp` now steps out of a line comment before looking backwards, so those find `(defn foo [])` and `(+ 1 2)` and leave the comments alone. With nothing but comments behind point it reports no form instead of handing one back, so the in-place commands say "No sexp before point to expand".

A `(comment ...)` form is a list and is unaffected, and a semicolon inside a string still isn't a comment. Found while reviewing #4171.
