### PR TITLE
Accept a port as a number or a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### Bugs fixed
 
+- [#4180](https://github.com/clojure-emacs/cider/pull/4180): Accept a `:port` given as a number, not just a string, in `cider-connect` and friends: the two spellings are now stored the same way, so a connection made with one is recognized when looked up with the other.
 - [#4172](https://github.com/clojure-emacs/cider/pull/4172): Stop treating the text of a line comment as code: with point in or after a comment, `cider-eval-last-sexp` and friends now target the form preceding the comment, and the in-place macroexpansion commands no longer overwrite the comment with an expansion.
 - [#4158](https://github.com/clojure-emacs/cider/pull/4158): Detect running `lein trampoline` REPLs in `cider-connect`'s port suggestions (the trampolined JVM has no "leiningen" marker for the process scan to find), and don't miss REPLs running without a controlling terminal.
 - [#4158](https://github.com/clojure-emacs/cider/pull/4158): Stop discarding `.nrepl-port` files on systems without `lsof` (absence of the tool is not evidence the port is dead), and only treat listening sockets as proof of a live server.

--- a/lisp/cider.el
+++ b/lisp/cider.el
@@ -545,7 +545,7 @@ PARAMS is a plist with the following keys (non-exhaustive list)
           (plist-put params :socket-file (cdr endpoint))
         (thread-first params
                       (plist-put :host (car endpoint))
-                      (plist-put :port (cdr endpoint)))))))
+                      (plist-put :port (nrepl--normalize-port (cdr endpoint))))))))
 
 (defun cider--update-cljs-init-function (params)
   "Update repl type and any init PARAMS for cljs connections.

--- a/lisp/nrepl-client.el
+++ b/lisp/nrepl-client.el
@@ -470,6 +470,16 @@ If NO-ERROR is non-nil, show messages instead of throwing an error."
                  (error msg))
                nil)))))
 
+(defun nrepl--normalize-port (port)
+  "Return PORT as a string, whatever it arrived as.
+Ports are strings throughout the client, but a number is the natural thing
+to hand to `nrepl-connect' or `cider-connect' from Lisp.  Accepting both and
+settling on one keeps the `equal' comparisons that match sessions and REPLs
+from failing on a number that looks just like the string beside it."
+  (if (numberp port)
+      (number-to-string port)
+    port))
+
 (defun nrepl-connect (host port)
   "Connect to the nREPL server identified by HOST and PORT.
 For local hosts use a direct connection.  For remote hosts, if
@@ -517,7 +527,7 @@ If NO-ERROR is non-nil, show messages instead of throwing an error."
     (message "[nREPL] Establishing direct connection to %s:%s ..." host port)
     (condition-case nil
         (prog1 (list :proc (open-network-stream "nrepl-connection" nil host port)
-                     :host host :port port)
+                     :host host :port (nrepl--normalize-port port))
           (message "[nREPL] Direct connection to %s:%s established" host port))
       (error (let ((msg (format "[nREPL] Direct connection to %s:%s failed" host port)))
                (if no-error

--- a/test/cider-connection-tests.el
+++ b/test/cider-connection-tests.el
@@ -779,7 +779,8 @@
                                     (with-current-buffer repl
                                       (setq endpoint-aft nrepl-endpoint)
                                       ;; (message ":endpoints %S %S" endpoint-bef endpoint-aft)
-                                      (not (= (plist-get endpoint-bef :port) (plist-get endpoint-aft :port)))))
+                                      (not (equal (plist-get endpoint-bef :port)
+                                                  (plist-get endpoint-aft :port)))))
                                   5)
           ;; kill server
           (delete-process (get-buffer-process client-buffer)))))))

--- a/test/nrepl-client-tests.el
+++ b/test/nrepl-client-tests.el
@@ -827,3 +827,21 @@
             (nrepl--process-plist-put proc :keep-server t)
             (expect (process-plist proc) :to-equal '(:nrepl-server-ready nil :keep-server t)))
         (delete-process proc)))))
+
+(describe "nrepl--normalize-port"
+  (it "turns a number into the string form the client uses everywhere"
+    (expect (nrepl--normalize-port 1234) :to-equal "1234"))
+
+  (it "leaves a string alone"
+    (expect (nrepl--normalize-port "1234") :to-equal "1234"))
+
+  (it "leaves nil alone, so a missing port still reads as missing"
+    (expect (nrepl--normalize-port nil) :to-be nil))
+
+  (it "makes the two spellings of a port compare equal"
+    ;; this is the point: session and REPL matching compares ports with
+    ;; `equal', so a number and its string must not look like different ports
+    (expect (equal (nrepl--normalize-port 1234)
+                   (nrepl--normalize-port "1234"))
+            :to-be-truthy)))
+


### PR DESCRIPTION
Ports are strings throughout CIDER - `cider-select-endpoint` insists on it for `cider-known-endpoints` - but a number is the natural thing to hand to `cider-connect` from Lisp, and both spellings connect happily today.

What doesn't work is mixing them. The port is stored exactly as it arrived, and session and REPL matching compares it with `equal`, so:

```elisp
(cider-connect (list :host "127.0.0.1" :port 51139 :project-dir "..."))
;; stored :port is the integer 51139
```

and a later lookup with `"51139"` finds nothing - CIDER offers to start a second session for a connection it already has, and `cider--score-repls` scores the right REPL lower than it should.

`nrepl--normalize-port` settles on the string form at the two points a port enters the client, so callers can pass either and they compare equal afterwards.

One test change worth flagging: the restart-session spec compared ports with `=`, which only worked because they happened to be numbers on that path. It uses `equal` now, like the code it exercises. That spec failing was also what surfaced this - it left a half-connected session behind and took three unrelated specs down with it.
