### PR TITLE
Fall back to the preceding form when nothing is at point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Changes
 
+- [#4175](https://github.com/clojure-emacs/cider/pull/4175): Have the "at point" commands (`cider-eval-sexp-at-point` and friends) fall back to the form preceding point when there's nothing at point, instead of erroring, so they can stand in for their `last-sexp` counterparts.
 - [#4166](https://github.com/clojure-emacs/cider/pull/4166): Treat the contents of a `comment` form as top level in the whole defun command family (pretty-printing, eval-to-comment, inspect, format, debug, etc.), not just `cider-eval-defun-at-point` and `cider-eval-dwim`; CIDER's commands no longer depend on `clojure-toplevel-inside-comment-form`.
 - [#4160](https://github.com/clojure-emacs/cider/pull/4160): Stop offering the previous session's port as the `cider-connect` default when nothing is listening on it anymore; the host is still offered and port inference takes over.
 - [#4159](https://github.com/clojure-emacs/cider/pull/4159): Make `cider-default-nrepl-port` customizable, keep `cider-connect` usable when Tramp's ssh-config completion errors, and document how port suggestions are computed in a new "How CIDER Finds Ports" manual section.

--- a/doc/modules/ROOT/pages/usage/code_evaluation.adoc
+++ b/doc/modules/ROOT/pages/usage/code_evaluation.adoc
@@ -110,7 +110,10 @@ don't have to move the cursor to its end first:
 
 These resolve the form generously: with the cursor on an opening delimiter you
 get the form it opens, on a closing delimiter the form it closes, and inside a
-symbol that symbol.
+symbol that symbol. Where there's nothing at the cursor at all - in the
+whitespace between forms, which is where you land after typing one - they fall
+back to the preceding form, so they're drop-in replacements for their
+`+...-last-sexp+` siblings rather than a separate mode of working.
 
 If you'd rather have this behavior on the keys you already use, rebind them.
 Nothing else changes:

--- a/lisp/cider-util.el
+++ b/lisp/cider-util.el
@@ -370,30 +370,38 @@ and is preserved here."
 
 (defun cider--goto-end-of-thing-at-point (thing)
   "Move point to the end of the THING at point, `sexp' or `list'.
-Signals a `user-error' when there is none.  The commands that operate on
-the thing at point are all built this way: step to its end, then hand off
-to the command that operates on the sexp preceding point, so the two
-share their handlers and their options."
-  (goto-char (cadr (or (pcase thing
+Where there is none - in the whitespace between forms, say - falls back to
+the sexp preceding point, and only then signals a `user-error'.  The
+commands that operate on the thing at point are all built this way: step
+to its end, then hand off to the command that operates on the sexp
+preceding point, so the two share their handlers and their options."
+  (goto-char (or (cadr (pcase thing
                          ('sexp (cider-sexp-at-point 'bounds))
                          ('list (cider-list-at-point 'bounds))
-                         (_ (error "Unknown thing: %S" thing)))
-                       (user-error "No %s at point" thing)))))
+                         (_ (error "Unknown thing: %S" thing))))
+                 ;; Nothing is at point in the whitespace between forms,
+                 ;; which is where you land after typing one.  Fall back
+                 ;; to the preceding form, so these commands can serve as
+                 ;; drop-in replacements for their `last-sexp' siblings.
+                 (cdr (cider--last-sexp-bounds))
+                 (user-error "No %s at point" thing))))
 
 (defun cider--goto-end-of-call-at-point ()
   "Move point to the end of the call form around point.
 That is the sexp at point when it is a compound form, and the enclosing
 list when it is a bare symbol or another atom, since an expansion needs a
-call form and never a lone symbol.  Signals a `user-error' when there is
-neither."
+call form and never a lone symbol.  Where there is neither, falls back to
+the sexp preceding point before signalling a `user-error'."
   (let ((sexp (cider-sexp-at-point 'bounds)))
-    (goto-char (cadr (or (and sexp
-                              ;; a compound form always ends in a closing
-                              ;; delimiter, whatever reader prefix it carries
-                              (eq (char-syntax (char-before (cadr sexp))) ?\))
-                              sexp)
-                         (cider-list-at-point 'bounds)
-                         (user-error "No call form at point"))))))
+    (goto-char (or (cadr (or (and sexp
+                                  ;; a compound form always ends in a closing
+                                  ;; delimiter, whatever reader prefix it carries
+                                  (eq (char-syntax (char-before (cadr sexp))) ?\))
+                                  sexp)
+                             (cider-list-at-point 'bounds)))
+                   ;; as above: in whitespace, act on the preceding form
+                   (cdr (cider--last-sexp-bounds))
+                   (user-error "No call form at point")))))
 
 (defun cider-start-of-next-sexp (&optional skip)
   "Move to the start of the next sexp.

--- a/test/cider-util-tests.el
+++ b/test/cider-util-tests.el
@@ -277,7 +277,15 @@
       (cider--goto-end-of-thing-at-point 'list)
       (expect (buffer-substring-no-properties (point-min) (point)) :to-equal "(when x (foo bar)")))
 
-  (it "signals a user-error when there is nothing there"
+  (it "falls back to the preceding form in the whitespace between forms"
+    (with-clojure-buffer "(+ 1 2) |"
+      (cider--goto-end-of-thing-at-point 'sexp)
+      (expect (buffer-substring-no-properties (point-min) (point)) :to-equal "(+ 1 2)"))
+    (with-clojure-buffer "(foo bar)\n\n|"
+      (cider--goto-end-of-thing-at-point 'sexp)
+      (expect (buffer-substring-no-properties (point-min) (point)) :to-equal "(foo bar)")))
+
+  (it "signals a user-error when there is nothing to fall back to either"
     (with-clojure-buffer "|"
       (expect (cider--goto-end-of-thing-at-point 'sexp) :to-throw 'user-error))))
 
@@ -297,7 +305,12 @@
       (cider--goto-end-of-call-at-point)
       (expect (buffer-substring-no-properties (point-min) (point)) :to-equal "(when x (foo bar))")))
 
-  (it "signals a user-error when there is no call form"
+  (it "falls back to the preceding form in the whitespace between forms"
+    (with-clojure-buffer "(foo bar) |"
+      (cider--goto-end-of-call-at-point)
+      (expect (buffer-substring-no-properties (point-min) (point)) :to-equal "(foo bar)")))
+
+  (it "signals a user-error when there is nothing to fall back to either"
     (with-clojure-buffer "|"
       (expect (cider--goto-end-of-call-at-point) :to-throw 'user-error))))
 


### PR DESCRIPTION
The at-point commands raised "No sexp at point" whenever the cursor sat in whitespace, which is exactly where you land after typing a form:

```
(+ 1 2) |      -> nothing at point
(foo bar)
|              -> nothing at point
```

That made them awkward to adopt as everyday commands, and it undercut the advice in the manual (added in #4174) to rebind `C-x C-e` to `cider-eval-sexp-at-point` if you'd rather point at a form than stand after it - the rebinding would break the moment you pressed space or RET.

They now fall back to the sexp preceding point. So they match their `-last-sexp` siblings wherever there's nothing to point at, and differ only where the cursor genuinely is on or inside a form. With nothing to fall back to either, the `user-error` still stands.

That makes them true drop-in replacements, which is the shape we landed on after the earlier round-trip: the structural behavior is available to anyone who wants it, on commands they opt into, with the defaults untouched.
