### PR TITLE
Give the remaining form operations an at-point variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### New features
 
+- [#4173](https://github.com/clojure-emacs/cider/pull/4173): Give the rest of the form commands an "at point" variant, as evaluation and tap already had: `cider-inspect-sexp-at-point`, `cider-pprint-eval-sexp-at-point`, `cider-macroexpand-1-at-point`, `cider-macroexpand-all-at-point`, `cider-format-edn-sexp-at-point` and `cider-insert-sexp-at-point-in-repl`, so you no longer have to move point after a form to act on it.
 - [#4164](https://github.com/clojure-emacs/cider/pull/4164): Resolve container-published nREPL ports: `cider-connect` suggestions from a `/docker:`/`/podman:` buffer are translated to the host ports they're published on, and jack-in over tramp-container connects back through the published port instead of failing on the unreachable container name.
 - [#4142](https://github.com/clojure-emacs/cider/pull/4142): Bring CIDER's dynamic font-locking (highlighting REPL-defined macros, functions, vars and deprecated/instrumented/traced symbols) to `clojure-ts-mode` buffers via tree-sitter; previously it only worked under `clojure-mode`.
 - [#4145](https://github.com/clojure-emacs/cider/pull/4145): Add `cider-preferred-clojure-mode` (default `auto`) controlling which Clojure major mode CIDER uses to font-lock the code it renders (REPL input/results, doc examples, overlays, xref labels, etc.); when set to (or auto-detecting) `clojure-ts-mode`, those snippets get tree-sitter highlighting instead of `clojure-mode`'s.

--- a/codespell.txt
+++ b/codespell.txt
@@ -1,6 +1,7 @@
 debbugs
 edn
 eduction
+fo
 hel
 hist
 juxt

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -931,8 +931,7 @@ If invoked with OUTPUT-TO-CURRENT-BUFFER, output the result to current buffer."
 If invoked with OUTPUT-TO-CURRENT-BUFFER, output the result to current buffer."
   (interactive "P")
   (save-excursion
-    (goto-char (cadr (or (cider-sexp-at-point 'bounds)
-                         (user-error "No sexp at point"))))
+    (cider--goto-end-of-thing-at-point 'sexp)
     (cider-eval-last-sexp output-to-current-buffer)))
 
 (defun cider-tap-last-sexp (&optional output-to-current-buffer)
@@ -951,8 +950,7 @@ buffer."
 If invoked with OUTPUT-TO-CURRENT-BUFFER, output the result to current buffer."
   (interactive "P")
   (save-excursion
-    (goto-char (cadr (or (cider-sexp-at-point 'bounds)
-                         (user-error "No sexp at point"))))
+    (cider--goto-end-of-thing-at-point 'sexp)
     (cider-tap-last-sexp output-to-current-buffer)))
 
 (defvar-local cider-previous-eval-context nil
@@ -1251,6 +1249,15 @@ buffer, else display in a popup buffer."
   (if output-to-current-buffer
       (cider-pprint-eval-last-sexp-to-comment)
     (cider--pprint-eval-form (cider-last-sexp 'bounds))))
+
+(defun cider-pprint-eval-sexp-at-point (&optional output-to-current-buffer)
+  "Evaluate the sexp around point and pprint its value.
+If invoked with OUTPUT-TO-CURRENT-BUFFER, insert as comment in the current
+buffer, else display in a popup buffer."
+  (interactive "P")
+  (save-excursion
+    (cider--goto-end-of-thing-at-point 'sexp)
+    (cider-pprint-eval-last-sexp output-to-current-buffer)))
 
 (defun cider--prompt-and-insert-inline-dbg ()
   "Insert a #dbg button at the current sexp."
@@ -1551,6 +1558,11 @@ The chosen printer is `let'-bound around the call, for this invocation only."
   (interactive (list (transient-args 'cider-eval-pprint-menu)))
   (cider-eval-pprint-menu--apply-args args #'cider-pprint-eval-last-sexp))
 
+(transient-define-suffix cider-eval-pprint-menu--sexp-at-point (args)
+  "Pretty-print the sexp around point, applying the menu's ARGS."
+  (interactive (list (transient-args 'cider-eval-pprint-menu)))
+  (cider-eval-pprint-menu--apply-args args #'cider-pprint-eval-sexp-at-point))
+
 (transient-define-suffix cider-eval-pprint-menu--defun (args)
   "Pretty-print the defun at point, applying the menu's ARGS."
   (interactive (list (transient-args 'cider-eval-pprint-menu)))
@@ -1580,6 +1592,7 @@ zprint, or a custom var) for this invocation only."
    ("-p" "Print function" "--print-fn=" :reader cider-eval-pprint-menu--read-print-fn)]
   [["Pretty-print"
     ("e" "Last sexp" cider-eval-pprint-menu--last-sexp)
+    ("v" "Sexp at point" cider-eval-pprint-menu--sexp-at-point)
     ("d" "Defun at point" cider-eval-pprint-menu--defun)]
    ["Send pretty-printed value to"
     ("c" "Comment (last sexp)" cider-eval-pprint-menu--last-sexp-to-comment)

--- a/lisp/cider-format.el
+++ b/lisp/cider-format.el
@@ -164,5 +164,12 @@ START and END represent the region's boundaries."
       (apply #'cider-format-edn-region bounds)
     (user-error "No sexp preceding point")))
 
+(defun cider-format-edn-sexp-at-point ()
+  "Format the EDN data of the sexp around point."
+  (interactive)
+  (save-excursion
+    (cider--goto-end-of-thing-at-point 'sexp)
+    (cider-format-edn-last-sexp)))
+
 (provide 'cider-format)
 ;;; cider-format.el ends here

--- a/lisp/cider-inspector.el
+++ b/lisp/cider-inspector.el
@@ -304,6 +304,14 @@ itself rather than the form it applies to."
   (cider-inspect-expr (cider-defun-at-point) (cider-current-ns)))
 
 ;;;###autoload
+(defun cider-inspect-sexp-at-point ()
+  "Inspect the result of the expression around point."
+  (interactive)
+  (save-excursion
+    (cider--goto-end-of-thing-at-point 'sexp)
+    (cider-inspect-last-sexp)))
+
+;;;###autoload
 (defun cider-inspect-last-result ()
   "Inspect the most recent eval result."
   (interactive)

--- a/lisp/cider-macroexpansion.el
+++ b/lisp/cider-macroexpansion.el
@@ -175,6 +175,27 @@ expansion can reach macros in nested sub-forms."
   (interactive)
   (cider-macroexpand-expr-inplace "macroexpand-all"))
 
+;;;###autoload
+(defun cider-macroexpand-1-at-point (&optional prefix)
+  "Invoke \\=`macroexpand-1\\=` on the call form around point.
+The target is the form at point, widened to the enclosing call when point
+is on a bare symbol: an expansion needs a call form.
+If invoked with a PREFIX argument, use \\=`macroexpand\\=` instead."
+  (interactive "P")
+  (save-excursion
+    (cider--goto-end-of-call-at-point)
+    (cider-macroexpand-1 prefix)))
+
+;;;###autoload
+(defun cider-macroexpand-all-at-point ()
+  "Invoke \\=`macroexpand-all\\=` on the call form around point.
+The target is the form at point, widened to the enclosing call when point
+is on a bare symbol."
+  (interactive)
+  (save-excursion
+    (cider--goto-end-of-call-at-point)
+    (cider-macroexpand-all)))
+
 (defun cider-initialize-macroexpansion-buffer (expansion ns)
   "Create a new Macroexpansion buffer with EXPANSION and namespace NS."
   (pop-to-buffer (cider-create-macroexpansion-buffer))
@@ -331,6 +352,16 @@ macroexpansion honors them for this invocation only."
   (interactive (list (transient-args 'cider-macroexpand-menu)))
   (cider-macroexpand-menu--apply-args args #'cider-macroexpand-1))
 
+(transient-define-suffix cider-macroexpand-menu--expand-1-at-point (args)
+  "Macroexpand-1 the call form around point, applying the menu's ARGS."
+  (interactive (list (transient-args 'cider-macroexpand-menu)))
+  (cider-macroexpand-menu--apply-args args #'cider-macroexpand-1-at-point))
+
+(transient-define-suffix cider-macroexpand-menu--expand-all-at-point (args)
+  "Fully macroexpand the call form around point, applying the menu's ARGS."
+  (interactive (list (transient-args 'cider-macroexpand-menu)))
+  (cider-macroexpand-menu--apply-args args #'cider-macroexpand-all-at-point))
+
 (transient-define-suffix cider-macroexpand-menu--expand-all (args)
   "Fully macroexpand into a popup buffer, applying the menu's ARGS."
   (interactive (list (transient-args 'cider-macroexpand-menu)))
@@ -347,7 +378,9 @@ namespaces and metadata for this invocation."
    ("-m" "Include metadata" "--meta")]
   [["Macroexpand (popup buffer)"
     ("1" "Macroexpand-1" cider-macroexpand-menu--expand-1)
-    ("a" "Macroexpand all" cider-macroexpand-menu--expand-all)]
+    ("a" "Macroexpand all" cider-macroexpand-menu--expand-all)
+    ("v" "Macroexpand-1 at point" cider-macroexpand-menu--expand-1-at-point)
+    ("V" "Macroexpand all at point" cider-macroexpand-menu--expand-all-at-point)]
    ["Inline (macrostep)"
     ("e" "Expand-1 inline" cider-macrostep-expand)
     ("E" "Expand all inline" cider-macrostep-expand-all)

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -213,6 +213,7 @@ With a prefix argument, prompt for function to run instead of -main."
   (let ((map (define-prefix-command 'cider-insert-commands-map)))
     ;; single key bindings defined last for display in menu
     (define-key map (kbd "e") #'cider-insert-last-sexp-in-repl)
+    (define-key map (kbd "v") #'cider-insert-sexp-at-point-in-repl)
     (define-key map (kbd "d") #'cider-insert-defun-in-repl)
     (define-key map (kbd "r") #'cider-insert-region-in-repl)
     (define-key map (kbd "n") #'cider-insert-ns-form-in-repl)
@@ -290,6 +291,14 @@ If EVAL is non-nil the form will also be evaluated.  Use
 If invoked with a prefix ARG eval the expression after inserting it."
   (interactive "P")
   (cider-insert-in-repl (cider-last-sexp) arg))
+
+(defun cider-insert-sexp-at-point-in-repl (&optional arg)
+  "Insert the expression around point in the REPL buffer.
+If invoked with a prefix ARG eval the expression after inserting it."
+  (interactive "P")
+  (save-excursion
+    (cider--goto-end-of-thing-at-point 'sexp)
+    (cider-insert-last-sexp-in-repl arg)))
 
 (defun cider-insert-defun-in-repl (&optional arg)
   "Insert the top level form at point in the REPL buffer.
@@ -474,6 +483,7 @@ If invoked with a prefix ARG eval the expression after inserting it."
      ["Browse classpath entry" cider-open-classpath-entry])
     ("Format"
      ["Format EDN last sexp" cider-format-edn-last-sexp]
+     ["Format EDN sexp at point" cider-format-edn-sexp-at-point]
      ["Format EDN region" cider-format-edn-region]
      ["Format EDN buffer" cider-format-edn-buffer])
     ("Macroexpand"

--- a/lisp/cider-util.el
+++ b/lisp/cider-util.el
@@ -368,6 +368,33 @@ and is preserved here."
       (when (< beg end)
         (cons beg end)))))
 
+(defun cider--goto-end-of-thing-at-point (thing)
+  "Move point to the end of the THING at point, `sexp' or `list'.
+Signals a `user-error' when there is none.  The commands that operate on
+the thing at point are all built this way: step to its end, then hand off
+to the command that operates on the sexp preceding point, so the two
+share their handlers and their options."
+  (goto-char (cadr (or (pcase thing
+                         ('sexp (cider-sexp-at-point 'bounds))
+                         ('list (cider-list-at-point 'bounds))
+                         (_ (error "Unknown thing: %S" thing)))
+                       (user-error "No %s at point" thing)))))
+
+(defun cider--goto-end-of-call-at-point ()
+  "Move point to the end of the call form around point.
+That is the sexp at point when it is a compound form, and the enclosing
+list when it is a bare symbol or another atom, since an expansion needs a
+call form and never a lone symbol.  Signals a `user-error' when there is
+neither."
+  (let ((sexp (cider-sexp-at-point 'bounds)))
+    (goto-char (cadr (or (and sexp
+                              ;; a compound form always ends in a closing
+                              ;; delimiter, whatever reader prefix it carries
+                              (eq (char-syntax (char-before (cadr sexp))) ?\))
+                              sexp)
+                         (cider-list-at-point 'bounds)
+                         (user-error "No call form at point"))))))
+
 (defun cider-start-of-next-sexp (&optional skip)
   "Move to the start of the next sexp.
 Skip any non-logical sexps like ^metadata or #reader macros.

--- a/test/cider-macroexpansion-tests.el
+++ b/test/cider-macroexpansion-tests.el
@@ -205,6 +205,35 @@
       ;; The undo actually took effect (the last change is gone).
       (expect (buffer-string) :not :to-match "bar"))))
 
+(describe "the at-point macroexpansion commands"
+  (it "expands the call around point, widening from a bare symbol"
+    (spy-on 'cider-macroexpand-expr)
+    (spy-on 'cider-ensure-macro)
+    (with-clojure-buffer "(when x (fo|o bar))"
+      (cider-macroexpand-1-at-point)
+      (expect (nth 1 (spy-calls-args-for 'cider-macroexpand-expr 0))
+              :to-equal "(foo bar)")))
+
+  (it "expands the form point opens rather than its parent"
+    (spy-on 'cider-macroexpand-expr)
+    (spy-on 'cider-ensure-macro)
+    (with-clojure-buffer "(when x |(foo bar))"
+      (cider-macroexpand-all-at-point)
+      (expect (nth 1 (spy-calls-args-for 'cider-macroexpand-expr 0))
+              :to-equal "(foo bar)")))
+
+  (it "leaves point where it was"
+    (spy-on 'cider-macroexpand-expr)
+    (spy-on 'cider-ensure-macro)
+    (with-clojure-buffer "(when x (fo|o bar))"
+      (let ((start (point)))
+        (cider-macroexpand-1-at-point)
+        (expect (point) :to-equal start))))
+
+  (it "signals a user-error when there is no call form"
+    (with-clojure-buffer "|"
+      (expect (cider-macroexpand-1-at-point) :to-throw 'user-error))))
+
 (provide 'cider-macroexpansion-tests)
 
 ;;; cider-macroexpansion-tests.el ends here

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -266,6 +266,41 @@
     (with-clojure-buffer "(comment (+ 1 2))|"
       (expect (cider-last-sexp) :to-equal "(comment (+ 1 2))"))))
 
+(describe "cider--goto-end-of-thing-at-point"
+  (it "moves to the end of the sexp around point"
+    (with-clojure-buffer "(when x (fo|o bar))"
+      (cider--goto-end-of-thing-at-point 'sexp)
+      (expect (buffer-substring-no-properties (point-min) (point)) :to-equal "(when x (foo")))
+
+  (it "moves to the end of the list around point"
+    (with-clojure-buffer "(when x (fo|o bar))"
+      (cider--goto-end-of-thing-at-point 'list)
+      (expect (buffer-substring-no-properties (point-min) (point)) :to-equal "(when x (foo bar)")))
+
+  (it "signals a user-error when there is nothing there"
+    (with-clojure-buffer "|"
+      (expect (cider--goto-end-of-thing-at-point 'sexp) :to-throw 'user-error))))
+
+(describe "cider--goto-end-of-call-at-point"
+  (it "widens a bare symbol to the call that encloses it"
+    (with-clojure-buffer "(when x (fo|o bar))"
+      (cider--goto-end-of-call-at-point)
+      (expect (buffer-substring-no-properties (point-min) (point)) :to-equal "(when x (foo bar)")))
+
+  (it "takes the form point opens, not its parent"
+    (with-clojure-buffer "(when x |(foo bar))"
+      (cider--goto-end-of-call-at-point)
+      (expect (buffer-substring-no-properties (point-min) (point)) :to-equal "(when x (foo bar)")))
+
+  (it "takes the form point closes"
+    (with-clojure-buffer "(when x (foo bar)|)"
+      (cider--goto-end-of-call-at-point)
+      (expect (buffer-substring-no-properties (point-min) (point)) :to-equal "(when x (foo bar))")))
+
+  (it "signals a user-error when there is no call form"
+    (with-clojure-buffer "|"
+      (expect (cider--goto-end-of-call-at-point) :to-throw 'user-error))))
+
 (describe "cider--last-sexp-bounds"
   (it "returns the bounds of the sexp before point"
     (with-clojure-buffer "a\n\n(defn ...)|\n\nb"


### PR DESCRIPTION
Evaluation could already act on the sexp or the list around point, and so could tap, but the rest of the family had no way to say "this one, where the cursor is" - inspection, pretty-printing, macroexpansion, EDN formatting and inserting into the REPL all insisted that point sit right after the form. Macroexpansion had it worst, having only ever offered the preceding sexp.

So this adds `cider-inspect-sexp-at-point`, `cider-pprint-eval-sexp-at-point`, `cider-macroexpand-1-at-point`, `cider-macroexpand-all-at-point`, `cider-format-edn-sexp-at-point` and `cider-insert-sexp-at-point-in-repl`. Each one follows the shape the two existing at-point commands already used: step to the end of the thing at point, then hand off to the `-last-sexp` command, so they inherit its handlers and prefix arguments for free. That step is now shared, and the two older commands use it too.

Macroexpansion is the one that needed thought, since it wants a call form rather than any sexp. Standing on a bare symbol widens to the call around it, because expanding a lone symbol is never what you meant, and standing on an opening delimiter expands the form it opens rather than its parent (which is what `cider-list-at-point` would have handed back):

```
(when x (fo|o bar))   ->  (foo bar)
(when x |(foo bar))   ->  (foo bar)
(when x (foo bar)|)   ->  (when x (foo bar))
```

Nothing existing changes behavior. The new commands are reachable from the macroexpansion and pretty-print menus, the insert keymap (`v`) and the format menu.

Inspection is still only reachable through the `cider-inspect` prefix-argument dispatcher, and I left that alone rather than adding a fourth prefix level to it. That dispatcher being the only one of its kind is worth revisiting separately.
