### PR TITLE
Tighten the CI runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,8 @@ commands:
       - run:
           name: Run Elisp-lint
           command: eldev lint -c
+  compile:
+    steps:
       - run:
           name: Byte-compile .el files
           command: eldev -dtT compile --warnings-as-errors
@@ -64,12 +66,15 @@ jobs:
       - setup
       - test
 
+  # Also byte-compiles here: newer Emacsen warn about obsoletions the
+  # Emacs 28 lint job can't see.
   test-ubuntu-emacs-30:
     docker:
       - image: silex/emacs:30-ci
         entrypoint: bash
     steps:
       - setup
+      - compile
       - test
 
   test-macos-emacs-latest:
@@ -95,6 +100,7 @@ jobs:
     steps:
       - setup
       - lint
+      - compile
 
 workflows:
   version: 2.1

--- a/.github/workflows/spell_checking.yml
+++ b/.github/workflows/spell_checking.yml
@@ -1,6 +1,10 @@
 name: Spell Checking
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   codespell:
@@ -16,6 +20,5 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install codespell
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Check spelling with codespell
         run: codespell --ignore-words=codespell.txt || exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
   integration:
     # Run integration tests for all OSs and EMACS_VERSIONs.
     runs-on: ${{matrix.os}}
+    # A hung mock server shouldn't burn the six-hour default.
+    timeout-minutes: 30
     # The Emacs snapshot build is an early-warning signal, not a gate, so a
     # failure there mustn't fail the workflow.
     continue-on-error: ${{ matrix.experimental || false }}

--- a/Eldev
+++ b/Eldev
@@ -34,7 +34,8 @@
                                     (eldev-pcase-exhaustive cider-test-type
                                                             (`main            "./test/*/")
                                                             (`integration     '("./test/"   "!./test/integration"))
-                                                            (`clojure-ts-mode '("./test/*/" "!./test/clojure-ts-mode"))
+                                                            ;; Only the tree-sitter specs; the main suite has its own run.
+                                                            (`clojure-ts-mode '("./test/*.el" "./test/*/" "!./test/clojure-ts-mode"))
                                                             (`all             '("./test/*/" "!./test/integration")))
                                     "test/integration/projects"
                                     ;; This file is _supposed_ to be excluded


### PR DESCRIPTION
The clojure-ts-mode test type was running the whole main suite plus the tree-sitter specs, so the Emacs 30 jobs ran those 1300 specs three times over; it now runs just the 28 tree-sitter ones. Also a 30-minute cap on the integration jobs, spell checks on pushes to master, and byte-compilation on Emacs 30 so newer obsoletion warnings become a CI signal.