### PR TITLE
Make the at-point commands reachable from the prefix keymaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Changes
 
+- [#4184](https://github.com/clojure-emacs/cider/pull/4184): Move `cider-jump-to-comment` from `C-c C-j v` to `C-c C-j j`, so `v` under the insert prefix is `cider-insert-sexp-at-point-in-repl` like the other at-point commands; the macroexpand and pretty-print at-point variants are now also in the plain `cider-macroexpand-map`/`cider-eval-pprint-commands-map`, not just the menus.
 - [#4177](https://github.com/clojure-emacs/cider/pull/4177): Rename `cider-format-defun` to `cider-format-defun-at-point` and `cider-send-to-comment` to `cider-send-defun-to-comment`, so they name the form they operate on like the rest of the form commands; the old names remain as obsolete aliases.
 - [#4175](https://github.com/clojure-emacs/cider/pull/4175): Have the "at point" commands (`cider-eval-sexp-at-point` and friends) fall back to the form preceding point when there's nothing at point, instead of erroring, so they can stand in for their `last-sexp` counterparts.
 - [#4166](https://github.com/clojure-emacs/cider/pull/4166): Treat the contents of a `comment` form as top level in the whole defun command family (pretty-printing, eval-to-comment, inspect, format, debug, etc.), not just `cider-eval-defun-at-point` and `cider-eval-dwim`; CIDER's commands no longer depend on `clojure-toplevel-inside-comment-form`.

--- a/doc/modules/ROOT/pages/debugging/macroexpansion.adoc
+++ b/doc/modules/ROOT/pages/debugging/macroexpansion.adoc
@@ -4,7 +4,7 @@
 Typing kbd:[C-c C-m] after some form in a source buffer or the REPL will show
 you the `macroexpand-1` expansion of the form in a new buffer.
 
-kbd:[C-c M-m] is a prefix map (`cider-macroexpand-map`) gathering all of CIDER's
+kbd:[C-c M-m] opens a menu (`cider-macroexpand-menu`) gathering all of CIDER's
 form-expanding commands:
 
 [cols="1,3"]
@@ -76,7 +76,8 @@ macroexpansion buffer.
 
 [TIP]
 ====
-Prefer kbd:[C-c C-m] as the prefix instead? Point it at the same map:
+Prefer kbd:[C-c C-m] as the prefix instead? Point it at `cider-macroexpand-map`,
+a plain keymap with the same keys as the menu:
 
 [source,lisp]
 ----

--- a/doc/modules/ROOT/pages/keybindings.adoc
+++ b/doc/modules/ROOT/pages/keybindings.adoc
@@ -133,6 +133,10 @@ you don't have to memorize the suffixes.  See xref:basics/up_and_running.adoc[Up
 | `cider-pprint-eval-defun-at-point`
 | Evaluate the top-level form and pretty-print the result in a popup.
 
+| kbd:[C-c C-v C-f v]
+| `cider-pprint-eval-sexp-at-point`
+| Evaluate the form at point and pretty-print the result in a popup.
+
 | kbd:[C-c M-;]
 | `cider-eval-defun-to-comment`
 | Evaluate the top-level form and insert the result as a comment.
@@ -144,6 +148,10 @@ you don't have to memorize the suffixes.  See xref:basics/up_and_running.adoc[Up
 | kbd:[C-c M-i]
 | `cider-inspect`
 | Evaluate an expression and open the result in the xref:debugging/inspector.adoc[inspector].
+
+| kbd:[C-c C-i]
+| `cider-inspect-menu`
+| Open a menu listing every way to start an inspection (last sexp, sexp at point, defun, last result, or an expression you type).
 |===
 
 TIP: See xref:usage/code_evaluation.adoc[Code Evaluation] for the evaluation
@@ -292,6 +300,14 @@ are its suffixes, so kbd:[C-c M-m a] means "open the menu, then press kbd:[a]".
 | `cider-macroexpand-all`
 | Fully expand the macro call at point.
 
+| kbd:[C-c M-m v]
+| `cider-macroexpand-1-at-point`
+| Expand the call at point once, without moving point after it first.
+
+| kbd:[C-c M-m V]
+| `cider-macroexpand-all-at-point`
+| Fully expand the call at point.
+
 | kbd:[C-c M-m e]
 | `cider-macrostep-expand`
 | Step through the expansion inline in the source buffer (requires `macrostep`).
@@ -416,11 +432,15 @@ TIP: See xref:debugging/debugger.adoc[Debugger] and xref:debugging/tracing.adoc[
 | `cider-insert-last-sexp-in-repl`
 | Copy the form preceding point into the REPL prompt.
 
+| kbd:[C-c C-j v]
+| `cider-insert-sexp-at-point-in-repl`
+| Copy the form at point into the REPL prompt.
+
 | kbd:[C-c C-j c]
 | `cider-send-defun-to-comment`
 | Copy the top-level form into the namespace's rich `comment` block.
 
-| kbd:[C-c C-j v]
+| kbd:[C-c C-j j]
 | `cider-jump-to-comment`
 | Move point into the namespace's rich `comment` block.
 

--- a/doc/modules/ROOT/pages/usage/code_evaluation.adoc
+++ b/doc/modules/ROOT/pages/usage/code_evaluation.adoc
@@ -707,7 +707,7 @@ self-documenting record of what you tried:
   )
 ----
 
-To visit the block itself, use `cider-jump-to-comment` (kbd:[C-c C-j v]). It
+To visit the block itself, use `cider-jump-to-comment` (kbd:[C-c C-j j]). It
 moves point into the last `comment` form (creating an empty one when there is
 none), pushing your previous location onto the mark ring so kbd:[C-u C-SPC]
 takes you back.
@@ -771,10 +771,18 @@ kbd:[C-c C-v C-q]
 | kbd:[C-u C-c M-p]
 | Load the form preceding point in the REPL buffer and eval.
 
+| `cider-insert-sexp-at-point-in-repl`
+| kbd:[C-c C-j v]
+| Copy the form at point into the REPL buffer; with a prefix argument, evaluate it there too.
+
 | `cider-pprint-eval-last-sexp`
 | kbd:[C-c C-p] +
 kbd:[C-c C-v C-f e]
 | Evaluate the form preceding point and pretty-print the result in a popup buffer. If invoked with a prefix argument, insert the result into the current buffer as a comment.
+
+| `cider-pprint-eval-sexp-at-point`
+| kbd:[C-c C-v C-f v]
+| Evaluate the form at point and pretty-print the result in a popup buffer. If invoked with a prefix argument, insert the result into the current buffer as a comment.
 
 | `cider-pprint-eval-defun-at-point`
 | kbd:[C-c C-v C-f d]

--- a/doc/modules/ROOT/pages/usage/formatting.adoc
+++ b/doc/modules/ROOT/pages/usage/formatting.adoc
@@ -61,5 +61,6 @@ Similarly to the `cljfmt` integration, CIDER also provides a convenient interfac
 to format EDN using `clojure.tools.reader.edn`. The following commands are provided:
 
 * `cider-format-edn-last-sexp`
+* `cider-format-edn-sexp-at-point`
 * `cider-format-edn-region`
 * `cider-format-edn-buffer`

--- a/lisp/cider-eval.el
+++ b/lisp/cider-eval.el
@@ -1487,6 +1487,7 @@ passing arguments."
   (let ((map (define-prefix-command 'cider-eval-pprint-commands-map)))
     ;; single key bindings defined last for display in menu
     (define-key map (kbd "e") #'cider-pprint-eval-last-sexp)
+    (define-key map (kbd "v") #'cider-pprint-eval-sexp-at-point)
     (define-key map (kbd "d") #'cider-pprint-eval-defun-at-point)
     (define-key map (kbd "c e") #'cider-pprint-eval-last-sexp-to-comment)
     (define-key map (kbd "c d") #'cider-pprint-eval-defun-to-comment)
@@ -1494,6 +1495,7 @@ passing arguments."
 
     ;; duplicates with C- for convenience
     (define-key map (kbd "C-e") #'cider-pprint-eval-last-sexp)
+    (define-key map (kbd "C-v") #'cider-pprint-eval-sexp-at-point)
     (define-key map (kbd "C-d") #'cider-pprint-eval-defun-at-point)
     (define-key map (kbd "C-c e") #'cider-pprint-eval-last-sexp-to-comment)
     (define-key map (kbd "C-c C-e") #'cider-pprint-eval-last-sexp-to-comment)
@@ -1632,6 +1634,7 @@ zprint, or a custom var) for this invocation only."
     ("r" "REPL (last sexp)" cider-eval-pprint-menu--last-sexp-to-repl)]]
   [:hide (lambda () t)
    ("C-e" "Last sexp" cider-eval-pprint-menu--last-sexp)
+   ("C-v" "Sexp at point" cider-eval-pprint-menu--sexp-at-point)
    ("C-d" "Defun at point" cider-eval-pprint-menu--defun)])
 
 ;;;###autoload (autoload 'cider-eval-menu "cider-eval" "Menu for CIDER's evaluation commands." t)

--- a/lisp/cider-macroexpansion.el
+++ b/lisp/cider-macroexpansion.el
@@ -319,14 +319,17 @@ buffer's key bindings."
   (let ((map (define-prefix-command 'cider-macroexpand-map)))
     (define-key map (kbd "1") #'cider-macroexpand-1)
     (define-key map (kbd "a") #'cider-macroexpand-all)
+    (define-key map (kbd "v") #'cider-macroexpand-1-at-point)
+    (define-key map (kbd "V") #'cider-macroexpand-all-at-point)
     (define-key map (kbd "e") #'cider-macrostep-expand)
     (define-key map (kbd "E") #'cider-macrostep-expand-all)
     (define-key map (kbd "b") #'cider-macrostep-expand-in-buffer)
     map)
   "CIDER macroexpansion keymap, grouping the form-expanding commands.
-Keys 1 and a open the macroexpansion buffer on one level or the full expansion;
-e and E expand inline (a single step, or all the way) via `cider-macrostep'; b
-runs an inline-style stepping session in a dedicated popup buffer.")
+Keys 1 and a open the macroexpansion buffer on one level or the full
+expansion; v and V do the same for the call at point; e and E expand inline
+\(a single step, or all the way) via `cider-macrostep'; b runs an inline-style
+stepping session in a dedicated popup buffer.")
 
 (defun cider-macroexpand-menu--read-display-ns (prompt initial-input history)
   "Read a namespace-display style for the macroexpand transient.

--- a/lisp/cider-mode.el
+++ b/lisp/cider-mode.el
@@ -218,15 +218,16 @@ With a prefix argument, prompt for function to run instead of -main."
     (define-key map (kbd "r") #'cider-insert-region-in-repl)
     (define-key map (kbd "n") #'cider-insert-ns-form-in-repl)
     (define-key map (kbd "c") #'cider-send-defun-to-comment)
-    (define-key map (kbd "v") #'cider-jump-to-comment)
+    (define-key map (kbd "j") #'cider-jump-to-comment)
 
     ;; duplicates with C- for convenience
     (define-key map (kbd "C-e") #'cider-insert-last-sexp-in-repl)
+    (define-key map (kbd "C-v") #'cider-insert-sexp-at-point-in-repl)
     (define-key map (kbd "C-d") #'cider-insert-defun-in-repl)
     (define-key map (kbd "C-r") #'cider-insert-region-in-repl)
     (define-key map (kbd "C-n") #'cider-insert-ns-form-in-repl)
     (define-key map (kbd "C-c") #'cider-send-defun-to-comment)
-    (define-key map (kbd "C-v") #'cider-jump-to-comment)
+    (define-key map (kbd "C-j") #'cider-jump-to-comment)
     map))
 
 ;;;###autoload (autoload 'cider-insert-menu "cider-mode" "Menu for inserting forms into the REPL." t)
@@ -234,19 +235,21 @@ With a prefix argument, prompt for function to run instead of -main."
   "Transient menu for inserting forms into the REPL."
   [["Insert into REPL"
     ("e" "Last sexp" cider-insert-last-sexp-in-repl)
+    ("v" "Sexp at point" cider-insert-sexp-at-point-in-repl)
     ("d" "Defun at point" cider-insert-defun-in-repl)
     ("r" "Region" cider-insert-region-in-repl)
     ("n" "Namespace form" cider-insert-ns-form-in-repl)]
    ["Rich comment"
     ("c" "Send to comment" cider-send-defun-to-comment)
-    ("v" "Jump to comment" cider-jump-to-comment)]]
+    ("j" "Jump to comment" cider-jump-to-comment)]]
   [:hide (lambda () t)
    ("C-e" "Last sexp" cider-insert-last-sexp-in-repl)
+   ("C-v" "Sexp at point" cider-insert-sexp-at-point-in-repl)
    ("C-d" "Defun at point" cider-insert-defun-in-repl)
    ("C-r" "Region" cider-insert-region-in-repl)
    ("C-n" "Namespace form" cider-insert-ns-form-in-repl)
    ("C-c" "Send to comment" cider-send-defun-to-comment)
-   ("C-v" "Jump to comment" cider-jump-to-comment)])
+   ("C-j" "Jump to comment" cider-jump-to-comment)])
 
 (defcustom cider-switch-to-repl-on-insert t
   "Whether to switch to the REPL when inserting a form into the REPL."

--- a/test/cider-tests.el
+++ b/test/cider-tests.el
@@ -61,6 +61,36 @@
                    cider-inspect-expr))
       (expect (commandp cmd) :to-be-truthy))))
 
+(describe "the at-point variants in the prefix keymaps"
+  (it "sit on v, like cider-eval-sexp-at-point does"
+    (expect (lookup-key cider-eval-commands-map (kbd "v")) :to-be 'cider-eval-sexp-at-point)
+    (expect (lookup-key cider-eval-pprint-commands-map (kbd "v")) :to-be 'cider-pprint-eval-sexp-at-point)
+    (expect (lookup-key cider-eval-pprint-commands-map (kbd "C-v")) :to-be 'cider-pprint-eval-sexp-at-point)
+    (expect (lookup-key cider-insert-commands-map (kbd "v")) :to-be 'cider-insert-sexp-at-point-in-repl)
+    (expect (lookup-key cider-insert-commands-map (kbd "C-v")) :to-be 'cider-insert-sexp-at-point-in-repl)
+    (expect (lookup-key cider-macroexpand-map (kbd "v")) :to-be 'cider-macroexpand-1-at-point)
+    (expect (lookup-key cider-macroexpand-map (kbd "V")) :to-be 'cider-macroexpand-all-at-point))
+
+  (it "moved cider-jump-to-comment to j to make room"
+    (expect (lookup-key cider-insert-commands-map (kbd "j")) :to-be 'cider-jump-to-comment)
+    (expect (lookup-key cider-insert-commands-map (kbd "C-j")) :to-be 'cider-jump-to-comment))
+
+  (it "is mirrored by the transient menus"
+    (cl-flet ((command-at (prefix key)
+                ;; `transient-get-suffix' returns the layout spec, whose
+                ;; shape differs between transient versions: the plist
+                ;; holding :command is either spliced into the spec or
+                ;; nested as its own element, so search it flattened.
+                (let ((suffix (transient-get-suffix prefix key)))
+                  (if (eieio-object-p suffix)
+                      (oref suffix command)
+                    (cadr (memq :command (flatten-tree suffix)))))))
+      (dolist (pair '((cider-insert-menu . cider-insert-sexp-at-point-in-repl)
+                      (cider-eval-pprint-menu . cider-eval-pprint-menu--sexp-at-point)
+                      (cider-macroexpand-menu . cider-macroexpand-menu--expand-1-at-point)))
+        (expect (command-at (car pair) "v") :to-be (cdr pair)))
+      (expect (command-at 'cider-insert-menu "j") :to-be 'cider-jump-to-comment))))
+
 (describe "customize-menu"
   (it "opens without error"
     (let ((inhibit-message t)) (customize-group 'cider))))


### PR DESCRIPTION
The insert keymap bound `v` twice, so `cider-insert-sexp-at-point-in-repl` from #4173 was only reachable via M-x. `cider-jump-to-comment` moves to `C-c C-j j` to free `v` for the at-point variant, matching the other prefix maps, and the macroexpand and pretty-print at-point commands land in the plain keymaps as well, not just the transients. The keybinding tables in the manual are updated to match, including the missing `C-c C-i` row.