### PR TITLE
Name two commands after what they operate on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Changes
 
+- [#4177](https://github.com/clojure-emacs/cider/pull/4177): Rename `cider-format-defun` to `cider-format-defun-at-point` and `cider-send-to-comment` to `cider-send-defun-to-comment`, so they name the form they operate on like the rest of the form commands; the old names remain as obsolete aliases.
 - [#4175](https://github.com/clojure-emacs/cider/pull/4175): Have the "at point" commands (`cider-eval-sexp-at-point` and friends) fall back to the form preceding point when there's nothing at point, instead of erroring, so they can stand in for their `last-sexp` counterparts.
 - [#4166](https://github.com/clojure-emacs/cider/pull/4166): Treat the contents of a `comment` form as top level in the whole defun command family (pretty-printing, eval-to-comment, inspect, format, debug, etc.), not just `cider-eval-defun-at-point` and `cider-eval-dwim`; CIDER's commands no longer depend on `clojure-toplevel-inside-comment-form`.
 - [#4160](https://github.com/clojure-emacs/cider/pull/4160): Stop offering the previous session's port as the `cider-connect` default when nothing is listening on it anymore; the host is still offered and port inference takes over.

--- a/doc/modules/ROOT/pages/keybindings.adoc
+++ b/doc/modules/ROOT/pages/keybindings.adoc
@@ -417,7 +417,7 @@ TIP: See xref:debugging/debugger.adoc[Debugger] and xref:debugging/tracing.adoc[
 | Copy the form preceding point into the REPL prompt.
 
 | kbd:[C-c C-j c]
-| `cider-send-to-comment`
+| `cider-send-defun-to-comment`
 | Copy the top-level form into the namespace's rich `comment` block.
 
 | kbd:[C-c C-j v]

--- a/doc/modules/ROOT/pages/usage/code_evaluation.adoc
+++ b/doc/modules/ROOT/pages/usage/code_evaluation.adoc
@@ -656,7 +656,7 @@ The `(comment ...)` form (often called a "rich comment" or RCF) is a popular
 place to keep throwaway experiments and usage examples that live with the code
 but never run when the namespace is loaded.
 
-`cider-send-to-comment` (kbd:[C-c C-j c]) copies the top-level form at point
+`cider-send-defun-to-comment` (kbd:[C-c C-j c]) copies the top-level form at point
 into the namespace's rich `comment` block, appending it to the last top-level
 `comment` form in the buffer (or creating one at the end of the buffer if there
 isn't any). Successive entries are separated by a blank line for readability.

--- a/doc/modules/ROOT/pages/usage/formatting.adoc
+++ b/doc/modules/ROOT/pages/usage/formatting.adoc
@@ -13,7 +13,7 @@ that uses different editors and IDEs.
 
 CIDER provides several commands to interact with `cljfmt`:
 
-* `cider-format-defun`
+* `cider-format-defun-at-point`
 * `cider-format-region`
 * `cider-format-buffer`
 

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -1141,7 +1141,7 @@ later insertions (the eval-to-comment handler inserts the result there)."
         (indent-region block-start (point))))
     (cons (marker-position beg) end)))
 
-(defun cider-send-to-comment (&optional eval)
+(defun cider-send-defun-to-comment (&optional eval)
   "Copy the top-level form at point into the namespace's rich `comment' block.
 The form is appended to the last top-level `comment' form in the buffer,
 creating one at the end of the buffer when none exists.  Point stays where it
@@ -1166,6 +1166,9 @@ it, honoring `cider-comment-style'."
            nil
            (cider--nrepl-print-request-plist fill-column)))))))
 
+
+(define-obsolete-function-alias 'cider-send-to-comment
+  #'cider-send-defun-to-comment "2.1.0")
 (defun cider-jump-to-comment ()
   "Move point into the namespace's rich `comment' block.
 Jump to the last top-level `comment' form in the buffer, creating an empty one

--- a/lisp/cider-format.el
+++ b/lisp/cider-format.el
@@ -110,11 +110,14 @@ START and END represent the region's boundaries."
 ;;; Format defun
 
 ;;;###autoload
-(defun cider-format-defun ()
+(defun cider-format-defun-at-point ()
   "Format the code in the current defun."
   (interactive)
   (let ((defun-bounds (cider-defun-at-point 't)))
     (cider-format-region (car defun-bounds) (cadr defun-bounds))))
+
+(define-obsolete-function-alias 'cider-format-defun
+  #'cider-format-defun-at-point "2.1.0")
 
 
 ;;; Format buffer

--- a/lisp/cider-inspiration.el
+++ b/lisp/cider-inspiration.el
@@ -206,7 +206,7 @@
     "Press <\\[cider-history]> to start CIDER's REPL input history browser."
     ;; Format
     "Press <\\[cider-format-buffer]> to format the entire buffer using cljfmt."
-    "Press <\\[cider-format-defun]> to format the top-level form at point using cljfmt."
+    "Press <\\[cider-format-defun-at-point]> to format the top-level form at point using cljfmt."
     "Use <M-x cider-format-edn-buffer RET> to pretty-print the current EDN buffer."
     ;; Namespace ops
     "Press <\\[cider-ns-refresh]> to reload modified and unloaded namespaces."

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -217,7 +217,7 @@ With a prefix argument, prompt for function to run instead of -main."
     (define-key map (kbd "d") #'cider-insert-defun-in-repl)
     (define-key map (kbd "r") #'cider-insert-region-in-repl)
     (define-key map (kbd "n") #'cider-insert-ns-form-in-repl)
-    (define-key map (kbd "c") #'cider-send-to-comment)
+    (define-key map (kbd "c") #'cider-send-defun-to-comment)
     (define-key map (kbd "v") #'cider-jump-to-comment)
 
     ;; duplicates with C- for convenience
@@ -225,7 +225,7 @@ With a prefix argument, prompt for function to run instead of -main."
     (define-key map (kbd "C-d") #'cider-insert-defun-in-repl)
     (define-key map (kbd "C-r") #'cider-insert-region-in-repl)
     (define-key map (kbd "C-n") #'cider-insert-ns-form-in-repl)
-    (define-key map (kbd "C-c") #'cider-send-to-comment)
+    (define-key map (kbd "C-c") #'cider-send-defun-to-comment)
     (define-key map (kbd "C-v") #'cider-jump-to-comment)
     map))
 
@@ -238,14 +238,14 @@ With a prefix argument, prompt for function to run instead of -main."
     ("r" "Region" cider-insert-region-in-repl)
     ("n" "Namespace form" cider-insert-ns-form-in-repl)]
    ["Rich comment"
-    ("c" "Send to comment" cider-send-to-comment)
+    ("c" "Send to comment" cider-send-defun-to-comment)
     ("v" "Jump to comment" cider-jump-to-comment)]]
   [:hide (lambda () t)
    ("C-e" "Last sexp" cider-insert-last-sexp-in-repl)
    ("C-d" "Defun at point" cider-insert-defun-in-repl)
    ("C-r" "Region" cider-insert-region-in-repl)
    ("C-n" "Namespace form" cider-insert-ns-form-in-repl)
-   ("C-c" "Send to comment" cider-send-to-comment)
+   ("C-c" "Send to comment" cider-send-defun-to-comment)
    ("C-v" "Jump to comment" cider-jump-to-comment)])
 
 (defcustom cider-switch-to-repl-on-insert t
@@ -410,9 +410,9 @@ If invoked with a prefix ARG eval the expression after inserting it."
     ["Insert top-level sexp in REPL" cider-insert-defun-in-repl]
     ["Insert region in REPL" cider-insert-region-in-repl]
     ["Insert ns form in REPL" cider-insert-ns-form-in-repl]
-    ["Send top-level sexp to comment block" cider-send-to-comment]
-    ["Send top-level sexp to comment block and eval" (cider-send-to-comment t)
-     :keys "\\[universal-argument] \\[cider-send-to-comment]"]
+    ["Send top-level sexp to comment block" cider-send-defun-to-comment]
+    ["Send top-level sexp to comment block and eval" (cider-send-defun-to-comment t)
+     :keys "\\[universal-argument] \\[cider-send-defun-to-comment]"]
     ["Jump to comment block" cider-jump-to-comment]
     "--"
     ["Load this buffer" cider-load-buffer]

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -37,6 +37,16 @@
 
 ;; Please, for each `describe', ensure there's an `it' block, so that its execution is visible in CI.
 
+(describe "the renamed form commands"
+  (it "keeps the old names working as obsolete aliases"
+    (dolist (pair '((cider-format-defun . cider-format-defun-at-point)
+                    (cider-send-to-comment . cider-send-defun-to-comment)))
+      (let ((old (car pair))
+            (new (cdr pair)))
+        (expect (fboundp new) :to-be-truthy)
+        (expect (indirect-function old) :to-be (indirect-function new))
+        (expect (get old 'byte-obsolete-info) :to-be-truthy)))))
+
 (describe "cider-inspect-menu"
   (it "is bound where the docs say it is"
     (expect (lookup-key cider-mode-map (kbd "C-c C-i")) :to-be 'cider-inspect-menu)


### PR DESCRIPTION
The last of the naming drift from the consistency audit.

`cider-format-defun` was the only defun-targeting command without `-at-point`; every other one says so, from `cider-eval-defun-at-point` through `cider-inspect-defun-at-point` to `cider-enlighten-defun-at-point`. It's now `cider-format-defun-at-point`.

`cider-send-to-comment` named neither its target nor its verb's object: it copies the top-level form at point into a rich `comment` block. It's now `cider-send-defun-to-comment`, which parallels `cider-eval-defun-to-comment` sitting next to it in the same keymap.

Both old names stay as obsolete aliases, so nothing anyone has bound or scripted breaks, and there's a spec pinning that.

I stopped there rather than sweeping wider. `cider-format-edn-last-sexp` and friends are consistent within the EDN family; the gap next to them is coverage (there's no plain `cider-format-last-sexp`), not naming. And `cider-eval-last-sexp-to-repl` versus `cider-insert-last-sexp-in-repl` use different prepositions for genuinely different operations, so I'd rather leave them than churn names for symmetry alone.
