### PR TITLE
Document how CIDER picks the form a command acts on

### DIFF
--- a/doc/modules/ROOT/pages/debugging/macroexpansion.adoc
+++ b/doc/modules/ROOT/pages/debugging/macroexpansion.adoc
@@ -17,6 +17,12 @@ form-expanding commands:
 | kbd:[C-c M-m a]
 | `macroexpand-all` into a macroexpansion buffer.
 
+| kbd:[C-c M-m v]
+| `macroexpand-1` the call at point (see xref:#target[Choosing what to expand]).
+
+| kbd:[C-c M-m V]
+| `macroexpand-all` the call at point.
+
 | kbd:[C-c M-m e]
 | Expand the macro at point one step, inline in the source buffer (see xref:#inline[inline macro stepping] below).
 
@@ -26,6 +32,43 @@ form-expanding commands:
 | kbd:[C-c M-m b]
 | Run an inline-style stepping session in a dedicated popup buffer.
 |===
+
+[[target]]
+== Choosing what to expand
+
+Like the rest of CIDER's form commands, the expansion commands act on the form
+_preceding_ the cursor; see
+xref:usage/code_evaluation.adoc#_selecting_the_form_to_operate_on[Selecting the
+Form to Operate On] for why that's the convention.
+
+Macroexpansion has one wrinkle the other operations don't, though: an expansion
+only makes sense for a *call form*. Expanding a bare symbol tells you nothing,
+and CIDER will refuse with "Not a macro" rather than pretend otherwise.
+
+That's why `cider-macroexpand-1-at-point` and `cider-macroexpand-all-at-point`
+resolve their target a little differently from their `+sexp-at-point+` cousins.
+Given `+(when x (foo bar))+`, with `+|+` marking the cursor:
+
+[cols="1,1"]
+|===
+| Cursor | Target
+
+| `+(when x (fo\|o bar))+`
+| `+(foo bar)+` - a bare symbol widens to the call around it
+
+| `+(when x \|(foo bar))+`
+| `+(foo bar)+` - the form you're standing on, not its parent
+
+| `+(when x (foo bar)\|)+`
+| `+(when x (foo bar))+` - the form the delimiter closes
+|===
+
+In other words: point at the call you're interested in, anywhere in it, and
+you'll expand that call.
+
+TIP: The inline commands let you drill into a nested call without leaving the
+source buffer, and kbd:[g] re-runs the last expansion from inside the
+macroexpansion buffer.
 
 [TIP]
 ====

--- a/doc/modules/ROOT/pages/usage/code_evaluation.adoc
+++ b/doc/modules/ROOT/pages/usage/code_evaluation.adoc
@@ -15,9 +15,116 @@ confusing to people not familiar with it. Let's take a look at it:
 * `sexp` - s-expression, form
 * `last-sexp` - the form preceding the cursor (`point` in Emacs lingo)
 * `sexp-at-point` - the form under/around the cursor
+* `list-at-point` - the innermost compound form (list, vector, map...) around the cursor
 * `buffer` - the abstraction used by Emacs to represent any content; most often backed by a file.
 * `region` - the selected part of a buffer
 * `load` - a synonym for "evaluate"; most often used in the context of buffers/files
+
+The first four are the ones worth internalizing, as they name the ways every
+CIDER command decides which form to act on. That's the subject of the next
+section.
+
+== Selecting the Form to Operate On
+
+Plenty of CIDER commands operate on "a form" - evaluating it, inspecting it,
+macroexpanding it, pretty-printing it, sending it to the REPL. They all pick
+that form the same way, so learning the rules once buys you the whole family.
+
+There are three ways to say which form you mean:
+
+[cols="1,2,2"]
+|===
+| Target | How you say it | Naming
+
+| The preceding form
+| Put the cursor right after the form
+| `+...-last-sexp+`
+
+| The form at the cursor
+| Put the cursor on or inside the form
+| `+...-sexp-at-point+`
+
+| The top-level form
+| Put the cursor anywhere inside it
+| `+...-defun-at-point+`
+|===
+
+*The preceding form is the default*, and it's what the flagship keybindings
+use: kbd:[C-x C-e] evaluates the form before the cursor, kbd:[C-c M-i]
+inspects it, kbd:[C-c C-m] macroexpands it.
+
+.Why is the cursor _after_ the form, rather than on it?
+****
+This is a deliberate design decision rather than an accident, and it long
+predates CIDER.
+
+Emacs Lisp's own `eval-last-sexp` (kbd:[C-x C-e]) works exactly this way, and
+so do SLIME and SLY, the Common Lisp environments that CIDER's command set was
+modelled on. Anyone arriving from another Lisp mode in Emacs already has the
+muscle memory, and the same keys do the same thing.
+
+There's a practical argument too: you've usually _just typed_ the form you want
+to evaluate, which leaves the cursor exactly where the command expects it.
+
+CIDER has stuck to this convention for over a decade, and intends to keep
+doing so. What it also offers, for those who prefer to point at a form rather
+than stand after it, is the `+at-point+` family below.
+****
+
+=== Acting on the form at the cursor
+
+Every operation also has a variant that works from _inside_ the form, so you
+don't have to move the cursor to its end first:
+
+[cols="1,1"]
+|===
+| Command | Operation
+
+| `cider-eval-sexp-at-point`
+| Evaluate
+
+| `cider-eval-list-at-point`
+| Evaluate the enclosing compound form
+
+| `cider-pprint-eval-sexp-at-point`
+| Evaluate and pretty-print
+
+| `cider-inspect-sexp-at-point`
+| Inspect
+
+| `cider-macroexpand-1-at-point`
+| Macroexpand one step
+
+| `cider-macroexpand-all-at-point`
+| Macroexpand fully
+
+| `cider-tap-sexp-at-point`
+| Tap
+
+| `cider-format-edn-sexp-at-point`
+| Format as EDN
+
+| `cider-insert-sexp-at-point-in-repl`
+| Insert into the REPL
+|===
+
+These resolve the form generously: with the cursor on an opening delimiter you
+get the form it opens, on a closing delimiter the form it closes, and inside a
+symbol that symbol.
+
+If you'd rather have this behavior on the keys you already use, rebind them.
+Nothing else changes:
+
+[source,lisp]
+----
+(with-eval-after-load 'cider-mode
+  (define-key cider-mode-map (kbd "C-x C-e") #'cider-eval-sexp-at-point)
+  (define-key cider-mode-map (kbd "C-c C-e") #'cider-eval-sexp-at-point))
+----
+
+NOTE: Macroexpansion resolves its target slightly differently, since an
+expansion needs a call form. See
+xref:debugging/macroexpansion.adoc#target[Choosing what to expand].
 
 == Basic Evaluation
 


### PR DESCRIPTION
Stacked on #4173, so the diff to review here is just the two doc pages.

The terminology section named `last-sexp` and `sexp-at-point` but never said what follows from them, so the rules had to be inferred command by command. There's now a section that spells out the three ways to say which form you mean, a table of the at-point variants, and a snippet you can paste to rebind the flagship keys to them if you prefer pointing at a form over standing after it.

It also records *why* the cursor goes after the form rather than on it, which until now was folklore: that's how Emacs Lisp's own `eval-last-sexp` works, and SLIME's and SLY's, and following that prior art has been a deliberate choice rather than an accident. The keybindings section already says as much about keys; the same reasoning governs form selection, and after the recent round-trip on this it seemed worth writing down.

Macroexpansion gets its own section, since it's the one operation that resolves its target differently: an expansion needs a call form, so a bare symbol widens to the call around it and an opening delimiter expands the form it opens rather than the parent.

Two things I have not done here. There are no GIFs illustrating the selection modes yet - they want a live REPL to show real evaluation overlays, and that harness is worth building properly rather than faking the illustration; I'd like to do it as its own PR. And I'd like to look at what SLIME, SLY, Geiser and the Emacs Lisp modes do that we don't, since we've only ever borrowed the convention itself and there may be more worth taking.
