### PR TITLE
Work around the Emacs 31 posification bug and test on 31.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,14 @@ jobs:
       - setup
       - test
 
+  test-ubuntu-emacs-31:
+    docker:
+      - image: silex/emacs:31-ci
+        entrypoint: bash
+    steps:
+      - setup
+      - test
+
   test-macos-emacs-latest:
     macos:
       xcode: "16.4.0"
@@ -108,6 +116,9 @@ workflows:
           requires:
             - test-lint
       - test-ubuntu-emacs-30:
+          requires:
+            - test-lint
+      - test-ubuntu-emacs-31:
           requires:
             - test-lint
       - test-windows-emacs-latest:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         # Test all Emacs versions on Ubuntu.
         os: [ubuntu-latest]
-        emacs_version: ['28.2', '29.3', '30.1', '30.2']
+        emacs_version: ['28.2', '29.3', '30.1', '30.2', '31.1']
         java_version: ['21']
         include:
           # For other OSes, test only the latest stable Emacs version.

--- a/Eldev
+++ b/Eldev
@@ -91,6 +91,22 @@
 ;; CIDER cannot be compiled otherwise.
 (setf eldev-build-load-before-byte-compiling t)
 
+;; Emacs 31 stamps source positions onto compiler-macro expansions in place
+;; (`macroexp--posify-form'), which corrupts the stored inline body of any
+;; argument-less `cl-defsubst' - `queue-create' is the one that bites us -
+;; once something calling it has been byte-compiled in this process.  In
+;; packaged mode Eldev compiles CIDER right before loading the specs, so the
+;; first test run after a source change failed 9 specs with
+;; `invalid-function cl-block' (Emacs bug#79599).  Upstream added this switch
+;; for exactly that kind of trouble; the only cost is less precise positions
+;; in byte-compile warnings.
+(setq macroexp-enable-preserve-posification nil)
+
+;; On macOS bsdtar stores extended attributes as `._*' AppleDouble entries,
+;; and Eldev's packaged copy of the project would then get a hundred of them
+;; byte-compiled as Lisp.
+(setenv "COPYFILE_DISABLE" "1")
+
 ;; package-lint is disabled because nrepl-*.el files intentionally use
 ;; the `nrepl-' prefix instead of the `cider-' package prefix.
 ;; `doc' is the linter's canonical name; `checkdoc' is only a command-line


### PR DESCRIPTION
On Emacs 31.1 the first `eldev -p test` after any source change failed nine specs with `invalid-function cl-block` and the rerun passed. The byte compiler stamps positions onto compiler-macro results in place, which corrupts `queue-create`'s stored inline body once the package has been compiled in-process; Emacs bug#79599 added a switch for it, which the Eldev file now turns off. The packaged copy also no longer picks up macOS AppleDouble files. Emacs 31.1 joins the CI matrix, which is where this should have shown up.