### PR TITLE
Fix two broken fragment links and label master in the docs version menu

### DIFF
--- a/doc/antora.yml
+++ b/doc/antora.yml
@@ -1,7 +1,11 @@
 name: cider
 title: CIDER
-# We always provide version without patch here (e.g. 1.1),
-# as patch versions should not appear in the docs.
+# The release commit sets this to the major.minor version, quoted (e.g. "2.1"):
+# unquoted, YAML reads 2.0 as the number 2 and the site shows "2".  Patch
+# versions never appear here.  Between releases it stays unversioned (~),
+# which makes master the site's default version.
 version: ~
+# What the version menu calls the unversioned master docs (otherwise "default").
+display_version: master
 nav:
 - modules/ROOT/nav.adoc

--- a/doc/modules/ROOT/pages/debugging/inspector.adoc
+++ b/doc/modules/ROOT/pages/debugging/inspector.adoc
@@ -41,7 +41,7 @@ arguments:
 
 The sub-keys are the same ones the evaluation menu uses, so `e`, `v` and
 `d` name the same three targets wherever you are; see
-xref:usage/code_evaluation.adoc#_selecting_the_form_to_operate_on[Selecting
+xref:usage/code_evaluation.adoc#selecting-the-form-to-operate-on[Selecting
 the Form to Operate On].
 
 NOTE: This menu is about _what_ to inspect. Once you're looking at a

--- a/doc/modules/ROOT/pages/debugging/macroexpansion.adoc
+++ b/doc/modules/ROOT/pages/debugging/macroexpansion.adoc
@@ -38,7 +38,7 @@ form-expanding commands:
 
 Like the rest of CIDER's form commands, the expansion commands act on the form
 _preceding_ the cursor; see
-xref:usage/code_evaluation.adoc#_selecting_the_form_to_operate_on[Selecting the
+xref:usage/code_evaluation.adoc#selecting-the-form-to-operate-on[Selecting the
 Form to Operate On] for why that's the convention.
 
 Macroexpansion has one wrinkle the other operations don't, though: an expansion


### PR DESCRIPTION
Two pages linked to `#_selecting_the_form_to_operate_on`, but the site generates ids without the underscore prefix, so the links landed at the top of the page. The version menu also called the master docs "default"; they're now labelled master, and the descriptor notes that the release commit must quote the version, since an unquoted 2.0 is what got the 2.0 docs listed as "2". Verified with a local site build.