### PR TITLE
Add page aliases and descriptions, drop the per-page experimental attribute

### DIFF
--- a/doc/modules/ROOT/pages/about/license.adoc
+++ b/doc/modules/ROOT/pages/about/license.adoc
@@ -1,5 +1,4 @@
 = License & Copyright
-:experimental:
 
 == Code License
 

--- a/doc/modules/ROOT/pages/additional_packages.adoc
+++ b/doc/modules/ROOT/pages/additional_packages.adoc
@@ -1,4 +1,5 @@
 = Additional Packages
+:description: Emacs packages that extend CIDER, from clj-refactor and cider-storm to kaocha-runner, plus generic Emacs extensions worth enabling alongside it.
 
 There are many additional Emacs packages that can enhance your Clojure programming
 experience. The majority of the minor modes listed here should be enabled for both

--- a/doc/modules/ROOT/pages/basics/installation.adoc
+++ b/doc/modules/ROOT/pages/basics/installation.adoc
@@ -1,5 +1,5 @@
 = Installation
-:experimental:
+:description: How to install CIDER from MELPA or MELPA Stable with package.el, and what Emacs, Java and Clojure versions it supports.
 
 The canonical way to install CIDER is via `package.el` (Emacs's built-in package
 manager).

--- a/doc/modules/ROOT/pages/basics/middleware_setup.adoc
+++ b/doc/modules/ROOT/pages/basics/middleware_setup.adoc
@@ -1,5 +1,4 @@
 = nREPL Middleware Setup
-:experimental:
 
 NOTE: You can skip this section if you don't plan to use `cider-connect` or don't care
 about the advanced functionality that requires `cider-nrepl`.

--- a/doc/modules/ROOT/pages/basics/quickstart.adoc
+++ b/doc/modules/ROOT/pages/basics/quickstart.adoc
@@ -1,5 +1,5 @@
 = Quick Start
-:experimental:
+:description: From an empty Emacs to a live CIDER session with a local Clojure project in a few minutes.
 
 This page gets you from nothing to a live CIDER session in a few minutes. It
 sticks to the common happy path - a local Clojure project and Emacs on the same

--- a/doc/modules/ROOT/pages/basics/remote.adoc
+++ b/doc/modules/ROOT/pages/basics/remote.adoc
@@ -1,5 +1,4 @@
 = Remote and Container Connections
-:experimental:
 
 Most of the time you'll run CIDER against an nREPL server on your own machine,
 as described in xref:basics/up_and_running.adoc[Up and Running]. This page

--- a/doc/modules/ROOT/pages/basics/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/basics/up_and_running.adoc
@@ -1,5 +1,5 @@
 = Up and Running
-:experimental:
+:description: Starting a CIDER session with cider-jack-in or cider-connect, and how CIDER works with tools.deps, Leiningen, Gradle and other build tools.
 
 To use CIDER, you'll need to connect it to a running nREPL server that
 is associated with your program. Most Clojure developers use standard

--- a/doc/modules/ROOT/pages/caveats.adoc
+++ b/doc/modules/ROOT/pages/caveats.adoc
@@ -1,5 +1,4 @@
 = Caveats
-:experimental:
 
 CIDER is certainly not perfect and has some limitations that everyone
 should be aware of.

--- a/doc/modules/ROOT/pages/cljs/figwheel.adoc
+++ b/doc/modules/ROOT/pages/cljs/figwheel.adoc
@@ -1,5 +1,4 @@
 = Using Figwheel
-:experimental:
 
 Figwheel is one of the most popular ClojureScript REPLs today. Below you'll find
 instructions on how to set up and use it with CIDER.

--- a/doc/modules/ROOT/pages/cljs/krell.adoc
+++ b/doc/modules/ROOT/pages/cljs/krell.adoc
@@ -1,5 +1,4 @@
 = Using Krell
-:experimental:
 
 https://github.com/vouch-opensource/krell[Krell] is the newest
 ClojureScript React Native REPL. In this section we'll discuss how to

--- a/doc/modules/ROOT/pages/cljs/other_repls.adoc
+++ b/doc/modules/ROOT/pages/cljs/other_repls.adoc
@@ -1,5 +1,4 @@
 = Using Other ClojureScript REPLs
-:experimental:
 
 While these days most people are using `figwheel` and `shadow-cljs`,
 CIDER supports other ClojureScript REPLs as well.

--- a/doc/modules/ROOT/pages/cljs/overview.adoc
+++ b/doc/modules/ROOT/pages/cljs/overview.adoc
@@ -1,5 +1,6 @@
 = ClojureScript
-:experimental:
+:page-aliases: basics/clojurescript.adoc
+:description: How CIDER supports ClojureScript, which features carry over from Clojure and which don't, and where to start.
 
 NOTE: CIDER works well with ClojureScript, but ClojureScript's
 compile-on-the-JVM, run-in-a-JavaScript-runtime model means a few Clojure

--- a/doc/modules/ROOT/pages/cljs/shadow-cljs.adoc
+++ b/doc/modules/ROOT/pages/cljs/shadow-cljs.adoc
@@ -1,5 +1,4 @@
 = Using shadow-cljs
-:experimental:
 
 `shadow-cljs` is one of the most popular toolchains for doing ClojureScript
 development these days. In this section we'll discuss how to set it up and

--- a/doc/modules/ROOT/pages/cljs/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/cljs/up_and_running.adoc
@@ -1,5 +1,4 @@
 = Up and Running
-:experimental:
 
 == Piggieback Setup
 

--- a/doc/modules/ROOT/pages/config/basic_config.adoc
+++ b/doc/modules/ROOT/pages/config/basic_config.adoc
@@ -1,5 +1,5 @@
 = Basic Configuration
-:experimental:
+:page-aliases: config/misc.adoc
 
 Like Emacs itself, almost every part of CIDER is configurable. The
 CIDER developers have tried to implement some reasonable defaults that

--- a/doc/modules/ROOT/pages/config/clojure_ts_mode.adoc
+++ b/doc/modules/ROOT/pages/config/clojure_ts_mode.adoc
@@ -1,5 +1,4 @@
 = Using clojure-ts-mode
-:experimental:
 
 https://github.com/clojure-emacs/clojure-ts-mode[clojure-ts-mode] is a
 tree-sitter-powered major mode for editing Clojure, and the eventual successor to

--- a/doc/modules/ROOT/pages/config/lsp.adoc
+++ b/doc/modules/ROOT/pages/config/lsp.adoc
@@ -1,5 +1,4 @@
 = Using CIDER with clojure-lsp
-:experimental:
 
 A lot of Clojure programmers run CIDER alongside
 https://clojure-lsp.io[clojure-lsp] (through

--- a/doc/modules/ROOT/pages/config/project_config.adoc
+++ b/doc/modules/ROOT/pages/config/project_config.adoc
@@ -1,5 +1,4 @@
 = Project-specific Configuration
-:experimental:
 
 A pretty common question about CIDER is how to handle project-specific configuration.
 There are many reasons for wanting to do something like this, but probably the first

--- a/doc/modules/ROOT/pages/contributing.adoc
+++ b/doc/modules/ROOT/pages/contributing.adoc
@@ -1,4 +1,5 @@
 = Contributing
+:description: How to report issues, propose changes and contribute code or documentation to CIDER.
 
 == Issues
 

--- a/doc/modules/ROOT/pages/debugging/debugger.adoc
+++ b/doc/modules/ROOT/pages/debugging/debugger.adoc
@@ -1,5 +1,5 @@
 = Debugger
-:experimental:
+:description: CIDER's interactive Clojure debugger: instrumenting functions, stepping, breakpoints and inspecting locals from Emacs.
 
 CIDER ships with a *powerful* interactive Clojure debugger inspired by Emacs's own
 http://www.gnu.org/software/emacs/manual/html_node/elisp/Edebug.html[Edebug]. You're going to love it!

--- a/doc/modules/ROOT/pages/debugging/enlighten.adoc
+++ b/doc/modules/ROOT/pages/debugging/enlighten.adoc
@@ -1,5 +1,4 @@
 = Enlighten
-:experimental:
 
 Enlighten Mode displays the value of locals in realtime, as your code
 runs. This feature is somewhat similar to a feature in the Light Table

--- a/doc/modules/ROOT/pages/debugging/inspector.adoc
+++ b/doc/modules/ROOT/pages/debugging/inspector.adoc
@@ -1,5 +1,5 @@
 = Inspector
-:experimental:
+:page-aliases: debugging/misc.adoc
 
 The value inspector allows you to inspect and navigate the structure of data. While you can use
 it for pretty much anything (e.g. primitive data types, var, ref types) it's most

--- a/doc/modules/ROOT/pages/debugging/logging.adoc
+++ b/doc/modules/ROOT/pages/debugging/logging.adoc
@@ -1,5 +1,4 @@
 = Logging
-:experimental:
 
 CIDER Log Mode allows you to capture, debug, inspect and view log
 events emitted by Java logging frameworks. The captured log events can

--- a/doc/modules/ROOT/pages/debugging/macroexpansion.adoc
+++ b/doc/modules/ROOT/pages/debugging/macroexpansion.adoc
@@ -1,5 +1,4 @@
 = Macroexpansion
-:experimental:
 
 Typing kbd:[C-c C-m] after some form in a source buffer or the REPL will show
 you the `macroexpand-1` expansion of the form in a new buffer.

--- a/doc/modules/ROOT/pages/debugging/tap.adoc
+++ b/doc/modules/ROOT/pages/debugging/tap.adoc
@@ -1,5 +1,4 @@
 = Tap Viewer
-:experimental:
 
 Clojure's `tap>` is a lightweight way to send a value somewhere without
 littering your code with prints or disturbing the value flow. CIDER can collect

--- a/doc/modules/ROOT/pages/debugging/tracing.adoc
+++ b/doc/modules/ROOT/pages/debugging/tracing.adoc
@@ -1,5 +1,4 @@
 = Tracing Function Execution
-:experimental:
 
 You can trace the arguments supplied to, and the result values produced
 by functions using kbd:[C-c M-t v]. CIDER will prompt you for the

--- a/doc/modules/ROOT/pages/faq.adoc
+++ b/doc/modules/ROOT/pages/faq.adoc
@@ -1,4 +1,5 @@
 = Frequently Asked Questions
+:description: Answers to common questions about CIDER's name and history, its relationship to nrepl.el, monroe, inf-clojure and Cursive, and its release cadence.
 
 [TIP]
 ====

--- a/doc/modules/ROOT/pages/index.adoc
+++ b/doc/modules/ROOT/pages/index.adoc
@@ -1,4 +1,5 @@
 = CIDER
+:description: CIDER turns Emacs into an interactive development environment for Clojure and ClojureScript, built around a REPL connection to your running program.
 
 CIDER is the **C**lojure(Script) **I**nteractive **D**evelopment **E**nvironment
 that **R**ocks!

--- a/doc/modules/ROOT/pages/keybindings.adoc
+++ b/doc/modules/ROOT/pages/keybindings.adoc
@@ -1,5 +1,5 @@
 = Keybindings
-:experimental:
+:description: The complete reference of cider-mode keybindings, grouped by task, with a printable quick-reference card.
 
 This is the reference for `cider-mode`'s keybindings - the commands available in
 Clojure(Script) source buffers once you've connected a REPL. They're grouped by

--- a/doc/modules/ROOT/pages/platforms/other_platforms.adoc
+++ b/doc/modules/ROOT/pages/platforms/other_platforms.adoc
@@ -1,4 +1,5 @@
 = Other Platforms
+:page-aliases: platforms/scittle_and_friends.adoc
 
 == Overview
 

--- a/doc/modules/ROOT/pages/platforms/overview.adoc
+++ b/doc/modules/ROOT/pages/platforms/overview.adoc
@@ -1,4 +1,5 @@
 = Overview
+:description: Using CIDER with Babashka, nbb, Basilisp, ClojureCLR and other Clojure-like languages that ship an nREPL server.
 
 CIDER is first and foremost a *Clojure* programming environment. Because all of
 its interaction with a running program goes through https://nrepl.org[nREPL],

--- a/doc/modules/ROOT/pages/repl/basic_usage.adoc
+++ b/doc/modules/ROOT/pages/repl/basic_usage.adoc
@@ -1,5 +1,4 @@
 = Basic Usage
-:experimental:
 
 CIDER comes with a powerful REPL that complements the interactive
 development functionality in `cider-mode`. Using the CIDER REPL you

--- a/doc/modules/ROOT/pages/repl/configuration.adoc
+++ b/doc/modules/ROOT/pages/repl/configuration.adoc
@@ -1,5 +1,4 @@
 = REPL Configuration
-:experimental:
 
 == Behavior on connect
 

--- a/doc/modules/ROOT/pages/repl/history.adoc
+++ b/doc/modules/ROOT/pages/repl/history.adoc
@@ -1,5 +1,4 @@
 = REPL history browser
-:experimental:
 
 You can browse your REPL input history with the command kbd:[M-x]
 `cider-history`.  This command is bound to kbd:[C-c M-p]

--- a/doc/modules/ROOT/pages/repl/keybindings.adoc
+++ b/doc/modules/ROOT/pages/repl/keybindings.adoc
@@ -1,5 +1,4 @@
 = REPL Keybindings
-:experimental:
 
 Here's a list of the keybindings that are available in CIDER's REPL:
 

--- a/doc/modules/ROOT/pages/testing/running_tests.adoc
+++ b/doc/modules/ROOT/pages/testing/running_tests.adoc
@@ -1,5 +1,4 @@
 = Running Tests
-:experimental:
 
 The Clojure ecosystem provides a lot of support for test-driven
 development (TDD) and other test-centric patterns. First, Clojure

--- a/doc/modules/ROOT/pages/testing/test_reports.adoc
+++ b/doc/modules/ROOT/pages/testing/test_reports.adoc
@@ -1,5 +1,4 @@
 = Interacting with Test Result Reports
-:experimental:
 
 Should tests fail then CIDER displays a test result report in the
 `+*cider-test-report*+` buffer. This buffer uses `cider-test-report-mode`,

--- a/doc/modules/ROOT/pages/troubleshooting.adoc
+++ b/doc/modules/ROOT/pages/troubleshooting.adoc
@@ -1,5 +1,5 @@
 = Troubleshooting
-:experimental:
+:description: How to diagnose CIDER problems: cider-doctor, debugging and profiling commands, inspecting nREPL traffic, and fixes for commonly encountered issues.
 
 In case you run into issues here are a few tips that can help you diagnose the
 problem.

--- a/doc/modules/ROOT/pages/usage/cider_mode.adoc
+++ b/doc/modules/ROOT/pages/usage/cider_mode.adoc
@@ -1,5 +1,4 @@
 = Using cider-mode
-:experimental:
 
 `cider-mode` is a pretty standard Emacs minor mode, which exists mostly to provide a
 common keymap for all of CIDER's REPL-powered commands that are meant to be used

--- a/doc/modules/ROOT/pages/usage/code_completion.adoc
+++ b/doc/modules/ROOT/pages/usage/code_completion.adoc
@@ -1,5 +1,4 @@
 = Code Completion
-:experimental:
 
 CIDER provides intelligent code completion for both source buffers (powered by
 `cider-mode`) and REPL buffers.

--- a/doc/modules/ROOT/pages/usage/code_evaluation.adoc
+++ b/doc/modules/ROOT/pages/usage/code_evaluation.adoc
@@ -1,4 +1,5 @@
 = Code Evaluation
+:description: The evaluation commands CIDER provides, which form each one targets, and how results are displayed.
 
 Code evaluation is at the heart of interactive programming.
 CIDER provides a ton of evaluation-related commands that can cover

--- a/doc/modules/ROOT/pages/usage/dealing_with_errors.adoc
+++ b/doc/modules/ROOT/pages/usage/dealing_with_errors.adoc
@@ -1,5 +1,5 @@
 = Dealing with Errors
-:experimental:
+:page-aliases: usage/navigating_stacktraces.adoc
 
 Every now and then you'll make some mistake in your code which is
 going to result in an evaluation error. Clojure's errors are

--- a/doc/modules/ROOT/pages/usage/formatting.adoc
+++ b/doc/modules/ROOT/pages/usage/formatting.adoc
@@ -1,5 +1,4 @@
 = Formatting Code
-:experimental:
 
 CIDER has its own code formatting (indentation) engine, described in
 xref:config/indentation.adoc[Indentation], but it can also drive the popular

--- a/doc/modules/ROOT/pages/usage/interactive_programming.adoc
+++ b/doc/modules/ROOT/pages/usage/interactive_programming.adoc
@@ -1,5 +1,5 @@
 = Interactive Programming
-:experimental:
+:description: What interactive, REPL-driven programming with CIDER looks like, and why it beats the edit-compile-run cycle.
 
 == Overview
 

--- a/doc/modules/ROOT/pages/usage/managing_connections.adoc
+++ b/doc/modules/ROOT/pages/usage/managing_connections.adoc
@@ -1,5 +1,4 @@
 = Managing Connections
-:experimental:
 
 NOTE: Because nREPL connections map one-to-one to REPL buffers in
 CIDER, for the purpose of this section we use "REPL" and "connection"

--- a/doc/modules/ROOT/pages/usage/misc_features.adoc
+++ b/doc/modules/ROOT/pages/usage/misc_features.adoc
@@ -1,5 +1,4 @@
 = Miscellaneous Features
-:experimental:
 
 As the infomercials always say, "But wait, there's more!" If
 simultaneous Clojure and ClojureScript REPLs, interactive programming,

--- a/doc/modules/ROOT/pages/usage/navigation.adoc
+++ b/doc/modules/ROOT/pages/usage/navigation.adoc
@@ -1,5 +1,4 @@
 = Code Navigation and Browsing
-:experimental:
 
 CIDER offers a rich set of commands for finding your way around a codebase and
 exploring a running program's structure. Jumping to a definition is covered in


### PR DESCRIPTION
Old URLs of the five pages that were renamed or merged away now redirect instead of 404ing, the main landing pages carry a description for search-engine snippets, and the `:experimental:` line repeated on 40 pages is gone because the playbook already sets it. Verified with a local site build: the redirect stubs are generated and the kbd macros still render.