### PR TITLE
Take the setup snippets' versions from antora.yml attributes

### DIFF
--- a/doc/antora.yml
+++ b/doc/antora.yml
@@ -9,3 +9,15 @@ version: ~
 display_version: master
 nav:
 - modules/ROOT/nav.adoc
+asciidoc:
+  attributes:
+    # Versions quoted in the manual's setup snippets.  Keep them in sync with
+    # what CIDER injects: cider-required-middleware-version and
+    # cider-injected-nrepl-version in lisp/cider-jack-in.el, the piggieback
+    # entry in cider-jack-in-cljs-dependencies, and
+    # cider-minimum-clojure-version.  Pages reference them as
+    # {cider-nrepl-version} and so on (code blocks need subs="attributes+").
+    cider-nrepl-version: '0.62.2'
+    nrepl-version: '1.7.0'
+    piggieback-version: '0.7.0'
+    clojure-min-version: '1.10'

--- a/doc/modules/ROOT/pages/basics/installation.adoc
+++ b/doc/modules/ROOT/pages/basics/installation.adoc
@@ -14,7 +14,7 @@ release. If you're new to Emacs you might want to go through
 https://www.gnu.org/software/emacs/tour/index.html[the guided tour of Emacs]
 and the built-in tutorial (just press kbd:[C-h t]).
 
-CIDER officially supports Emacs 28.1+, Java 8+, and Clojure(Script) 1.10+. If
+CIDER officially supports Emacs 28.1+, Java 8+, and Clojure(Script) {clojure-min-version}+. If
 you need to work with earlier versions, check
 xref:about/compatibility.adoc#compatibility-matrix[compatibility matrix].
 

--- a/doc/modules/ROOT/pages/basics/middleware_setup.adoc
+++ b/doc/modules/ROOT/pages/basics/middleware_setup.adoc
@@ -18,16 +18,16 @@ dependencies to your Clojure project (explained in the following sections).
 Use the convenient plugin for defaults, either in your project's
 `project.clj` file or in the `:repl` profile in `~/.lein/profiles.clj`.
 
-[source,clojure]
+[source,clojure,subs="attributes+"]
 ----
-:plugins [[cider/cider-nrepl "0.59.0"]]
+:plugins [[cider/cider-nrepl "{cider-nrepl-version}"]]
 ----
 
 A minimal `profiles.clj` for CIDER would be:
 
-[source,clojure]
+[source,clojure,subs="attributes+"]
 ----
-{:repl {:plugins [[cider/cider-nrepl "0.59.0"]]}}
+{:repl {:plugins [[cider/cider-nrepl "{cider-nrepl-version}"]]}}
 ----
 
 WARNING: Be careful not to place this in the `:user` profile, as this way CIDER's
@@ -41,14 +41,14 @@ a standalone Clojure(Script) nREPL server with CIDER middleware from
 the commandline with something like `clj -A:cider-clj`. Then from emacs
 run `cider-connect` or `cider-connect-cljs`.
 
-[source,clojure]
+[source,clojure,subs="attributes+"]
 ----
-  :cider-clj {:extra-deps {cider/cider-nrepl {:mvn/version "0.59.0"}}
+  :cider-clj {:extra-deps {cider/cider-nrepl {:mvn/version "{cider-nrepl-version}"}}
               :main-opts ["-m" "nrepl.cmdline" "--middleware" "[cider.nrepl/cider-middleware]"]}
 
   :cider-cljs {:extra-deps {org.clojure/clojurescript {:mvn/version "1.10.339"}
-                            cider/cider-nrepl {:mvn/version "0.59.0"}
-                            cider/piggieback {:mvn/version "0.6.1"}}
+                            cider/cider-nrepl {:mvn/version "{cider-nrepl-version}"}
+                            cider/piggieback {:mvn/version "{piggieback-version}"}}
                :main-opts ["-m" "nrepl.cmdline" "--middleware"
                            "[cider.nrepl/cider-middleware,cider.piggieback/wrap-cljs-repl]"]}
 ----
@@ -95,11 +95,11 @@ See `bin/launchpad --help` or the [README](https://github.com/lambdaisland/launc
 NOTE: Make sure you're using https://github.com/clojurephant/clojurephant[Clojurephant] 0.4.0 or newer.
 
 .build.gradle
-[source, groovy]
+[source,groovy,subs="attributes+"]
 ----
 dependencies {
-  devImplementation 'nrepl:nrepl:1.7.0'
-  devImplementation 'cider:cider-nrepl:0.59.0'
+  devImplementation 'nrepl:nrepl:{nrepl-version}'
+  devImplementation 'cider:cider-nrepl:{cider-nrepl-version}'
 }
 
 tasks.named('clojureRepl') {

--- a/doc/modules/ROOT/pages/basics/remote.adoc
+++ b/doc/modules/ROOT/pages/basics/remote.adoc
@@ -208,11 +208,11 @@ devcontainer up --workspace-folder /home/me/my-clj-code
 Then we can start a nREPL server inside the container on the remote host as shown below (executed from your local machine).
 The command tunnels as well the remote port 12345 to local machine on port 12345:
 
-[source,sh]
+[source,sh,subs="attributes+"]
 ----
 ssh -t -L 12345:localhost:12345 MY_REMOTE_SERVER \
     devcontainer exec  --workspace-folder /home/me/my-clj-code \
-    "clojure -Sdeps '{:deps {nrepl/nrepl {:mvn/version \"1.7.0\"} cider/cider-nrepl {:mvn/version \"0.59.0\"}}}' -m nrepl.cmdline -p 12345 -b 0.0.0.0 --middleware '[\"cider.nrepl/cider-middleware\"]' "
+    "clojure -Sdeps '{:deps {nrepl/nrepl {:mvn/version \"{nrepl-version}\"} cider/cider-nrepl {:mvn/version \"{cider-nrepl-version}\"}}}' -m nrepl.cmdline -p 12345 -b 0.0.0.0 --middleware '[\"cider.nrepl/cider-middleware\"]' "
 ----
 
 For this to work, we need as well to configure `devcontainer.json` with a snippet that exposes port `12345` from the container to the (remote) host:

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -89,7 +89,10 @@ simple - CIDER passes the extra dependencies and nREPL configuration to
 your build tool in the command it runs to start the nREPL server. Here's how
 this looks for `tools.deps`:
 
-  $ clojure -Sdeps '{:deps {nrepl {:mvn/version "1.7.0"} cider/cider-nrepl {:mvn/version "0.59.0"}}}' -m nrepl.cmdline --middleware '["cider.nrepl/cider-middleware"]'
+[source,sh,subs="attributes+"]
+----
+$ clojure -Sdeps '{:deps {nrepl {:mvn/version "{nrepl-version}"} cider/cider-nrepl {:mvn/version "{cider-nrepl-version}"}}}' -m nrepl.cmdline --middleware '["cider.nrepl/cider-middleware"]'
+----
 
 TIP: If you don't want `cider-jack-in` to inject dependencies automatically, set
 `cider-inject-dependencies-at-jack-in` to `nil`. Note that you'll have to setup
@@ -417,9 +420,9 @@ This will start the project's nREPL server.
 
 It is also possible for plain `clj`, although the command is somewhat longer:
 
-[source,sh]
+[source,sh,subs="attributes+"]
 ----
-$ clj -Sdeps '{:deps {cider/cider-nrepl {:mvn/version "0.59.0"}}}' -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"
+$ clj -Sdeps '{:deps {cider/cider-nrepl {:mvn/version "{cider-nrepl-version}"}}}' -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"
 ----
 
 Alternatively, you can start nREPL either manually or using the facilities

--- a/doc/modules/ROOT/pages/cljs/figwheel.adoc
+++ b/doc/modules/ROOT/pages/cljs/figwheel.adoc
@@ -23,9 +23,9 @@ You'll also have to configure Piggieback manually if you're planning to use
 
 . Add this to your dev `:dependencies` (not needed for `cider-jack-in-cljs`):
 +
-[source,clojure]
+[source,clojure,subs="attributes+"]
 ----
-[cider/piggieback "0.6.1"]
+[cider/piggieback "{piggieback-version}"]
 ----
 +
 . Add this to your dev `:repl-options` (not needed for `cider-jack-in-cljs`):
@@ -121,9 +121,9 @@ You can also use https://github.com/bhauman/lein-figwheel[Figwheel] with CIDER.
 in the root of your Leiningen project definition.
 . Add these to your dev `:dependencies`:
 +
-[source,clojure]
+[source,clojure,subs="attributes+"]
 ----
-[cider/piggieback "0.6.1"] ; not needed for cider-jack-in-cljs
+[cider/piggieback "{piggieback-version}"] ; not needed for cider-jack-in-cljs
 [figwheel-sidecar "0.5.19"] ; use here whatever the current version of figwheel is
 ----
 +

--- a/doc/modules/ROOT/pages/cljs/shadow-cljs.adoc
+++ b/doc/modules/ROOT/pages/cljs/shadow-cljs.adoc
@@ -61,14 +61,15 @@ And connect to it with `cider-connect`.
 
 ...For that to work, `shadow-cljs.edn` contents like the following are assumed:
 
-```clj
- :dependencies [[cider/cider-nrepl "0.59.0"] ;; mandatory (unless it's inherited from deps.edn or otherwise present in the classpath of shadow-cljs's JVM process)
+[source,clojure,subs="attributes+"]
+----
+ :dependencies [[cider/cider-nrepl "{cider-nrepl-version}"] ;; mandatory (unless it's inherited from deps.edn or otherwise present in the classpath of shadow-cljs's JVM process)
                 [refactor-nrepl/refactor-nrepl "3.9.0"]] ;; refactor-nrepl is optional
 
  :nrepl {:middleware [cider.nrepl/cider-middleware ;; it's advisable to explicitly add this middleware. It's automatically added by shadow-cljs (if available in the classpath), unless `:nrepl {:cider false}`
                       refactor-nrepl.middleware/wrap-refactor] ;; refactor-nrepl is optional
          :port 50655} ;; optional - if not specified, a random free port will be used
-```
+----
 
 NOTE: If https://docs.cider.mx/cider-nrepl/[cider-nrepl] isn't in your
 classpath you should make sure it's there. You can do this by correctly filling

--- a/doc/modules/ROOT/pages/cljs/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/cljs/up_and_running.adoc
@@ -21,10 +21,10 @@ to connect to an already running nREPL server using
 To setup piggieback, add the following dependencies to your project
 (`project.clj` or `deps.edn`):
 
-[source,clojure]
+[source,clojure,subs="attributes+"]
 ----
 ;; use whatever are the most recent versions here
-[cider/piggieback "0.6.1"]
+[cider/piggieback "{piggieback-version}"]
 [org.clojure/clojure "1.12.0"]
 ----
 
@@ -48,12 +48,12 @@ or in `deps.edn`:
 
 or in `build.gradle`:
 
-[source, groovy]
+[source,groovy,subs="attributes+"]
 ----
 dependencies {
-  devImplementation 'nrepl:nrepl:1.7.0'
-  devImplementation 'cider:cider-nrepl:0.59.0'
-  devImplementation 'cider:cider-piggieback:0.6.1'
+  devImplementation 'nrepl:nrepl:{nrepl-version}'
+  devImplementation 'cider:cider-nrepl:{cider-nrepl-version}'
+  devImplementation 'cider:cider-piggieback:{piggieback-version}'
 }
 
 tasks.named('clojureRepl') {

--- a/doc/modules/ROOT/pages/troubleshooting.adoc
+++ b/doc/modules/ROOT/pages/troubleshooting.adoc
@@ -260,7 +260,7 @@ in the "Middleware Setup" section.
 ==== You see `not installed` or `nil`, and you're starting the REPL with `cider-jack-in`
 
 * Do `C-h v cider-inject-dependencies-at-jack-in`, and check that this variable is non-nil.
-* Make sure your project depends on at least Clojure `1.7.0`.
+* Make sure your project depends on at least Clojure `{clojure-min-version}`.
 * If you use Leiningen, make sure your `lein --version` is at least `2.9.0`.
 
 If the above doesn't work, you can try specifying the cider-nrepl middleware


### PR DESCRIPTION
The manual pinned cider-nrepl 0.59.0 in nine snippets while CIDER injects 0.62.2, piggieback was two releases behind, and troubleshooting still asked for Clojure 1.7. The versions are now component attributes in doc/antora.yml with a comment on where they come from, and the snippets reference them. Verified with a local site build that every reference is substituted.