### PR TITLE
Optionally flash the region that was evaluated

### DIFF
--- a/doc/modules/ROOT/pages/usage/code_evaluation.adoc
+++ b/doc/modules/ROOT/pages/usage/code_evaluation.adoc
@@ -115,6 +115,26 @@ whitespace between forms, which is where you land after typing one - they fall
 back to the preceding form, so they're drop-in replacements for their
 `+...-last-sexp+` siblings rather than a separate mode of working.
 
+=== Seeing what was picked
+
+If you'd like CIDER to show you which form it acted on, rather than leaving you
+to infer it, turn on `cider-flash-evaluated-region`:
+
+[source,lisp]
+----
+(setq cider-flash-evaluated-region t)
+----
+
+Every evaluation then briefly flashes the region it sent, using
+`cider-flash-face`. Set the option to a face instead of `t` to flash with that
+face. It's off by default.
+
+TIP: This one is borrowed from SLY, which flashes the region it compiles.
+It's especially handy while you're getting a feel for the difference between
+the targets above.
+
+=== Rebinding the keys
+
 If you'd rather have this behavior on the keys you already use, rebind them.
 Nothing else changes:
 

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -58,6 +58,7 @@
 (require 'cider-common)
 (require 'cider-compilation)
 (require 'cider-overlays)
+(require 'pulse)
 (require 'cider-popup)
 (require 'cider-stacktrace)
 (require 'cider-util)
@@ -820,6 +821,33 @@ window."
 (defvar-local cider-interactive-eval-override nil
   "Function to call instead of `cider-interactive-eval'.")
 
+(defcustom cider-flash-evaluated-region nil
+  "Whether to briefly flash the region CIDER evaluated.
+
+Evaluation commands differ in which form they act on, and the answer
+isn\='t always obvious from where the cursor sits - on a delimiter, say,
+or in the whitespace after a form.  Flashing the region shows you what
+was actually sent, right where you are looking.
+
+nil, the default, flashes nothing.  t flashes with `cider-flash-face'.
+A face flashes with that face instead."
+  :type '(choice (const :tag "Don\='t flash" nil)
+                 (const :tag "Flash with `cider-flash-face'" t)
+                 (face :tag "Flash with this face"))
+  :group 'cider
+  :package-version '(cider . "2.1.0"))
+
+(defun cider--flash-region (start end)
+  "Briefly flash the region between START and END.
+Does nothing unless `cider-flash-evaluated-region' asks for it."
+  (when cider-flash-evaluated-region
+    (let ((pulse-flag t))
+      (pulse-momentary-highlight-region
+       start end
+       (if (facep cider-flash-evaluated-region)
+           cider-flash-evaluated-region
+         'cider-flash-face)))))
+
 (defun cider-interactive-eval (form &optional callback bounds additional-params)
   "Evaluate FORM and dispatch the response to CALLBACK.
 If the code to be evaluated comes from a buffer, it is preferred to use a
@@ -843,7 +871,8 @@ arguments and only proceed with evaluation if it returns nil."
       ;; partial overlays, leading to duplicate eval results in some situations.
       (dolist (ov (overlays-in start end))
         (when (eq (overlay-get ov 'cider-temporary) t)
-          (delete-overlay ov))))
+          (delete-overlay ov)))
+      (cider--flash-region start end))
     (unless (and cider-interactive-eval-override
                  (functionp cider-interactive-eval-override)
                  (condition-case _

--- a/lisp/cider-overlays.el
+++ b/lisp/cider-overlays.el
@@ -166,6 +166,14 @@ This function also removes itself from `post-command-hook'."
   (remove-hook 'post-command-hook #'cider--remove-result-overlay-after-command 'local)
   (add-hook 'post-command-hook #'cider--remove-result-overlay nil 'local))
 
+(defface cider-flash-face
+  '((t (:inherit highlight)))
+  "Face for the brief flash over the region CIDER just evaluated.
+See `cider-flash-evaluated-region'."
+  ;; Emacs 28 refuses to infer the group
+  :group 'cider
+  :package-version '(cider . "2.1.0"))
+
 (defface cider-fringe-good-face
   '((((class color) (background light)) :foreground "lightgreen")
     (((class color) (background dark)) :foreground "darkgreen"))

--- a/test/cider-eval-tests.el
+++ b/test/cider-eval-tests.el
@@ -721,3 +721,41 @@
       (let ((bounds (nth 2 (spy-calls-args-for 'cider-interactive-eval 0))))
         (expect (apply #'buffer-substring-no-properties bounds)
                 :to-equal "(+ 1 2)")))))
+
+(describe "cider--flash-region"
+  (it "does nothing when the option is off"
+    (let ((cider-flash-evaluated-region nil)
+          (pulsed nil))
+      (cl-letf (((symbol-function 'pulse-momentary-highlight-region)
+                 (lambda (&rest args) (setq pulsed args))))
+        (cider--flash-region 1 5))
+      (expect pulsed :to-be nil)))
+
+  (it "flashes with `cider-flash-face' when simply enabled"
+    (let ((cider-flash-evaluated-region t)
+          (pulsed nil))
+      (cl-letf (((symbol-function 'pulse-momentary-highlight-region)
+                 (lambda (&rest args) (setq pulsed args))))
+        (cider--flash-region 1 5))
+      (expect pulsed :to-equal '(1 5 cider-flash-face))))
+
+  (it "honors a face given as the option's value"
+    (let ((cider-flash-evaluated-region 'cider-error-overlay-face)
+          (pulsed nil))
+      (cl-letf (((symbol-function 'pulse-momentary-highlight-region)
+                 (lambda (&rest args) (setq pulsed args))))
+        (cider--flash-region 1 5))
+      (expect pulsed :to-equal '(1 5 cider-error-overlay-face)))))
+
+(describe "flashing the evaluated region"
+  (it "happens for any command that evaluates a region of the buffer"
+    (let ((cider-flash-evaluated-region t)
+          (pulsed nil))
+      (cl-letf (((symbol-function 'pulse-momentary-highlight-region)
+                 (lambda (&rest args) (setq pulsed args)))
+                ((symbol-function 'cider-ensure-session) #'ignore)
+                ((symbol-function 'cider-map-repls) (lambda (&rest _) nil)))
+        (with-clojure-buffer "(+ 1 2)|"
+          (cider-interactive-eval nil nil (list 1 8))))
+      (expect pulsed :to-equal '(1 8 cider-flash-face)))))
+


### PR DESCRIPTION
Which form an evaluation command picks isn't always obvious from where the cursor sits - on a delimiter, or in the whitespace after a form - and having to infer it after the fact is exactly the confusion that keeps coming up.

SLY solves this by flashing the region it compiles (`sly-flash-region`), which answers the question where you're already looking and doesn't change what gets picked. This does the same for CIDER.

```elisp
(setq cider-flash-evaluated-region t)
```

Off by default. `t` flashes with the new `cider-flash-face`; set it to a face instead and it flashes with that. The call sits in `cider-interactive-eval`, where the bounds are already in hand, so every command that evaluates a region of the buffer gets it at once rather than each one growing its own.

I left the default off deliberately - it's a visible change for everyone, and it's a one-line flip if you'd rather it were on out of the box.

Came out of a survey of SLIME, SLY, Geiser and the Emacs Lisp modes. Two other findings from that, for the record: none of them has an at-point command family, and all of them (Emacs Lisp included) still read comment text as code the way CIDER did before #4172.
