### PR TITLE
Present the per-build-tool setup instructions as tabs

### DIFF
--- a/doc/modules/ROOT/pages/basics/middleware_setup.adoc
+++ b/doc/modules/ROOT/pages/basics/middleware_setup.adoc
@@ -12,8 +12,11 @@ dependencies to your Clojure project (explained in the following sections).
 
 == Setting Up a Standalone REPL
 
-=== Using Leiningen
-
+[tabs]
+======
+Leiningen::
++
+--
 Use the convenient plugin for defaults, either in your project's
 `project.clj` file or in the `:repl` profile in `~/.lein/profiles.clj`.
 
@@ -32,9 +35,11 @@ A minimal `profiles.clj` for CIDER would be:
 WARNING: Be careful not to place this in the `:user` profile, as this way CIDER's
 middleware will always get loaded, causing `lein` to start slower.  You really
 need it just for `lein repl` and this is what the `:repl` profile is for.
+--
 
-=== Using tools.deps
-
+tools.deps::
++
+--
 You can add the following aliases to your deps.edn in order to launch
 a standalone Clojure(Script) nREPL server with CIDER middleware from
 the commandline with something like `clj -A:cider-clj`. Then from emacs
@@ -55,13 +60,15 @@ run `cider-connect` or `cider-connect-cljs`.
 NOTE: the suggested ClojureScript setup is apt for e.g. library development, but not for frontend development.
 For those cases, you may want to check out our xref:cljs/shadow-cljs.adoc#using-cider-connect-cljs[shadow-cljs]
 or xref:cljs/figwheel.adoc#clojure-cli-setup[figwheel] setups instead.
+--
 
-=== Using Launchpad
-
-[Launchpad](https://github.com/lambdaisland/launchpad) lets you start a nREPL server from the command line,
+Launchpad::
++
+--
+https://github.com/lambdaisland/launchpad[Launchpad] lets you start a nREPL server from the command line,
 while including the middleware your editor requires and providing additional developer conveniences.
 
-In your project, create `bin/launchpad`. The only requirement is [babashka](https://babashka.org/).
+In your project, create `bin/launchpad`. The only requirement is https://babashka.org/[babashka].
 
 [source,clojure]
 ----
@@ -80,17 +87,18 @@ Now `bin/launchpad --emacs` will start a Clojure process, and connect Emacs to y
 
 To load additional middleware, configure it inside `bin/launchpad`
 
-
 [source,clojure]
 ----
 ;; <snip> ... as before ... <snip>
 (launchpad/main {:middleware [your.custom/nrepl-middleware]})
 ----
 
-See `bin/launchpad --help` or the [README](https://github.com/lambdaisland/launchpad) for more info.
+See `bin/launchpad --help` or the https://github.com/lambdaisland/launchpad[README] for more info.
+--
 
-=== Using Gradle
-
+Gradle::
++
+--
 NOTE: Make sure you're using https://github.com/clojurephant/clojurephant[Clojurephant] 0.4.0 or newer.
 
 .build.gradle
@@ -109,10 +117,14 @@ tasks.named('clojureRepl') {
 You can then launch the nREPL server from the command line via: `./gradlew clojureRepl`.
 
 For more information, see the https://clojurephant.dev[Clojurephant docs].
+--
 
-=== Using Maven
-
+Maven::
++
+--
 NOTE: This section is currently a stub. Contributions welcome!
+--
+======
 
 == Using Embedded nREPL Server
 

--- a/doc/modules/ROOT/pages/cljs/up_and_running.adoc
+++ b/doc/modules/ROOT/pages/cljs/up_and_running.adoc
@@ -27,26 +27,33 @@ To setup piggieback, add the following dependencies to your project
 [org.clojure/clojure "1.12.0"]
 ----
 
-as well as `piggieback` nREPL middleware:
+as well as the `piggieback` nREPL middleware:
 
-in `project.clj`:
-
+[tabs]
+======
+project.clj::
++
+--
 [source,clojure]
 ----
 :repl-options {:nrepl-middleware [cider.piggieback/wrap-cljs-repl]}
 ----
+--
 
-or in `deps.edn`:
-
+deps.edn::
++
+--
 [source,clojure]
 ----
 {:aliases { :cider-cljs { :main-opts
   ["-m" "nrepl.cmdline" "--middleware"
    "[cider.nrepl/cider-middleware,cider.piggieback/wrap-cljs-repl]"]}}}
 ----
+--
 
-or in `build.gradle`:
-
+build.gradle::
++
+--
 [source,groovy,subs="attributes+"]
 ----
 dependencies {
@@ -59,6 +66,8 @@ tasks.named('clojureRepl') {
   middleware = ['cider.nrepl/cider-middleware', 'cider.piggieback/wrap-cljs-repl']
 }
 ----
+--
+======
 
 == Starting a ClojureScript REPL
 


### PR DESCRIPTION
The standalone REPL setup and the manual piggieback setup now use `[tabs]` blocks instead of a run of per-tool subsections. This depends on clojure-emacs/docs.cider.mx#7 for the extension (without it the blocks render as a labelled list) and is based on #4195, since both touch the same snippets. The Launchpad section also had Markdown links that rendered literally.