### PR TITLE
Docs polish ahead of 2.1.0

### DIFF
--- a/doc/modules/ROOT/pages/basics/remote.adoc
+++ b/doc/modules/ROOT/pages/basics/remote.adoc
@@ -156,11 +156,14 @@ The nREPL port should be set to a fixed value as we need to give this during the
 container to host. This requires as well that nREPL server listens to "0.0.0.0" and not only to "localhost".
 
 TIP: Publish the port under the *same* number on both sides (e.g.
-`-p 7888:7888`).  A mismatched mapping like `-p 12345:7888` technically
-works, but it blinds CIDER's port suggestions: a `.nrepl-port` file in a
-mounted project directory records the *container's* port, which on the host
-side is either wrong or (correctly) discarded as dead, so `cider-connect`
-can't suggest anything and you have to type the forwarded port yourself.
+`-p 7888:7888`).  A mismatched mapping like `-p 12345:7888` works when you
+edit the project through a `/docker:` or `/podman:` Tramp path: CIDER asks
+the container CLI which host port it publishes and suggests (or, for
+`cider-jack-in`, connects to) that one.  It does blind the suggestions when
+the project is opened from the host through a mounted directory, though: the
+`.nrepl-port` file there records the *container's* port, which on the host
+side is either wrong or (correctly) discarded as dead, so you have to type
+the forwarded port yourself.
 
 If your source directories are mounted into the container, also set
 `cider-path-translations` so that stacktraces and jump-to-definition

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -466,6 +466,11 @@ xref:basics/remote.adoc[Remote Development] and
 `cider-infer-remote-nrepl-ports` if you want CIDER to look for ports over
 SSH.
 
+When none of the sources turns anything up, the prompt falls back to
+`cider-default-nrepl-port` (`"7888"` by default). If you always start your
+servers on some other port, set that variable and a bare kbd:[RET] at the
+prompt will do.
+
 If you frequently connect to the same hosts and ports, you can tell
 CIDER about them and it will use the information to do completing
 reads for the host and port prompts when you invoke

--- a/doc/modules/ROOT/pages/config/clojure_ts_mode.adoc
+++ b/doc/modules/ROOT/pages/config/clojure_ts_mode.adoc
@@ -30,11 +30,21 @@ xref:basics/quickstart.adoc[Quick Start]).
 
 == Current state and limitations
 
-CIDER has solid, but still-evolving, support for `clojure-ts-mode`. The important
-thing to know is that it *still depends on `clojure-mode`* for some of its work -
-notably for extracting information about the Clojure code in a buffer. So even
-when you edit with `clojure-ts-mode`, you should keep `clojure-mode` installed
-(it's a hard dependency of CIDER anyway, so it will be).
+CIDER has solid, but still-evolving, support for `clojure-ts-mode`. Most of
+what CIDER does in a buffer now works natively with tree-sitter:
+
+* xref:config/syntax_highlighting.adoc#dynamic-syntax-highlighting[dynamic
+  syntax highlighting] of REPL-defined macros, functions and vars, including
+  the markers for deprecated, instrumented and traced symbols
+* highlighting of the `#break`, `#dbg` and `#light` debugging reader tags
+* CIDER's own Clojure buffers (macroexpansions, evaluation results, tracing
+  output and the like), which open in `clojure-ts-mode` when that's your
+  preferred mode (see below)
+
+The important thing to know is that CIDER *still depends on `clojure-mode`* for
+some of its work - notably for extracting information about the Clojure code in
+a buffer. So even when you edit with `clojure-ts-mode`, you should keep
+`clojure-mode` installed (it's a hard dependency of CIDER anyway, so it will be).
 
 The long-term plan is to make `clojure-ts-mode` capable of providing CIDER with
 everything it needs directly, at which point the `clojure-mode` dependency for
@@ -45,3 +55,27 @@ smoothly, that mismatch is the usual cause.
 TIP: If you're deciding whether to switch, `clojure-ts-mode`'s own README tracks
 its maturity and feature coverage. CIDER will keep supporting `clojure-mode` for
 the foreseeable future, so there's no rush.
+
+[#preferred-clojure-mode]
+== Choosing the mode CIDER renders Clojure with
+
+Besides the buffers you edit, CIDER produces a fair amount of Clojure of its own:
+REPL input and results, examples in documentation buffers, debugger and enlighten
+overlays, xref labels, and the display buffers for macroexpansion, evaluation
+results and tracing. `cider-preferred-clojure-mode` controls which major mode
+font-locks all of that:
+
+* `auto` (the default) picks `clojure-ts-mode` when your Clojure source files
+  open in it and its tree-sitter grammar is ready, and `clojure-mode` otherwise.
+* `clojure-mode` always uses `clojure-mode`.
+* `clojure-ts-mode` uses `clojure-ts-mode` when it's available and falls back
+  to `clojure-mode` when it isn't.
+
+The default follows your editing setup, so you rarely need to touch it. Set it
+explicitly if, say, you edit with `clojure-ts-mode` but prefer the classic
+highlighting in the REPL:
+
+[source,lisp]
+----
+(setq cider-preferred-clojure-mode 'clojure-mode)
+----

--- a/doc/modules/ROOT/pages/config/syntax_highlighting.adoc
+++ b/doc/modules/ROOT/pages/config/syntax_highlighting.adoc
@@ -9,6 +9,14 @@ code that has already been loaded into nREPL, so it can provide a richer and mor
 syntax highlighting. We call this functionality "dynamic syntax highlighting" (as opposed to
 the somewhat static syntax highlighting you'd get from `clojure-mode`).
 
+Everything below applies to `clojure-ts-mode` buffers as well - the dynamic
+highlighting is implemented on top of tree-sitter there. See
+xref:config/clojure_ts_mode.adoc[Using clojure-ts-mode] for the details, and
+for `cider-preferred-clojure-mode`, which decides which of the two modes
+highlights the Clojure that CIDER itself renders (REPL results, doc examples,
+overlays and so on).
+
+[#dynamic-syntax-highlighting]
 == Dynamic syntax highlighting
 
 NOTE: The Emacs term for "syntax highlighting" is "font-locking". That's why

--- a/doc/modules/ROOT/pages/debugging/tap.adoc
+++ b/doc/modules/ROOT/pages/debugging/tap.adoc
@@ -7,8 +7,8 @@ those values for you: kbd:[M-x] `cider-tap` opens a `+*cider-tap*+` buffer that
 streams every value sent to `tap>`.
 
 Any `+(tap> some-value)+` in your code shows up in that buffer as it happens, as
-does anything you tap from the xref:inspector.adoc[inspector]. The buffer follows
-the tail, so the newest value is always in view.
+does anything you tap from the xref:debugging/inspector.adoc[inspector]. The
+buffer follows the tail, so the newest value is always in view.
 
 image::cider-tap-buffer.png[The cider-tap buffer streaming tapped values]
 

--- a/doc/modules/ROOT/pages/repl/basic_usage.adoc
+++ b/doc/modules/ROOT/pages/repl/basic_usage.adoc
@@ -7,7 +7,7 @@ can experiment with your running program, test functions, or just
 explore a new library you're interested in using. The CIDER REPL offers a number of advanced features:
 
 * code completion
-* font-locking (the same as in `clojure-mode`)
+* font-locking (the same as in your Clojure major mode, see `cider-preferred-clojure-mode`)
 * quick access to many CIDER commands (e.g. definition and documentation lookup, tracing, etc)
 * pretty-printing of evaluation results
 * inline display of images

--- a/doc/modules/ROOT/pages/repl/configuration.adoc
+++ b/doc/modules/ROOT/pages/repl/configuration.adoc
@@ -208,8 +208,10 @@ details.
 
 == Font-locking
 
-Normally, code in the REPL is font-locked the same way as in
-`clojure-mode`. Alternatively, REPL input can be font-locked with
+Normally, code in the REPL is font-locked the same way as in your Clojure
+major mode - `clojure-mode` or `clojure-ts-mode`, as selected by
+xref:config/clojure_ts_mode.adoc#preferred-clojure-mode[`cider-preferred-clojure-mode`].
+Alternatively, REPL input can be font-locked with
 `cider-repl-input-face` (after pressing kbd:[Return]) and results
 with `cider-repl-result-face`. If you prefer that behavior use:
 

--- a/doc/modules/ROOT/pages/troubleshooting.adoc
+++ b/doc/modules/ROOT/pages/troubleshooting.adoc
@@ -99,15 +99,17 @@ That's CIDER's way of representing the request (marked with `+-->+`) and respons
 nREPL message logging is not enabled by default. Set `nrepl-log-messages` to `t`
 to activate it. Alternatively you can use kbd:[M-x]
 `nrepl-toggle-message-logging` to enable/disable logging temporarily within your
-current Emacs session. Note that enabling message logging can impact
-performance.
+current Emacs session (the "Log protocol messages" entry in the nREPL menu does
+the same and shows whether logging is currently on). Note that enabling message
+logging can impact performance.
 
 You can find the message log in the `+*nrepl-messages repl-info*+` buffer,
 provided you've enabled nREPL message logging. There's going to be one buffer
 per each active REPL.
 
 TIP: You can jump quickly to the relevant messages buffer by pressing
-kbd:[C-c M-s m].
+kbd:[C-c M-s m], or via "Show nREPL messages" in the nREPL menu. When logging
+is off, `nrepl-show-messages` offers to turn it on for you.
 
 == Commonly encountered problems (and how to solve them)
 
@@ -131,8 +133,9 @@ you can step forward until you find the problem.
 nREPL message logging is not enabled by default. Set `nrepl-log-messages` to `t`
 to activate it. Alternatively you can use kbd:[M-x]
 `nrepl-toggle-message-logging` to enable/disable logging temporarily within your
-current Emacs session. Note that enabling message logging can impact
-performance.
+current Emacs session, or just run kbd:[M-x] `nrepl-show-messages`, which
+offers to enable logging when it's off. Note that enabling message logging can
+impact performance.
 
 === `cider-debug` complains that it "`failed to instrument ...`"
 


### PR DESCRIPTION
A pass over the manual for things the 2.1.0 work left undocumented: cider-preferred-clojure-mode and what now works natively under clojure-ts-mode, cider-default-nrepl-port, and the Docker port-mapping tip, which stopped being true once container-published ports got resolved. Also fixes a broken xref on the tap page and points the troubleshooting page at the nREPL messages menu entries.